### PR TITLE
Fix for crash in AnimSkeleton::getNumJoints()

### DIFF
--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -31,7 +31,7 @@ class AnimInverseKinematics;
 // Rig instances are reentrant.
 // However only specific methods thread-safe.  Noted below.
 
-class Rig : public QObject, public std::enable_shared_from_this<Rig> {
+class Rig : public QObject {
     Q_OBJECT
 public:
     struct StateHandler {


### PR DESCRIPTION
When initAnimGraph is called it asynchronously loads the Animation graph in the background.
If the model url is changed, or the Model is deleted in between the initial load and it's completion,
It's possible to access a bad Rig::_animSkeleton pointer. The fix is to hold onto the _animSkeleton pointer via a weak ref.