### PR TITLE
10024 Wallet: TextField Focus Problems

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
@@ -352,25 +352,6 @@ Item {
             right: parent.right;
         }
 
-        Image {
-            id: lowerKeyboardButton;
-            z: 999;
-            source: "images/lowerKeyboard.png";
-            anchors.right: keyboard.right;
-            anchors.top: keyboard.showMirrorText ? keyboard.top : undefined;
-            anchors.bottom: keyboard.showMirrorText ? undefined : keyboard.bottom;
-            height: 50;
-            width: 60;
-
-            MouseArea {
-                anchors.fill: parent;
-
-                onClicked: {
-                    root.keyboardRaised = false;
-                }
-            }
-        }
-
         HifiControlsUit.Keyboard {
             id: keyboard;
             raised: HMD.mounted && root.keyboardRaised;

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
@@ -206,16 +206,6 @@ Item {
                 root.isPasswordField = (focus && passphraseField.echoMode === TextInput.Password);
             }
 
-            MouseArea {
-                anchors.fill: parent;
-
-                onClicked: {
-                    root.keyboardRaised = true;
-                    root.isPasswordField = (passphraseField.echoMode === TextInput.Password);
-                    mouse.accepted = false;
-                }
-            }
-
             onAccepted: {
                 submitPassphraseInputButton.enabled = false;
                 commerce.setPassphrase(passphraseField.text);

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
@@ -87,15 +87,6 @@ Item {
             }
         }
 
-        MouseArea {
-            anchors.fill: parent;
-            onPressed: {
-                var hidePassword = (currentPassphraseField.echoMode === TextInput.Password);
-                sendSignalToWallet({method: 'walletSetup_raiseKeyboard', isPasswordField: hidePassword});
-                mouse.accepted = false;
-            }
-        }
-
         onAccepted: {
             passphraseField.focus = true;
         }
@@ -114,15 +105,6 @@ Item {
         placeholderText: root.isShowingTip ? "" : "enter new passphrase";
         activeFocusOnPress: true;
         activeFocusOnTab: true;
-
-        MouseArea {
-            anchors.fill: parent;
-            onPressed: {
-                var hidePassword = (passphraseField.echoMode === TextInput.Password);
-                sendSignalToWallet({method: 'walletSetup_raiseKeyboard', isPasswordField: hidePassword});
-                mouse.accepted = false;
-            }
-        }
 
         onFocusChanged: {
             if (focus) {
@@ -150,15 +132,6 @@ Item {
         placeholderText: root.isShowingTip ? "" : "re-enter new passphrase";
         activeFocusOnPress: true;
         activeFocusOnTab: true;
-
-        MouseArea {
-            anchors.fill: parent;
-            onPressed: {
-                var hidePassword = (passphraseFieldAgain.echoMode === TextInput.Password);
-                sendSignalToWallet({method: 'walletSetup_raiseKeyboard', isPasswordField: hidePassword});
-                mouse.accepted = false;
-            }
-        }
 
         onFocusChanged: {
             if (focus) {

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
@@ -82,8 +82,6 @@ Item {
             if (focus) {
                 var hidePassword = (currentPassphraseField.echoMode === TextInput.Password);
                 sendSignalToWallet({method: 'walletSetup_raiseKeyboard', isPasswordField: hidePassword});
-            } else if (!passphraseFieldAgain.focus) {
-                sendSignalToWallet({method: 'walletSetup_lowerKeyboard', isPasswordField: false});
             }
         }
 
@@ -110,8 +108,6 @@ Item {
             if (focus) {
                 var hidePassword = (passphraseField.echoMode === TextInput.Password);
                 sendMessageToLightbox({method: 'walletSetup_raiseKeyboard', isPasswordField: hidePassword});
-            } else if (!passphraseFieldAgain.focus) {
-                sendMessageToLightbox({method: 'walletSetup_lowerKeyboard', isPasswordField: false});
             }
         }
 
@@ -137,8 +133,6 @@ Item {
             if (focus) {
                 var hidePassword = (passphraseFieldAgain.echoMode === TextInput.Password);
                 sendMessageToLightbox({method: 'walletSetup_raiseKeyboard', isPasswordField: hidePassword});
-            } else if (!passphraseField.focus) {
-                sendMessageToLightbox({method: 'walletSetup_lowerKeyboard', isPasswordField: false});
             }
         }
 

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -666,25 +666,6 @@ Rectangle {
             right: parent.right;
         }
 
-        Image {
-            id: lowerKeyboardButton;
-            z: 999;
-            source: "images/lowerKeyboard.png";
-            anchors.right: keyboard.right;
-            anchors.top: keyboard.showMirrorText ? keyboard.top : undefined;
-            anchors.bottom: keyboard.showMirrorText ? undefined : keyboard.bottom;
-            height: 50;
-            width: 60;
-
-            MouseArea {
-                anchors.fill: parent;
-
-                onClicked: {
-                    root.keyboardRaised = false;
-                }
-            }
-        }
-
         HifiControlsUit.Keyboard {
             id: keyboard;
             raised: HMD.mounted && root.keyboardRaised;


### PR DESCRIPTION
This PR attempts to fix 'https://highfidelity.fogbugz.com/f/cases/10024/Wallet-TextField-Focus-Problems' and simplify code by removing excessive MouseArea-s. 

It also removes additional 'collapse keyboard' button in Wallet (90-degree-rotated symbol '>' like on the screenshot below): 

![image](https://user-images.githubusercontent.com/23638/33578788-bdb91508-d958-11e7-9faf-7ce97caa7fbf.png)


***Test plan*** 

1. Switch to VR
2. Open the Wallet app. 
3. Click the "Show passphrase" checkbox on the "Please Enter Your Passphrase" screen.
4. Ensure you still can click inside the passphrase TextField to give keyboard focus to the TextField.
5. Ensure virtual keyboard appears on clicking into text edit on all the Wallet screens
6. Ensure virtual keyboard don't have additional 'collapse keyboard' button. 