### PR TITLE
Remove useless Wallet.buy() scripting endpoint

### DIFF
--- a/interface/src/scripting/WalletScriptingInterface.cpp
+++ b/interface/src/scripting/WalletScriptingInterface.cpp
@@ -22,31 +22,3 @@ void WalletScriptingInterface::refreshWalletStatus() {
     auto wallet = DependencyManager::get<Wallet>();
     wallet->getWalletStatus();
 }
-
-static const QString CHECKOUT_QML_PATH = qApp->applicationDirPath() + "../../../qml/hifi/commerce/checkout/Checkout.qml";
-void WalletScriptingInterface::buy(const QString& name, const QString& id, const int& price, const QString& href) {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "buy", Q_ARG(const QString&, name), Q_ARG(const QString&, id), Q_ARG(const int&, price), Q_ARG(const QString&, href));
-        return;
-    }
-
-    auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
-
-    tablet->loadQMLSource(CHECKOUT_QML_PATH);
-    DependencyManager::get<HMDScriptingInterface>()->openTablet();
-
-    QQuickItem* root = nullptr;
-    if (tablet->getToolbarMode() || (!tablet->getTabletRoot() && !qApp->isHMDMode())) {
-        root = DependencyManager::get<OffscreenUi>()->getRootItem();
-    } else {
-        root = tablet->getTabletRoot();
-    }
-    CheckoutProxy* checkout = new CheckoutProxy(root->findChild<QObject*>("checkout"));
-
-    // Example: Wallet.buy("Test Flaregun", "0d90d21c-ce7a-4990-ad18-e9d2cf991027", 17, "http://mpassets.highfidelity.com/0d90d21c-ce7a-4990-ad18-e9d2cf991027-v1/flaregun.json");
-    checkout->writeProperty("itemName", name);
-    checkout->writeProperty("itemId", id);
-    checkout->writeProperty("itemPrice", price);
-    checkout->writeProperty("itemHref", href);
-}

--- a/interface/src/scripting/WalletScriptingInterface.h
+++ b/interface/src/scripting/WalletScriptingInterface.h
@@ -41,8 +41,6 @@ public:
     Q_INVOKABLE uint getWalletStatus() { return _walletStatus; }
     void setWalletStatus(const uint& status) { _walletStatus = status; }
 
-    Q_INVOKABLE void buy(const QString& name, const QString& id, const int& price, const QString& href);
-
 signals:
     void walletStatusChanged();
     void walletNotSetup();


### PR DESCRIPTION
The Content team was going to use this originally, but never ended up doing so. At this point, this endpoint is both not working and potentially problematic. Absolutely nothing uses it, except for Menithal's griefing script. All the more reason to get rid of it before anyone figures out that it exists and tries to get it to do something else nasty.

There's no way to QA this PR, really.

**Test Plan:**
1. Open up the JavaScript Scripting Console. Type `Wallet.buy()`. It won't work. Test passed.