### PR TITLE
Make lasers scale with avatar

### DIFF
--- a/scripts/system/controllers/controllerDispatcher.js
+++ b/scripts/system/controllers/controllerDispatcher.js
@@ -412,6 +412,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             triggers: [{action: Controller.Standard.LTClick, button: "Focus"}, {action: Controller.Standard.LTClick, button: "Primary"}],
             posOffset: getGrabPointSphereOffset(Controller.Standard.LeftHand, true),
             hover: true,
+            scaleWithAvatar: true,
             distanceScaleEnd: true,
             hand: LEFT_HAND
         });
@@ -421,6 +422,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             triggers: [{action: Controller.Standard.RTClick, button: "Focus"}, {action: Controller.Standard.RTClick, button: "Primary"}],
             posOffset: getGrabPointSphereOffset(Controller.Standard.RightHand, true),
             hover: true,
+            scaleWithAvatar: true,
             distanceScaleEnd: true,
             hand: RIGHT_HAND
         });
@@ -431,6 +433,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             posOffset: getGrabPointSphereOffset(Controller.Standard.LeftHand, true),
             triggers: [{action: Controller.Standard.LTClick, button: "Focus"}, {action: Controller.Standard.LTClick, button: "Primary"}],
             hover: true,
+            scaleWithAvatar: true,
             distanceScaleEnd: true,
             hand: LEFT_HAND
         });
@@ -441,6 +444,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
             posOffset: getGrabPointSphereOffset(Controller.Standard.RightHand, true),
             triggers: [{action: Controller.Standard.RTClick, button: "Focus"}, {action: Controller.Standard.RTClick, button: "Primary"}],
             hover: true,
+            scaleWithAvatar: true,
             distanceScaleEnd: true,
             hand: RIGHT_HAND
         });

--- a/scripts/system/controllers/grab.js
+++ b/scripts/system/controllers/grab.js
@@ -269,6 +269,7 @@ function Grabber() {
         joint: "Mouse",
         filter: Picks.PICK_ENTITIES,
         faceAvatar: true,
+        scaleWithAvatar: true,
         enabled: true,
         renderStates: renderStates
     });


### PR DESCRIPTION
After the latest refactoring of the lasers logic inside controllerDispatcher.js, the lasers are not scaling with the avatar.

This PR add the scaleWithAvatar parameter to the Pointer creation method and fix the issue.

## TEST PLAN
- Change the size of your avatar and make it big.
- Use the lasers. They should look scaled accordingly. (no ultra thin lasers)
- Change the size of your avatar and make it small.
- Use the lasers. They should look scaled accordingly. (no ultra thick lasers)