### PR TITLE
Fix >20 web entities crash

### DIFF
--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -124,7 +124,10 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
     withWriteLock([&] {
         // This work must be done on the main thread
         if (!hasWebSurface()) {
-            buildWebSurface(entity);
+            // If we couldn't create a new web surface, exit
+            if (!buildWebSurface(entity)) {
+                return;
+            }
         }
 
         if (_contextPosition != entity->getWorldPosition()) {


### PR DESCRIPTION
This is a (temporary) fix for a crash when you create more than 20 web entities.

https://highfidelity.manuscript.com/f/cases/10379/Web-Entity-Question
https://highfidelity.manuscript.com/f/cases/7371/FluffyJenkins-web-entity-script-crashes-users-in-Pumpkin

Test plan:
- Run [this ](https://gist.githubusercontent.com/SamGondelman/3fdddffb8e6c499f47fa2b2ef671131d/raw/6153a310f81df39353a1f5145091bcfeb6edad0c/WebOverlayTest2.js) in an empty domain.
- Press spacebar.  20 web entities will appear in front of you.
- Move slightly and press spacebar again.  20 more web entities will appear but they won't render, and you shouldn't crash.
- Delete one of the rendering web entities.  One of the invisible web entities should appear.