### PR TITLE
Fix equirectangular skybox loading (RC-61)

### DIFF
--- a/libraries/image/src/image/Image.cpp
+++ b/libraries/image/src/image/Image.cpp
@@ -981,7 +981,7 @@ public:
     static QImage extractEquirectangularFace(const QImage& source, gpu::Texture::CubeFace face, int faceWidth) {
         QImage image(faceWidth, faceWidth, source.format());
 
-        glm::vec2 dstInvSize(1.0f / (float)source.width(), 1.0f / (float)source.height());
+        glm::vec2 dstInvSize(1.0f / faceWidth);
 
         struct CubeToXYZ {
             gpu::Texture::CubeFace _face;


### PR DESCRIPTION
Test plan:
- Find an equirectangular skybox image (easy to google, aspect ratio should be 2x1).  Create a zone and set the image as the background.  It should load properly.
- Clear your KTX Cache (Developer -> Render -> Clear KTX Cache).  Restart Interface.
- The image should still appear properly.