### PR TITLE
8992 Login window is small in tablet

### DIFF
--- a/interface/resources/qml/LoginDialog/LinkAccountBody.qml
+++ b/interface/resources/qml/LoginDialog/LinkAccountBody.qml
@@ -52,7 +52,11 @@ Item {
                 targetHeight += hifi.dimensions.contentSpacing.y + additionalInformation.height
             }
 
-            parent.width = root.width = Math.max(d.minWidth, Math.min(d.maxWidth, targetWidth));
+            var newWidth = Math.max(d.minWidth, Math.min(d.maxWidth, targetWidth));
+            if(!isNaN(newWidth)) {
+                parent.width = root.width = newWidth;
+            }
+
             parent.height = root.height = Math.max(d.minHeight, Math.min(d.maxHeight, targetHeight))
                     + (keyboardEnabled && keyboardRaised ? (200 + 2 * hifi.dimensions.contentSpacing.y) : hifi.dimensions.contentSpacing.y);
         }


### PR DESCRIPTION
This is alternative attempt to fix FB 8992 which is another 'hack'. Fix is based on preventing 'NaN' value to break width binding. Unfortunately it turned out current resizing logic is a bit broken, in particular this: 

var targetWidth = Math.max(titleWidth, form.contentWidth);

... is 'NaN', because form.contentWidth is undefined. 

As the result 'Math.max(d.minWidth, Math.min(d.maxWidth, targetWidth));' is also 'NaN'. 

Please use test plan from this PR: https://github.com/highfidelity/hifi/pull/11853