### PR TITLE
Remove unneeded getDedicatedMemory

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl/src/gpu/gl/GLBackend.cpp
@@ -40,10 +40,6 @@ static bool disableOpenGL45 = QProcessEnvironment::systemEnvironment().contains(
 static GLBackend* INSTANCE{ nullptr };
 
 BackendPointer GLBackend::createBackend() {
-    // The ATI memory info extension only exposes 'free memory' so we want to force it to 
-    // cache the value as early as possible
-    getDedicatedMemory();
-
     // FIXME provide a mechanism to override the backend for testing
     // Where the gpuContext is initialized and where the TRUE Backend is created and assigned
     auto version = QOpenGLContextWrapper::currentContextVersion();

--- a/libraries/gpu-gl/src/gpu/gl/GLShared.h
+++ b/libraries/gpu-gl/src/gpu/gl/GLShared.h
@@ -28,7 +28,6 @@ void serverWait();
 // Create a fence and synchronously wait on the fence
 void clientWait();
 
-gpu::Size getDedicatedMemory();
 gpu::Size getFreeDedicatedMemory();
 ComparisonFunction comparisonFuncFromGL(GLenum func);
 State::StencilOp stencilOpFromGL(GLenum stencilOp);


### PR DESCRIPTION
If any future logic depends on the amount of dedicated memory, you can access it via the newer `GPUIdent::getInstance()->getMemory()`.

wglGetGPUInfoAMD was crashing with the AMD card I was testing on (which seems to be a known issue) and this code is currently unused so here we go.

https://highfidelity.manuscript.com/f/cases/10497/Crash-on-startup-on-Samuel-s-new-i5-with-AMD-card

Test plan:
- Should start without crashing on NVIDIA and AMD cards.