### PR TITLE
10334 Unable to type in Go To app search bar after UI reappears from …

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
@@ -20,6 +20,8 @@ import "../"
 import "../toolbars"
 import "../../styles-uit" as HifiStyles
 import "../../controls-uit" as HifiControls
+import QtQuick.Controls 2.2 as QQC2
+import QtQuick.Templates 2.2 as T
 
 // references HMD, AddressManager, AddressBarDialog from root context
 
@@ -223,7 +225,7 @@ StackView {
                 visible: addressLine.text.length === 0
             }
 
-            TextField {
+            QQC2.TextField {
                 id: addressLine
                 width: addressLineContainer.width - addressLineContainer.anchors.leftMargin - addressLineContainer.anchors.rightMargin;
                 anchors {
@@ -238,16 +240,36 @@ StackView {
                     addressBarDialog.keyboardEnabled = false;
                     toggleOrGo();
                 }
-                placeholderText: "Type domain address here"
+
+                // unfortunately TextField from Quick Controls 2 disallow customization of placeHolderText color without creation of new style
+                property string placeholderText2: "Type domain address here"
                 verticalAlignment: TextInput.AlignBottom
-                style: TextFieldStyle {
-                    textColor: hifi.colors.text
-                    placeholderTextColor: "gray"
-                    font {
-                        family: hifi.fonts.fontFamily
-                        pixelSize: hifi.fonts.pixelSize * 0.75
+
+                font {
+                    family: hifi.fonts.fontFamily
+                    pixelSize: hifi.fonts.pixelSize * 0.75
+                }
+
+                color: hifi.colors.text
+                background: Item {}
+
+                QQC2.Label {
+                    T.TextField {
+                        id: control
+
+                        padding: 6 // numbers taken from Qt\5.9.2\Src\qtquickcontrols2\src\imports\controls\TextField.qml
+                        leftPadding: padding + 4
                     }
-                    background: Item {}
+
+                    font: parent.font
+
+                    x: control.leftPadding
+                    y: control.topPadding
+
+                    text: parent.placeholderText2
+                    verticalAlignment: "AlignVCenter"
+                    color: 'gray'
+                    visible: parent.text === ''
                 }
             }
 


### PR DESCRIPTION
…moving Avatar

** Test plan ** 

1. Open the Go To app in the toolbar
2. Click away from the Go To app (Click on the ground in the world)
3. Move the avatar in any way (Walk forward) so that UI hides while Avatar moves
4. Stop moving, wait until UI reappears
5. Ensure you can still type in the search bar 

For devs: 

The whole issue looks like some Qt bug somewhere inside TextField. I found only two workarounds: 
1. Remove MouseArea (but this would lead to behavior change because playing sound happens on click and because MouseArea is a bit bigger than TextField)
2. Switch to TextField from Quick Controls 2 which seem to work just find with current code. 

Unfortunately QQC2 TextField disallow easy customization of placeholderText color (as I understand it is possible only via style creation and moreover, in this case this property will be global for all TextField-s) so instead of using 'placeHolderText' I've introduced 'placeHolderText2' property. 

I'm not sure how critical to get 'gray' color for placeholder text (default one is 'light gray'). If not critical - then 'placeholderText2' can be removed and code simplified a lot. 