### PR TITLE
fix logic that resets own-avatar collisions after a parenting grab is released

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1626,6 +1626,10 @@ void EntityItem::setParentID(const QUuid& value) {
             newParentNoBootstrapping |= Simulation::NO_BOOTSTRAPPING;
         }
 
+        if (!oldParentID.isNull() && (oldParentID == Physics::getSessionUUID() || oldParentID == AVATAR_SELF_ID)) {
+            oldParentNoBootstrapping |= Simulation::NO_BOOTSTRAPPING;
+        }
+
         if ((bool)(oldParentNoBootstrapping ^ newParentNoBootstrapping)) {
             if ((bool)(newParentNoBootstrapping & Simulation::NO_BOOTSTRAPPING)) {
                 markDirtyFlags(Simulation::NO_BOOTSTRAPPING);


### PR DESCRIPTION
see https://github.com/highfidelity/hifi/pull/12015
