### PR TITLE
Commerce Data Tracking: Iteration 3 (Purchases)

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -33,6 +33,7 @@ Rectangle {
     property string itemName;
     property string itemId;
     property string itemHref;
+    property string itemAuthor;
     property double balanceAfterPurchase;
     property bool alreadyOwned: false;
     property int itemPrice: -1;
@@ -81,12 +82,12 @@ Rectangle {
             if (result.status !== 'success') {
                 failureErrorText.text = result.message;
                 root.activeView = "checkoutFailure";
-                UserActivityLogger.commercePurchaseFailure(root.itemId, root.itemPrice, !root.alreadyOwned, result.message);
+                UserActivityLogger.commercePurchaseFailure(root.itemId, root.itemAuthor, root.itemPrice, !root.alreadyOwned, result.message);
             } else {
                 root.itemHref = result.data.download_url;
                 root.isWearable = result.data.categories.indexOf("Wearables") > -1;
                 root.activeView = "checkoutSuccess";
-                UserActivityLogger.commercePurchaseSuccess(root.itemId, root.itemPrice, !root.alreadyOwned);
+                UserActivityLogger.commercePurchaseSuccess(root.itemId, root.itemAuthor, root.itemPrice, !root.alreadyOwned);
             }
         }
 
@@ -879,6 +880,7 @@ Rectangle {
                 root.itemPrice = message.params.itemPrice;
                 itemHref = message.params.itemHref;
                 referrer = message.params.referrer;
+                itemAuthor = message.params.itemAuthor;
                 setBuyText();
             break;
             default:

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.cpp
@@ -89,17 +89,19 @@ void UserActivityLoggerScriptingInterface::doLogAction(QString action, QJsonObje
                               Q_ARG(QJsonObject, details));
 }
 
-void UserActivityLoggerScriptingInterface::commercePurchaseSuccess(QString marketplaceID, int cost, bool firstPurchaseOfThisItem) {
+void UserActivityLoggerScriptingInterface::commercePurchaseSuccess(QString marketplaceID, QString contentCreator, int cost, bool firstPurchaseOfThisItem) {
     QJsonObject payload;
     payload["marketplaceID"] = marketplaceID;
+    payload["contentCreator"] = contentCreator;
     payload["cost"] = cost;
     payload["firstPurchaseOfThisItem"] = firstPurchaseOfThisItem;
     doLogAction("commercePurchaseSuccess", payload);
 }
 
-void UserActivityLoggerScriptingInterface::commercePurchaseFailure(QString marketplaceID, int cost, bool firstPurchaseOfThisItem, QString errorDetails) {
+void UserActivityLoggerScriptingInterface::commercePurchaseFailure(QString marketplaceID, QString contentCreator, int cost, bool firstPurchaseOfThisItem, QString errorDetails) {
     QJsonObject payload;
     payload["marketplaceID"] = marketplaceID;
+    payload["contentCreator"] = contentCreator;
     payload["cost"] = cost;
     payload["firstPurchaseOfThisItem"] = firstPurchaseOfThisItem;
     payload["errorDetails"] = errorDetails;

--- a/libraries/networking/src/UserActivityLoggerScriptingInterface.h
+++ b/libraries/networking/src/UserActivityLoggerScriptingInterface.h
@@ -33,8 +33,8 @@ public:
     Q_INVOKABLE void bubbleToggled(bool newValue);
     Q_INVOKABLE void bubbleActivated();
     Q_INVOKABLE void logAction(QString action, QVariantMap details = QVariantMap{});
-    Q_INVOKABLE void commercePurchaseSuccess(QString marketplaceID, int cost, bool firstPurchaseOfThisItem);
-    Q_INVOKABLE void commercePurchaseFailure(QString marketplaceID, int cost, bool firstPurchaseOfThisItem, QString errorDetails);
+    Q_INVOKABLE void commercePurchaseSuccess(QString marketplaceID, QString contentCreator, int cost, bool firstPurchaseOfThisItem);
+    Q_INVOKABLE void commercePurchaseFailure(QString marketplaceID, QString contentCreator, int cost, bool firstPurchaseOfThisItem, QString errorDetails);
     Q_INVOKABLE void commerceEntityRezzed(QString marketplaceID, QString source, QString type);
     Q_INVOKABLE void commerceWalletSetupStarted(int timestamp, QString setupAttemptID, int setupFlowVersion, QString referrer, QString currentDomain);
     Q_INVOKABLE void commerceWalletSetupProgress(int timestamp, QString setupAttemptID, int secondsElapsed, int currentStepNumber, QString currentStepName);

--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -250,7 +250,8 @@
             itemName: name,
             itemPrice: price ? parseInt(price, 10) : 0,
             itemHref: href,
-            referrer: referrer
+            referrer: referrer,
+            itemAuthor: author
         }));
     }
 


### PR DESCRIPTION
Adds `contentCreator` to Purchases data tracking.

*Test Plan:*
1. Buy a costed item from the Marketplace, then buy a free item from the Marketplace.
2. Send a message to me on Slack and tell me you're done with the above. I'll check Metabase to verify that your data showed up 👀 (I use the following query: `select * from user_activities where action = 'commercePurchaseSuccess';`)