### PR TITLE
remove unecessary parenting of Agent script engine

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -343,7 +343,6 @@ void Agent::scriptRequestFinished() {
 
 void Agent::executeScript() {
     _scriptEngine = scriptEngineFactory(ScriptEngine::AGENT_SCRIPT, _scriptContents, _payload);
-    _scriptEngine->setParent(this); // be the parent of the script engine so it gets moved when we do
 
     DependencyManager::get<RecordingScriptingInterface>()->setScriptEngine(_scriptEngine);
 


### PR DESCRIPTION
Caught this with the address sanitizer - we were double deleting the Agent's ScriptEngine which could cause a crash on Agent shutdown.