### PR TITLE
Fix gray/incorrect security image after relog

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
@@ -68,6 +68,7 @@ Item {
     Connections {
         target: GlobalServices
         onMyUsernameChanged: {
+            transactionHistoryModel.clear();
             usernameText.text = Account.username;
         }
     }

--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -321,6 +321,16 @@ Wallet::Wallet() {
     auto accountManager = DependencyManager::get<AccountManager>();
     connect(accountManager.data(), &AccountManager::usernameChanged, this, [&]() {
         getWalletStatus();
+        _publicKeys.clear();
+
+        if (_securityImage) {
+            delete _securityImage;
+        }
+        _securityImage = nullptr;
+
+        // tell the provider we got nothing
+        updateImageProvider();
+        _passphrase->clear();
     });
 }
 


### PR DESCRIPTION
Also ensure recent activity gets cleared after relog.

Potentially fixes [FB10110](https://highfidelity.fogbugz.com/f/cases/10110/Security-Pic-turns-gray-in-wallet-app).

Test Plan:
1. Run Interface, log in, and open the Wallet app. If you don't already have a wallet set up, set one up.
2. Verify that your security picture is correct (and not gray) throughout the Wallet app.
3. Close the Wallet app. Log out. Log in to a different account.
4. Open the Wallet app. If you don't already have a wallet set up, set one up. *Make sure the security picture that you select is different from the one in step (1).
5. Verify that your security picture is correct (and not gray) throughout the Wallet app.
6. Open Wallet Home
7. Log out of your High Fidelity account (keep the Wallet app open)
8. Log in to the same account as in (1).
9. After you log in, you'll be presented with the Authenticate screen. Verify that your security picture is correct for that wallet.
10. Authenticate your Wallet.
11. Verify that your security picture is correct (and not gray) throughout the Wallet app.