### PR TITLE
Provides a nice alert in case of insufficient funds to make a purchase

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -905,7 +905,7 @@ Rectangle {
                     }
                     buyTextContainer.color = "#FFC3CD";
                     buyTextContainer.border.color = "#F3808F";
-                    buyGlyph.text = hifi.glyphs.error;
+                    buyGlyph.text = hifi.glyphs.alert;
                     buyGlyph.size = 54;
                 } else {
                     if (root.alreadyOwned) {


### PR DESCRIPTION
This fix allows a uniform alert symbol to be displayed during an attempted purchase in case of insufficient funds in the Wallet, regardless of whether the item was purchased before or not. 

https://highfidelity.fogbugz.com/f/cases/10232/

Test Plan
1.  Open Wallet, check balance
2.  Open Marketplace, choose item to purchase which costs more than available funds in Wallet.  This
    may require prior exhaustion or near-exhaustion of Wallet funds. 
3.  The "Buy" button should result in a page similar to one of the two shown:

![image](https://user-images.githubusercontent.com/30704877/33743702-cb9a2016-db62-11e7-8801-e30444eb23dd.png)

![image](https://user-images.githubusercontent.com/30704877/33743742-f32e03ea-db62-11e7-992d-70d619e8beb0.png)


