### PR TITLE
Fix error state for Commerce passphrase TextInputs

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
@@ -50,9 +50,11 @@ Item {
             submitPassphraseInputButton.enabled = true;
             if (!isAuthenticated) {
                 errorText.text = "Authentication failed - please try again.";
+                passphraseField.error = true;
                 UserActivityLogger.commercePassphraseAuthenticationStatus("auth failure");
             } else {
                 sendSignalToParent({method: 'authSuccess'});
+                passphraseField.error = false;
                 UserActivityLogger.commercePassphraseAuthenticationStatus("auth success");
             }
         }
@@ -72,6 +74,7 @@ Item {
     // TODO: Fix this unlikely bug
     onVisibleChanged: {
         if (visible) {
+            passphraseField.error = false;
             passphraseField.focus = true;
             sendSignalToParent({method: 'disableHmdPreview'});
         } else {

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
@@ -54,6 +54,9 @@ Item {
     // TODO: Fix this unlikely bug
     onVisibleChanged: {
         if (visible) {
+            passphraseField.error = false;
+            passphraseFieldAgain.error = false;
+            currentPassphraseField.error = false;
             if (root.shouldImmediatelyFocus) {
                 focusFirstTextField();
             }


### PR DESCRIPTION
Fixes [this](https://highfidelity.fogbugz.com/f/cases/10628/Wallet-passphrase-text-box-UI-edge-case-fix).

**Test Plan:**
1. Open Interface and login to an account with which you have a wallet
2. Open the Wallet app. You'll see the authentication screen. Enter a password that you know is incorrect, and attempt to authenticate. Verify that you see the TextInput turn red and that you see the "authentication failed" error message.
3. Click "Cancel"
4. Open the Wallet app again. Verify that the passphrase TextInput is no longer red
5. Authenticate your wallet with your passphrase
6. Go to the Security tab and click Change Passphrase
7. Put an "a" in the first TextInput and "ab" in the second TextInput, then press "SUBMIT". Verify that you see the three TextInputs turn red.
8. Click "Cancel"
9. Click Change Passphrase again. Verify that the three TextInputs are no longer red.