### PR TITLE
Fix for hand controller avatar scaling.

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -114,7 +114,8 @@ MyAvatar::MyAvatar(QThread* thread) :
 
     _skeletonModel = std::make_shared<MySkeletonModel>(this, nullptr);
     connect(_skeletonModel.get(), &Model::setURLFinished, this, &Avatar::setModelURLFinished);
-
+    connect(_skeletonModel.get(), &Model::rigReady, this, &Avatar::rigReady);
+    connect(_skeletonModel.get(), &Model::rigReset, this, &Avatar::rigReset);
 
     using namespace recording;
     _skeletonModel->flagAsCauterized();

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -257,8 +257,8 @@ public:
 
     Q_INVOKABLE virtual float getEyeHeight() const override;
 
-    // returns eye height of avatar in meters, ignoreing avatar scale.
-    // if _targetScale is 1 then this will be identical to getEyeHeight;
+    // returns eye height of avatar in meters, ignoring avatar scale.
+    // if _targetScale is 1 then this will be identical to getEyeHeight.
     virtual float getUnscaledEyeHeight() const override;
 
     // returns true, if an acurate eye height estimage can be obtained by inspecting the avatar model skeleton and geometry,
@@ -280,10 +280,17 @@ public slots:
     glm::vec3 getRightPalmPosition() const;
     glm::quat getRightPalmRotation() const;
 
+    // hooked up to Model::setURLFinished signal
     void setModelURLFinished(bool success);
+
+    // hooked up to Model::rigReady & rigReset signals
+    void rigReady();
+    void rigReset();
 
 protected:
     float getUnscaledEyeHeightFromSkeleton() const;
+    void buildUnscaledEyeHeightCache();
+    void clearUnscaledEyeHeightCache();
     virtual const QString& getSessionDisplayNameForTransport() const override { return _empty; } // Save a tiny bit of bandwidth. Mixer won't look at what we send.
     QString _empty{};
     virtual void maybeUpdateSessionDisplayNameFromTransport(const QString& sessionDisplayName) override { _sessionDisplayName = sessionDisplayName; } // don't use no-op setter!
@@ -384,6 +391,8 @@ protected:
 
     float _displayNameTargetAlpha { 1.0f };
     float _displayNameAlpha { 1.0f };
+
+    ThreadSafeValueCache<float> _unscaledEyeHeightCache { DEFAULT_AVATAR_EYE_HEIGHT };
 };
 
 #endif // hifi_Avatar_h

--- a/libraries/avatars-renderer/src/avatars-renderer/OtherAvatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/OtherAvatar.cpp
@@ -13,4 +13,6 @@ OtherAvatar::OtherAvatar(QThread* thread) : Avatar(thread) {
     _headData = new Head(this);
     _skeletonModel = std::make_shared<SkeletonModel>(this, nullptr);
     connect(_skeletonModel.get(), &Model::setURLFinished, this, &Avatar::setModelURLFinished);
+    connect(_skeletonModel.get(), &Model::rigReady, this, &Avatar::rigReady);
+    connect(_skeletonModel.get(), &Model::rigReset, this, &Avatar::rigReset);
 }

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -483,8 +483,22 @@ public:
     virtual void setTargetScale(float targetScale);
 
     float getDomainLimitedScale() const;
-    float getDomainMinScale() const;
-    float getDomainMaxScale() const;
+
+    /**jsdoc
+     * returns the minimum scale allowed for this avatar in the current domain.
+     * This value can change as the user changes avatars or when changing domains.
+     * @function AvatarData.getDomainMinScale
+     * @returns {number} minimum scale allowed for this avatar in the current domain.
+     */
+    Q_INVOKABLE float getDomainMinScale() const;
+
+    /**jsdoc
+     * returns the maximum scale allowed for this avatar in the current domain.
+     * This value can change as the user changes avatars or when changing domains.
+     * @function AvatarData.getDomainMaxScale
+     * @returns {number} maximum scale allowed for this avatar in the current domain.
+     */
+    Q_INVOKABLE float getDomainMaxScale() const;
 
     // returns eye height of avatar in meters, ignoreing avatar scale.
     // if _targetScale is 1 then this will be identical to getEyeHeight;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -286,6 +286,7 @@ void Model::reset() {
     if (isLoaded()) {
         const FBXGeometry& geometry = getFBXGeometry();
         _rig.reset(geometry);
+        emit rigReset();
     }
 }
 
@@ -322,6 +323,7 @@ bool Model::updateGeometry() {
             _blendedVertexBuffers.push_back(buffer);
         }
         needFullUpdate = true;
+        emit rigReady();
     }
     return needFullUpdate;
 }

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -273,6 +273,8 @@ signals:
     void setURLFinished(bool success);
     void setCollisionModelURLFinished(bool success);
     void requestRenderUpdate();
+    void rigReady();
+    void rigReset();
 
 protected:
 

--- a/scripts/system/controllers/controllerModules/scaleAvatar.js
+++ b/scripts/system/controllers/controllerModules/scaleAvatar.js
@@ -12,6 +12,10 @@
 (function () {
     var dispatcherUtils = Script.require("/~/system/libraries/controllerDispatcherUtils.js");
 
+    function clamp(val, min, max) {
+        return Math.max(min, Math.min(max, val));
+    }
+
     function ScaleAvatar(hand) {
         this.hand = hand;
         this.scalingStartAvatarScale = 0;
@@ -61,7 +65,7 @@
                             controllerData.controllerLocations[this.otherHand()].position));
 
                     var newAvatarScale = (scalingCurrentDistance / this.scalingStartDistance) * this.scalingStartAvatarScale;
-                    MyAvatar.scale = newAvatarScale;
+                    MyAvatar.scale = clamp(newAvatarScale, MyAvatar.getDomainMinScale(), MyAvatar.getDomainMaxScale());
                     MyAvatar.scaleChanged();
                 }
                 return dispatcherUtils.makeRunningValues(true, [], []);


### PR DESCRIPTION
* Added getDomainMaxScale() and getDomainMinScale() to JS api.
* Updated scaleAvatar controller module to use this to prevent scaling past the limits.
* Made sure that getDomainMaxScale() getDomainMinScale() and getUnscaledEyeHeight are thread safe,
  so that they can be invoked on the script thread.
* Added signals to Model class that can be used to let observers know when the Rig has finished initializing it's skeleton and also when the skeleton is no longer valid.  These hooks are used to cache the unscaled eye height of the avatar.