### PR TITLE
Fix broken Buy buttons on main Marketplace page

### DIFF
--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -265,8 +265,10 @@
         });
 
         $('.grid-item').find('#price-or-edit').find('a').each(function() {
-            $(this).attr('data-href', $(this).attr('href'));
-            $(this).attr('href', '#');
+            if ($(this).attr('href') !== '#') { // Guard necessary because of the AJAX nature of Marketplace site
+                $(this).attr('data-href', $(this).attr('href'));
+                $(this).attr('href', '#');
+            }
             cost = $(this).closest('.col-xs-3').find('.item-cost').text();
 
             $(this).closest('.col-xs-3').prev().attr("class", 'col-xs-6');


### PR DESCRIPTION
Because of the AJAX nature of the marketplace, there is a chance that, via JS injection, we overwrite a links `href` twice, which causes the Checkout page to break. This PR fixes that problem.

[Manuscript ticket](https://highfidelity.manuscript.com/f/cases/10601/Some-Buy-buttons-are-broken-on-main-Marketplace-page)

**Test Plan:**
1. Make sure you have a Wallet set up
2. Open the MARKET app
3. Change the selected category to "Avatars in the top left"
4. Scroll down until you see "The barbarian" (it's a ways down)
5. Click the "FREE" button
6. On the confirmation screen, click the "GET ITEM" button
7. Verify that you see a popup that asks you if you want to wear the barbarian as your avatar