### PR TITLE
Fix for invisible or stuttering avatars, PendingReceivedMessage use after free

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerSlave.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlave.cpp
@@ -214,7 +214,7 @@ void AvatarMixerSlave::broadcastAvatarDataToAgent(const SharedNodePointer& node)
         uint64_t getTimestamp() const override {
             return _lastEncodeTime;
         }
-        const AvatarSharedPointer& getAvatar() const { return _avatar; }
+        AvatarSharedPointer getAvatar() const { return _avatar; }
 
     private:
         AvatarSharedPointer _avatar;
@@ -326,7 +326,7 @@ void AvatarMixerSlave::broadcastAvatarDataToAgent(const SharedNodePointer& node)
 
     int remainingAvatars = (int)sortedAvatars.size();
     while (!sortedAvatars.empty()) {
-        const auto& avatarData = sortedAvatars.top().getAvatar();
+        const auto avatarData = sortedAvatars.top().getAvatar();
         sortedAvatars.pop();
         remainingAvatars--;
 

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -150,7 +150,7 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
         glm::vec3 getPosition() const override { return _avatar->getWorldPosition(); }
         float getRadius() const override { return std::static_pointer_cast<Avatar>(_avatar)->getBoundingRadius(); }
         uint64_t getTimestamp() const override { return std::static_pointer_cast<Avatar>(_avatar)->getLastRenderUpdateTime(); }
-        const AvatarSharedPointer& getAvatar() const { return _avatar; }
+        AvatarSharedPointer getAvatar() const { return _avatar; }
     private:
         AvatarSharedPointer _avatar;
     };
@@ -185,7 +185,7 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
     render::Transaction transaction;
     while (!sortedAvatars.empty()) {
         const SortableAvatar& sortData = sortedAvatars.top();
-        const auto& avatar = std::static_pointer_cast<Avatar>(sortData.getAvatar());
+        const auto avatar = std::static_pointer_cast<Avatar>(sortData.getAvatar());
 
         bool ignoring = DependencyManager::get<NodeList>()->isPersonalMutingNode(avatar->getID());
         if (ignoring) {
@@ -239,7 +239,7 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
             sortedAvatars.pop();
             while (inView && !sortedAvatars.empty()) {
                 const SortableAvatar& newSortData = sortedAvatars.top();
-                const auto& newAvatar = std::static_pointer_cast<Avatar>(newSortData.getAvatar());
+                const auto newAvatar = std::static_pointer_cast<Avatar>(newSortData.getAvatar());
                 inView = newSortData.getPriority() > OUT_OF_VIEW_THRESHOLD;
                 if (inView && newAvatar->hasNewJointData()) {
                     numAVatarsNotUpdated++;

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -349,7 +349,7 @@ void EntityTreeRenderer::updateChangedEntities(const render::ScenePointer& scene
             float getRadius() const override { return 0.5f * _renderer->getEntity()->getQueryAACube().getScale(); }
             uint64_t getTimestamp() const override { return _renderer->getUpdateTime(); }
 
-            const EntityRendererPointer& getRenderer() const { return _renderer; }
+            EntityRendererPointer getRenderer() const { return _renderer; }
         private:
             EntityRendererPointer _renderer;
         };
@@ -382,7 +382,7 @@ void EntityTreeRenderer::updateChangedEntities(const render::ScenePointer& scene
             std::unordered_map<EntityItemID, EntityRendererPointer>::iterator itr;
             size_t numSorted = sortedRenderables.size();
             while (!sortedRenderables.empty() && usecTimestampNow() < expiry) {
-                const EntityRendererPointer& renderable = sortedRenderables.top().getRenderer();
+                const auto renderable = sortedRenderables.top().getRenderer();
                 renderable->updateInScene(scene, transaction);
                 _renderablesToUpdate.erase(renderable->getEntity()->getID());
                 sortedRenderables.pop();

--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -191,6 +191,8 @@ void Connection::queueReceivedMessagePacket(std::unique_ptr<Packet> packet) {
 
     pendingMessage.enqueuePacket(std::move(packet));
 
+    bool processedLastOrOnly = false;
+
     while (pendingMessage.hasAvailablePackets()) {
         auto packet = pendingMessage.removeNextPacket();
 
@@ -201,8 +203,12 @@ void Connection::queueReceivedMessagePacket(std::unique_ptr<Packet> packet) {
         // if this was the last or only packet, then we can remove the pending message from our hash
         if (packetPosition == Packet::PacketPosition::LAST ||
             packetPosition == Packet::PacketPosition::ONLY) {
-            _pendingReceivedMessages.erase(messageNumber);
+            processedLastOrOnly = true;
         }
+    }
+
+    if (processedLastOrOnly) {
+        _pendingReceivedMessages.erase(messageNumber);
     }
 }
 

--- a/libraries/shared/src/PrioritySortUtil.h
+++ b/libraries/shared/src/PrioritySortUtil.h
@@ -28,7 +28,7 @@
         glm::vec3 getPosition() const override { return _thing->getPosition(); }
         float getRadius() const override { return 0.5f * _thing->getBoundingRadius(); }
         uint64_t getTimestamp() const override { return _thing->getLastTime(); }
-        const Thing& getThing() const { return _thing; }
+        Thing getThing() const { return _thing; }
     private:
         Thing _thing;
     };
@@ -42,6 +42,13 @@
     }
 
 (3) Loop over your priority queue and do timeboxed work:
+
+    NOTE: Be careful using references to members of instances of T from std::priority_queue<T>.
+          Under the hood std::priority_queue<T> may re-use instances of T.
+          For example, after a pop() or a push() the top T may have the same memory address
+          as the top T before the pop() or push() (but point to a swapped instance of T).
+          This causes a reference to member variable of T to point to a different value
+          when operations taken on std::priority_queue<T> shuffle around the instances of T.
 
     uint64_t cutoffTime = usecTimestampNow() + TIME_BUDGET;
     while (!sortedThings.empty()) {


### PR DESCRIPTION
This PR fixes an issue with the avatar mixer prioritization that decides which avatars to send you updates for. The bug was causing the avatar mixer to not send or very infrequently send clients avatar data and identity packets for specific other avatars.

I additionally wrapped in a fix for a use after free bug introduced with recent changes to `udt::Connection`. I believe that bug is a potential cause of a crash we were seeing when the avatar mixer was processing many identity packets.

#### Technical description

Be careful using references to members of instances of T from std::priority_queue<T>. Under the hood std::priority_queue<T> may re-use instances of T. For example, after a pop() or a push() the top T may have the same memory address as the top T before the pop() or push() (but point to a swapped instance of T). This causes a reference to member variable of T to point to a different value when operations taken on std::priority_queue<T> shuffle around the instances of T.