### PR TITLE
Don't send commerce requests to backend if cached public keys is empty

### DIFF
--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -83,19 +83,28 @@ void QmlCommerce::buy(const QString& assetId, int cost, const bool controlledFai
 void QmlCommerce::balance() {
     auto ledger = DependencyManager::get<Ledger>();
     auto wallet = DependencyManager::get<Wallet>();
-    ledger->balance(wallet->listPublicKeys());
+    QStringList cachedPublicKeys = wallet->listPublicKeys();
+    if (!cachedPublicKeys.isEmpty()) {
+        ledger->balance(cachedPublicKeys);
+    }
 }
 
 void QmlCommerce::inventory() {
     auto ledger = DependencyManager::get<Ledger>();
     auto wallet = DependencyManager::get<Wallet>();
-    ledger->inventory(wallet->listPublicKeys());
+    QStringList cachedPublicKeys = wallet->listPublicKeys();
+    if (!cachedPublicKeys.isEmpty()) {
+        ledger->inventory(cachedPublicKeys);
+    }
 }
 
 void QmlCommerce::history() {
     auto ledger = DependencyManager::get<Ledger>();
     auto wallet = DependencyManager::get<Wallet>();
-    ledger->history(wallet->listPublicKeys());
+    QStringList cachedPublicKeys = wallet->listPublicKeys();
+    if (!cachedPublicKeys.isEmpty()) {
+        ledger->history(cachedPublicKeys);
+    }
 }
 
 void QmlCommerce::changePassphrase(const QString& oldPassphrase, const QString& newPassphrase) {


### PR DESCRIPTION
This should prevent the backend from receiving commerce requests from the client that don't make any sense.

**Test Plan**
1. *If you don't already have a wallet*, set up your wallet and get seeded.
2. Open the Wallet app. Verify that you see the correct balance and activity in Recent Activity.
3. Open the "My Purchases" app and verify that your inventory is correct (purchase an item first if you haven't purchased anything before).