### PR TITLE
Fix Circle3DOverlays uninitialized member variables, cloning, getProperty

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -61,8 +61,8 @@ public:
 
     void notifyRenderVariableChange() const;
 
-    void setProperties(const QVariantMap& properties) override;
-    QVariant getProperty(const QString& property) override;
+    virtual void setProperties(const QVariantMap& properties) override;
+    virtual QVariant getProperty(const QString& property) override;
 
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
                                         BoxFace& face, glm::vec3& surfaceNormal);

--- a/interface/src/ui/overlays/Circle3DOverlay.cpp
+++ b/interface/src/ui/overlays/Circle3DOverlay.cpp
@@ -16,10 +16,7 @@
 
 QString const Circle3DOverlay::TYPE = "circle3d";
 
-Circle3DOverlay::Circle3DOverlay() {
-    memset(&_minorTickMarksColor, 0, sizeof(_minorTickMarksColor));
-    memset(&_majorTickMarksColor, 0, sizeof(_majorTickMarksColor));
-}
+Circle3DOverlay::Circle3DOverlay() {}
 
 Circle3DOverlay::Circle3DOverlay(const Circle3DOverlay* circle3DOverlay) :
     Planar3DOverlay(circle3DOverlay),
@@ -27,17 +24,21 @@ Circle3DOverlay::Circle3DOverlay(const Circle3DOverlay* circle3DOverlay) :
     _endAt(circle3DOverlay->_endAt),
     _outerRadius(circle3DOverlay->_outerRadius),
     _innerRadius(circle3DOverlay->_innerRadius),
+    _innerStartColor(circle3DOverlay->_innerStartColor),
+    _innerEndColor(circle3DOverlay->_innerEndColor),
+    _outerStartColor(circle3DOverlay->_outerStartColor),
+    _outerEndColor(circle3DOverlay->_outerEndColor),
+    _innerStartAlpha(circle3DOverlay->_innerStartAlpha),
+    _innerEndAlpha(circle3DOverlay->_innerEndAlpha),
+    _outerStartAlpha(circle3DOverlay->_outerStartAlpha),
+    _outerEndAlpha(circle3DOverlay->_outerEndAlpha),
     _hasTickMarks(circle3DOverlay->_hasTickMarks),
     _majorTickMarksAngle(circle3DOverlay->_majorTickMarksAngle),
     _minorTickMarksAngle(circle3DOverlay->_minorTickMarksAngle),
     _majorTickMarksLength(circle3DOverlay->_majorTickMarksLength),
     _minorTickMarksLength(circle3DOverlay->_minorTickMarksLength),
     _majorTickMarksColor(circle3DOverlay->_majorTickMarksColor),
-    _minorTickMarksColor(circle3DOverlay->_minorTickMarksColor),
-    _quadVerticesID(GeometryCache::UNKNOWN_ID),
-    _lineVerticesID(GeometryCache::UNKNOWN_ID),
-    _majorTicksVerticesID(GeometryCache::UNKNOWN_ID),
-    _minorTicksVerticesID(GeometryCache::UNKNOWN_ID)
+    _minorTickMarksColor(circle3DOverlay->_minorTickMarksColor)
 {
 }
 
@@ -80,9 +81,8 @@ void Circle3DOverlay::render(RenderArgs* args) {
 
     Q_ASSERT(args->_batch);
     auto& batch = *args->_batch;
-    if (args->_shapePipeline) {
-        batch.setPipeline(args->_shapePipeline->pipeline);
-    }
+
+    DependencyManager::get<GeometryCache>()->bindSimpleProgram(batch, false, isTransparent(), false, !getIsSolid(), true);
 
     batch.setModelTransform(getRenderTransform());
 
@@ -185,11 +185,10 @@ void Circle3DOverlay::render(RenderArgs* args) {
     // for our overlay, is solid means we draw a ring between the inner and outer radius of the circle, otherwise
     // we just draw a line...
     if (getHasTickMarks()) {
-        
-        if (_majorTicksVerticesID == GeometryCache::UNKNOWN_ID) {
+        if (!_majorTicksVerticesID) {
             _majorTicksVerticesID = geometryCache->allocateID();
         }
-        if (_minorTicksVerticesID == GeometryCache::UNKNOWN_ID) {
+        if (!_minorTicksVerticesID) {
             _minorTicksVerticesID = geometryCache->allocateID();
         }
         
@@ -384,6 +383,30 @@ QVariant Circle3DOverlay::getProperty(const QString& property) {
     if (property == "innerRadius") {
         return _innerRadius;
     }
+    if (property == "innerStartColor") {
+        return xColorToVariant(_innerStartColor);
+    }
+    if (property == "innerEndColor") {
+        return xColorToVariant(_innerEndColor);
+    }
+    if (property == "outerStartColor") {
+        return xColorToVariant(_outerStartColor);
+    }
+    if (property == "outerEndColor") {
+        return xColorToVariant(_outerEndColor);
+    }
+    if (property == "innerStartAlpha") {
+        return _innerStartAlpha;
+    }
+    if (property == "innerEndAlpha") {
+        return _innerEndAlpha;
+    }
+    if (property == "outerStartAlpha") {
+        return _outerStartAlpha;
+    }
+    if (property == "outerEndAlpha") {
+        return _outerEndAlpha;
+    }
     if (property == "hasTickMarks") {
         return _hasTickMarks;
     }
@@ -408,7 +431,6 @@ QVariant Circle3DOverlay::getProperty(const QString& property) {
 
     return Planar3DOverlay::getProperty(property);
 }
-
 
 bool Circle3DOverlay::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
                                             BoxFace& face, glm::vec3& surfaceNormal) {

--- a/interface/src/ui/overlays/Circle3DOverlay.h
+++ b/interface/src/ui/overlays/Circle3DOverlay.h
@@ -65,22 +65,22 @@ protected:
     float _outerRadius { 1 };
     float _innerRadius { 0 };
 
-    xColor _innerStartColor;
-    xColor _innerEndColor;
-    xColor _outerStartColor;
-    xColor _outerEndColor;
-    float _innerStartAlpha;
-    float _innerEndAlpha;
-    float _outerStartAlpha;
-    float _outerEndAlpha;
+    xColor _innerStartColor { DEFAULT_OVERLAY_COLOR };
+    xColor _innerEndColor { DEFAULT_OVERLAY_COLOR };
+    xColor _outerStartColor { DEFAULT_OVERLAY_COLOR };
+    xColor _outerEndColor { DEFAULT_OVERLAY_COLOR };
+    float _innerStartAlpha { DEFAULT_ALPHA };
+    float _innerEndAlpha { DEFAULT_ALPHA };
+    float _outerStartAlpha { DEFAULT_ALPHA };
+    float _outerEndAlpha { DEFAULT_ALPHA };
 
     bool _hasTickMarks { false };
     float _majorTickMarksAngle { 0 };
     float _minorTickMarksAngle { 0 };
     float _majorTickMarksLength { 0 };
     float _minorTickMarksLength { 0 };
-    xColor _majorTickMarksColor;
-    xColor _minorTickMarksColor;
+    xColor _majorTickMarksColor { DEFAULT_OVERLAY_COLOR };
+    xColor _minorTickMarksColor { DEFAULT_OVERLAY_COLOR };
     gpu::Primitive _solidPrimitive { gpu::TRIANGLE_FAN };
     int _quadVerticesID { 0 };
     int _lineVerticesID { 0 };

--- a/interface/src/ui/overlays/Overlay.cpp
+++ b/interface/src/ui/overlays/Overlay.cpp
@@ -15,8 +15,8 @@
 
 #include "Application.h"
 
-static const xColor DEFAULT_OVERLAY_COLOR = { 255, 255, 255 };
-static const float DEFAULT_ALPHA = 0.7f;
+const xColor Overlay::DEFAULT_OVERLAY_COLOR = { 255, 255, 255 };
+const float Overlay::DEFAULT_ALPHA = 0.7f;
 
 Overlay::Overlay() :
     _renderItemID(render::Item::INVALID_ITEM_ID),

--- a/interface/src/ui/overlays/Overlay.h
+++ b/interface/src/ui/overlays/Overlay.h
@@ -122,6 +122,9 @@ protected:
 
     unsigned int _stackOrder { 0 };
 
+    static const xColor DEFAULT_OVERLAY_COLOR;
+    static const float DEFAULT_ALPHA;
+
 private:
     OverlayID _overlayID; // only used for non-3d overlays
 };

--- a/interface/src/ui/overlays/Planar3DOverlay.h
+++ b/interface/src/ui/overlays/Planar3DOverlay.h
@@ -27,8 +27,8 @@ public:
     void setDimensions(float value) { setDimensions(glm::vec2(value)); }
     void setDimensions(const glm::vec2& value);
     
-    void setProperties(const QVariantMap& properties) override;
-    QVariant getProperty(const QString& property) override;
+    virtual void setProperties(const QVariantMap& properties) override;
+    virtual QVariant getProperty(const QString& property) override;
 
     virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
                                         BoxFace& face, glm::vec3& surfaceNormal) override;


### PR DESCRIPTION
Fixes some issues with Circle3DOverlays.

https://highfidelity.manuscript.com/f/cases/10499/Circle3DOverlay-bugs-cloning-uninitialized-variables-incorrect-pipeline
https://highfidelity.manuscript.com/f/cases/9636/Cannot-get-the-values-of-the-some-circle3d-overlay-properties
https://highfidelity.manuscript.com/f/cases/9637/Major-tickmarks-for-circle3d-overlays-don-t-render
https://highfidelity.manuscript.com/f/cases/9638/Tickmark-property-values-of-second-circle3d-overlay-change-the-tickmarks-rendered-in-a-first-circle3d-overlay

Test plan:
- I don't know where else this will repro, but on the computer I just set up, the home button would appear black:
![circle3d2](https://user-images.githubusercontent.com/7650116/33905262-e7842406-df32-11e7-8c90-13678c9713d6.png)
- And on master, some of Circle3DOverlay's properties were uninitialized, and cloning them did not work:
![circle3d](https://user-images.githubusercontent.com/7650116/33909523-cc1c5446-df40-11e7-8e1c-63abb259aec2.png)
- With these changes, run [this](https://gist.githubusercontent.com/SamGondelman/8b1e53f25a669413f129a2556516df44/raw/19ecc04f037f00d5bc3d9970ed77e043464691d1/Circle3DOverlayTest2.js) script.
- You should see something close to:
![circle3d](https://user-images.githubusercontent.com/7650116/33905043-30b870ce-df32-11e7-8ff6-834777232f98.png)
- And the following should print:
`{"blue":0,"green":0,"red":255} {"blue":0,"green":255,"red":0} {"blue":255,"green":0,"red":0} {"blue":0,"green":255,"red":255} 1 0.75 0 1`
- The home button on the tablet should still be visible and highlight properly.