### PR TITLE
allow custom metaverse URL to be used with env var

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -477,7 +477,7 @@ void EntityServer::startDynamicDomainVerification() {
                 QNetworkRequest networkRequest;
                 networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
                 networkRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-                QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL;
+                QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL();
                 requestURL.setPath("/api/v1/commerce/proof_of_purchase_status/location");
                 QJsonObject request;
                 request["certificate_id"] = i.key();

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -94,7 +94,7 @@ bool DomainServer::forwardMetaverseAPIRequest(HTTPConnection* connection,
     root.insert(requestSubobjectKey, subobject);
     QJsonDocument doc { root };
 
-    QUrl url { NetworkingConstants::METAVERSE_SERVER_URL.toString() + metaversePath };
+    QUrl url { NetworkingConstants::METAVERSE_SERVER_URL().toString() + metaversePath };
 
     QNetworkRequest req(url);
     req.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);
@@ -420,7 +420,7 @@ bool DomainServer::optionallySetupOAuth() {
 
     // if we don't have an oauth provider URL then we default to the default node auth url
     if (_oauthProviderURL.isEmpty()) {
-        _oauthProviderURL = NetworkingConstants::METAVERSE_SERVER_URL;
+        _oauthProviderURL = NetworkingConstants::METAVERSE_SERVER_URL();
     }
 
     auto accountManager = DependencyManager::get<AccountManager>();
@@ -2159,7 +2159,7 @@ bool DomainServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
             QJsonDocument doc(root);
 
 
-            QUrl url { NetworkingConstants::METAVERSE_SERVER_URL.toString() + "/api/v1/places/" + place_id };
+            QUrl url { NetworkingConstants::METAVERSE_SERVER_URL().toString() + "/api/v1/places/" + place_id };
 
             url.setQuery("access_token=" + accessTokenVariant->toString());
 

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -208,7 +208,7 @@ void IceServer::requestDomainPublicKey(const QUuid& domainID) {
     // send a request to the metaverse API for the public key for this domain
     auto& networkAccessManager = NetworkAccessManager::getInstance();
 
-    QUrl publicKeyURL { NetworkingConstants::METAVERSE_SERVER_URL };
+    QUrl publicKeyURL { NetworkingConstants::METAVERSE_SERVER_URL() };
     QString publicKeyPath = QString("/api/v1/domains/%1/public_key").arg(uuidStringWithoutCurlyBraces(domainID));
     publicKeyURL.setPath(publicKeyPath);
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -971,7 +971,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
     // set the account manager's root URL and trigger a login request if we don't have the access token
     accountManager->setIsAgent(true);
-    accountManager->setAuthURL(NetworkingConstants::METAVERSE_SERVER_URL);
+    accountManager->setAuthURL(NetworkingConstants::METAVERSE_SERVER_URL());
 
     auto addressManager = DependencyManager::get<AddressManager>();
 

--- a/interface/src/commerce/Ledger.cpp
+++ b/interface/src/commerce/Ledger.cpp
@@ -130,7 +130,7 @@ QString amountString(const QString& label, const QString&color, const QJsonValue
     return result + QString("</font>");
 }
 
-static const QString MARKETPLACE_ITEMS_BASE_URL = NetworkingConstants::METAVERSE_SERVER_URL.toString() + "/marketplace/items/";
+static const QString MARKETPLACE_ITEMS_BASE_URL = NetworkingConstants::METAVERSE_SERVER_URL().toString() + "/marketplace/items/";
 void Ledger::historySuccess(QNetworkReply& reply) {
     // here we send a historyResult with some extra stuff in it
     // Namely, the styled text we'd like to show.  The issue is the

--- a/interface/src/networking/CloseEventSender.cpp
+++ b/interface/src/networking/CloseEventSender.cpp
@@ -28,7 +28,7 @@ QNetworkRequest createNetworkRequest() {
 
     QNetworkRequest request;
 
-    QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL;
+    QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL();
     requestURL.setPath(USER_ACTIVITY_URL);
 
     request.setUrl(requestURL);

--- a/interface/src/ui/AddressBarDialog.h
+++ b/interface/src/ui/AddressBarDialog.h
@@ -30,7 +30,7 @@ public:
     bool forwardEnabled() { return _forwardEnabled; }
     bool useFeed() { return _useFeed; }
     void setUseFeed(bool useFeed) { if (_useFeed != useFeed) { _useFeed = useFeed; emit useFeedChanged(); } }
-    QString metaverseServerUrl() { return NetworkingConstants::METAVERSE_SERVER_URL.toString(); }
+    QString metaverseServerUrl() { return NetworkingConstants::METAVERSE_SERVER_URL().toString(); }
 
 signals:
     void backEnabledChanged();

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -289,7 +289,7 @@ void ContextOverlayInterface::openInspectionCertificate() {
                     QNetworkRequest networkRequest;
                     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
                     networkRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-                    QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL;
+                    QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL();
                     requestURL.setPath("/api/v1/commerce/proof_of_purchase_status/transfer");
                     QJsonObject request;
                     request["certificate_id"] = entityProperties.getCertificateID();
@@ -359,7 +359,7 @@ void ContextOverlayInterface::openInspectionCertificate() {
     }
 }
 
-static const QString MARKETPLACE_BASE_URL = NetworkingConstants::METAVERSE_SERVER_URL.toString() + "/marketplace/items/";
+static const QString MARKETPLACE_BASE_URL = NetworkingConstants::METAVERSE_SERVER_URL().toString() + "/marketplace/items/";
 
 void ContextOverlayInterface::openMarketplace() {
     // lets open the tablet and go to the current item in

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -2840,7 +2840,7 @@ void EntityItem::retrieveMarketplacePublicKey() {
     QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
     QNetworkRequest networkRequest;
     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-    QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL;
+    QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL();
     requestURL.setPath("/api/v1/commerce/marketplace_key");
     QJsonObject request;
     networkRequest.setUrl(requestURL);

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -17,7 +17,6 @@
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/ecdsa.h>
-#include <NetworkingConstants.h>
 #include <NetworkAccessManager.h>
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QNetworkRequest>

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1308,7 +1308,7 @@ void EntityTree::validatePop(const QString& certID, const EntityItemID& entityIt
     QNetworkRequest networkRequest;
     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
     networkRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-    QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL;
+    QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL();
     requestURL.setPath("/api/v1/commerce/proof_of_purchase_status/transfer");
     QJsonObject request;
     request["certificate_id"] = certID;

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -97,7 +97,7 @@ public:
     void setTemporaryDomain(const QUuid& domainID, const QString& key);
     const QString& getTemporaryDomainKey(const QUuid& domainID) { return _accountInfo.getTemporaryDomainKey(domainID); }
 
-    QUrl getMetaverseServerURL() { return NetworkingConstants::METAVERSE_SERVER_URL; }
+    QUrl getMetaverseServerURL() { return NetworkingConstants::METAVERSE_SERVER_URL(); }
 
 public slots:
     void requestAccessToken(const QString& login, const QString& password);

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -28,9 +28,12 @@ namespace NetworkingConstants {
     const QUrl METAVERSE_SERVER_URL_STABLE("https://metaverse.highfidelity.com");
     const QUrl METAVERSE_SERVER_URL_STAGING("https://staging.highfidelity.com");
 
+    // You can change the return of this function if you want to use a custom metaverse URL at compile time
+    // or you can pass a custom URL via the env variable
     static const QUrl METAVERSE_SERVER_URL() {
-        static const QUrl serverURL = QProcessEnvironment::systemEnvironment().contains("HIFI_STAGING_METAVERSE")
-            ? METAVERSE_SERVER_URL_STAGING
+        static const QString HIFI_METAVERSE_URL_ENV = "HIFI_METAVERSE_URL";
+        static const QUrl serverURL = QProcessEnvironment::systemEnvironment().contains(HIFI_METAVERSE_URL_ENV)
+            ? QUrl(QProcessEnvironment::systemEnvironment().value(HIFI_METAVERSE_URL_ENV))
             : METAVERSE_SERVER_URL_STABLE;
         return serverURL;
     };

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -12,15 +12,28 @@
 #ifndef hifi_NetworkingConstants_h
 #define hifi_NetworkingConstants_h
 
+#include <QtCore/QProcessEnvironment>
 #include <QtCore/QUrl>
 
 namespace NetworkingConstants {
     // If you want to use STAGING instead of STABLE,
-    //     don't forget to ALSO change the Domain Server Metaverse Server URL inside of:
+    // links from the Domain Server web interface (like the connect account token generation)
+    // will still point at stable unless you ALSO change the Domain Server Metaverse Server URL inside of:
     // <hifi repo>\domain-server\resources\web\js\shared.js
+
+    // You can avoid changing that and still effectively use a connected domain on staging
+    // if you manually generate a personal access token for the domains scope
+    // at https://staging.highfidelity.com/user/tokens/new?for_domain_server=true
+
     const QUrl METAVERSE_SERVER_URL_STABLE("https://metaverse.highfidelity.com");
     const QUrl METAVERSE_SERVER_URL_STAGING("https://staging.highfidelity.com");
-    const QUrl METAVERSE_SERVER_URL = METAVERSE_SERVER_URL_STABLE;
+
+    static const QUrl METAVERSE_SERVER_URL() {
+        static const QUrl serverURL = QProcessEnvironment::systemEnvironment().contains("HIFI_STAGING_METAVERSE")
+            ? METAVERSE_SERVER_URL_STAGING
+            : METAVERSE_SERVER_URL_STABLE;
+        return serverURL;
+    };
 }
 
 #endif // hifi_NetworkingConstants_h

--- a/libraries/networking/src/OAuthNetworkAccessManager.cpp
+++ b/libraries/networking/src/OAuthNetworkAccessManager.cpp
@@ -35,7 +35,7 @@ QNetworkReply* OAuthNetworkAccessManager::createRequest(QNetworkAccessManager::O
     auto accountManager = DependencyManager::get<AccountManager>();
     
     if (accountManager->hasValidAccessToken()
-        && req.url().host() == NetworkingConstants::METAVERSE_SERVER_URL.host()) {
+        && req.url().host() == NetworkingConstants::METAVERSE_SERVER_URL().host()) {
         QNetworkRequest authenticatedRequest(req);
         authenticatedRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
         authenticatedRequest.setHeader(QNetworkRequest::UserAgentHeader, HIGH_FIDELITY_USER_AGENT);

--- a/libraries/script-engine/src/XMLHttpRequestClass.cpp
+++ b/libraries/script-engine/src/XMLHttpRequestClass.cpp
@@ -22,7 +22,7 @@
 #include "ScriptEngine.h"
 #include "XMLHttpRequestClass.h"
 
-const QString METAVERSE_API_URL = NetworkingConstants::METAVERSE_SERVER_URL.toString() + "/api/";
+const QString METAVERSE_API_URL = NetworkingConstants::METAVERSE_SERVER_URL().toString() + "/api/";
 
 Q_DECLARE_METATYPE(QByteArray*)
 

--- a/libraries/ui/src/ui/types/RequestFilters.cpp
+++ b/libraries/ui/src/ui/types/RequestFilters.cpp
@@ -20,7 +20,7 @@
 namespace {
 
     bool isAuthableHighFidelityURL(const QUrl& url) {
-        auto metaverseServerURL = NetworkingConstants::METAVERSE_SERVER_URL;
+        auto metaverseServerURL = NetworkingConstants::METAVERSE_SERVER_URL();
         static const QStringList HF_HOSTS = {
             "highfidelity.com", "highfidelity.io",
             metaverseServerURL.toString(), "metaverse.highfidelity.io"

--- a/tools/ac-client/src/ACClientApp.cpp
+++ b/tools/ac-client/src/ACClientApp.cpp
@@ -106,7 +106,7 @@ ACClientApp::ACClientApp(int argc, char* argv[]) :
 
     auto accountManager = DependencyManager::get<AccountManager>();
     accountManager->setIsAgent(true);
-    accountManager->setAuthURL(NetworkingConstants::METAVERSE_SERVER_URL);
+    accountManager->setAuthURL(NetworkingConstants::METAVERSE_SERVER_URL());
 
     auto nodeList = DependencyManager::get<NodeList>();
 

--- a/tools/atp-client/src/ATPClientApp.cpp
+++ b/tools/atp-client/src/ATPClientApp.cpp
@@ -145,7 +145,7 @@ ATPClientApp::ATPClientApp(int argc, char* argv[]) :
 
     auto accountManager = DependencyManager::get<AccountManager>();
     accountManager->setIsAgent(true);
-    accountManager->setAuthURL(NetworkingConstants::METAVERSE_SERVER_URL);
+    accountManager->setAuthURL(NetworkingConstants::METAVERSE_SERVER_URL());
 
     auto nodeList = DependencyManager::get<NodeList>();
 


### PR DESCRIPTION
- allow a custom metaverse URL to be used via HIFI_METAVERSE_URL