### PR TITLE
Commerce: Add Passphrase Auth Status data tracking

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -59,6 +59,7 @@ Rectangle {
             } else if (walletStatus === 2) {
                 if (root.activeView !== "passphraseModal") {
                     root.activeView = "passphraseModal";
+                    UserActivityLogger.commercePassphraseEntry("marketplace checkout");
                 }
             } else if (walletStatus === 3) {
                 authSuccessStep();

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -54,6 +54,7 @@ Rectangle {
             } else if (walletStatus === 2) {
                 if (root.activeView !== "passphraseModal") {
                     root.activeView = "passphraseModal";
+                    UserActivityLogger.commercePassphraseEntry("marketplace purchases");
                 }
             } else if (walletStatus === 3) {
                 if ((Settings.getValue("isFirstUseOfPurchases", true) || root.isDebuggingFirstUseTutorial) && root.activeView !== "firstUseTutorial") {

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
@@ -50,8 +50,10 @@ Item {
             submitPassphraseInputButton.enabled = true;
             if (!isAuthenticated) {
                 errorText.text = "Authentication failed - please try again.";
+                UserActivityLogger.commercePassphraseAuthenticationStatus("auth failure");
             } else {
-                sendSignalToParent({method: 'authSuccess'});;
+                sendSignalToParent({method: 'authSuccess'});
+                UserActivityLogger.commercePassphraseAuthenticationStatus("auth success");
             }
         }
     }
@@ -336,6 +338,7 @@ Item {
                 text: "Cancel"
                 onClicked: {
                     sendSignalToParent({method: 'passphrasePopup_cancelClicked'});
+                    UserActivityLogger.commercePassphraseAuthenticationStatus("passphrase modal cancelled");
                 }
             }
         }

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -57,6 +57,7 @@ Rectangle {
             } else if (walletStatus === 2) {
                 if (root.activeView !== "passphraseModal") {
                     root.activeView = "passphraseModal";
+                    UserActivityLogger.commercePassphraseEntry("wallet app");
                 }
             } else if (walletStatus === 3) {
                 root.activeView = "walletHome";

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
@@ -141,3 +141,16 @@ void UserActivityLoggerScriptingInterface::commerceWalletSetupFinished(int times
     payload["secondsToComplete"] = secondsToComplete;
     doLogAction("commerceWalletSetupFinished", payload);
 }
+
+void UserActivityLoggerScriptingInterface::commercePassphraseEntry(QString source) {
+    QJsonObject payload;
+    payload["source"] = source;
+    doLogAction("commercePassphraseEntry", payload);
+}
+
+void UserActivityLoggerScriptingInterface::commercePassphraseAuthenticationStatus(QString status) {
+    QJsonObject payload;
+    payload["status"] = status;
+    doLogAction("commercePassphraseAuthenticationStatus", payload);
+
+}

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.h
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.h
@@ -39,6 +39,8 @@ public:
     Q_INVOKABLE void commerceWalletSetupStarted(int timestamp, QString setupAttemptID, int setupFlowVersion, QString referrer, QString currentDomain);
     Q_INVOKABLE void commerceWalletSetupProgress(int timestamp, QString setupAttemptID, int secondsElapsed, int currentStepNumber, QString currentStepName);
     Q_INVOKABLE void commerceWalletSetupFinished(int timestamp, QString setupAttemptID, int secondsToComplete);
+    Q_INVOKABLE void commercePassphraseEntry(QString source);
+    Q_INVOKABLE void commercePassphraseAuthenticationStatus(QString status);
 private:
     void doLogAction(QString action, QJsonObject details = {});
 };


### PR DESCRIPTION
This PR enables Metabase/ClearStory tracking of the following Commerce-related data:
1. `commercePassphraseEntry` (occurs when the user is prompted to enter their wallet passphrase)
    - `source` (string) ("marketplace checkout", "marketplace purchases", "wallet app")
2. `commercePassphraseAuthenticationStatus`
    - `status` (string) ("auth failure", "auth success", "passphrase modal cancelled")

*Test Plan:*
1. Open Interface and log in to the main account you use with the Commerce feature
2. Open the Wallet app, then press "cancel" on the auth modal
3. Open the Marketplace app, then click "My Purchases" at the top. Then, click "cancel" on the auth modal
4. Go to buy a costed item. When asked to authenticate your wallet, type in the wrong passphrase and attempt to auth.
5. Type in the correct passphrase, then attempt to auth.
6. Send a message to me on Slack and tell me you're done with the above. I'll check Metabase to verify that your data showed up 👀