### PR TITLE
Set Wallet Status to 'Ready' after correctly authenticating wallet

### DIFF
--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -315,7 +315,6 @@ Wallet::Wallet() {
         }
 
         walletScriptingInterface->setWalletStatus(status);
-        emit walletStatusResult(status);
     });
 
     auto accountManager = DependencyManager::get<AccountManager>();
@@ -491,6 +490,7 @@ bool Wallet::walletIsAuthenticatedWithPassphrase() {
     }
     if (_publicKeys.count() > 0) {
         // we _must_ be authenticated if the publicKeys are there
+        DependencyManager::get<WalletScriptingInterface>()->setWalletStatus((uint)WalletStatus::WALLET_STATUS_READY);
         return true;
     }
 
@@ -503,6 +503,7 @@ bool Wallet::walletIsAuthenticatedWithPassphrase() {
 
             // be sure to add the public key so we don't do this over and over
             _publicKeys.push_back(publicKey.toBase64());
+            DependencyManager::get<WalletScriptingInterface>()->setWalletStatus((uint)WalletStatus::WALLET_STATUS_READY);
             return true;
         }
     }
@@ -801,15 +802,12 @@ void Wallet::account() {
 
 void Wallet::getWalletStatus() {
     auto walletScriptingInterface = DependencyManager::get<WalletScriptingInterface>();
-    uint status;
 
     if (DependencyManager::get<AccountManager>()->isLoggedIn()) {
         // This will set account info for the wallet, allowing us to decrypt and display the security image.
         account();
     } else {
-        status = (uint)WalletStatus::WALLET_STATUS_NOT_LOGGED_IN;
-        emit walletStatusResult(status);
-        walletScriptingInterface->setWalletStatus(status);
+        walletScriptingInterface->setWalletStatus((uint)WalletStatus::WALLET_STATUS_NOT_LOGGED_IN);
         return;
     }
 }

--- a/interface/src/scripting/WalletScriptingInterface.cpp
+++ b/interface/src/scripting/WalletScriptingInterface.cpp
@@ -22,3 +22,8 @@ void WalletScriptingInterface::refreshWalletStatus() {
     auto wallet = DependencyManager::get<Wallet>();
     wallet->getWalletStatus();
 }
+
+void WalletScriptingInterface::setWalletStatus(const uint& status) {
+    _walletStatus = status;
+    emit DependencyManager::get<Wallet>()->walletStatusResult(status);
+}

--- a/interface/src/scripting/WalletScriptingInterface.h
+++ b/interface/src/scripting/WalletScriptingInterface.h
@@ -39,7 +39,7 @@ public:
 
     Q_INVOKABLE void refreshWalletStatus();
     Q_INVOKABLE uint getWalletStatus() { return _walletStatus; }
-    void setWalletStatus(const uint& status) { _walletStatus = status; }
+    void setWalletStatus(const uint& status);
 
 signals:
     void walletStatusChanged();

--- a/interface/src/scripting/WalletScriptingInterface.h
+++ b/interface/src/scripting/WalletScriptingInterface.h
@@ -39,6 +39,8 @@ public:
 
     Q_INVOKABLE void refreshWalletStatus();
     Q_INVOKABLE uint getWalletStatus() { return _walletStatus; }
+    // setWalletStatus() should never be made Q_INVOKABLE. If it were,
+    //     scripts could cause the Wallet to incorrectly report its status.
     void setWalletStatus(const uint& status);
 
 signals:


### PR DESCRIPTION
The big thing here is that I'm now forcing the wallet status to be "READY" as soon as the user properly authenticates the wallet with their passphrase. This should have been done from the beginning, instead of us relying on some other method checking and updating the status in another location.

This fixes [Manuscript #10485](https://highfidelity.manuscript.com/f/cases/10485/Marketplace-Your-Wallet-is-not-set-up-notification-appears-after-rezzing-a-newly-purchased-free-item) (and probably some other bugs).

**Test Plan:**
1. Start up Interface logged in, but don't authenticate your wallet
2. Open up marketplace and search for "Jimi the snail"
3. Buy a copy of "Jimi the snail". Enter your wallet passphrase when prompted
4. On the confirmation page after purchasing, rez the item
5. Verify that you DO NOT see a notification in the top right of Interface that your "wallet isn't set up"
    - Unfortunately, due to another (unrelated) bug, Jimi the snail won't pass static certificate verification, so he won't rez. That's not what this PR addresses.