### PR TITLE
Commerce Data Tracking: Iteration One

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -79,10 +79,23 @@ Rectangle {
             if (result.status !== 'success') {
                 failureErrorText.text = result.message;
                 root.activeView = "checkoutFailure";
+                var data = {
+                    "marketplaceID": root.itemId,
+                    "cost": root.itemPrice,
+                    "firstPurchaseOfThisItem": !root.alreadyOwned,
+                    "errorDetails": result.message
+                }
+                UserActivityLogger.logAction("commercePurchaseFailure", data);
             } else {
                 root.itemHref = result.data.download_url;
                 root.isWearable = result.data.categories.indexOf("Wearables") > -1;
                 root.activeView = "checkoutSuccess";
+                var data = {
+                    "marketplaceID": root.itemId,
+                    "cost": root.itemPrice,
+                    "firstPurchaseOfThisItem": !root.alreadyOwned
+                }
+                UserActivityLogger.logAction("commercePurchaseSuccess", data);
             }
         }
 
@@ -599,6 +612,12 @@ Rectangle {
                 sendToScript({method: 'checkout_rezClicked', itemHref: root.itemHref, isWearable: root.isWearable});
                 rezzedNotifContainer.visible = true;
                 rezzedNotifContainerTimer.start();
+                var data = {
+                    "marketplaceID": root.itemId,
+                    "source": "checkout",
+                    "type": root.isWearable ? "rez" : "wear"
+                }
+                UserActivityLogger.logAction("commerceEntityRezzed", data);
             }
         }
         RalewaySemiBold {

--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -79,23 +79,12 @@ Rectangle {
             if (result.status !== 'success') {
                 failureErrorText.text = result.message;
                 root.activeView = "checkoutFailure";
-                var data = {
-                    "marketplaceID": root.itemId,
-                    "cost": root.itemPrice,
-                    "firstPurchaseOfThisItem": !root.alreadyOwned,
-                    "errorDetails": result.message
-                }
-                UserActivityLogger.logAction("commercePurchaseFailure", data);
+                UserActivityLogger.commercePurchaseFailure(root.itemId, root.itemPrice, !root.alreadyOwned, result.message);
             } else {
                 root.itemHref = result.data.download_url;
                 root.isWearable = result.data.categories.indexOf("Wearables") > -1;
                 root.activeView = "checkoutSuccess";
-                var data = {
-                    "marketplaceID": root.itemId,
-                    "cost": root.itemPrice,
-                    "firstPurchaseOfThisItem": !root.alreadyOwned
-                }
-                UserActivityLogger.logAction("commercePurchaseSuccess", data);
+                UserActivityLogger.commercePurchaseSuccess(root.itemId, root.itemPrice, !root.alreadyOwned);
             }
         }
 
@@ -612,12 +601,7 @@ Rectangle {
                 sendToScript({method: 'checkout_rezClicked', itemHref: root.itemHref, isWearable: root.isWearable});
                 rezzedNotifContainer.visible = true;
                 rezzedNotifContainerTimer.start();
-                var data = {
-                    "marketplaceID": root.itemId,
-                    "source": "checkout",
-                    "type": root.isWearable ? "rez" : "wear"
-                }
-                UserActivityLogger.logAction("commerceEntityRezzed", data);
+                UserActivityLogger.commerceEntityRezzed(root.itemId, "checkout", root.isWearable ? "rez" : "wear");
             }
         }
         RalewaySemiBold {

--- a/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
@@ -349,12 +349,7 @@ Item {
                 sendToPurchases({method: 'purchases_rezClicked', itemHref: root.itemHref, isWearable: root.isWearable});
                 rezzedNotifContainer.visible = true;
                 rezzedNotifContainerTimer.start();
-                var data = {
-                    "marketplaceID": root.itemId,
-                    "source": "purchases",
-                    "type": root.isWearable ? "rez" : "wear"
-                }
-                UserActivityLogger.logAction("commerceEntityRezzed", data);
+                UserActivityLogger.commerceEntityRezzed(root.itemId, "purchases", root.isWearable ? "rez" : "wear");
             }
 
             style: ButtonStyle {

--- a/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
@@ -349,6 +349,12 @@ Item {
                 sendToPurchases({method: 'purchases_rezClicked', itemHref: root.itemHref, isWearable: root.isWearable});
                 rezzedNotifContainer.visible = true;
                 rezzedNotifContainerTimer.start();
+                var data = {
+                    "marketplaceID": root.itemId,
+                    "source": "purchases",
+                    "type": root.isWearable ? "rez" : "wear"
+                }
+                UserActivityLogger.logAction("commerceEntityRezzed", data);
             }
 
             style: ButtonStyle {

--- a/interface/resources/qml/hifi/commerce/wallet/Help.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Help.qml
@@ -55,6 +55,38 @@ Item {
         // Style
         color: hifi.colors.blueHighlight;
     }
+    
+    HifiControlsUit.Button {		
+        id: clearCachedPassphraseButton;		
+        visible: root.showDebugButtons;		
+        color: hifi.buttons.black;		
+        colorScheme: hifi.colorSchemes.dark;		
+        anchors.top: parent.top;		
+        anchors.left: helpTitleText.right;		
+        anchors.leftMargin: 20;		
+        height: 40;		
+        width: 150;		
+        text: "DBG: Clear Pass";		
+        onClicked: {		
+            commerce.setPassphrase("");		
+            sendSignalToWallet({method: 'passphraseReset'});		
+        }		
+    }		
+    HifiControlsUit.Button {		
+        id: resetButton;		
+        visible: root.showDebugButtons;		
+        color: hifi.buttons.red;		
+        colorScheme: hifi.colorSchemes.dark;		
+        anchors.top: clearCachedPassphraseButton.top;		
+        anchors.left: clearCachedPassphraseButton.right;		
+        height: 40;		
+        width: 150;		
+        text: "DBG: RST Wallet";		
+        onClicked: {		
+            commerce.reset();		
+            sendSignalToWallet({method: 'walletReset'});		
+        }		
+    }
 
     ListModel {
         id: helpModel;
@@ -147,7 +179,7 @@ Item {
                     text: model.isExpanded ? "-" : "+";
                     // Anchors
                     anchors.top: parent.top;
-                    anchors.topMargin: model.isExpanded ? -9 : 0;
+                    anchors.topMargin: model.isExpanded ?9 : 0;
                     anchors.bottom: parent.bottom;
                     anchors.left: parent.left;
                     width: 60;

--- a/interface/resources/qml/hifi/commerce/wallet/Help.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Help.qml
@@ -55,38 +55,6 @@ Item {
         // Style
         color: hifi.colors.blueHighlight;
     }
-    
-    HifiControlsUit.Button {		
-        id: clearCachedPassphraseButton;		
-        visible: root.showDebugButtons;		
-        color: hifi.buttons.black;		
-        colorScheme: hifi.colorSchemes.dark;		
-        anchors.top: parent.top;		
-        anchors.left: helpTitleText.right;		
-        anchors.leftMargin: 20;		
-        height: 40;		
-        width: 150;		
-        text: "DBG: Clear Pass";		
-        onClicked: {		
-            commerce.setPassphrase("");		
-            sendSignalToWallet({method: 'passphraseReset'});		
-        }		
-    }		
-    HifiControlsUit.Button {		
-        id: resetButton;		
-        visible: root.showDebugButtons;		
-        color: hifi.buttons.red;		
-        colorScheme: hifi.colorSchemes.dark;		
-        anchors.top: clearCachedPassphraseButton.top;		
-        anchors.left: clearCachedPassphraseButton.right;		
-        height: 40;		
-        width: 150;		
-        text: "DBG: RST Wallet";		
-        onClicked: {		
-            commerce.reset();		
-            sendSignalToWallet({method: 'walletReset'});		
-        }		
-    }
 
     ListModel {
         id: helpModel;
@@ -179,7 +147,7 @@ Item {
                     text: model.isExpanded ? "-" : "+";
                     // Anchors
                     anchors.top: parent.top;
-                    anchors.topMargin: model.isExpanded ?9 : 0;
+                    anchors.topMargin: model.isExpanded ? -9 : 0;
                     anchors.bottom: parent.bottom;
                     anchors.left: parent.left;
                     width: 60;

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -177,7 +177,7 @@ Rectangle {
         Connections {
             onSendSignalToWallet: {
                 if (msg.method === 'walletSetup_finished') {
-                    if (msg.referrer === '') {
+                    if (msg.referrer === '' || msg.referrer === 'marketplace cta') {
                         root.activeView = "initialize";
                         commerce.getWalletStatus();
                     } else if (msg.referrer === 'purchases') {

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -50,14 +50,8 @@ Rectangle {
                     commerce.resetLocalWalletOnly();
                     var timestamp = new Date();
                     walletSetup.startingTimestamp = timestamp;
-                    var data = {
-                        "timestamp": timestamp,
-                        "setupAttemptID": guid(),
-                        "setupFlowVersion": walletSetup.setupFlowVersion,
-                        "referrer": walletSetup.referrer,
-                        "currentDomain": (AddressManager.placename || AddressManager.hostname || '') + (AddressManager.pathname ? AddressManager.pathname.match(/\/[^\/]+/)[0] : '')
-                    }
-                    UserActivityLogger.logAction("commerceWalletSetupStarted", data);
+                    UserActivityLogger.commerceWalletSetupStarted(timestamp, generateUUID(), walletSetup.setupFlowVersion, walletSetup.referrer ? walletSetup.referrer : "wallet app",
+                        (AddressManager.placename || AddressManager.hostname || '') + (AddressManager.pathname ? AddressManager.pathname.match(/\/[^\/]+/)[0] : ''));
                 }
             } else if (walletStatus === 2) {
                 if (root.activeView !== "passphraseModal") {
@@ -711,12 +705,28 @@ Rectangle {
             case 'updateWalletReferrer':
                 walletSetup.referrer = message.referrer;
             break;
+            case 'inspectionCertificate_resetCert':
+                // NOP
+            break;
             default:
                 console.log('Unrecognized message from wallet.js:', JSON.stringify(message));
         }
     }
     signal sendToScript(var message);
 
+    // generateUUID() taken from:
+    // https://stackoverflow.com/a/8809472
+    function generateUUID() { // Public Domain/MIT
+        var d = new Date().getTime();
+        if (typeof performance !== 'undefined' && typeof performance.now === 'function'){
+            d += performance.now(); //use high-precision timer if available
+        }
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+            var r = (d + Math.random() * 16) % 16 | 0;
+            d = Math.floor(d / 16);
+            return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+        });
+    }
     //
     // FUNCTION DEFINITIONS END
     //

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -50,7 +50,8 @@ Rectangle {
                     commerce.resetLocalWalletOnly();
                     var timestamp = new Date();
                     walletSetup.startingTimestamp = timestamp;
-                    UserActivityLogger.commerceWalletSetupStarted(timestamp, generateUUID(), walletSetup.setupFlowVersion, walletSetup.referrer ? walletSetup.referrer : "wallet app",
+                    walletSetup.setupAttemptID = generateUUID();
+                    UserActivityLogger.commerceWalletSetupStarted(timestamp, setupAttemptID, walletSetup.setupFlowVersion, walletSetup.referrer ? walletSetup.referrer : "wallet app",
                         (AddressManager.placename || AddressManager.hostname || '') + (AddressManager.pathname ? AddressManager.pathname.match(/\/[^\/]+/)[0] : ''));
                 }
             } else if (walletStatus === 2) {

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -48,6 +48,16 @@ Rectangle {
                 if (root.activeView !== "walletSetup") {
                     root.activeView = "walletSetup";
                     commerce.resetLocalWalletOnly();
+                    var timestamp = new Date();
+                    walletSetup.startingTimestamp = timestamp;
+                    var data = {
+                        "timestamp": timestamp,
+                        "setupAttemptID": guid(),
+                        "setupFlowVersion": walletSetup.setupFlowVersion,
+                        "referrer": walletSetup.referrer,
+                        "currentDomain": (AddressManager.placename || AddressManager.hostname || '') + (AddressManager.pathname ? AddressManager.pathname.match(/\/[^\/]+/)[0] : '')
+                    }
+                    UserActivityLogger.logAction("commerceWalletSetupStarted", data);
                 }
             } else if (walletStatus === 2) {
                 if (root.activeView !== "passphraseModal") {

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -73,13 +73,7 @@ Item {
     onActiveViewChanged: {
         var timestamp = new Date();
         var currentStepNumber = root.activeView.substring(5);
-        var data = {
-            "timestamp": timestamp,
-            "secondsElapsed": (root.startingTimestamp - timestamp),
-            "currentStepNumber": currentStepNumber,
-            "currentStepName": root.setupStepNames[currentStepNumber]
-        }
-        UserActivityLogger.logAction("commerceWalletSetupProgress", data);
+        UserActivityLogger.commerceWalletSetupProgress(timestamp, Math.round((timestamp - root.startingTimestamp)/1000), currentStepNumber, root.setupStepNames[currentStepNumber - 1]);
     }
 
     //
@@ -747,11 +741,7 @@ Item {
                     sendSignalToWallet({method: 'walletSetup_finished', referrer: root.referrer ? root.referrer : ""});
                     
                     var timestamp = new Date();
-                    var data = {
-                        "timestamp": timestamp,
-                        "secondsToComplete": (root.startingTimestamp - timestamp)
-                    }
-                    UserActivityLogger.logAction("commerceWalletSetupFinished", data);
+                    UserActivityLogger.commerceWalletSetupFinished(timestamp, Math.round((timestamp - root.startingTimestamp)/1000));
                 }
             }
         }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -32,6 +32,7 @@ Item {
     property string referrer;
     property string keyFilePath;
     property date startingTimestamp;
+    property string setupAttemptID;
     readonly property int setupFlowVersion: 1;
     readonly property var setupStepNames: [ "Setup Prompt", "Security Image Selection", "Passphrase Selection", "Private Keys Ready" ];
 
@@ -73,7 +74,8 @@ Item {
     onActiveViewChanged: {
         var timestamp = new Date();
         var currentStepNumber = root.activeView.substring(5);
-        UserActivityLogger.commerceWalletSetupProgress(timestamp, Math.round((timestamp - root.startingTimestamp)/1000), currentStepNumber, root.setupStepNames[currentStepNumber - 1]);
+        UserActivityLogger.commerceWalletSetupProgress(timestamp, root.setupAttemptID,
+            Math.round((timestamp - root.startingTimestamp)/1000), currentStepNumber, root.setupStepNames[currentStepNumber - 1]);
     }
 
     //
@@ -741,7 +743,7 @@ Item {
                     sendSignalToWallet({method: 'walletSetup_finished', referrer: root.referrer ? root.referrer : ""});
                     
                     var timestamp = new Date();
-                    UserActivityLogger.commerceWalletSetupFinished(timestamp, Math.round((timestamp - root.startingTimestamp)/1000));
+                    UserActivityLogger.commerceWalletSetupFinished(timestamp, setupAttemptID, Math.round((timestamp - root.startingTimestamp)/1000));
                 }
             }
         }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -31,6 +31,9 @@ Item {
     property bool hasShownSecurityImageTip: false;
     property string referrer;
     property string keyFilePath;
+    property date startingTimestamp;
+    readonly property int setupFlowVersion: 1;
+    readonly property var setupStepNames: [ "Setup Prompt", "Security Image Selection", "Passphrase Selection", "Private Keys Ready" ];
 
     Image {
         anchors.fill: parent;
@@ -65,6 +68,18 @@ Item {
         id: lightboxPopup;
         visible: false;
         anchors.fill: parent;
+    }
+
+    onActiveViewChanged: {
+        var timestamp = new Date();
+        var currentStepNumber = root.activeView.substring(5);
+        var data = {
+            "timestamp": timestamp,
+            "secondsElapsed": (root.startingTimestamp - timestamp),
+            "currentStepNumber": currentStepNumber,
+            "currentStepName": root.setupStepNames[currentStepNumber]
+        }
+        UserActivityLogger.logAction("commerceWalletSetupProgress", data);
     }
 
     //
@@ -730,6 +745,13 @@ Item {
                     root.visible = false;
                     root.hasShownSecurityImageTip = false;
                     sendSignalToWallet({method: 'walletSetup_finished', referrer: root.referrer ? root.referrer : ""});
+                    
+                    var timestamp = new Date();
+                    var data = {
+                        "timestamp": timestamp,
+                        "secondsToComplete": (root.startingTimestamp - timestamp)
+                    }
+                    UserActivityLogger.logAction("commerceWalletSetupFinished", data);
                 }
             }
         }

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
@@ -88,3 +88,28 @@ void UserActivityLoggerScriptingInterface::doLogAction(QString action, QJsonObje
                               Q_ARG(QString, action),
                               Q_ARG(QJsonObject, details));
 }
+
+void UserActivityLoggerScriptingInterface::commercePurchaseSuccess(QString marketplaceID, int cost, bool firstPurchaseOfThisItem) {
+    QJsonObject payload;
+    payload["marketplaceID"] = marketplaceID;
+    payload["cost"] = cost;
+    payload["firstPurchaseOfThisItem"] = firstPurchaseOfThisItem;
+    doLogAction("commercePurchaseSuccess", payload);
+}
+
+void UserActivityLoggerScriptingInterface::commercePurchaseFailure(QString marketplaceID, int cost, bool firstPurchaseOfThisItem, QString errorDetails) {
+    QJsonObject payload;
+    payload["marketplaceID"] = marketplaceID;
+    payload["cost"] = cost;
+    payload["firstPurchaseOfThisItem"] = firstPurchaseOfThisItem;
+    payload["errorDetails"] = errorDetails;
+    doLogAction("commercePurchaseFailure", payload);
+}
+
+void UserActivityLoggerScriptingInterface::commerceEntityRezzed(QString marketplaceID, QString source, QString type) {
+    QJsonObject payload;
+    payload["marketplaceID"] = marketplaceID;
+    payload["source"] = source;
+    payload["type"] = type;
+    doLogAction("commerceEntityRezzed", payload);
+}

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
@@ -113,3 +113,32 @@ void UserActivityLoggerScriptingInterface::commerceEntityRezzed(QString marketpl
     payload["type"] = type;
     doLogAction("commerceEntityRezzed", payload);
 }
+
+void UserActivityLoggerScriptingInterface::commerceWalletSetupStarted(float timestamp, QString setupAttemptID, int setupFlowVersion, QString referrer, QString currentDomain) {
+    QJsonObject payload;
+    payload["timestamp"] = timestamp;
+    payload["setupAttemptID"] = setupAttemptID;
+    payload["setupFlowVersion"] = setupFlowVersion;
+    payload["referrer"] = referrer;
+    payload["currentDomain"] = currentDomain;
+    qDebug() << "ZRF" << payload;
+    //doLogAction("commerceWalletSetupStarted", payload);
+}
+
+void UserActivityLoggerScriptingInterface::commerceWalletSetupProgress(float timestamp, float secondsElapsed, int currentStepNumber, QString currentStepName) {
+    QJsonObject payload;
+    payload["timestamp"] = timestamp;
+    payload["secondsElapsed"] = secondsElapsed;
+    payload["currentStepNumber"] = currentStepNumber;
+    payload["currentStepName"] = currentStepName;
+    qDebug() << "ZRF" << payload;
+    //doLogAction("commerceWalletSetupProgress", payload);
+}
+
+void UserActivityLoggerScriptingInterface::commerceWalletSetupFinished(float timestamp, float secondsToComplete) {
+    QJsonObject payload;
+    payload["timestamp"] = timestamp;
+    payload["secondsToComplete"] = secondsToComplete;
+    qDebug() << "ZRF" << payload;
+    //doLogAction("commerceWalletSetupFinished", payload);
+}

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
@@ -114,7 +114,7 @@ void UserActivityLoggerScriptingInterface::commerceEntityRezzed(QString marketpl
     doLogAction("commerceEntityRezzed", payload);
 }
 
-void UserActivityLoggerScriptingInterface::commerceWalletSetupStarted(float timestamp, QString setupAttemptID, int setupFlowVersion, QString referrer, QString currentDomain) {
+void UserActivityLoggerScriptingInterface::commerceWalletSetupStarted(int timestamp, QString setupAttemptID, int setupFlowVersion, QString referrer, QString currentDomain) {
     QJsonObject payload;
     payload["timestamp"] = timestamp;
     payload["setupAttemptID"] = setupAttemptID;
@@ -125,7 +125,7 @@ void UserActivityLoggerScriptingInterface::commerceWalletSetupStarted(float time
     //doLogAction("commerceWalletSetupStarted", payload);
 }
 
-void UserActivityLoggerScriptingInterface::commerceWalletSetupProgress(float timestamp, float secondsElapsed, int currentStepNumber, QString currentStepName) {
+void UserActivityLoggerScriptingInterface::commerceWalletSetupProgress(int timestamp, int secondsElapsed, int currentStepNumber, QString currentStepName) {
     QJsonObject payload;
     payload["timestamp"] = timestamp;
     payload["secondsElapsed"] = secondsElapsed;
@@ -135,7 +135,7 @@ void UserActivityLoggerScriptingInterface::commerceWalletSetupProgress(float tim
     //doLogAction("commerceWalletSetupProgress", payload);
 }
 
-void UserActivityLoggerScriptingInterface::commerceWalletSetupFinished(float timestamp, float secondsToComplete) {
+void UserActivityLoggerScriptingInterface::commerceWalletSetupFinished(int timestamp, int secondsToComplete) {
     QJsonObject payload;
     payload["timestamp"] = timestamp;
     payload["secondsToComplete"] = secondsToComplete;

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
@@ -121,8 +121,7 @@ void UserActivityLoggerScriptingInterface::commerceWalletSetupStarted(int timest
     payload["setupFlowVersion"] = setupFlowVersion;
     payload["referrer"] = referrer;
     payload["currentDomain"] = currentDomain;
-    qDebug() << "ZRF" << payload;
-    //doLogAction("commerceWalletSetupStarted", payload);
+    doLogAction("commerceWalletSetupStarted", payload);
 }
 
 void UserActivityLoggerScriptingInterface::commerceWalletSetupProgress(int timestamp, int secondsElapsed, int currentStepNumber, QString currentStepName) {
@@ -131,14 +130,12 @@ void UserActivityLoggerScriptingInterface::commerceWalletSetupProgress(int times
     payload["secondsElapsed"] = secondsElapsed;
     payload["currentStepNumber"] = currentStepNumber;
     payload["currentStepName"] = currentStepName;
-    qDebug() << "ZRF" << payload;
-    //doLogAction("commerceWalletSetupProgress", payload);
+    doLogAction("commerceWalletSetupProgress", payload);
 }
 
 void UserActivityLoggerScriptingInterface::commerceWalletSetupFinished(int timestamp, int secondsToComplete) {
     QJsonObject payload;
     payload["timestamp"] = timestamp;
     payload["secondsToComplete"] = secondsToComplete;
-    qDebug() << "ZRF" << payload;
-    //doLogAction("commerceWalletSetupFinished", payload);
+    doLogAction("commerceWalletSetupFinished", payload);
 }

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
@@ -124,18 +124,20 @@ void UserActivityLoggerScriptingInterface::commerceWalletSetupStarted(int timest
     doLogAction("commerceWalletSetupStarted", payload);
 }
 
-void UserActivityLoggerScriptingInterface::commerceWalletSetupProgress(int timestamp, int secondsElapsed, int currentStepNumber, QString currentStepName) {
+void UserActivityLoggerScriptingInterface::commerceWalletSetupProgress(int timestamp, QString setupAttemptID, int secondsElapsed, int currentStepNumber, QString currentStepName) {
     QJsonObject payload;
     payload["timestamp"] = timestamp;
+    payload["setupAttemptID"] = setupAttemptID;
     payload["secondsElapsed"] = secondsElapsed;
     payload["currentStepNumber"] = currentStepNumber;
     payload["currentStepName"] = currentStepName;
     doLogAction("commerceWalletSetupProgress", payload);
 }
 
-void UserActivityLoggerScriptingInterface::commerceWalletSetupFinished(int timestamp, int secondsToComplete) {
+void UserActivityLoggerScriptingInterface::commerceWalletSetupFinished(int timestamp, QString setupAttemptID, int secondsToComplete) {
     QJsonObject payload;
     payload["timestamp"] = timestamp;
+    payload["setupAttemptID"] = setupAttemptID;
     payload["secondsToComplete"] = secondsToComplete;
     doLogAction("commerceWalletSetupFinished", payload);
 }

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.h
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.h
@@ -36,9 +36,9 @@ public:
     Q_INVOKABLE void commercePurchaseSuccess(QString marketplaceID, int cost, bool firstPurchaseOfThisItem);
     Q_INVOKABLE void commercePurchaseFailure(QString marketplaceID, int cost, bool firstPurchaseOfThisItem, QString errorDetails);
     Q_INVOKABLE void commerceEntityRezzed(QString marketplaceID, QString source, QString type);
-    Q_INVOKABLE void commerceWalletSetupStarted(float timestamp, QString setupAttemptID, int setupFlowVersion, QString referrer, QString currentDomain);
-    Q_INVOKABLE void commerceWalletSetupProgress(float timestamp, float secondsElapsed, int currentStepNumber, QString currentStepName);
-    Q_INVOKABLE void commerceWalletSetupFinished(float timestamp, float secondsToComplete);
+    Q_INVOKABLE void commerceWalletSetupStarted(int timestamp, QString setupAttemptID, int setupFlowVersion, QString referrer, QString currentDomain);
+    Q_INVOKABLE void commerceWalletSetupProgress(int timestamp, int secondsElapsed, int currentStepNumber, QString currentStepName);
+    Q_INVOKABLE void commerceWalletSetupFinished(int timestamp, int secondsToComplete);
 private:
     void doLogAction(QString action, QJsonObject details = {});
 };

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.h
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.h
@@ -33,6 +33,9 @@ public:
     Q_INVOKABLE void bubbleToggled(bool newValue);
     Q_INVOKABLE void bubbleActivated();
     Q_INVOKABLE void logAction(QString action, QVariantMap details = QVariantMap{});
+    Q_INVOKABLE void commercePurchaseSuccess(QString marketplaceID, int cost, bool firstPurchaseOfThisItem);
+    Q_INVOKABLE void commercePurchaseFailure(QString marketplaceID, int cost, bool firstPurchaseOfThisItem, QString errorDetails);
+    Q_INVOKABLE void commerceEntityRezzed(QString marketplaceID, QString source, QString type);
 private:
     void doLogAction(QString action, QJsonObject details = {});
 };

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.h
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.h
@@ -37,8 +37,8 @@ public:
     Q_INVOKABLE void commercePurchaseFailure(QString marketplaceID, int cost, bool firstPurchaseOfThisItem, QString errorDetails);
     Q_INVOKABLE void commerceEntityRezzed(QString marketplaceID, QString source, QString type);
     Q_INVOKABLE void commerceWalletSetupStarted(int timestamp, QString setupAttemptID, int setupFlowVersion, QString referrer, QString currentDomain);
-    Q_INVOKABLE void commerceWalletSetupProgress(int timestamp, int secondsElapsed, int currentStepNumber, QString currentStepName);
-    Q_INVOKABLE void commerceWalletSetupFinished(int timestamp, int secondsToComplete);
+    Q_INVOKABLE void commerceWalletSetupProgress(int timestamp, QString setupAttemptID, int secondsElapsed, int currentStepNumber, QString currentStepName);
+    Q_INVOKABLE void commerceWalletSetupFinished(int timestamp, QString setupAttemptID, int secondsToComplete);
 private:
     void doLogAction(QString action, QJsonObject details = {});
 };

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.h
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.h
@@ -36,6 +36,9 @@ public:
     Q_INVOKABLE void commercePurchaseSuccess(QString marketplaceID, int cost, bool firstPurchaseOfThisItem);
     Q_INVOKABLE void commercePurchaseFailure(QString marketplaceID, int cost, bool firstPurchaseOfThisItem, QString errorDetails);
     Q_INVOKABLE void commerceEntityRezzed(QString marketplaceID, QString source, QString type);
+    Q_INVOKABLE void commerceWalletSetupStarted(float timestamp, QString setupAttemptID, int setupFlowVersion, QString referrer, QString currentDomain);
+    Q_INVOKABLE void commerceWalletSetupProgress(float timestamp, float secondsElapsed, int currentStepNumber, QString currentStepName);
+    Q_INVOKABLE void commerceWalletSetupFinished(float timestamp, float secondsToComplete);
 private:
     void doLogAction(QString action, QJsonObject details = {});
 };

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -112,8 +112,8 @@
         onMarketplaceScreen = type === "Web" && url.indexOf(MARKETPLACE_URL) !== -1;
         onWalletScreen = url.indexOf(MARKETPLACE_WALLET_QML_PATH) !== -1;
         onCommerceScreen = type === "QML" && (url.indexOf(MARKETPLACE_CHECKOUT_QML_PATH_BASE) !== -1 || url === MARKETPLACE_PURCHASES_QML_PATH
-            || url.indexOf(MARKETPLACE_INSPECTIONCERTIFICATE_QML_PATH) !== -1 || onWalletScreen);
-        wireEventBridge(onMarketplaceScreen || onCommerceScreen);
+            || url.indexOf(MARKETPLACE_INSPECTIONCERTIFICATE_QML_PATH) !== -1);
+        wireEventBridge(onMarketplaceScreen || onCommerceScreen || onWalletScreen);
 
         if (url === MARKETPLACE_PURCHASES_QML_PATH) {
             tablet.sendToQml({

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -399,6 +399,7 @@
                     referrer: "purchases"
                 });
                 openWallet();
+                break;
             case 'checkout_walletNotSetUp':
                 wireEventBridge(true);
                 tablet.sendToQml({

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -110,8 +110,9 @@
     var filterText; // Used for updating Purchases QML
     function onScreenChanged(type, url) {
         onMarketplaceScreen = type === "Web" && url.indexOf(MARKETPLACE_URL) !== -1;
-        onCommerceScreen = type === "QML" && (url.indexOf(MARKETPLACE_CHECKOUT_QML_PATH_BASE) !== -1 || url === MARKETPLACE_PURCHASES_QML_PATH || url.indexOf(MARKETPLACE_INSPECTIONCERTIFICATE_QML_PATH) !== -1);
-        wireEventBridge(onCommerceScreen);
+        onCommerceScreen = type === "QML" && (url.indexOf(MARKETPLACE_CHECKOUT_QML_PATH_BASE) !== -1 || url === MARKETPLACE_PURCHASES_QML_PATH
+            || url.indexOf(MARKETPLACE_INSPECTIONCERTIFICATE_QML_PATH) !== -1 || url.indexOf(MARKETPLACE_WALLET_QML_PATH) !== -1);
+        wireEventBridge(onMarketplaceScreen || onCommerceScreen);
 
         if (url === MARKETPLACE_PURCHASES_QML_PATH) {
             tablet.sendToQml({
@@ -322,6 +323,11 @@
             } else if (parsedJsonMessage.type === "LOGIN") {
                 openLoginWindow();
             } else if (parsedJsonMessage.type === "WALLET_SETUP") {
+                wireEventBridge(true);
+                tablet.sendToQml({
+                    method: 'updateWalletReferrer',
+                    referrer: "marketplace cta"
+                });
                 openWallet();
             } else if (parsedJsonMessage.type === "MY_ITEMS") {
                 referrerURL = MARKETPLACE_URL_INITIAL;

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -110,8 +110,9 @@
     var filterText; // Used for updating Purchases QML
     function onScreenChanged(type, url) {
         onMarketplaceScreen = type === "Web" && url.indexOf(MARKETPLACE_URL) !== -1;
+        onWalletScreen = url.indexOf(MARKETPLACE_WALLET_QML_PATH) !== -1;
         onCommerceScreen = type === "QML" && (url.indexOf(MARKETPLACE_CHECKOUT_QML_PATH_BASE) !== -1 || url === MARKETPLACE_PURCHASES_QML_PATH
-            || url.indexOf(MARKETPLACE_INSPECTIONCERTIFICATE_QML_PATH) !== -1 || url.indexOf(MARKETPLACE_WALLET_QML_PATH) !== -1);
+            || url.indexOf(MARKETPLACE_INSPECTIONCERTIFICATE_QML_PATH) !== -1 || onWalletScreen);
         wireEventBridge(onMarketplaceScreen || onCommerceScreen);
 
         if (url === MARKETPLACE_PURCHASES_QML_PATH) {
@@ -123,7 +124,7 @@
         }
 
         // for toolbar mode: change button to active when window is first openend, false otherwise.
-        marketplaceButton.editProperties({ isActive: onMarketplaceScreen || onCommerceScreen });
+        marketplaceButton.editProperties({ isActive: (onMarketplaceScreen || onCommerceScreen) && !onWalletScreen });
         if (type === "Web" && url.indexOf(MARKETPLACE_URL) !== -1) {
             ContextOverlay.isInMarketplaceInspectionMode = true;
         } else {


### PR DESCRIPTION
**I'm not yet sure if this belongs in RC60 as a hotfix, or RC61.**

Also fixes a couple of loose frontend bugs :)

This PR enables Metabase/ClearStory tracking of the following Commerce-related data:
1. `commercePurchaseSuccess`
    - `marketplaceID` (string)
    - `cost` (integer)
    - `firstPurchaseOfThisItem` (true or false)
2. `commercePurchaseFailure`
    - `marketplaceID` (string)
    - `cost` (integer)
    - `firstPurchaseOfThisItem` (true or false)
    - `errorDetails` (string)
3. `commerceEntityRezzed`
    - `marketplaceID` (string)
    - `source` (string) (either "checkout" or "purchases")
    - `type` (string) (either "rez" or "wear")
5. `commerceWalletSetupStarted`
    - `timestamp` (integer)
    - `setupAttemptID` (string) (a GUID that's randomly generated upon entering setup)
    - `setupFlowVersion` (integer) (currently `1`)
    - `referrer` (string) (either `marketplace cta`, `wallet app`, or the UUID of a marketplace item)
    - `currentDomain` (string) (the current domain that the user is in)
5. `commerceWalletSetupProgress`
    - `timestamp` (integer)
    - `secondsElapsed` (integer) (how long since the user started wallet setup)
    - `currentStepNumber` (integer) (the numerical ID of the current setup step)
    - `currentStepName` (string) (the text name of the current setup step)
6. `commerceWalletSetupFinished`
    - `timestamp` (integer)
    - `secondsToComplete` (integer) (how long since the user started wallet setup)

Note that *seeding data is not tracked from the frontend.* Fortunately, seeding data is already queryable from the database - so a well-designed Metabase query could simply query the seeding table based on username. `has_seeded` determines if a user has seeded, and the `updated_at` field changes when `has_seeded` becomes `true`.

*Test Plan:*
1. Log in to a brand new account. Tell me this account's username so that I can seed it.
2. Using this new account, create a new Wallet.
3. Buy a few costed items from the Marketplace. Some of them should be wearables, some of them should be non-wearables. Rez some of them from the Purchase Confirmation screen, and rez some of them from the My Purchases screen.
4. Send a message to me on Slack and tell me you're done with the above. I'll check Metabase to verify that your data showed up 👀