### PR TITLE
Case 10594 - Fix entity property href not being able to reset (empty) ...

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -961,7 +961,10 @@ void EntityItem::setMass(float mass) {
 
 void EntityItem::setHref(QString value) {
     auto href = value.toLower();
-    if (! (value.toLower().startsWith("hifi://")) ) {
+
+    // If the string has something and doesn't start with with "hifi://" it shouldn't be set
+    // We allow the string to be empty, because that's the initial state of this property
+    if ( !(value.toLower().startsWith("hifi://")) && !value.isEmpty()) {
         return;
     }
     withWriteLock([&] {


### PR DESCRIPTION
[Case 10594](https://highfidelity.fogbugz.com/f/cases/10594/Edit-js-Unable-to-clear-href-easily) Edit.js: Unable to clear href easily

This PR attempts to fix this:
Repro steps:
1. Create an entity and add an href property to it (hifi://dev-content)
2. Delete the text in the href field
3. Hit enter

Expected: 100% of the time, it clears the text
Actual: some of the time, the text doesn't not clear

## Test
Prerequisites: Installing interface + **sandbox**

1. Go to Sandbox.
2. Create a Cube and go to the entity properties.
3. Add an href property to it (**hifi://dev-content**)
4. Delete the text in the href field
5. Hit enter

Expected: 100% of the time, it clears the text

6. Close the tablet application. Open again, select the cube and verify whether the href field is the same before you left (clear).

7. Add the following href property "**132 random**". Hit enter.
Expected: the field will be clear.

8. Add the following href property "**hifi://myaddress**". Hit enter.
Expected: the field will show "**hifi://myaddress**".

9. Close interface.exe. 

10. Open again interface.exe. 

11. Go to your sandbox and open Create mode. 

12. Select the cube that you created in the beginning and verify whether the href field is the same before you left (**hifi://myaddress**).
