### PR TITLE
return to main mktplace page from rez page

### DIFF
--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -420,8 +420,9 @@
                 tablet.pushOntoStack(MARKETPLACE_PURCHASES_QML_PATH);
                 break;
             case 'checkout_itemLinkClicked':
+                tablet.gotoWebScreen(MARKETPLACE_URL + '/items/' + message.itemId, MARKETPLACES_INJECT_SCRIPT_URL);
+                break;
             case 'checkout_continueShopping':
-                //tablet.gotoWebScreen(MARKETPLACE_URL + '/items/' + message.itemId, MARKETPLACES_INJECT_SCRIPT_URL);
                 tablet.gotoWebScreen(MARKETPLACE_URL_INITIAL, MARKETPLACES_INJECT_SCRIPT_URL);
                 //tablet.popFromStack();
                 break;

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -421,7 +421,8 @@
                 break;
             case 'checkout_itemLinkClicked':
             case 'checkout_continueShopping':
-                tablet.gotoWebScreen(MARKETPLACE_URL + '/items/' + message.itemId, MARKETPLACES_INJECT_SCRIPT_URL);
+                //tablet.gotoWebScreen(MARKETPLACE_URL + '/items/' + message.itemId, MARKETPLACES_INJECT_SCRIPT_URL);
+                tablet.gotoWebScreen(MARKETPLACE_URL_INITIAL, MARKETPLACES_INJECT_SCRIPT_URL);
                 //tablet.popFromStack();
                 break;
             case 'purchases_itemInfoClicked':


### PR DESCRIPTION
Once an item is purchased, allows "Continue Shopping" to return to main Marketplace page. 
https://highfidelity.fogbugz.com/f/cases/10229/Confirmation-page-after-a-purchase

Test Plan

1.  Open Marketplace 
2.  Buy an item or obtain a free item
3.  Confirm purchase
4.  On the Thank You page (with the REZ IT or WEAR IT button): 
    Click on "CONTINUE SHOPPING"
5. You should arrive at the main page of Marketplace
