### PR TITLE
Commerce: Fix the behavior of the 'cancel' button in Wallet Setup

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -41,6 +41,7 @@ Rectangle {
     property bool debugCheckoutSuccess: false;
     property bool canRezCertifiedItems: Entities.canRezCertified() || Entities.canRezTmpCertified();
     property bool isWearable;
+    property string referrer;
     // Style
     color: hifi.colors.white;
     Hifi.QmlCommerce {
@@ -131,7 +132,7 @@ Rectangle {
         id: notSetUpTimer;
         interval: 200;
         onTriggered: {
-            sendToScript({method: 'checkout_walletNotSetUp', itemId: itemId});
+            sendToScript({method: 'checkout_walletNotSetUp', itemId: itemId, referrer: referrer});
         }
     }
 
@@ -877,6 +878,7 @@ Rectangle {
                 itemName = message.params.itemName;
                 root.itemPrice = message.params.itemPrice;
                 itemHref = message.params.itemHref;
+                referrer = message.params.referrer;
                 setBuyText();
             break;
             default:

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -252,7 +252,7 @@ Item {
             height: 50;
             text: "Cancel";
             onClicked: {
-                sendSignalToWallet({method: 'walletSetup_cancelClicked'});
+                sendSignalToWallet({method: 'walletSetup_cancelClicked', referrer: root.referrer ? root.referrer : "" });
             }
         }   
     }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -252,7 +252,7 @@ Item {
             height: 50;
             text: "Cancel";
             onClicked: {
-                sendSignalToWallet({method: 'walletSetup_cancelClicked', referrer: root.referrer ? root.referrer : "" });
+                sendSignalToWallet({method: 'walletSetup_cancelClicked', referrer: root.referrer });
             }
         }   
     }

--- a/scripts/system/commerce/wallet.js
+++ b/scripts/system/commerce/wallet.js
@@ -61,9 +61,23 @@
     function fromQml(message) {
         switch (message.method) {
             case 'passphrasePopup_cancelClicked':
-            case 'walletSetup_cancelClicked':
             case 'needsLogIn_cancelClicked':
                 tablet.gotoHomeScreen();
+                break;
+            case 'walletSetup_cancelClicked':
+                switch (message.referrer) {
+                    case '': // User clicked "Wallet" app
+                        tablet.gotoHomeScreen();
+                        break;
+                    case 'purchases':
+                    case 'marketplace cta':
+                    case 'mainPage':
+                        tablet.gotoWebScreen(MARKETPLACE_URL, MARKETPLACES_INJECT_SCRIPT_URL);
+                        break;
+                    default: // User needs to return to an individual marketplace item URL
+                        tablet.gotoWebScreen(MARKETPLACE_URL + '/items/' + message.referrer, MARKETPLACES_INJECT_SCRIPT_URL);
+                        break;
+                }
                 break;
             case 'needsLogIn_loginClicked':
                 openLoginWindow();

--- a/scripts/system/commerce/wallet.js
+++ b/scripts/system/commerce/wallet.js
@@ -67,6 +67,8 @@
             case 'walletSetup_cancelClicked':
                 switch (message.referrer) {
                     case '': // User clicked "Wallet" app
+                    case undefined:
+                    case null:
                         tablet.gotoHomeScreen();
                         break;
                     case 'purchases':

--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -243,13 +243,14 @@
         });
     }
 
-    function buyButtonClicked(id, name, author, price, href) {
+    function buyButtonClicked(id, name, author, price, href, referrer) {
         EventBridge.emitWebEvent(JSON.stringify({
             type: "CHECKOUT",
             itemId: id,
             itemName: name,
             itemPrice: price ? parseInt(price, 10) : 0,
-            itemHref: href
+            itemHref: href,
+            referrer: referrer
         }));
     }
 
@@ -316,7 +317,8 @@
                 $(this).closest('.grid-item').find('.item-title').text(),
                 $(this).closest('.grid-item').find('.creator').find('.value').text(),
                 $(this).closest('.grid-item').find('.item-cost').text(),
-                $(this).attr('data-href'));
+                $(this).attr('data-href'),
+                "mainPage");
         });
     }
 
@@ -420,7 +422,8 @@
                             $('#top-center').find('h1').text(),
                             $('#creator').find('.value').text(),
                             cost,
-                            href);
+                            href,
+                            "itemPage");
                         }
                     });
                 maybeAddPurchasesButton();

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -437,7 +437,7 @@ var selectionDisplay = null; // for gridTool.js to ignore
                 wireEventBridge(true);
                 tablet.sendToQml({
                     method: 'updateWalletReferrer',
-                    referrer: message.itemId
+                    referrer: message.referrer === "itemPage" ? message.itemId : message.referrer
                 });
                 openWallet();
                 break;


### PR DESCRIPTION
Fixes [FB10233](https://highfidelity.fogbugz.com/f/cases/10233/Setup-Wallet-page-cancel-does-not-go-back).

**Test Plan:**
1. Log into an account that doesn't have a wallet set up.
2. Open the Wallet app from the Tablet, then press the "cancel" button on the setup prompt that appears. Verify that you are returned to the Tablet home screen.
3. Open the Wallet app from the HUD, then press the "cancel" button on the setup prompt that appears. Verify that the Wallet app closes.
4. Open the Marketplace app. Click the "Set up your wallet" CTA towards the top of the page, then click the "cancel" button on the setup prompt that appears. Verify that you return to the main Marketplace page.
5. Click the "My Purchases" link at the top of the page, then click the "cancel" button on the setup prompt that appears. Verify that you return to the main Marketplace page.
6. From the main Marketplace page, click the "FREE" or "X HFC" button below any marketplace item, then click the "cancel" button on the setup prompt that appears. Verify that you return to the main Marketplace page.
7. From the main Marketplace page, click on any Marketplace item. Then, click the "Get Item" or "Buy" button below any marketplace item, then click the "cancel" button on the setup prompt that appears. Verify that you return directly to the item's Marketplace page.