### PR TITLE
list assignment types in assignment-client help

### DIFF
--- a/assignment-client/src/AssignmentClientApp.cpp
+++ b/assignment-client/src/AssignmentClientApp.cpp
@@ -46,8 +46,14 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
 
     const QCommandLineOption helpOption = parser.addHelpOption();
 
-    const QCommandLineOption clientTypeOption(ASSIGNMENT_TYPE_OVERRIDE_OPTION,
-                                              "run single assignment client of given type", "type");
+    QString typeDescription = "run single assignment client of given type\n# | Type\n============================";
+    for (Assignment::Type type = Assignment::FirstType;
+        type != Assignment::AllTypes;
+        type = static_cast<Assignment::Type>(static_cast<int>(type) + 1)) {
+        typeDescription.append(QStringLiteral("\n%1 | %2").arg(QString::number(type), Assignment::typeToString(type)));
+    }
+    const QCommandLineOption clientTypeOption(ASSIGNMENT_TYPE_OVERRIDE_OPTION, typeDescription, "type");
+
     parser.addOption(clientTypeOption);
 
     const QCommandLineOption poolOption(ASSIGNMENT_POOL_OPTION, "set assignment pool", "pool-name");

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -945,7 +945,7 @@ void DomainServer::createStaticAssignmentsForType(Assignment::Type type, const Q
 
 void DomainServer::populateDefaultStaticAssignmentsExcludingTypes(const QSet<Assignment::Type>& excludedTypes) {
     // enumerate over all assignment types and see if we've already excluded it
-    for (Assignment::Type defaultedType = Assignment::AudioMixerType;
+    for (Assignment::Type defaultedType = Assignment::FirstType;
          defaultedType != Assignment::AllTypes;
          defaultedType =  static_cast<Assignment::Type>(static_cast<int>(defaultedType) + 1)) {
         if (!excludedTypes.contains(defaultedType) && defaultedType != Assignment::AgentType) {

--- a/libraries/networking/src/Assignment.cpp
+++ b/libraries/networking/src/Assignment.cpp
@@ -127,7 +127,11 @@ void Assignment::swap(Assignment& otherAssignment) {
 }
 
 const char* Assignment::getTypeName() const {
-    switch (_type) {
+    return typeToString(_type);
+}
+
+const char* Assignment::typeToString(Assignment::Type type) {
+    switch (type) {
         case Assignment::AudioMixerType:
             return "audio-mixer";
         case Assignment::AvatarMixerType:

--- a/libraries/networking/src/Assignment.h
+++ b/libraries/networking/src/Assignment.h
@@ -28,6 +28,7 @@ class Assignment : public QObject {
 public:
 
     enum Type : uint8_t {
+        FirstType = 0,
         AudioMixerType = 0,
         AvatarMixerType = 1,
         AgentType = 2,
@@ -89,6 +90,7 @@ public:
     const QString& getNodeVersion() const { return _nodeVersion; }
     
     const char* getTypeName() const;
+    static const char* typeToString(Assignment::Type type);
 
     friend QDebug operator<<(QDebug debug, const Assignment& assignment);
     friend QDataStream& operator<<(QDataStream &out, const Assignment& assignment);


### PR DESCRIPTION
## test plan
1. Run assignment-client --help on your favorite OS
   - Windows: run `assingment-client.exe --help` from cmd or powershell.
   - OSX/Unix: run `./assignment-client --help` from terminal
2. The help command output should contain assignment types table:

![image](https://user-images.githubusercontent.com/607735/34133752-6028ce2a-e40b-11e7-96ef-fbf35dd5c054.png)

(example)
