### PR TITLE
Fix getActiveDevice deadlocks on Linux

### DIFF
--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -680,9 +680,7 @@ void OffscreenQmlSurface::create() {
     // Setup the update of the QML media components with the current audio output device
     QObject::connect(&_audioOutputUpdateTimer, &QTimer::timeout, this, [this]() {
         if (_currentAudioOutputDevice.size() > 0) {
-            QMutexLocker lock(&_audioHandlerMutex);
-            QString audioDeviceName = _currentAudioOutputDevice;
-            new AudioHandler(sharedFromThis(), audioDeviceName);
+            new AudioHandler(sharedFromThis(), _currentAudioOutputDevice);
         }
     });
     int waitForAudioQmlMs = 200;

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -680,7 +680,9 @@ void OffscreenQmlSurface::create() {
     // Setup the update of the QML media components with the current audio output device
     QObject::connect(&_audioOutputUpdateTimer, &QTimer::timeout, this, [this]() {
         if (_currentAudioOutputDevice.size() > 0) {
-            new AudioHandler(sharedFromThis(), _currentAudioOutputDevice);
+            QMutexLocker lock(&_audioHandlerMutex);
+            QString audioDeviceName = _currentAudioOutputDevice;
+            new AudioHandler(sharedFromThis(), audioDeviceName);
         }
     });
     int waitForAudioQmlMs = 200;

--- a/libraries/ui/src/ui/OffscreenQmlSurface.h
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.h
@@ -173,6 +173,7 @@ private:
     uint64_t _lastRenderTime { 0 };
     uvec2 _size;
 
+    QMutex _audioHandlerMutex;
     QTimer _audioOutputUpdateTimer;
     QString _currentAudioOutputDevice;
 

--- a/libraries/ui/src/ui/OffscreenQmlSurface.h
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.h
@@ -173,7 +173,6 @@ private:
     uint64_t _lastRenderTime { 0 };
     uvec2 _size;
 
-    QMutex _audioHandlerMutex;
     QTimer _audioOutputUpdateTimer;
     QString _currentAudioOutputDevice;
 


### PR DESCRIPTION
This PR fix the deadlocks on Linux when calling AudioClient::getActiveAudioDevice

https://highfidelity.fogbugz.com/f/cases/10535/audioIO-getActiveAudioDevice-is-causing-deadlocks-on-Linux

...

## TEST PLAN

The following steps should be tested on Windows and Linux.
When testing in Linux make sure it doesn't hang on any of the steps.

== WEB ENTITIES
- Go to the Sandbox or other domain where you can create entities.
- Create a new web entity.
- Change its url to youtube.com.
- Select any video and start watching ( they should reproduce sound using the current device ).
- Go to the audio menu and change the output audio device.
- The video will reproduce sound using the selected device.
- Delete the web entity.

== QML MULTIMEDIA
- Open the script window (Edit -> Running Scripts... or CTRL + J) 
- Click on "FROM URL" and add the link https://s3-us-west-1.amazonaws.com/hifio/qmlmediatest.js
- An audio loaded from a QML file should start playing using the selected output device. 
- Go to the audio menu and change the output audio device.
- The audio will reproduce sound using the selected device.