### PR TITLE
Fix bug preventing 'get' buttons from working in Marketplace

### DIFF
--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -415,7 +415,7 @@
                 }
 
                 purchaseButton.on('click', function () {
-                    if ('availabile' === availability) {
+                    if ('available' === availability) {
                         buyButtonClicked(window.location.pathname.split("/")[3],
                             $('#top-center').find('h1').text(),
                             $('#creator').find('.value').text(),


### PR DESCRIPTION
😆 

**Test Plan:**
1. Point your Interface client to the staging Metaverse
    - You need an environment variable `HIFI_METAVERSE_URL` with `https://staging.highfidelity.com` as the value
2. Create a wallet if you don't already have one
3. Look for 'Staging Flare Gun' in the marketplace, and click on it
4. Verify that the button that normally is blue, and suggests you purchase it, is now grey, and says "sold out"
5. Try to click the button -- nothing happens.
6. Look for "Finnegon" in the marketplace, and click on it
7. Verify that the button says "Get Item", and that, when you click on it, you see the Confirm Purchase screen