### PR TITLE
Remove _model from ModelMeshPartPayload

### DIFF
--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -24,7 +24,6 @@ ModelOverlay::ModelOverlay()
     : _model(std::make_shared<Model>(nullptr, this)),
       _modelTextures(QVariantMap())
 {
-    _model->init();
     _model->setLoadingPriority(_loadPriority);
     _isLoaded = false;
 }
@@ -38,7 +37,6 @@ ModelOverlay::ModelOverlay(const ModelOverlay* modelOverlay) :
     _scaleToFit(modelOverlay->_scaleToFit),
     _loadPriority(modelOverlay->_loadPriority)
 {
-    _model->init();
     _model->setLoadingPriority(_loadPriority);
     if (_url.isValid()) {
         _updateModel = true;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -138,7 +138,6 @@ Avatar::~Avatar() {
 
 void Avatar::init() {
     getHead()->init();
-    _skeletonModel->init();
     _initialized = true;
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1213,7 +1213,6 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
         connect(model.get(), &Model::requestRenderUpdate, this, &ModelEntityRenderer::requestRenderUpdate);
         connect(entity.get(), &RenderableModelEntityItem::requestCollisionGeometryUpdate, this, &ModelEntityRenderer::flagForCollisionGeometryUpdate);
         model->setLoadingPriority(EntityTreeRenderer::getEntityLoadingPriority(*entity));
-        model->init();
         entity->setModel(model);
         withWriteLock([&] { _model = model; });
     }

--- a/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
+++ b/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
@@ -40,17 +40,7 @@ void CauterizedMeshPartPayload::updateTransformForCauterizedMesh(const Transform
 
 void CauterizedMeshPartPayload::bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const {
     // Still relying on the raw data from the model
-    bool useCauterizedMesh = (renderMode != RenderArgs::RenderMode::SHADOW_RENDER_MODE && renderMode != RenderArgs::RenderMode::SECONDARY_CAMERA_RENDER_MODE);
-    if (useCauterizedMesh) {
-        ModelPointer model = _model.lock();
-        if (model) {
-            CauterizedModel* skeleton = static_cast<CauterizedModel*>(model.get());
-            useCauterizedMesh = useCauterizedMesh && skeleton->getEnableCauterization();
-        } else {
-            useCauterizedMesh = false;
-        }
-    }
-
+    bool useCauterizedMesh = (renderMode != RenderArgs::RenderMode::SHADOW_RENDER_MODE && renderMode != RenderArgs::RenderMode::SECONDARY_CAMERA_RENDER_MODE) && _enableCauterization;
     if (useCauterizedMesh) {
         if (_cauterizedClusterBuffer) {
             batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::SKINNING, _cauterizedClusterBuffer);

--- a/libraries/render-utils/src/CauterizedMeshPartPayload.h
+++ b/libraries/render-utils/src/CauterizedMeshPartPayload.h
@@ -21,9 +21,12 @@ public:
 
     void bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const override;
 
+    void setEnableCauterization(bool enableCauterization) { _enableCauterization = enableCauterization; }
+
 private:
     gpu::BufferPointer _cauterizedClusterBuffer;
     Transform _cauterizedTransform;
+    bool _enableCauterization { false };
 };
 
 #endif // hifi_CauterizedMeshPartPayload_h

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -209,9 +209,9 @@ void CauterizedModel::updateRenderItems() {
                     }
                     data.updateTransformForCauterizedMesh(renderTransform);
 
-                    data.setKey(data.evalKey(isVisible, isLayeredInFront, isLayeredInHUD));
-                    data.setLayer(data.evalLayer(isLayeredInFront, isLayeredInHUD));
-                    data.setShapeKey(invalidatePayloadShapeKey ? render::ShapeKey::Builder::invalid() : data.evalShapeKey(isWireframe));
+                    data.setKey(isVisible, isLayeredInFront || isLayeredInHUD);
+                    data.setLayer(isLayeredInFront, isLayeredInHUD);
+                    data.setShapeKey(invalidatePayloadShapeKey, isWireframe);
                 });
             }
 

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -182,6 +182,7 @@ void CauterizedModel::updateRenderItems() {
             bool isVisible = self->isVisible();
             bool isLayeredInFront = self->isLayeredInFront();
             bool isLayeredInHUD = self->isLayeredInHUD();
+            bool enableCauterization = self->getEnableCauterization();
 
             render::Transaction transaction;
             for (int i = 0; i < (int)self->_modelMeshRenderItemIDs.size(); i++) {
@@ -194,7 +195,7 @@ void CauterizedModel::updateRenderItems() {
                 bool invalidatePayloadShapeKey = self->shouldInvalidatePayloadShapeKey(meshIndex);
 
                 transaction.updateItem<CauterizedMeshPartPayload>(itemID, [modelTransform, clusterMatrices, clusterMatricesCauterized, invalidatePayloadShapeKey,
-                        isWireframe, isVisible, isLayeredInFront, isLayeredInHUD](CauterizedMeshPartPayload& data) {
+                        isWireframe, isVisible, isLayeredInFront, isLayeredInHUD, enableCauterization](CauterizedMeshPartPayload& data) {
                     data.updateClusterBuffer(clusterMatrices, clusterMatricesCauterized);
 
                     Transform renderTransform = modelTransform;
@@ -209,6 +210,7 @@ void CauterizedModel::updateRenderItems() {
                     }
                     data.updateTransformForCauterizedMesh(renderTransform);
 
+                    data.setEnableCauterization(enableCauterization);
                     data.setKey(isVisible, isLayeredInFront || isLayeredInHUD);
                     data.setLayer(isLayeredInFront, isLayeredInHUD);
                     data.setShapeKey(invalidatePayloadShapeKey, isWireframe);

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -178,6 +178,11 @@ void CauterizedModel::updateRenderItems() {
             modelTransform.setTranslation(self->getTranslation());
             modelTransform.setRotation(self->getRotation());
 
+            bool isWireframe = self->isWireframe();
+            bool isVisible = self->isVisible();
+            bool isLayeredInFront = self->isLayeredInFront();
+            bool isLayeredInHUD = self->isLayeredInHUD();
+
             render::Transaction transaction;
             for (int i = 0; i < (int)self->_modelMeshRenderItemIDs.size(); i++) {
 
@@ -186,7 +191,10 @@ void CauterizedModel::updateRenderItems() {
                 auto clusterMatrices(self->getMeshState(meshIndex).clusterMatrices);
                 auto clusterMatricesCauterized(self->getCauterizeMeshState(meshIndex).clusterMatrices);
 
-                transaction.updateItem<CauterizedMeshPartPayload>(itemID, [modelTransform, clusterMatrices, clusterMatricesCauterized](CauterizedMeshPartPayload& data) {
+                bool invalidatePayloadShapeKey = self->shouldInvalidatePayloadShapeKey(meshIndex);
+
+                transaction.updateItem<CauterizedMeshPartPayload>(itemID, [modelTransform, clusterMatrices, clusterMatricesCauterized, invalidatePayloadShapeKey,
+                        isWireframe, isVisible, isLayeredInFront, isLayeredInHUD](CauterizedMeshPartPayload& data) {
                     data.updateClusterBuffer(clusterMatrices, clusterMatricesCauterized);
 
                     Transform renderTransform = modelTransform;
@@ -200,6 +208,10 @@ void CauterizedModel::updateRenderItems() {
                         renderTransform = modelTransform.worldTransform(Transform(clusterMatricesCauterized[0]));
                     }
                     data.updateTransformForCauterizedMesh(renderTransform);
+
+                    data.setKey(data.evalKey(isVisible, isLayeredInFront, isLayeredInHUD));
+                    data.setLayer(data.evalLayer(isLayeredInFront, isLayeredInHUD));
+                    data.setShapeKey(invalidatePayloadShapeKey ? render::ShapeKey::Builder::invalid() : data.evalShapeKey(isWireframe));
                 });
             }
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -339,13 +339,10 @@ ModelMeshPartPayload::ModelMeshPartPayload(ModelPointer model, int meshIndex, in
     }
     updateTransformForSkinnedMesh(renderTransform, transform);
 
-    initCache();
+    initCache(model);
 }
 
-void ModelMeshPartPayload::initCache() {
-    ModelPointer model = _model.lock();
-    assert(model && model->isLoaded());
-
+void ModelMeshPartPayload::initCache(const ModelPointer& model) {
     if (_drawMesh) {
         auto vertexFormat = _drawMesh->getVertexFormat();
         _hasColorAttrib = vertexFormat->hasAttribute(gpu::Stream::COLOR);
@@ -355,6 +352,7 @@ void ModelMeshPartPayload::initCache() {
         const FBXMesh& mesh = geometry.meshes.at(_meshIndex);
 
         _isBlendShaped = !mesh.blendshapes.isEmpty();
+        _hasTangents = !mesh.tangents.isEmpty();
     }
 
     auto networkMaterial = model->getGeometry()->getShapeMaterial(_shapeID);
@@ -388,94 +386,65 @@ void ModelMeshPartPayload::updateTransformForSkinnedMesh(const Transform& render
     _worldBound.transform(boundTransform);
 }
 
-ItemKey ModelMeshPartPayload::getKey() const {
+render::ItemKey ModelMeshPartPayload::evalKey(bool isVisible, bool isLayeredInFront, bool isLayeredInHUD) const {
     ItemKey::Builder builder;
     builder.withTypeShape();
 
-    ModelPointer model = _model.lock();
-    if (model) {
-        if (!model->isVisible()) {
-            builder.withInvisible();
-        }
+    if (!isVisible) {
+        builder.withInvisible();
+    }
 
-        if (model->isLayeredInFront() || model->isLayeredInHUD()) {
-            builder.withLayered();
-        }
+    if (isLayeredInFront || isLayeredInHUD) {
+        builder.withLayered();
+    }
 
-        if (_isBlendShaped || _isSkinned) {
-            builder.withDeformed();
-        }
+    if (_isBlendShaped || _isSkinned) {
+        builder.withDeformed();
+    }
 
-        if (_drawMaterial) {
-            auto matKey = _drawMaterial->getKey();
-            if (matKey.isTranslucent()) {
-                builder.withTransparent();
-            }
+    if (_drawMaterial) {
+        auto matKey = _drawMaterial->getKey();
+        if (matKey.isTranslucent()) {
+            builder.withTransparent();
         }
     }
+
     return builder.build();
 }
 
-int ModelMeshPartPayload::getLayer() const {
-    ModelPointer model = _model.lock();
-    if (model) {
-        if (model->isLayeredInFront()) {
-            return Item::LAYER_3D_FRONT;
-        } else if (model->isLayeredInHUD()) {
-            return Item::LAYER_3D_HUD;
-        }
-    }
-    return Item::LAYER_3D;
+ItemKey ModelMeshPartPayload::getKey() const {
+    return _itemKey;
 }
 
-ShapeKey ModelMeshPartPayload::getShapeKey() const {
-    // guard against partially loaded meshes
-    ModelPointer model = _model.lock();
-    if (!model || !model->isLoaded() || !model->getGeometry()) {
-        return ShapeKey::Builder::invalid();
+int ModelMeshPartPayload::evalLayer(bool isLayeredInFront, bool isLayeredInHUD) const {
+    if (isLayeredInFront) {
+        return Item::LAYER_3D_FRONT;
+    } else if (isLayeredInHUD) {
+        return Item::LAYER_3D_HUD;
+    } else {
+        return Item::LAYER_3D;
     }
+}
 
-    const FBXGeometry& geometry = model->getFBXGeometry();
-    const auto& networkMeshes = model->getGeometry()->getMeshes();
+int ModelMeshPartPayload::getLayer() const {
+    return _layer;
+}
 
-    // guard against partially loaded meshes
-    if (_meshIndex >= (int)networkMeshes.size() || _meshIndex >= (int)geometry.meshes.size() || _meshIndex >= (int)model->_meshStates.size()) {
-        return ShapeKey::Builder::invalid();
-    }
-
-    const FBXMesh& mesh = geometry.meshes.at(_meshIndex);
-
-    // if our index is ever out of range for either meshes or networkMeshes, then skip it, and set our _meshGroupsKnown
-    // to false to rebuild out mesh groups.
-    if (_meshIndex < 0 || _meshIndex >= (int)networkMeshes.size() || _meshIndex > geometry.meshes.size()) {
-        model->_needsFixupInScene = true; // trigger remove/add cycle
-        model->invalidCalculatedMeshBoxes(); // if we have to reload, we need to assume our mesh boxes are all invalid
-        return ShapeKey::Builder::invalid();
-    }
-
-
-    int vertexCount = mesh.vertices.size();
-    if (vertexCount == 0) {
-        // sanity check
-        return ShapeKey::Builder::invalid(); // FIXME
-    }
-
-
+ShapeKey ModelMeshPartPayload::evalShapeKey(bool isWireframe) const {
     model::MaterialKey drawMaterialKey;
     if (_drawMaterial) {
         drawMaterialKey = _drawMaterial->getKey();
     }
 
     bool isTranslucent = drawMaterialKey.isTranslucent();
-    bool hasTangents = drawMaterialKey.isNormalMap() && !mesh.tangents.isEmpty();
+    bool hasTangents = drawMaterialKey.isNormalMap() && _hasTangents;
     bool hasSpecular = drawMaterialKey.isMetallicMap();
     bool hasLightmap = drawMaterialKey.isLightmapMap();
     bool isUnlit = drawMaterialKey.isUnlit();
 
     bool isSkinned = _isSkinned;
-    bool wireframe = model->isWireframe();
 
-    if (wireframe) {
+    if (isWireframe) {
         isTranslucent = hasTangents = hasSpecular = hasLightmap = isSkinned = false;
     }
 
@@ -500,10 +469,14 @@ ShapeKey ModelMeshPartPayload::getShapeKey() const {
     if (isSkinned) {
         builder.withSkinned();
     }
-    if (wireframe) {
+    if (isWireframe) {
         builder.withWireframe();
     }
     return builder.build();
+}
+
+ShapeKey ModelMeshPartPayload::getShapeKey() const {
+    return _shapeKey;
 }
 
 void ModelMeshPartPayload::bindMesh(gpu::Batch& batch) {
@@ -549,24 +522,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
         return; // bail asap
     }
 
-    if (_state == WAITING_TO_START) {
-        if (model->isLoaded()) {
-            _state = STARTED;
-            model->setRenderItemsNeedUpdate();
-        } else {
-            return;
-        }
-    }
-
-    if (_materialNeedsUpdate && model->getGeometry()->areTexturesLoaded()) {
-        model->setRenderItemsNeedUpdate();
-        _materialNeedsUpdate = false;
-    }
-
     if (!args) {
-        return;
-    }
-    if (!getShapeKey().isValid()) {
         return;
     }
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -386,7 +386,7 @@ void ModelMeshPartPayload::updateTransformForSkinnedMesh(const Transform& render
     _worldBound.transform(boundTransform);
 }
 
-render::ItemKey ModelMeshPartPayload::evalKey(bool isVisible, bool isLayeredInFront, bool isLayeredInHUD) const {
+void ModelMeshPartPayload::setKey(bool isVisible, bool isLayered) {
     ItemKey::Builder builder;
     builder.withTypeShape();
 
@@ -394,7 +394,7 @@ render::ItemKey ModelMeshPartPayload::evalKey(bool isVisible, bool isLayeredInFr
         builder.withInvisible();
     }
 
-    if (isLayeredInFront || isLayeredInHUD) {
+    if (isLayered) {
         builder.withLayered();
     }
 
@@ -409,20 +409,20 @@ render::ItemKey ModelMeshPartPayload::evalKey(bool isVisible, bool isLayeredInFr
         }
     }
 
-    return builder.build();
+    _itemKey = builder.build();
 }
 
 ItemKey ModelMeshPartPayload::getKey() const {
     return _itemKey;
 }
 
-int ModelMeshPartPayload::evalLayer(bool isLayeredInFront, bool isLayeredInHUD) const {
+void ModelMeshPartPayload::setLayer(bool isLayeredInFront, bool isLayeredInHUD) {
     if (isLayeredInFront) {
-        return Item::LAYER_3D_FRONT;
+        _layer = Item::LAYER_3D_FRONT;
     } else if (isLayeredInHUD) {
-        return Item::LAYER_3D_HUD;
+        _layer = Item::LAYER_3D_HUD;
     } else {
-        return Item::LAYER_3D;
+        _layer = Item::LAYER_3D;
     }
 }
 
@@ -430,7 +430,12 @@ int ModelMeshPartPayload::getLayer() const {
     return _layer;
 }
 
-ShapeKey ModelMeshPartPayload::evalShapeKey(bool isWireframe) const {
+void ModelMeshPartPayload::setShapeKey(bool invalidateShapeKey, bool isWireframe) {
+    if (invalidateShapeKey) {
+        _shapeKey = ShapeKey::Builder::invalid();
+        return;
+    }
+
     model::MaterialKey drawMaterialKey;
     if (_drawMaterial) {
         drawMaterialKey = _drawMaterial->getKey();
@@ -472,7 +477,7 @@ ShapeKey ModelMeshPartPayload::evalShapeKey(bool isWireframe) const {
     if (isWireframe) {
         builder.withWireframe();
     }
-    return builder.build();
+    _shapeKey = builder.build();
 }
 
 ShapeKey ModelMeshPartPayload::getShapeKey() const {

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -107,7 +107,6 @@ public:
     void computeAdjustedLocalBound(const std::vector<glm::mat4>& clusterMatrices);
 
     gpu::BufferPointer _clusterBuffer;
-    ModelWeakPointer _model;
 
     int _meshIndex;
     int _shapeID;
@@ -119,6 +118,7 @@ public:
 private:
     void initCache(const ModelPointer& model);
 
+    gpu::BufferPointer _blendedVertexBuffer;
     render::ItemKey _itemKey { render::ItemKey::Builder::opaqueShape().build() };
     render::ShapeKey _shapeKey { render::ShapeKey::Builder::invalid() };
     int _layer { render::Item::LAYER_3D };

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -96,12 +96,9 @@ public:
     render::ShapeKey getShapeKey() const override; // shape interface
     void render(RenderArgs* args) override;
 
-    render::ItemKey evalKey(bool isVisible, bool isLayeredInFront, bool isLayeredInHUD) const;
-    void setKey(const render::ItemKey& itemKey) { _itemKey = itemKey; }
-    int evalLayer(bool isLayeredInFront, bool isLayeredInHUD) const;
-    void setLayer(int layer) { _layer = layer; }
-    render::ShapeKey evalShapeKey(bool isWireframe) const;
-    void setShapeKey(const render::ShapeKey& shapeKey) { _shapeKey = shapeKey; };
+    void setKey(bool isVisible, bool isLayered);
+    void setLayer(bool isLayeredInFront, bool isLayeredInHUD);
+    void setShapeKey(bool invalidateShapeKey, bool isWireframe);
 
     // ModelMeshPartPayload functions to perform render
     void bindMesh(gpu::Batch& batch) override;
@@ -123,8 +120,8 @@ private:
     void initCache(const ModelPointer& model);
 
     render::ItemKey _itemKey { render::ItemKey::Builder::opaqueShape().build() };
-    int _layer { render::Item::LAYER_3D };
     render::ShapeKey _shapeKey { render::ShapeKey::Builder::invalid() };
+    int _layer { render::Item::LAYER_3D };
 };
 
 namespace render {

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -96,11 +96,16 @@ public:
     render::ShapeKey getShapeKey() const override; // shape interface
     void render(RenderArgs* args) override;
 
+    render::ItemKey evalKey(bool isVisible, bool isLayeredInFront, bool isLayeredInHUD) const;
+    void setKey(const render::ItemKey& itemKey) { _itemKey = itemKey; }
+    int evalLayer(bool isLayeredInFront, bool isLayeredInHUD) const;
+    void setLayer(int layer) { _layer = layer; }
+    render::ShapeKey evalShapeKey(bool isWireframe) const;
+    void setShapeKey(const render::ShapeKey& shapeKey) { _shapeKey = shapeKey; };
+
     // ModelMeshPartPayload functions to perform render
     void bindMesh(gpu::Batch& batch) override;
     void bindTransform(gpu::Batch& batch, const render::ShapePipeline::LocationsPointer locations, RenderArgs::RenderMode renderMode) const override;
-
-    void initCache();
 
     void computeAdjustedLocalBound(const std::vector<glm::mat4>& clusterMatrices);
 
@@ -112,16 +117,14 @@ public:
 
     bool _isSkinned{ false };
     bool _isBlendShaped { false };
-    bool _materialNeedsUpdate { true };
+    bool _hasTangents { false };
 
 private:
+    void initCache(const ModelPointer& model);
 
-    enum State : uint8_t {
-        WAITING_TO_START = 0,
-        STARTED = 1,
-    };
-
-    mutable State _state { WAITING_TO_START } ;
+    render::ItemKey _itemKey { render::ItemKey::Builder::opaqueShape().build() };
+    int _layer { render::Item::LAYER_3D };
+    render::ShapeKey _shapeKey { render::ShapeKey::Builder::invalid() };
 };
 
 namespace render {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -278,9 +278,9 @@ void Model::updateRenderItems() {
                 }
                 data.updateTransformForSkinnedMesh(renderTransform, modelTransform);
 
-                data.setKey(data.evalKey(isVisible, isLayeredInFront, isLayeredInHUD));
-                data.setLayer(data.evalLayer(isLayeredInFront, isLayeredInHUD));
-                data.setShapeKey(invalidatePayloadShapeKey ? render::ShapeKey::Builder::invalid() : data.evalShapeKey(isWireframe));
+                data.setKey(isVisible, isLayeredInFront || isLayeredInHUD);
+                data.setLayer(isLayeredInFront, isLayeredInHUD);
+                data.setShapeKey(invalidatePayloadShapeKey, isWireframe);
             });
         }
 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -122,7 +122,6 @@ public:
     void setIsWireframe(bool isWireframe) { _isWireframe = isWireframe; }
     bool isWireframe() const { return _isWireframe; }
 
-    void init();
     void reset();
 
     void setSnapModelToRegistrationPoint(bool snapModelToRegistrationPoint, const glm::vec3& registrationPoint);
@@ -346,11 +345,7 @@ protected:
     // hook for derived classes to be notified when setUrl invalidates the current model.
     virtual void onInvalidate() {};
 
-
-protected:
-
     virtual void deleteGeometry();
-    void initJointTransforms();
 
     QVector<float> _blendshapeCoefficients;
 
@@ -418,6 +413,8 @@ protected:
 
     bool _isLayeredInFront { false };
     bool _isLayeredInHUD { false };
+
+    bool shouldInvalidatePayloadShapeKey(int meshIndex);
 
 private:
     float _loadingPriority { 0.0f };


### PR DESCRIPTION
Instead of repeatedly checking properties of _model in ModelMeshPartPayload::getShapeKey(), getKey(), and getLayer(), we only need to update those properties when they could have changed, which we can do in updateRenderItems().  Also some other small Model-related cleanup.

Although not extremely expensive, these functions are called very often.  Here, for example, you can see the effect of moving the computation to setShapeKey() and calling it only when things have changed, in the same scene:
Before:
![getshapekey1](https://user-images.githubusercontent.com/7650116/34223817-8684b28a-e575-11e7-8390-10bc76482f45.png)
Now:
![getshapekey2](https://user-images.githubusercontent.com/7650116/34223842-98f3e1f2-e575-11e7-92e8-12729f85152d.png)

Test plan:
- Go to an empty domain.  Reload content.  Clear your KTX cache (Developer -> Render -> Clear KTX Cache).  Restart.
- Go to a domain with lots of model entities, like dev-welcome or AvatarIsland (or SamsWorld/leviathan if AvatarIsland is on a different protocol version).  Verify that all models load and that if you wait, all of their textures load.  Bring in some models from the marketplace.  Verify that they appear correctly.
- Repeatedly toggle the visibility on a model using Create.  Verify that the model's visibility always matches the checkbox.
- Manually edit the textures on a model (select a model with textures, replace some of the links to random pictures).  Verify that the textures on the model actually change when you replace the links.
- Replace a model's URL with a different model URL.  Verify that the model actually switches to use the new URL.
- Make a model with an invalid URL.  You should see a green cube.  Replace the URL with a valid URL and verify that the model appears and the green cube disappears.
- Have someone else join you.  Make sure their avatar renders.  Have them change avatars.  You should see the change.
- Make sure you can see your own avatar, and that it updates when you change avatars.
- Switch between first and third person.  You should be able to see your head in third person.  When in first person, if you walk backwards, you should not see your eyes/mouth.  In HMD, when you move your head around, you should not see your eyes/mouth.