### PR TITLE
Fix for Haze crash (bug 10537)

### DIFF
--- a/libraries/render-utils/src/DrawHaze.cpp
+++ b/libraries/render-utils/src/DrawHaze.cpp
@@ -169,7 +169,12 @@ void DrawHaze::run(const render::RenderContextPointer& renderContext, const Inpu
         auto hazeStage = args->_scene->getStage<HazeStage>();
         if (hazeStage && hazeStage->_currentFrame._hazes.size() > 0) {
             model::HazePointer hazePointer = hazeStage->getHaze(hazeStage->_currentFrame._hazes.front());
-            batch.setUniformBuffer(HazeEffect_ParamsSlot, hazePointer->getHazeParametersBuffer());
+            if (hazePointer) {
+                batch.setUniformBuffer(HazeEffect_ParamsSlot, hazePointer->getHazeParametersBuffer());
+            } else {
+                // Something is wrong, so just quit Haze
+                return;
+            }
         }
 
         batch.setUniformBuffer(HazeEffect_TransformBufferSlot, transformBuffer->getFrameTransformBuffer());
@@ -178,7 +183,7 @@ void DrawHaze::run(const render::RenderContextPointer& renderContext, const Inpu
 	    if (lightStage) {
 	        model::LightPointer keyLight;
 	        keyLight = lightStage->getCurrentKeyLight();
-	        if (keyLight != nullptr) {
+	        if (keyLight) {
 	            batch.setUniformBuffer(HazeEffect_LightingMapSlot, keyLight->getLightSchemaBuffer());
 	        }
 	    }


### PR DESCRIPTION
Mitigating crash 10537, which seems to be due to a null hazePointer.

The crash seems to occur when tele-porting between a hierarchy of zones, each with different haze modes( Inherit, Off or On).

Testing consists of building such a hierarchy and moving between these zones.

The zones are as follows:
![image](https://user-images.githubusercontent.com/29026026/34016705-c2922f20-e0d7-11e7-8c7b-d438466eb1de.png)

1.  In a domain with full privileges, in an area with no entities, run the attached script.
[testHaze.zip](https://github.com/highfidelity/hifi/files/1560913/testHaze.zip)

2.  Teleport and move between the various zones (marked by coloured rectangles) and verify that Interface does not crash.

3.  Change the Haze modes for the different zone and repeat step 2. Do this a few times, with different combinations of Inherit/Off/On.
