### PR TITLE
Fix for Connections UI lockup

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -26,6 +26,7 @@ Rectangle {
     // Style
     color: "#E3E3E3";
     // Properties
+    property bool debug: false
     property int myCardWidth: width - upperRightInfoContainer.width;
     property int myCardHeight: 80;
     property int rowHeight: 60;
@@ -1120,7 +1121,9 @@ Rectangle {
             break;
         case 'connections':
             var data = message.params;
-            console.log('Got connection data: ', JSON.stringify(data));
+            if (pal.debug) {
+                console.log('Got connection data: ', JSON.stringify(data));
+            }
             connectionsUserModelData = data;
             sortConnectionsModel();
             connectionsLoading.visible = false;

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -26,7 +26,7 @@ Rectangle {
     // Style
     color: "#E3E3E3";
     // Properties
-    property bool debug: false
+    property bool debug: false;
     property int myCardWidth: width - upperRightInfoContainer.width;
     property int myCardHeight: 80;
     property int rowHeight: 60;


### PR DESCRIPTION
Fixes problem where Users having many (>50?) connections experience a UI lockup when accessing the PAL's Connections tab.

This PR disables a console.log statement that appears related to the problem (though it's not entirely clear why logging an overly-large JSON blob actually locks up the UI).

#### Testing
NOTE: for accurate test you'll need to have lots of Connections (for me it started locking up at around 50or so, but that threshold might vary).
* Run this PR build
* Open the PAL
* Click to the Connections Tab
* Verify the results are displayed relatively quickly (one symptom of the lockup is that the busy animation stops spinning).

cc: https://highfidelity.fogbugz.com/f/cases/9953
