### PR TITLE
10108 marketplace category cannot scroll

### DIFF
--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -327,6 +327,19 @@
         });
     }
 
+    // fix for 10108 - marketplace category cannot scroll
+    function injectAddScrollbarToCategories() {
+        $('#categories-dropdown').on('show.bs.dropdown', function () {
+            $('body > div.container').css('display', 'none')
+            $('#categories-dropdown > ul.dropdown-menu').css({ 'overflow': 'auto', 'height': 'calc(100vh - 110px)' })
+        });
+
+        $('#categories-dropdown').on('hide.bs.dropdown', function () {
+            $('body > div.container').css('display', '')
+            $('#categories-dropdown > ul.dropdown-menu').css({ 'overflow': '', 'height': '' })
+        });
+    }
+
     function injectHiFiCode() {
         if (commerceMode) {
             maybeAddLogInButton();
@@ -358,6 +371,7 @@
         }
 
         injectUnfocusOnSearch();
+        injectAddScrollbarToCategories();
     }
 
     function injectHiFiItemPageCode() {


### PR DESCRIPTION
This PR should address the issue https://highfidelity.manuscript.com/f/cases/10108/marketplace-category-cannot-scroll

by introducing the following changes for 'marketplace' screen: 

On expanding categories:
- main scrollbar (at the right) will be hidden
- categories list will get its own scrollbar if doesn't fit into screen

On collapsing categories
- main scrollbar reappear
- categories scrollbar hidden together with categories

**Test plan**

0. Download 'marketplacesInject.js' from here: https://www.dropbox.com/s/6cp1b7mbyywedkz/marketplacesInject.js?dl=0
1. Put it to the following directory:  "<Hifi Install Folder\scripts\system\html\js\marketplacesInject.js". This is required to create additional categories 'Animation1' - 'Animation10'. 
2. Switch to VR
3. Open tablet, go to marketplace
4. Ensure expanding categories hides main scrollbar (at the right edge) and shows one for categories. 
5. Ensure collapsing categories returns main scrollbar and hides categories scrollbar
6. Repeat steps 3-5 for Desktop mode. 