### PR TITLE
Leopoly_Phase1_008_ScriptInitalizer

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -697,6 +697,7 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     DependencyManager::set<AccountManager>(std::bind(&Application::getUserAgent, qApp));
     DependencyManager::set<StatTracker>();
     DependencyManager::set<ScriptEngines>(ScriptEngine::CLIENT_SCRIPT);
+    DependencyManager::set<ScriptInitializerMixin, NativeScriptInitializers>();
     DependencyManager::set<Preferences>();
     DependencyManager::set<recording::Deck>();
     DependencyManager::set<recording::Recorder>();

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -133,6 +133,20 @@ QUrl expandScriptUrl(const QUrl& rawScriptURL) {
 
 QObject* scriptsModel();
 
+bool NativeScriptInitializers::registerNativeScriptInitializer(NativeScriptInitializer initializer) {
+    return registerScriptInitializer([=](ScriptEnginePointer engine) {
+        initializer(qobject_cast<QScriptEngine*>(engine.data()));
+    });
+}
+
+bool NativeScriptInitializers::registerScriptInitializer(ScriptInitializer initializer) {
+    if (auto scriptEngines = DependencyManager::get<ScriptEngines>().data()) {
+        scriptEngines->registerScriptInitializer(initializer);
+        return true;
+    }
+    return false;
+}
+
 void ScriptEngines::registerScriptInitializer(ScriptInitializer initializer) {
     _scriptInitializers.push_back(initializer);
 }

--- a/libraries/script-engine/src/ScriptEngines.h
+++ b/libraries/script-engine/src/ScriptEngines.h
@@ -19,12 +19,19 @@
 
 #include <SettingHandle.h>
 #include <DependencyManager.h>
+#include <shared/ScriptInitializerMixin.h>
 
 #include "ScriptEngine.h"
 #include "ScriptsModel.h"
 #include "ScriptsModelFilter.h"
 
 class ScriptEngine;
+
+class NativeScriptInitializers : public ScriptInitializerMixin {
+public:
+    bool registerNativeScriptInitializer(NativeScriptInitializer initializer) override;
+    bool registerScriptInitializer(ScriptInitializer initializer) override;
+};
 
 class ScriptEngines : public QObject, public Dependency {
     Q_OBJECT
@@ -34,7 +41,7 @@ class ScriptEngines : public QObject, public Dependency {
     Q_PROPERTY(QString debugScriptUrl READ getDebugScriptUrl WRITE setDebugScriptUrl)
 
 public:
-    using ScriptInitializer = std::function<void(ScriptEnginePointer)>;
+    using ScriptInitializer = ScriptInitializerMixin::ScriptInitializer;
 
     ScriptEngines(ScriptEngine::Context context);
     void registerScriptInitializer(ScriptInitializer initializer);

--- a/libraries/shared/src/shared/ScriptInitializerMixin.h
+++ b/libraries/shared/src/shared/ScriptInitializerMixin.h
@@ -1,0 +1,38 @@
+//
+//  ScriptInitializerMixin.h
+//  libraries/shared/src/shared
+//
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+
+#pragma once
+
+#include <functional>
+#include <QSharedPointer>
+#include "../DependencyManager.h"
+
+class QScriptEngine;
+class ScriptEngine;
+
+class ScriptInitializerMixin : public QObject, public Dependency {
+    Q_OBJECT
+public:
+    // Lightweight `QScriptEngine*` initializer (only depends on built-in Qt components)
+    // example registration:
+    // eg: [&](QScriptEngine* engine) -> bool {
+    //     engine->globalObject().setProperties("API", engine->newQObject(...instance...))
+    //     return true;
+    // }
+    using NativeScriptInitializer = std::function<void(QScriptEngine*)>;
+    virtual bool registerNativeScriptInitializer(NativeScriptInitializer initializer) = 0;
+
+    // Heavyweight `ScriptEngine*` initializer (tightly coupled to Interface and script-engine library internals)
+    // eg: [&](ScriptEnginePointer scriptEngine) -> bool {
+    //     engine->registerGlobalObject("API", ...instance..);
+    //     return true;
+    // }
+    using ScriptEnginePointer = QSharedPointer<ScriptEngine>;
+    using ScriptInitializer = std::function<void(ScriptEnginePointer)>;
+    virtual bool registerScriptInitializer(ScriptInitializer initializer) { return false; };
+};


### PR DESCRIPTION
This PR includes plumbing for a header-only script initializer approach which enables plugin DLLs to provide new JS APIs (eg: Leopoly, Limitless, etc.).

This is meant to be a short term workaround until a more formal module/API registration system emerges in conjunction with the engine team.

The only dependencies right now are `libraries/shared`, `libraries/plugin` and `QScriptEngine` -- so that plugins using this approach remain relatively-decoupled from other application internals.

#### Testing
No impact on existing application functionality is expected (general smoke test sufficient). 
