### PR TITLE
Fix web entities accessing the webcam RC-61

### DIFF
--- a/interface/resources/html/createGlobalEventBridge.js
+++ b/interface/resources/html/createGlobalEventBridge.js
@@ -34,7 +34,7 @@ var EventBridge;
         var tempEventBridge = EventBridge;
         EventBridge = channel.objects.eventBridge;
         EventBridge.audioOutputDeviceChanged.connect(function(deviceName) {      
-            navigator.mediaDevices.getUserMedia({ audio: true, video: true }).then(function(mediaStream) {
+            navigator.mediaDevices.getUserMedia({ audio: true, video: false }).then(function(mediaStream) {
                 navigator.mediaDevices.enumerateDevices().then(function(devices) {
                     devices.forEach(function(device) {
                         if (device.kind == "audiooutput") {


### PR DESCRIPTION
This PR fixes a security problem when using web entities. 

https://highfidelity.fogbugz.com/f/cases/10420/High-Fidelity-wants-to-use-webcam#

To test this PR is necessary to have a webcam properly installed on the computer.

...

## TEST PLAN
- Download and install a 30 days trial of Bitdefender TOTAL SECURITY 2018 https://www.bitdefender.com/Downloads/
- Open Bitdefender and go to privacy (top-left eye icon), and View Features. Make sure that Webcam Protection is ON.
- Install the latest dev build (7550 at this time), go to your sandbox and create a web entity.
- When the page is loaded Bitdefender should alert you that interface.exe is trying to gain access to the webcam. If not try this step again.
- Install this PR, go to sandbox and create a web entity. You should not receive any notification from Bitdefender this time.

This PR passed the QA test here: https://github.com/highfidelity/hifi/pull/11973