### PR TITLE
[Case 4315]  Edit menu color picker OK button is hard to use in HMD

### DIFF
--- a/scripts/system/html/css/colpick.css
+++ b/scripts/system/html/css/colpick.css
@@ -26,6 +26,7 @@ colpick Color Picker / colpick.com
 /*Color selection box with gradients*/
 .colpick_color {
 	position: absolute;
+	touch-action: none;
 	left: 7px;
 	top: 7px;
 	width: 156px;
@@ -84,6 +85,7 @@ colpick Color Picker / colpick.com
 /*Vertical hue bar*/
 .colpick_hue {
 	position: absolute;
+	touch-action: none;
 	top: 6px;
 	left: 175px;
 	width: 19px;
@@ -94,6 +96,7 @@ colpick Color Picker / colpick.com
 /*Hue bar sliding indicator*/
 .colpick_hue_arrs {
 	position: absolute;
+	touch-action: none;
 	left: -8px;
 	width: 35px;
 	height: 7px;
@@ -101,6 +104,7 @@ colpick Color Picker / colpick.com
 }
 .colpick_hue_larr {
 	position:absolute;
+	touch-action: none;
 	width: 0; 
 	height: 0; 
 	border-top: 6px solid transparent;
@@ -109,6 +113,7 @@ colpick Color Picker / colpick.com
 }
 .colpick_hue_rarr {
 	position:absolute;
+	touch-action: none;
 	right:0;
 	width: 0; 
 	height: 0; 
@@ -119,6 +124,7 @@ colpick Color Picker / colpick.com
 /*New color box*/
 .colpick_new_color {
 	position: absolute;
+	touch-action: none;
 	left: 207px;
 	top: 6px;
 	width: 60px;
@@ -129,6 +135,7 @@ colpick Color Picker / colpick.com
 /*Current color box*/
 .colpick_current_color {
 	position: absolute;
+	touch-action: none;
 	left: 277px;
 	top: 6px;
 	width: 60px;
@@ -139,6 +146,7 @@ colpick Color Picker / colpick.com
 /*Input field containers*/
 .colpick_field, .colpick_hex_field  {
 	position: absolute;
+	touch-action: none;
 	height: 20px;
 	width: 60px;
 	overflow:hidden;
@@ -198,6 +206,7 @@ colpick Color Picker / colpick.com
 /*Text inputs*/
 .colpick_field input, .colpick_hex_field input {
 	position: absolute;
+	touch-action: none;
 	right: 11px;
 	margin: 0;
 	padding: 0;
@@ -217,6 +226,7 @@ colpick Color Picker / colpick.com
 /*Field up/down arrows*/
 .colpick_field_arrs {
 	position: absolute;
+	touch-action: none;
 	top: 0;
 	right: 0;
 	width: 9px;
@@ -225,6 +235,7 @@ colpick Color Picker / colpick.com
 }
 .colpick_field_uarr {
 	position: absolute;
+	touch-action: none;
 	top: 5px;
 	width: 0; 
 	height: 0; 
@@ -234,6 +245,7 @@ colpick Color Picker / colpick.com
 }
 .colpick_field_darr {
 	position: absolute;
+	touch-action: none;
 	bottom:5px;
 	width: 0; 
 	height: 0; 
@@ -244,6 +256,7 @@ colpick Color Picker / colpick.com
 /*Submit/Select button*/
 .colpick_submit {
 	position: absolute;
+	touch-action: none;
 	left: 207px;
 	top: 149px;
 	width: 130px;

--- a/scripts/system/html/css/colpick.css
+++ b/scripts/system/html/css/colpick.css
@@ -311,7 +311,7 @@ colpick Color Picker / colpick.com
 	display:none;
 }
 .colpick_rgbhex_ns .colpick_new_color{
-	width:68px;
+	width:34;
 	border: 1px solid #8f8f8f;
 }
 .colpick_rgbhex_ns .colpick_rgb_r {

--- a/scripts/system/html/css/colpick.css
+++ b/scripts/system/html/css/colpick.css
@@ -266,7 +266,7 @@ colpick Color Picker / colpick.com
 }
 
 /*full layout with no submit button*/
-.colpick_full_ns  .colpick_submit, .colpick_full_ns .colpick_current_color{
+.colpick_full_ns  .colpick_submit {
 	display:none;
 }
 .colpick_full_ns .colpick_new_color {
@@ -307,7 +307,7 @@ colpick Color Picker / colpick.com
 }
 
 /*rgbhex layout, no submit button*/
-.colpick_rgbhex_ns  .colpick_submit, .colpick_rgbhex_ns .colpick_current_color{
+.colpick_rgbhex_ns  .colpick_submit {
 	display:none;
 }
 .colpick_rgbhex_ns .colpick_new_color{
@@ -366,7 +366,7 @@ colpick Color Picker / colpick.com
 }
 
 /*hex layout, no submit button*/
-.colpick_hex_ns  .colpick_submit, .colpick_hex_ns .colpick_current_color {
+.colpick_hex_ns  .colpick_submit {
 	display:none;
 }
 .colpick_hex_ns .colpick_hex_field {

--- a/scripts/system/html/css/edit-style.css
+++ b/scripts/system/html/css/edit-style.css
@@ -800,13 +800,19 @@ div.refresh input[type="button"] {
     display: none !important;
 }
 
-#property-color-control1 {
+.base-color-fieldset, #property-color-control1 {
     display: table-cell;
     float: none;
 }
 
-#property-color-control1 + label  {
+#base-color-section + label  {
     border-left: 20px transparent solid;
+}
+
+.base-color-fieldset legend {
+    display: table-cell;
+    vertical-align: top;
+    margin-bottom: 4px;
 }
 
 .rgb label {
@@ -1490,7 +1496,7 @@ input#reset-to-natural-dimensions {
 }
 
 /* items to hide    */
-#properties-list.ParticleEffectMenu #base-color-section,
+#properties-list.ParticleEffectMenu .base-color-fieldset,
 #properties-list.ParticleEffectMenu #hyperlink,
 #properties-list.ParticleEffectMenu #light,
 #properties-list.ParticleEffectMenu #model,
@@ -1532,7 +1538,7 @@ input#reset-to-natural-dimensions {
 }
 /* items to hide */
 #properties-list.LightMenu #shape-list,
-#properties-list.LightMenu #base-color-section {
+#properties-list.LightMenu .base-color-fieldset {
     display: none
 }
 
@@ -1568,7 +1574,7 @@ input#reset-to-natural-dimensions {
 }
 /* items to hide */
 #properties-list.ModelMenu #shape-list,
-#properties-list.ModelMenu #base-color-section {
+#properties-list.ModelMenu .base-color-fieldset {
     display: none
 }
 
@@ -1604,7 +1610,7 @@ input#reset-to-natural-dimensions {
 }
 /* items to hide */
 #properties-list.ZoneMenu #shape-list,
-#properties-list.ZoneMenu #base-color-section {
+#properties-list.ZoneMenu .base-color-fieldset {
     display: none
 }
 
@@ -1640,7 +1646,7 @@ input#reset-to-natural-dimensions {
 }
 /* items to hide */
 #properties-list.WebMenu #shape-list,
-#properties-list.WebMenu #base-color-section {
+#properties-list.WebMenu .base-color-fieldset {
     display: none;
 }
 
@@ -1677,7 +1683,7 @@ input#reset-to-natural-dimensions {
 }
 /* items to hide */
 #properties-list.TextMenu #shape-list,
-#properties-list.TextMenu #base-color-section {
+#properties-list.TextMenu .base-color-fieldset {
     display: none
 }
 

--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -66,15 +66,12 @@
                 <label for="property-name">Name</label>
                 <input type="text" id="property-name">
             </div>
-            <div class="physical-group color-section property rgb fstuple" id="base-color-section">
-                <div class="color-picker" id="property-color-control2"></div>
-                <label>Entity color</label>
-                <div class="tuple">
-                    <div><input type="number" class="red" id="property-color-red"><label for="property-color-red">Red:</label></div>
-                    <div><input type="number" class="green" id="property-color-green"><label for="property-color-green">Green:</label></div>
-                    <div><input type="number" class="blue" id="property-color-blue"><label for="property-color-blue">Blue:</label></div>
+            <fieldset class="physical-group base-color-fieldset property fstuple">
+                <legend>Entity color</legend>
+                <div class="physical-group color-section" id="base-color-section">
+                    <div class="color-picker" id="property-color-control1"></div>
                 </div>
-            </div>
+            </fieldset>
         </fieldset>
 
         <fieldset id="collision-info" class="major">

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -124,28 +124,22 @@ For usage and examples: colpick.com/plugin
             },
             // Change style on blur and on focus of inputs
             blur = function (ev) {
-                console.log( "ColorPicker::blur" );
                 $(this).parent().removeClass('colpick_focus');
             },
             focus = function () {
-                console.log( "ColorPicker::focus" );
                 $(this).parent().parent().data('colpick').fields.parent().removeClass('colpick_focus');
                 $(this).parent().addClass('colpick_focus');
             },
             // Increment/decrement arrows functions
             downIncrement = function (ev) {
-                console.log( "ColorPicker::downIncrement" );
                 if (ev.preventDefault) {
-                    console.log( "ColorPicker::downIncrement -- preventDefault triggered" );
                     ev.preventDefault();
                 } else { 
-                    console.log( "ColorPicker::downIncrement -- ev.returnValue -> false" );
                     ev.returnValue = false;
                 }
                 var field = $(this).parent().parent().find('input');
                 var oldValue = parseInt(field.val(), 10);
                 field.val(Math.max(oldValue - 1, 0).toString());
-                console.log( "ColorPicker::downIncrement -- fieldValue: " + field.val() + " oldValue: " + oldValue );
                 var current = {
                     el: $(this).parent().parent().addClass('colpick_slider'),
                     y: ev.pageY,
@@ -158,7 +152,6 @@ For usage and examples: colpick.com/plugin
                 $(document).mousemove(current, moveIncrement);
             },
             moveIncrement = function (ev) {
-                console.log( "ColorPicker::moveIncrement" );
                 ev.data.field.val(Math.max(0, Math.min(ev.data.max, parseInt(ev.data.val - ev.pageY + ev.data.y, 10))));
                 if (ev.data.preview) {
                     change.apply(ev.data.field.get(0), [true]);
@@ -166,12 +159,9 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             upIncrement = function (ev) {
-                console.log( "ColorPicker::upIncrement" );
                 if (ev.preventDefault) {
-                    console.log( "ColorPicker::upIncrement -- preventDefault triggered" );
                     ev.preventDefault();
                 } else { 
-                    console.log( "ColorPicker::upIncrement -- ev.returnValue -> false" );
                     ev.returnValue = false;
                 }
                 var field = $(this).parent().parent().find('input');
@@ -179,7 +169,6 @@ For usage and examples: colpick.com/plugin
                     (this.parentNode.parentNode.className.indexOf('_hsb') > 0 ? 100 : 255);
                 var oldValue = parseInt(field.val(), 10);
                 field.val(Math.min(oldValue + 1, maxValueAllowed).toString());
-                console.log( "ColorPicker::upIncrement -- fieldValue: " + field.val() + " oldValue: " + oldValue + " maxAllowed: " + maxValueAllowed );
                 var current = {
                     el: $(this).parent().parent().addClass('colpick_slider'),
                     max: maxValueAllowed,
@@ -194,18 +183,15 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             releaseIncrement = function (ev) {
-                console.log( "ColorPicker::releaseIncrement" );
-                console.log( "ColorPicker::releaseIncrement -- fieldValue: " + ev.data.field.val() + " field.get(0): " + ev.data.field.get(0) );
                 
                 change.apply(ev.data.field.get(0), [true]);
-                ev.data.el.removeClass('colpick_slider').find('input');//.focus();
+                ev.data.el.removeClass('colpick_slider').find('input');
 
                 $(document).off('mouseup', releaseIncrement);
                 $(document).off('mousemove', moveIncrement);
             },
             // Hue slider functions
             downHue = function (ev) {
-                console.log( "ColorPicker::downHue" );
                 if (ev.preventDefault) {
                     ev.preventDefault();
                 } else { 
@@ -227,7 +213,6 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             moveHue = function (ev) {
-                console.log( "ColorPicker::moveHue" );
                 var pageY = ((ev.type === 'touchmove') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
                     ev.data.cal.data('colpick').fields.eq(4).val(parseInt(360*(ev.data.cal.data('colpick').height - 
@@ -239,7 +224,6 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             upHue = function (ev) {
-                console.log( "ColorPicker::upHue" );
                 fillRGBFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 fillHexFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 $(document).off('mouseup touchend',upHue);
@@ -248,7 +232,6 @@ For usage and examples: colpick.com/plugin
             },
             // Color selector functions
             downSelector = function (ev) {
-                console.log( "ColorPicker::downSelector" );
                 if (ev.preventDefault) {
                     ev.preventDefault();
                 } else { 
@@ -281,7 +264,6 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             moveSelector = function (ev) {
-                console.log( "ColorPicker::moveSelector" );
                 var pageX,pageY;
                 if (ev.type === 'touchmove') {
                     pageX = ev.originalEvent.changedTouches[0].pageX;
@@ -303,7 +285,6 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             upSelector = function (ev) {
-                console.log( "ColorPicker::upSelector" );
                 fillRGBFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 fillHexFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 $(document).off('mouseup touchend',upSelector);
@@ -320,7 +301,6 @@ For usage and examples: colpick.com/plugin
             },
             // Show/hide the color picker
             show = function (ev) {
-                console.log( "ColorPicker::show" );
                 // Prevent the trigger of any direct parent
                 ev.stopPropagation();
                 var cal = $('#' + $(this).data('colpickId'));
@@ -344,7 +324,6 @@ For usage and examples: colpick.com/plugin
                 });
             },
             hide = function (ev) {
-                console.log( "ColorPicker::hide" );
                 if (ev.data.cal.data('colpick').onHide.apply(this, [ev.data.cal.get(0)]) !== false) {
                     ev.data.cal.hide();
                 }

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -302,6 +302,8 @@ For usage and examples: colpick.com/plugin
                 setSelector(col, cal.get(0));
                 setHue(col, cal.get(0));
                 setNewColor(col, cal.get(0));
+                // If the user triggered this behavior, then any prior color change should be negated.
+                cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el, 0]);
             };
         return {
             init: function (opt) {

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -6,7 +6,7 @@ under the MIT and GPL licenses
 For usage and examples: colpick.com/plugin
  */
 
-/* global document, Element, EventBridge, jQuery, navigator, window, _ $ */
+/* global console, document, Element, EventBridge, jQuery, navigator, window, _ $ */
 
 (function ($) {
     var colpick = function () {
@@ -124,33 +124,41 @@ For usage and examples: colpick.com/plugin
             },
             // Change style on blur and on focus of inputs
             blur = function (ev) {
+                console.log( "ColorPicker::blur" );
                 $(this).parent().removeClass('colpick_focus');
             },
             focus = function () {
+                console.log( "ColorPicker::focus" );
                 $(this).parent().parent().data('colpick').fields.parent().removeClass('colpick_focus');
                 $(this).parent().addClass('colpick_focus');
             },
             // Increment/decrement arrows functions
             downIncrement = function (ev) {
-                if (ev.preventDefault !== null ) {
+                console.log( "ColorPicker::downIncrement" );
+                if (ev.preventDefault) {
+                    console.log( "ColorPicker::downIncrement -- preventDefault triggered" );
                     ev.preventDefault();
                 } else { 
+                    console.log( "ColorPicker::downIncrement -- ev.returnValue -> false" );
                     ev.returnValue = false;
                 }
-                var field = $(this).parent().find('input').focus();
+                var field = $(this).parent().parent().find('input');
+                var oldValue = parseInt(field.val(), 10);
+                field.val(Math.max(oldValue - 1, 0).toString());
+                console.log( "ColorPicker::downIncrement -- fieldValue: " + field.val() + " oldValue: " + oldValue );
                 var current = {
-                    el: $(this).parent().addClass('colpick_slider'),
-                    max: this.parentNode.className.indexOf('_hsb_h') > 0 ? 360 : 
-                        (this.parentNode.className.indexOf('_hsb') > 0 ? 100 : 255),
+                    el: $(this).parent().parent().addClass('colpick_slider'),
                     y: ev.pageY,
                     field: field,
                     val: parseInt(field.val(), 10),
-                    preview: $(this).parent().parent().data('colpick').livePreview
+                    previousVal: oldValue,
+                    preview: $(this).parent().parent().parent().data('colpick').livePreview
                 };
-                $(document).mouseup(current, upIncrement);
+                $(document).mouseup(current, releaseIncrement);
                 $(document).mousemove(current, moveIncrement);
             },
             moveIncrement = function (ev) {
+                console.log( "ColorPicker::moveIncrement" );
                 ev.data.field.val(Math.max(0, Math.min(ev.data.max, parseInt(ev.data.val - ev.pageY + ev.data.y, 10))));
                 if (ev.data.preview) {
                     change.apply(ev.data.field.get(0), [true]);
@@ -158,15 +166,47 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             upIncrement = function (ev) {
-                change.apply(ev.data.field.get(0), [true]);
-                ev.data.el.removeClass('colpick_slider').find('input').focus();
-                $(document).off('mouseup', upIncrement);
-                $(document).off('mousemove', moveIncrement);
+                console.log( "ColorPicker::upIncrement" );
+                if (ev.preventDefault) {
+                    console.log( "ColorPicker::upIncrement -- preventDefault triggered" );
+                    ev.preventDefault();
+                } else { 
+                    console.log( "ColorPicker::upIncrement -- ev.returnValue -> false" );
+                    ev.returnValue = false;
+                }
+                var field = $(this).parent().parent().find('input');
+                var maxValueAllowed = this.parentNode.parentNode.className.indexOf('_hsb_h') > 0 ? 360 : 
+                    (this.parentNode.parentNode.className.indexOf('_hsb') > 0 ? 100 : 255);
+                var oldValue = parseInt(field.val(), 10);
+                field.val(Math.min(oldValue + 1, maxValueAllowed).toString());
+                console.log( "ColorPicker::upIncrement -- fieldValue: " + field.val() + " oldValue: " + oldValue + " maxAllowed: " + maxValueAllowed );
+                var current = {
+                    el: $(this).parent().parent().addClass('colpick_slider'),
+                    max: maxValueAllowed,
+                    y: ev.pageY,
+                    field: field,
+                    val: parseInt(field.val(), 10),
+                    previousVal: oldValue,
+                    preview: $(this).parent().parent().parent().data('colpick').livePreview
+                };
+                $(document).mouseup(current, releaseIncrement);
+                $(document).mousemove(current, moveIncrement);
                 return false;
+            },
+            releaseIncrement = function (ev) {
+                console.log( "ColorPicker::releaseIncrement" );
+                console.log( "ColorPicker::releaseIncrement -- fieldValue: " + ev.data.field.val() + " field.get(0): " + ev.data.field.get(0) );
+                
+                change.apply(ev.data.field.get(0), [true]);
+                ev.data.el.removeClass('colpick_slider').find('input');//.focus();
+
+                $(document).off('mouseup', releaseIncrement);
+                $(document).off('mousemove', moveIncrement);
             },
             // Hue slider functions
             downHue = function (ev) {
-                if (ev.preventDefault !== null ) {
+                console.log( "ColorPicker::downHue" );
+                if (ev.preventDefault) {
                     ev.preventDefault();
                 } else { 
                     ev.returnValue = false;
@@ -187,6 +227,7 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             moveHue = function (ev) {
+                console.log( "ColorPicker::moveHue" );
                 var pageY = ((ev.type === 'touchmove') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
                     ev.data.cal.data('colpick').fields.eq(4).val(parseInt(360*(ev.data.cal.data('colpick').height - 
@@ -198,6 +239,7 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             upHue = function (ev) {
+                console.log( "ColorPicker::upHue" );
                 fillRGBFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 fillHexFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 $(document).off('mouseup touchend',upHue);
@@ -206,7 +248,8 @@ For usage and examples: colpick.com/plugin
             },
             // Color selector functions
             downSelector = function (ev) {
-                if (ev.preventDefault !== null ) {
+                console.log( "ColorPicker::downSelector" );
+                if (ev.preventDefault) {
                     ev.preventDefault();
                 } else { 
                     ev.returnValue = false;
@@ -238,6 +281,7 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             moveSelector = function (ev) {
+                console.log( "ColorPicker::moveSelector" );
                 var pageX,pageY;
                 if (ev.type === 'touchmove') {
                     pageX = ev.originalEvent.changedTouches[0].pageX;
@@ -259,6 +303,7 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             upSelector = function (ev) {
+                console.log( "ColorPicker::upSelector" );
                 fillRGBFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 fillHexFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 $(document).off('mouseup touchend',upSelector);
@@ -275,6 +320,7 @@ For usage and examples: colpick.com/plugin
             },
             // Show/hide the color picker
             show = function (ev) {
+                console.log( "ColorPicker::show" );
                 // Prevent the trigger of any direct parent
                 ev.stopPropagation();
                 var cal = $('#' + $(this).data('colpickId'));
@@ -298,6 +344,7 @@ For usage and examples: colpick.com/plugin
                 });
             },
             hide = function (ev) {
+                console.log( "ColorPicker::hide" );
                 if (ev.data.cal.data('colpick').onHide.apply(this, [ev.data.cal.get(0)]) !== false) {
                     ev.data.cal.hide();
                 }
@@ -386,8 +433,9 @@ For usage and examples: colpick.com/plugin
                         cal.find('div.colpick_submit').html(options.submitText).click(clickSubmit);
                         // Setup input fields
                         options.fields = cal.find('input').change(change).blur(blur).focus(focus);
-                        cal.find('div.colpick_field_arrs').mousedown(downIncrement).end().
-                            find('div.colpick_current_color').click(restoreOriginal);
+                        cal.find('div.colpick_field_uarr').mousedown(upIncrement);
+                        cal.find('div.colpick_field_darr').mousedown(downIncrement);
+                        cal.find('div.colpick_current_color').click(restoreOriginal);
                         // Setup hue selector
                         options.selector = cal.find('div.colpick_color').on('mousedown touchstart',downSelector);
                         options.selectorIndic = options.selector.find('div.colpick_selector_outer');

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -1,18 +1,45 @@
 /*
 colpick Color Picker
-Copyright 2013 Jose Vargas. Licensed under GPL license. Based on Stefan Petre's Color Picker www.eyecon.ro, dual licensed under the MIT and GPL licenses
+Copyright 2013 Jose Vargas. Licensed under GPL license. Based on Stefan Petre's Color Picker www.eyecon.ro, dual licensed 
+under the MIT and GPL licenses
 
 For usage and examples: colpick.com/plugin
  */
 
+/* global document, Element, EventBridge, jQuery, navigator, window, _ $ */
+
 (function ($) {
     var colpick = function () {
         var
-            tpl = '<div class="colpick"><div class="colpick_color"><div class="colpick_color_overlay1"><div class="colpick_color_overlay2"><div class="colpick_selector_outer"><div class="colpick_selector_inner"></div></div></div></div></div><div class="colpick_hue"><div class="colpick_hue_arrs"><div class="colpick_hue_larr"></div><div class="colpick_hue_rarr"></div></div></div><div class="colpick_new_color"></div><div class="colpick_current_color"></div><div class="colpick_hex_field"><div class="colpick_field_letter">#</div><input type="text" maxlength="6" size="6" /></div><div class="colpick_rgb_r colpick_field"><div class="colpick_field_letter">R</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_rgb_g colpick_field"><div class="colpick_field_letter">G</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_rgb_b colpick_field"><div class="colpick_field_letter">B</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_hsb_h colpick_field"><div class="colpick_field_letter">H</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_hsb_s colpick_field"><div class="colpick_field_letter">S</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_hsb_b colpick_field"><div class="colpick_field_letter">B</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_submit"></div></div>',
+            tpl = '<div class="colpick"><div class="colpick_color"><div class="colpick_color_overlay1">' +
+                '<div class="colpick_color_overlay2"><div class="colpick_selector_outer"><div class="colpick_selector_inner">' +
+                '</div></div></div></div></div><div class="colpick_hue"><div class="colpick_hue_arrs">' + 
+                '<div class="colpick_hue_larr"></div><div class="colpick_hue_rarr"></div></div></div>' + 
+                '<div class="colpick_new_color"></div><div class="colpick_current_color"></div>' + 
+                '<div class="colpick_hex_field"><div class="colpick_field_letter">#</div>' + 
+                '<input type="text" maxlength="6" size="6" /></div><div class="colpick_rgb_r colpick_field">' + 
+                '<div class="colpick_field_letter">R</div><input type="text" maxlength="3" size="3" />' + 
+                '<div class="colpick_field_arrs"><div class="colpick_field_uarr"></div>' + 
+                '<div class="colpick_field_darr"></div></div></div><div class="colpick_rgb_g colpick_field">' + 
+                '<div class="colpick_field_letter">G</div><input type="text" maxlength="3" size="3" />' + 
+                '<div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div>' +
+                '</div></div><div class="colpick_rgb_b colpick_field"><div class="colpick_field_letter">B</div>' + 
+                '<input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs">' + 
+                '<div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div>' + 
+                '<div class="colpick_hsb_h colpick_field"><div class="colpick_field_letter">H</div>' + 
+                '<input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs">' + 
+                '<div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div>' + 
+                '<div class="colpick_hsb_s colpick_field"><div class="colpick_field_letter">S</div>' + 
+                '<input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs">' + 
+                '<div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div>' + 
+                '<div class="colpick_hsb_b colpick_field"><div class="colpick_field_letter">B</div>' +
+                '<input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs">' + 
+                '<div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div>' + 
+                '<div class="colpick_submit"></div></div>',
             defaults = {
                 showEvent: 'click',
                 onShow: function () {},
-                onBeforeShow: function(){},
+                onBeforeShow: function (){},
                 onHide: function () {},
                 onChange: function () {},
                 onSubmit: function () {},
@@ -25,15 +52,15 @@ For usage and examples: colpick.com/plugin
                 submitText: 'OK',
                 height: 156
             },
-            //Fill the inputs of the plugin
-            fillRGBFields = function  (hsb, cal) {
+            // Fill the inputs of the plugin
+            fillRGBFields = function (hsb, cal) {
                 var rgb = hsbToRgb(hsb);
                 $(cal).data('colpick').fields
                     .eq(1).val(rgb.r).end()
                     .eq(2).val(rgb.g).end()
                     .eq(3).val(rgb.b).end();
             },
-            fillHSBFields = function  (hsb, cal) {
+            fillHSBFields = function (hsb, cal) {
                 $(cal).data('colpick').fields
                     .eq(4).val(Math.round(hsb.h)).end()
                     .eq(5).val(Math.round(hsb.s)).end()
@@ -42,7 +69,7 @@ For usage and examples: colpick.com/plugin
             fillHexFields = function (hsb, cal) {
                 $(cal).data('colpick').fields.eq(0).val(hsbToHex(hsb));
             },
-            //Set the round selector position
+            // Set the round selector position
             setSelector = function (hsb, cal) {
                 $(cal).data('colpick').selector.css('backgroundColor', '#' + hsbToHex({h: hsb.h, s: 100, b: 100}));
                 $(cal).data('colpick').selectorIndic.css({
@@ -50,18 +77,19 @@ For usage and examples: colpick.com/plugin
                     top: parseInt($(cal).data('colpick').height * (100-hsb.b)/100, 10)
                 });
             },
-            //Set the hue selector position
+            // Set the hue selector position
             setHue = function (hsb, cal) {
-                $(cal).data('colpick').hue.css('top', parseInt($(cal).data('colpick').height - $(cal).data('colpick').height * hsb.h/360, 10));
+                $(cal).data('colpick').hue.css('top', parseInt($(cal).data('colpick').height - 
+                    $(cal).data('colpick').height * hsb.h/360, 10));
             },
-            //Set current and new colors
+            // Set current and new colors
             setCurrentColor = function (hsb, cal) {
                 $(cal).data('colpick').currentColor.css('backgroundColor', '#' + hsbToHex(hsb));
             },
             setNewColor = function (hsb, cal) {
                 $(cal).data('colpick').newColor.css('backgroundColor', '#' + hsbToHex(hsb));
             },
-            //Called when the new color is changed
+            // Called when the new color is changed
             change = function (ev) {
                 var cal = $(this).parent().parent(), col;
                 if (this.parentNode.className.indexOf('_hex') > 0) {
@@ -91,9 +119,10 @@ For usage and examples: colpick.com/plugin
                 setSelector(col, cal.get(0));
                 setHue(col, cal.get(0));
                 setNewColor(col, cal.get(0));
-                cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el, 0]);
+                cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), 
+                    hsbToRgb(col), cal.data('colpick').el, 0]);
             },
-            //Change style on blur and on focus of inputs
+            // Change style on blur and on focus of inputs
             blur = function (ev) {
                 $(this).parent().removeClass('colpick_focus');
             },
@@ -101,13 +130,18 @@ For usage and examples: colpick.com/plugin
                 $(this).parent().parent().data('colpick').fields.parent().removeClass('colpick_focus');
                 $(this).parent().addClass('colpick_focus');
             },
-            //Increment/decrement arrows functions
+            // Increment/decrement arrows functions
             downIncrement = function (ev) {
-                ev.preventDefault ? ev.preventDefault() : ev.returnValue = false;
+                if (ev.preventDefault !== null ) {
+                    ev.preventDefault();
+                } else { 
+                    ev.returnValue = false;
+                }
                 var field = $(this).parent().find('input').focus();
                 var current = {
                     el: $(this).parent().addClass('colpick_slider'),
-                    max: this.parentNode.className.indexOf('_hsb_h') > 0 ? 360 : (this.parentNode.className.indexOf('_hsb') > 0 ? 100 : 255),
+                    max: this.parentNode.className.indexOf('_hsb_h') > 0 ? 360 : 
+                        (this.parentNode.className.indexOf('_hsb') > 0 ? 100 : 255),
                     y: ev.pageY,
                     field: field,
                     val: parseInt(field.val(), 10),
@@ -130,9 +164,13 @@ For usage and examples: colpick.com/plugin
                 $(document).off('mousemove', moveIncrement);
                 return false;
             },
-            //Hue slider functions
+            // Hue slider functions
             downHue = function (ev) {
-                ev.preventDefault ? ev.preventDefault() : ev.returnValue = false;
+                if (ev.preventDefault !== null ) {
+                    ev.preventDefault();
+                } else { 
+                    ev.returnValue = false;
+                }
                 var current = {
                     cal: $(this).parent(),
                     y: $(this).offset().top
@@ -140,20 +178,20 @@ For usage and examples: colpick.com/plugin
                 $(document).on('mouseup touchend',current,upHue);
                 $(document).on('mousemove touchmove',current,moveHue);
                 
-                var pageY = ((ev.type == 'touchstart') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
+                var pageY = ((ev.type === 'touchstart') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
-                    current.cal.data('colpick')
-                    .fields.eq(4).val(parseInt(360*(current.cal.data('colpick').height - (pageY - current.y))/current.cal.data('colpick').height, 10))
-                        .get(0),
+                    current.cal.data('colpick').fields.eq(4).val(parseInt(360*(current.cal.data('colpick').height - 
+                        (pageY - current.y))/current.cal.data('colpick').height, 10)).get(0),
                     [current.cal.data('colpick').livePreview]
                 );
                 return false;
             },
             moveHue = function (ev) {
-                var pageY = ((ev.type == 'touchmove') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
+                var pageY = ((ev.type === 'touchmove') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
-                    ev.data.cal.data('colpick')
-                    .fields.eq(4).val(parseInt(360*(ev.data.cal.data('colpick').height - Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageY - ev.data.y))))/ev.data.cal.data('colpick').height, 10))
+                    ev.data.cal.data('colpick').fields.eq(4).val(parseInt(360*(ev.data.cal.data('colpick').height - 
+                        Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageY - ev.data.y)))) / 
+                            ev.data.cal.data('colpick').height, 10))
                         .get(0),
                     [ev.data.preview]
                 );
@@ -166,9 +204,13 @@ For usage and examples: colpick.com/plugin
                 $(document).off('mousemove touchmove',moveHue);
                 return false;
             },
-            //Color selector functions
+            // Color selector functions
             downSelector = function (ev) {
-                ev.preventDefault ? ev.preventDefault() : ev.returnValue = false;
+                if (ev.preventDefault !== null ) {
+                    ev.preventDefault();
+                } else { 
+                    ev.returnValue = false;
+                }
                 var current = {
                     cal: $(this).parent(),
                     pos: $(this).offset()
@@ -178,9 +220,9 @@ For usage and examples: colpick.com/plugin
                 $(document).on('mouseup touchend',current,upSelector);
                 $(document).on('mousemove touchmove',current,moveSelector);
 
-                var payeX,pageY;
-                if(ev.type == 'touchstart') {
-                    pageX = ev.originalEvent.changedTouches[0].pageX,
+                var pageX,pageY;
+                if (ev.type === 'touchstart') {
+                    pageX = ev.originalEvent.changedTouches[0].pageX;
                     pageY = ev.originalEvent.changedTouches[0].pageY;
                 } else {
                     pageX = ev.pageX;
@@ -188,18 +230,17 @@ For usage and examples: colpick.com/plugin
                 }
 
                 change.apply(
-                    current.cal.data('colpick').fields
-                    .eq(6).val(parseInt(100*(current.cal.data('colpick').height - (pageY - current.pos.top))/current.cal.data('colpick').height, 10)).end()
-                    .eq(5).val(parseInt(100*(pageX - current.pos.left)/current.cal.data('colpick').height, 10))
-                    .get(0),
+                    current.cal.data('colpick').fields.eq(6).val(parseInt(100*(current.cal.data('colpick').height - 
+                        (pageY - current.pos.top)) / current.cal.data('colpick').height, 10)).end().eq(5).
+                        val(parseInt(100*(pageX - current.pos.left)/current.cal.data('colpick').height, 10)).get(0),
                     [current.preview]
                 );
                 return false;
             },
             moveSelector = function (ev) {
-                var payeX,pageY;
-                if(ev.type == 'touchmove') {
-                    pageX = ev.originalEvent.changedTouches[0].pageX,
+                var pageX,pageY;
+                if (ev.type === 'touchmove') {
+                    pageX = ev.originalEvent.changedTouches[0].pageX;
                     pageY = ev.originalEvent.changedTouches[0].pageY;
                 } else {
                     pageX = ev.pageX;
@@ -207,10 +248,12 @@ For usage and examples: colpick.com/plugin
                 }
 
                 change.apply(
-                    ev.data.cal.data('colpick').fields
-                    .eq(6).val(parseInt(100*(ev.data.cal.data('colpick').height - Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageY - ev.data.pos.top))))/ev.data.cal.data('colpick').height, 10)).end()
-                    .eq(5).val(parseInt(100*(Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageX - ev.data.pos.left))))/ev.data.cal.data('colpick').height, 10))
-                    .get(0),
+                    ev.data.cal.data('colpick').fields.
+                        eq(6).val(parseInt(100*(ev.data.cal.data('colpick').height - 
+                        Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageY - ev.data.pos.top)))) / 
+                        ev.data.cal.data('colpick').height, 10)).end().eq(5).
+                        val(parseInt(100*(Math.max(0,Math.min(ev.data.cal.data('colpick').height,
+                            (pageX - ev.data.pos.left))))/ev.data.cal.data('colpick').height, 10)).get(0),
                     [ev.data.preview]
                 );
                 return false;
@@ -222,7 +265,7 @@ For usage and examples: colpick.com/plugin
                 $(document).off('mousemove touchmove',moveSelector);
                 return false;
             },
-            //Submit button
+            // Submit button
             clickSubmit = function (ev) {
                 var cal = $(this).parent();
                 var col = cal.data('colpick').color;
@@ -230,7 +273,7 @@ For usage and examples: colpick.com/plugin
                 setCurrentColor(col, cal.get(0));
                 cal.data('colpick').onSubmit(col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el);
             },
-            //Show/hide the color picker
+            // Show/hide the color picker
             show = function (ev) {
                 // Prevent the trigger of any direct parent
                 ev.stopPropagation();
@@ -245,27 +288,29 @@ For usage and examples: colpick.com/plugin
                     left -= calW;
                 }
                 cal.css({left: left + 'px', top: top + 'px'});
-                if (cal.data('colpick').onShow.apply(this, [cal.get(0)]) != false) {
+                if (cal.data('colpick').onShow.apply(this, [cal.get(0)]) !== false) {
                     cal.show();
                 }
-                //Hide when user clicks outside
+                // Hide when user clicks outside
                 $('html').mousedown({cal:cal}, hide);
-                cal.mousedown(function(ev){ev.stopPropagation();})
+                cal.mousedown(function(ev) {
+                    ev.stopPropagation();
+                });
             },
             hide = function (ev) {
-                if (ev.data.cal.data('colpick').onHide.apply(this, [ev.data.cal.get(0)]) != false) {
+                if (ev.data.cal.data('colpick').onHide.apply(this, [ev.data.cal.get(0)]) !== false) {
                     ev.data.cal.hide();
                 }
                 $('html').off('mousedown', hide);
             },
             getViewport = function () {
-                var m = document.compatMode == 'CSS1Compat';
+                var m = document.compatMode === 'CSS1Compat';
                 return {
                     l : window.pageXOffset || (m ? document.documentElement.scrollLeft : document.body.scrollLeft),
                     w : window.innerWidth || (m ? document.documentElement.clientWidth : document.body.clientWidth)
                 };
             },
-            //Fix the values if the user enters a negative or high value
+            // Fix the values if the user enters a negative or high value
             fixHSB = function (hsb) {
                 return {
                     h: Math.min(360, Math.max(0, hsb.h)),
@@ -303,71 +348,85 @@ For usage and examples: colpick.com/plugin
                 setHue(col, cal.get(0));
                 setNewColor(col, cal.get(0));
                 // If the user triggered this behavior, then any prior color change should be negated.
-                cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el, 0]);
+                cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), 
+                    hsbToRgb(col), cal.data('colpick').el, 0]);
             };
         return {
             init: function (opt) {
                 opt = $.extend({}, defaults, opt||{});
-                //Set color
-                if (typeof opt.color == 'string') {
+                // Set color
+                if (typeof opt.color === 'string') {
                     opt.color = hexToHsb(opt.color);
-                } else if (opt.color.r != undefined && opt.color.g != undefined && opt.color.b != undefined) {
+                } else if (opt.color.r !== undefined && opt.color.g !== undefined && opt.color.b !== undefined) {
                     opt.color = rgbToHsb(opt.color);
-                } else if (opt.color.h != undefined && opt.color.s != undefined && opt.color.b != undefined) {
+                } else if (opt.color.h !== undefined && opt.color.s !== undefined && opt.color.b !== undefined) {
                     opt.color = fixHSB(opt.color);
                 } else {
                     return this;
                 }
                 
-                //For each selected DOM element
+                // For each selected DOM element
                 return this.each(function () {
-                    //If the element does not have an ID
+                    // If the element does not have an ID
                     if (!$(this).data('colpickId')) {
                         var options = $.extend({}, opt);
                         options.origColor = opt.color;
-                        //Generate and assign a random ID
+                        // enerate and assign a random ID
                         var id = 'collorpicker_' + parseInt(Math.random() * 1000);
                         $(this).data('colpickId', id);
-                        //Set the tpl's ID and get the HTML
+                        // Set the tpl's ID and get the HTML
                         var cal = $(tpl).attr('id', id);
-                        //Add class according to layout
+                        // Add class according to layout
                         cal.addClass('colpick_'+options.layout+(options.submit?'':' colpick_'+options.layout+'_ns'));
-                        //Add class if the color scheme is not default
-                        if(options.colorScheme != 'light') {
+                        // Add class if the color scheme is not default
+                        if (options.colorScheme !== 'light') {
                             cal.addClass('colpick_'+options.colorScheme);
                         }
-                        //Setup submit button
+                        // Setup submit button
                         cal.find('div.colpick_submit').html(options.submitText).click(clickSubmit);
-                        //Setup input fields
+                        // Setup input fields
                         options.fields = cal.find('input').change(change).blur(blur).focus(focus);
-                        cal.find('div.colpick_field_arrs').mousedown(downIncrement).end().find('div.colpick_current_color').click(restoreOriginal);
-                        //Setup hue selector
+                        cal.find('div.colpick_field_arrs').mousedown(downIncrement).end().
+                            find('div.colpick_current_color').click(restoreOriginal);
+                        // Setup hue selector
                         options.selector = cal.find('div.colpick_color').on('mousedown touchstart',downSelector);
                         options.selectorIndic = options.selector.find('div.colpick_selector_outer');
-                        //Store parts of the plugin
+                        // Store parts of the plugin
                         options.el = this;
                         options.hue = cal.find('div.colpick_hue_arrs');
-                        huebar = options.hue.parent();
-                        //Paint the hue bar
+                        options.huebar = options.hue.parent();
+                        // Paint the hue bar
                         var UA = navigator.userAgent.toLowerCase();
                         var isIE = navigator.appName === 'Microsoft Internet Explorer';
-                        var IEver = isIE ? parseFloat( UA.match( /msie ([0-9]{1,}[\.0-9]{0,})/ )[1] ) : 0;
+                        var IEver = isIE ? parseFloat( UA.match( /msie ([0-9]{1,}[.0-9]{0,})/ )[1] ) : 0;
                         var ngIE = ( isIE && IEver < 10 );
-                        var stops = ['#ff0000','#ff0080','#ff00ff','#8000ff','#0000ff','#0080ff','#00ffff','#00ff80','#00ff00','#80ff00','#ffff00','#ff8000','#ff0000'];
-                        if(ngIE) {
+                        var stops = ['#ff0000','#ff0080','#ff00ff','#8000ff','#0000ff','#0080ff','#00ffff','#00ff80','#00ff00',
+                            '#80ff00','#ffff00','#ff8000','#ff0000'];
+                        if (ngIE) {
                             var i, div;
-                            for(i=0; i<=11; i++) {
-                                div = $('<div></div>').attr('style','height:8.333333%; filter:progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='+stops[i]+', endColorstr='+stops[i+1]+'); -ms-filter: "progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='+stops[i]+', endColorstr='+stops[i+1]+')";');
-                                huebar.append(div);
+                            for (i=0; i<=11; i++) {
+                                div = $('<div></div>').attr('style',
+                                    'height:8.333333%; filter:progid:' + 
+                                    'DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='+stops[i]+
+                                    ', endColorstr='+stops[i+1]+
+                                    '); -ms-filter: "progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='+
+                                    stops[i]+', endColorstr='+stops[i+1]+')";');
+                                options.huebar.append(div);
                             }
                         } else {
-                            stopList = stops.join(',');
-                            huebar.attr('style','background:-webkit-linear-gradient(top,'+stopList+'); background: -o-linear-gradient(top,'+stopList+'); background: -ms-linear-gradient(top,'+stopList+'); background:-moz-linear-gradient(top,'+stopList+'); -webkit-linear-gradient(top,'+stopList+'); background:linear-gradient(to bottom,'+stopList+'); ');
+                            options.stopList = stops.join(',');
+                            var stopList = options.stopList;
+                            options.huebar.attr('style','background:-webkit-linear-gradient(top,'+stopList+
+                                '); background: -o-linear-gradient(top,'+stopList+
+                                '); background: -ms-linear-gradient(top,'+stopList+
+                                '); background:-moz-linear-gradient(top,'+stopList+
+                                '); -webkit-linear-gradient(top,'+stopList+
+                                '); background:linear-gradient(to bottom,'+stopList+'); ');
                         }
                         cal.find('div.colpick_hue').on('mousedown touchstart',downHue);
                         options.newColor = cal.find('div.colpick_new_color');
                         options.currentColor = cal.find('div.colpick_current_color');
-                        //Store options and fill with default color
+                        // Store options and fill with default color
                         cal.data('colpick', options);
                         fillRGBFields(options.color, cal.get(0));
                         fillHSBFields(options.color, cal.get(0));
@@ -376,7 +435,7 @@ For usage and examples: colpick.com/plugin
                         setSelector(options.color, cal.get(0));
                         setCurrentColor(options.color, cal.get(0));
                         setNewColor(options.color, cal.get(0));
-                        //Append to body if flat=false, else show in place
+                        // Append to body if flat=false, else show in place
                         if (options.flat) {
                             cal.appendTo(this).show();
                             cal.css({
@@ -393,7 +452,7 @@ For usage and examples: colpick.com/plugin
                     }
                 });
             },
-            //Shows the picker
+            // Shows the picker
             showPicker: function() {
                 return this.each( function () {
                     if ($(this).data('colpickId')) {
@@ -401,7 +460,7 @@ For usage and examples: colpick.com/plugin
                     }
                 });
             },
-            //Hides the picker
+            // Hides the picker
             hidePicker: function() {
                 return this.each( function () {
                     if ($(this).data('colpickId')) {
@@ -409,14 +468,14 @@ For usage and examples: colpick.com/plugin
                     }
                 });
             },
-            //Sets a color as new and current (default)
+            // Sets a color as new and current (default)
             setColor: function(col, setCurrent) {
                 setCurrent = (typeof setCurrent === "undefined") ? 1 : setCurrent;
-                if (typeof col == 'string') {
+                if (typeof col === 'string') {
                     col = hexToHsb(col);
-                } else if (col.r != undefined && col.g != undefined && col.b != undefined) {
+                } else if (col.r !== undefined && col.g !== undefined && col.b !== undefined) {
                     col = rgbToHsb(col);
-                } else if (col.h != undefined && col.s != undefined && col.b != undefined) {
+                } else if (col.h !== undefined && col.s !== undefined && col.b !== undefined) {
                     col = fixHSB(col);
                 } else {
                     return this;
@@ -433,8 +492,9 @@ For usage and examples: colpick.com/plugin
                         setSelector(col, cal.get(0));
                         
                         setNewColor(col, cal.get(0));
-                        cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el, 1]);
-                        if(setCurrent) {
+                        cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), 
+                            hsbToRgb(col), cal.data('colpick').el, 1]);
+                        if (setCurrent) {
                             setCurrentColor(col, cal.get(0));
                         }
                     }
@@ -442,10 +502,10 @@ For usage and examples: colpick.com/plugin
             }
         };
     }();
-    //Color space convertions
+    // Color space convertions
     var hexToRgb = function (hex) {
-        var hex = parseInt(((hex.indexOf('#') > -1) ? hex.substring(1) : hex), 16);
-        return {r: hex >> 16, g: (hex & 0x00FF00) >> 8, b: (hex & 0x0000FF)};
+        var hexValue = parseInt(((hex.indexOf('#') > -1) ? hex.substring(1) : hex), 16);
+        return {r: hexValue >> 16, g: (hexValue & 0x00FF00) >> 8, b: (hexValue & 0x0000FF)};
     };
     var hexToHsb = function (hex) {
         return rgbToHsb(hexToRgb(hex));
@@ -456,14 +516,22 @@ For usage and examples: colpick.com/plugin
         var max = Math.max(rgb.r, rgb.g, rgb.b);
         var delta = max - min;
         hsb.b = max;
-        hsb.s = max != 0 ? 255 * delta / max : 0;
-        if (hsb.s != 0) {
-            if (rgb.r == max) hsb.h = (rgb.g - rgb.b) / delta;
-            else if (rgb.g == max) hsb.h = 2 + (rgb.b - rgb.r) / delta;
-            else hsb.h = 4 + (rgb.r - rgb.g) / delta;
-        } else hsb.h = -1;
+        hsb.s = max !== 0 ? 255 * delta / max : 0;
+        if (hsb.s !== 0) {
+            if (rgb.r === max) {
+                hsb.h = (rgb.g - rgb.b) / delta;
+            } else if (rgb.g === max) {
+                hsb.h = 2 + (rgb.b - rgb.r) / delta;
+            } else {
+                hsb.h = 4 + (rgb.r - rgb.g) / delta;
+            }
+        } else { 
+            hsb.h = -1;
+        }
         hsb.h *= 60;
-        if (hsb.h < 0) hsb.h += 360;
+        if (hsb.h < 0) {
+            hsb.h += 360;
+        }
         hsb.s *= 100/255;
         hsb.b *= 100/255;
         return hsb;
@@ -473,20 +541,37 @@ For usage and examples: colpick.com/plugin
         var h = hsb.h;
         var s = hsb.s*255/100;
         var v = hsb.b*255/100;
-        if(s == 0) {
+        if (s === 0) {
             rgb.r = rgb.g = rgb.b = v;
         } else {
             var t1 = v;
             var t2 = (255-s)*v/255;
             var t3 = (t1-t2)*(h%60)/60;
-            if(h==360) h = 0;
-            if(h<60) {rgb.r=t1;    rgb.b=t2; rgb.g=t2+t3}
-            else if(h<120) {rgb.g=t1; rgb.b=t2;    rgb.r=t1-t3}
-            else if(h<180) {rgb.g=t1; rgb.r=t2;    rgb.b=t2+t3}
-            else if(h<240) {rgb.b=t1; rgb.r=t2;    rgb.g=t1-t3}
-            else if(h<300) {rgb.b=t1; rgb.g=t2;    rgb.r=t2+t3}
-            else if(h<360) {rgb.r=t1; rgb.g=t2;    rgb.b=t1-t3}
-            else {rgb.r=0; rgb.g=0;    rgb.b=0}
+            if (h===360) {
+                h = 0;
+            }
+            if (h<60) { 
+                rgb.r=t1;
+                rgb.b=t2; rgb.g=t2+t3;
+            } else if (h<120) { 
+                rgb.g=t1; rgb.b=t2; 
+                rgb.r=t1-t3;
+            } else if (h<180) {
+                rgb.g=t1; rgb.r=t2;
+                rgb.b=t2+t3;
+            } else if (h<240) {
+                rgb.b=t1; rgb.r=t2;
+                rgb.g=t1-t3;
+            } else if (h<300) {
+                rgb.b=t1; rgb.g=t2;
+                rgb.r=t2+t3;
+            } else if (h<360) {
+                rgb.r=t1; rgb.g=t2;
+                rgb.b=t1-t3;
+            } else {
+                rgb.r=0; rgb.g=0;
+                rgb.b=0;
+            }
         }
         return {r:Math.round(rgb.r), g:Math.round(rgb.g), b:Math.round(rgb.b)};
     };
@@ -497,7 +582,7 @@ For usage and examples: colpick.com/plugin
             rgb.b.toString(16)
         ];
         $.each(hex, function (nr, val) {
-            if (val.length == 1) {
+            if (val.length === 1) {
                 hex[nr] = '0' + val;
             }
         });

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -41,6 +41,10 @@ function debugPrint(message) {
     );
 }
 
+function isVariableValid( element ) {
+    return (element !== undefined && element !== null);
+}
+
 function enableChildren(el, selector) {
     var elSelectors = el.querySelectorAll(selector);
     for (var selectorIndex = 0; selectorIndex < elSelectors.length; ++selectorIndex) {
@@ -587,10 +591,13 @@ function loaded() {
         var elClearUserData = document.getElementById("userdata-clear");
         var elSaveUserData = document.getElementById("userdata-save");
         var elNewJSONEditor = document.getElementById('userdata-new-editor');
-        var elColorControlVariant2 = document.getElementById("property-color-control2");
-        var elColorRed = document.getElementById("property-color-red");
-        var elColorGreen = document.getElementById("property-color-green");
-        var elColorBlue = document.getElementById("property-color-blue");
+        var elColorControlVariant1 = document.getElementById("property-color-control1");
+        // ColorControlVariant1 strictly utilizes the color picker in rgbhex mode, thus there aren't any
+        // color channel elements to grab here; however, we do still need to track them during selection to ensure that the
+        // picker's color is set up initially.
+        var baseColorRed = 0;
+        var baseColorGreen = 0;
+        var baseColorBlue = 0;
 
         var elShape = document.getElementById("property-shape");
 
@@ -949,10 +956,10 @@ function loaded() {
 
                         if (properties.type === "Shape" || properties.type === "Box" || 
                                 properties.type === "Sphere" || properties.type === "ParticleEffect") {
-                            elColorRed.value = properties.color.red;
-                            elColorGreen.value = properties.color.green;
-                            elColorBlue.value = properties.color.blue;
-                            elColorControlVariant2.style.backgroundColor = "rgb(" + properties.color.red + "," + 
+                            baseColorRed = properties.color.red;
+                            baseColorGreen = properties.color.green;
+                            baseColorBlue = properties.color.blue;
+                            elColorControlVariant1.style.backgroundColor = "rgb(" + properties.color.red + "," + 
                                                                      properties.color.green + "," + properties.color.blue + ")";
                         }
 
@@ -1276,24 +1283,19 @@ function loaded() {
             showSaveUserDataButton();
         });
 
-        var colorChangeFunction = createEmitColorPropertyUpdateFunction(
-            'color', elColorRed, elColorGreen, elColorBlue);
-        elColorRed.addEventListener('change', colorChangeFunction);
-        elColorGreen.addEventListener('change', colorChangeFunction);
-        elColorBlue.addEventListener('change', colorChangeFunction);
-/*        colorPickers.push($('#property-color-control1').colpick({
+        colorPickers.push($('#property-color-control1').colpick({
             colorScheme: 'dark',
-            layout: 'hex',
+            layout: 'rgbhex',
             color: '000000',
-            submit: false,  // We don't want to have a submission button
+            submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-color-control1').attr('active', 'true');
                 
                 // The original color preview within the picker needs to be updated on show because
                 // prior to the picker being shown we don't have access to the selections' starting color.
-                colorPickers[0].colpickSetColor({ "r": elColorRed.value, 
-                    "g": elColorGreen.value, 
-                    "b": elColorBlue.value});
+                colorPickers[0].colpickSetColor({ "r": baseColorRed, 
+                    "g": baseColorGreen, 
+                    "b": baseColorBlue});
             },
             onHide: function(colpick) {
                 $('#property-color-control1').attr('active', 'false');
@@ -1301,11 +1303,10 @@ function loaded() {
             onChange: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
-                // Keep the companion control in sync
-                elColorControl2.style.backgroundColor = "rgb(" + rgb.r + "," + rgb.g + "," + rgb.b + ")";
             }
         }));
-*/
+
+/*
         colorPickers.push($('#property-color-control2').colpick({
             colorScheme: 'dark',
             layout: 'hex',
@@ -1316,9 +1317,9 @@ function loaded() {
 
                 // The original color preview within the picker needs to be updated on show because
                 // prior to the picker being shown we don't have access to the selections' starting color.
-                colorPickers[/*1*/0].colpickSetColor({ "r": elColorRed.value, 
-                    "g": elColorGreen.value,
-                    "b": elColorBlue.value});
+                colorPickers[1].colpickSetColor({ "r": isVariableValid( elColorRed ) ? elColorRed.value : 0, 
+                    "g": isVariableValid( elColorGreen ) ? elColorGreen.value : 0,
+                    "b": isVariableValid( elColorBlue ) ? elColorBlue.value : 0 });
             },
             onHide: function(colpick) {
                 $('#property-color-control2').attr('active', 'false');
@@ -1329,7 +1330,7 @@ function loaded() {
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
             }
         }));
-
+*/
         elLightSpotLight.addEventListener('change', createEmitCheckedPropertyUpdateFunction('isSpotlight'));
 
         var lightColorChangeFunction = createEmitColorPropertyUpdateFunction(

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1281,17 +1281,49 @@ function loaded() {
         elColorRed.addEventListener('change', colorChangeFunction);
         elColorGreen.addEventListener('change', colorChangeFunction);
         elColorBlue.addEventListener('change', colorChangeFunction);
+/*        colorPickers.push($('#property-color-control1').colpick({
+            colorScheme: 'dark',
+            layout: 'hex',
+            color: '000000',
+            submit: false,  // We don't want to have a submission button
+            onShow: function(colpick) {
+                $('#property-color-control1').attr('active', 'true');
+                
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers[0].colpickSetColor({ "r": elColorRed.value, 
+                    "g": elColorGreen.value, 
+                    "b": elColorBlue.value});
+            },
+            onHide: function(colpick) {
+                $('#property-color-control1').attr('active', 'false');
+            },
+            onChange: function(hsb, hex, rgb, el) {
+                $(el).css('background-color', '#' + hex);
+                emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
+                // Keep the companion control in sync
+                elColorControl2.style.backgroundColor = "rgb(" + rgb.r + "," + rgb.g + "," + rgb.b + ")";
+            }
+        }));
+*/
         colorPickers.push($('#property-color-control2').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
+            submit: false,  // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-color-control2').attr('active', 'true');
+
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers[/*1*/0].colpickSetColor({ "r": elColorRed.value, 
+                    "g": elColorGreen.value,
+                    "b": elColorBlue.value});
             },
             onHide: function(colpick) {
                 $('#property-color-control2').attr('active', 'false');
             },
-            onSubmit: function(hsb, hex, rgb, el) {
+            onChange: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
                 $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1306,31 +1306,6 @@ function loaded() {
             }
         }));
 
-/*
-        colorPickers.push($('#property-color-control2').colpick({
-            colorScheme: 'dark',
-            layout: 'hex',
-            color: '000000',
-            submit: false,  // We don't want to have a submission button
-            onShow: function(colpick) {
-                $('#property-color-control2').attr('active', 'true');
-
-                // The original color preview within the picker needs to be updated on show because
-                // prior to the picker being shown we don't have access to the selections' starting color.
-                colorPickers[1].colpickSetColor({ "r": isVariableValid( elColorRed ) ? elColorRed.value : 0, 
-                    "g": isVariableValid( elColorGreen ) ? elColorGreen.value : 0,
-                    "b": isVariableValid( elColorBlue ) ? elColorBlue.value : 0 });
-            },
-            onHide: function(colpick) {
-                $('#property-color-control2').attr('active', 'false');
-            },
-            onChange: function(hsb, hex, rgb, el) {
-                $(el).css('background-color', '#' + hex);
-                $(el).colpickHide();
-                emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
-            }
-        }));
-*/
         elLightSpotLight.addEventListener('change', createEmitCheckedPropertyUpdateFunction('isSpotlight'));
 
         var lightColorChangeFunction = createEmitColorPropertyUpdateFunction(

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -29,7 +29,7 @@ var ICON_FOR_TYPE = {
 
 var EDITOR_TIMEOUT_DURATION = 1500;
 var KEY_P = 80; // Key code for letter p used for Parenting hotkey.
-var colorPickers = [];
+var colorPickers = {};
 var lastEntityID = null;
 
 function debugPrint(message) {
@@ -73,8 +73,8 @@ function enableProperties() {
 function disableProperties() {
     disableChildren(document.getElementById("properties-list"), "input, textarea, checkbox, .dropdown dl, .color-picker");
     disableChildren(document, ".colpick");
-    for (var i = 0; i < colorPickers.length; i++) {
-        colorPickers[i].colpickHide();
+    for (var pickKey in colorPickers) {
+        colorPickers[pickKey].colpickHide();
     }
     var elLocked = document.getElementById("property-locked");
 
@@ -1283,7 +1283,7 @@ function loaded() {
             showSaveUserDataButton();
         });
 
-        colorPickers.push($('#property-color-control1').colpick({
+        colorPickers['#property-color-control1'] = $('#property-color-control1').colpick({
             colorScheme: 'dark',
             layout: 'rgbhex',
             color: '000000',
@@ -1293,7 +1293,7 @@ function loaded() {
                 
                 // The original color preview within the picker needs to be updated on show because
                 // prior to the picker being shown we don't have access to the selections' starting color.
-                colorPickers[0].colpickSetColor({ "r": baseColorRed, 
+                colorPickers['#property-color-control1'].colpickSetColor({ "r": baseColorRed, 
                     "g": baseColorGreen, 
                     "b": baseColorBlue});
             },
@@ -1304,7 +1304,7 @@ function loaded() {
                 $(el).css('background-color', '#' + hex);
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
             }
-        }));
+        });
 
         elLightSpotLight.addEventListener('change', createEmitCheckedPropertyUpdateFunction('isSpotlight'));
 
@@ -1313,12 +1313,20 @@ function loaded() {
         elLightColorRed.addEventListener('change', lightColorChangeFunction);
         elLightColorGreen.addEventListener('change', lightColorChangeFunction);
         elLightColorBlue.addEventListener('change', lightColorChangeFunction);
-        colorPickers.push($('#property-light-color').colpick({
+        colorPickers['#property-light-color'] = $('#property-light-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             onShow: function(colpick) {
                 $('#property-light-color').attr('active', 'true');
+
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-light-color'].colpickSetColor({
+                    "r": elLightColorRed.value,
+                    "g": elLightColorGreen.value,
+                    "b": elLightColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-light-color').attr('active', 'false');
@@ -1328,7 +1336,7 @@ function loaded() {
                 $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
             }
-        }));
+        });
 
         elLightIntensity.addEventListener('change', createEmitNumberPropertyUpdateFunction('intensity', 1));
         elLightFalloffRadius.addEventListener('change', createEmitNumberPropertyUpdateFunction('falloffRadius', 1));
@@ -1368,12 +1376,19 @@ function loaded() {
         elTextTextColorRed.addEventListener('change', textTextColorChangeFunction);
         elTextTextColorGreen.addEventListener('change', textTextColorChangeFunction);
         elTextTextColorBlue.addEventListener('change', textTextColorChangeFunction);
-        colorPickers.push($('#property-text-text-color').colpick({
+        colorPickers['#property-text-text-color'] = $('#property-text-text-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             onShow: function(colpick) {
                 $('#property-text-text-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-text-text-color'].colpickSetColor({
+                    "r": elTextTextColorRed.value,
+                    "g": elTextTextColorGreen.value,
+                    "b": elTextTextColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-text-text-color').attr('active', 'false');
@@ -1384,19 +1399,26 @@ function loaded() {
                 $(el).attr('active', 'false');
                 emitColorPropertyUpdate('textColor', rgb.r, rgb.g, rgb.b);
             }
-        }));
+        });
 
         var textBackgroundColorChangeFunction = createEmitColorPropertyUpdateFunction(
             'backgroundColor', elTextBackgroundColorRed, elTextBackgroundColorGreen, elTextBackgroundColorBlue);
         elTextBackgroundColorRed.addEventListener('change', textBackgroundColorChangeFunction);
         elTextBackgroundColorGreen.addEventListener('change', textBackgroundColorChangeFunction);
         elTextBackgroundColorBlue.addEventListener('change', textBackgroundColorChangeFunction);
-        colorPickers.push($('#property-text-background-color').colpick({
+        colorPickers['#property-text-background-color'] = $('#property-text-background-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             onShow: function(colpick) {
                 $('#property-text-background-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-text-background-color'].colpickSetColor({
+                    "r": elTextBackgroundColorRed.value,
+                    "g": elTextBackgroundColorGreen.value,
+                    "b": elTextBackgroundColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-text-background-color').attr('active', 'false');
@@ -1406,16 +1428,23 @@ function loaded() {
                 $(el).colpickHide();
                 emitColorPropertyUpdate('backgroundColor', rgb.r, rgb.g, rgb.b);
             }
-        }));
+        });
 
         elZoneStageSunModelEnabled.addEventListener('change', 
             createEmitGroupCheckedPropertyUpdateFunction('stage', 'sunModelEnabled'));
-        colorPickers.push($('#property-zone-key-light-color').colpick({
+        colorPickers['#property-zone-key-light-color'] = $('#property-zone-key-light-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             onShow: function(colpick) {
                 $('#property-zone-key-light-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-zone-key-light-color'].colpickSetColor({
+                    "r": elZoneKeyLightColorRed.value,
+                    "g": elZoneKeyLightColorGreen.value,
+                    "b": elZoneKeyLightColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-zone-key-light-color').attr('active', 'false');
@@ -1425,7 +1454,7 @@ function loaded() {
                 $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b, 'keyLight');
             }
-        }));
+        });
         var zoneKeyLightColorChangeFunction = createEmitGroupColorPropertyUpdateFunction('keyLight', 'color', 
             elZoneKeyLightColorRed, elZoneKeyLightColorGreen, elZoneKeyLightColorBlue);
         elZoneKeyLightColorRed.addEventListener('change', zoneKeyLightColorChangeFunction);
@@ -1452,12 +1481,19 @@ function loaded() {
 
         elZoneHazeRange.addEventListener('change', createEmitGroupNumberPropertyUpdateFunction('haze', 'hazeRange'));
 
-        colorPickers.push($('#property-zone-haze-color').colpick({
+        colorPickers['#property-zone-haze-color'] = $('#property-zone-haze-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             onShow: function(colpick) {
                 $('#property-zone-haze-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-zone-haze-color'].colpickSetColor({
+                    "r": elZoneHazeColorRed.value,
+                    "g": elZoneHazeColorGreen.value,
+                    "b": elZoneHazeColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-zone-haze-color').attr('active', 'false');
@@ -1467,7 +1503,7 @@ function loaded() {
                 $(el).colpickHide();
                 emitColorPropertyUpdate('hazeColor', rgb.r, rgb.g, rgb.b, 'haze');
             }
-        }));
+        });
         var zoneHazeColorChangeFunction = createEmitGroupColorPropertyUpdateFunction('haze', 'hazeColor', 
             elZoneHazeColorRed, 
             elZoneHazeColorGreen, 
@@ -1477,12 +1513,19 @@ function loaded() {
         elZoneHazeColorGreen.addEventListener('change', zoneHazeColorChangeFunction);
         elZoneHazeColorBlue.addEventListener('change', zoneHazeColorChangeFunction);
 
-        colorPickers.push($('#property-zone-haze-glare-color').colpick({
+        colorPickers['#property-zone-haze-glare-color'] = $('#property-zone-haze-glare-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             onShow: function(colpick) {
                 $('#property-zone-haze-glare-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-zone-haze-glare-color'].colpickSetColor({
+                    "r": elZoneHazeGlareColorRed.value,
+                    "g": elZoneHazeGlareColorGreen.value,
+                    "b": elZoneHazeGlareColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-zone-haze-glare-color').attr('active', 'false');
@@ -1492,7 +1535,7 @@ function loaded() {
                 $(el).colpickHide();
                 emitColorPropertyUpdate('hazeGlareColor', rgb.r, rgb.g, rgb.b, 'haze');
             }
-        }));
+        });
         var zoneHazeGlareColorChangeFunction = createEmitGroupColorPropertyUpdateFunction('haze', 'hazeGlareColor', 
             elZoneHazeGlareColorRed, 
             elZoneHazeGlareColorGreen, 
@@ -1529,12 +1572,19 @@ function loaded() {
         elZoneSkyboxColorRed.addEventListener('change', zoneSkyboxColorChangeFunction);
         elZoneSkyboxColorGreen.addEventListener('change', zoneSkyboxColorChangeFunction);
         elZoneSkyboxColorBlue.addEventListener('change', zoneSkyboxColorChangeFunction);
-        colorPickers.push($('#property-zone-skybox-color').colpick({
+        colorPickers['#property-zone-skybox-color'] = $('#property-zone-skybox-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             onShow: function(colpick) {
                 $('#property-zone-skybox-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-zone-skybox-color'].colpickSetColor({
+                    "r": elZoneSkyboxColorRed.value,
+                    "g": elZoneSkyboxColorGreen.value,
+                    "b": elZoneSkyboxColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-zone-skybox-color').attr('active', 'false');
@@ -1544,7 +1594,7 @@ function loaded() {
                 $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b, 'skybox');
             }
-        }));
+        });
 
         elZoneSkyboxURL.addEventListener('change', createEmitGroupTextPropertyUpdateFunction('skybox', 'url'));
 


### PR DESCRIPTION
* Fixes the issue scrolling versus color selection in HMD mode while the color picker is up.
* Has various ESLint & JSHint fixes.
* Adds a means of cancelling color alterations via the current color preview tile.
* Fixes issue with the color pickers where the current color started as black as opposed to the expected color of the entity selected.
* Shape color picker has been changed to use the picker's <code>rgbhex</code> mode as opposed to <code>hex</code> used by the other color fields to be tested against the other fields to see which is preferred.
    * Fixed color channel increment/decrement buttons.  Previously, clicking them wouldn't have any influence on the indicated channel values.  The user was forced to directly edit the value via the keyboard.
    * Fixed some layout issues with <code>rgbhex</code> mode

**Testing**

**Phase 1:**  Though this applies to both Desktop & HMD mode, I found it easier to test in Desktop mode where it was easier to grab and select objects within the world.

Create or select an instance of a light, text, shape, and zone entity within the world.  For the following fields the color portrayed in the color picker element  should also be shown in the color preview area when clicked as opposed to starting out black. 

* Light Color
* Text Color
* Text Background Color
* Shape Color
* Haze Key Light Color
* Haze Glaze Color
* Haze Glare Color

**_Before Example using Light Color Field:_**
![case4315_lightcolor_before](https://user-images.githubusercontent.com/28965411/34362103-8f8ed086-ea3e-11e7-9d0b-b424c13df5ed.jpg)

**_After Example using Light Color Field:_**
![case4315_lightcolor_after](https://user-images.githubusercontent.com/28965411/34362079-62237c1e-ea3e-11e7-8551-819cc641aa91.jpg)

**Phase 2:**  This must be tested in both HMD & Desktop Mode.

* Create or select an instance of a light object.
* Select the Light Color field to open the color picker.
* In HMD:  
    * Confirm that when moving the cursor around in the gradient square, that the Properties page which contains the picker doesn't scroll.  The page is stationary and the user is able to tweak the color by using the gradient square. 
    * Confirm the same is true for the Hue strip located to the right of the gradient square in the color picker.
* In Desktop:
    * Confirm that the picker operated as it did before, and that the fixes to the HMD mode didn't alter or have an ill effect the Desktop implementation.

**Phase 3:**  This can be tested in either Desktop or HMD mode.

Part 1:
* Create or select an instance of a shape object.
* Select the Entity Color field to open the color picker.
* Observe that this picker opens in a different mode containing the following items:
    * Color picker gradient square
    * Color picker hue strip
    * R Channel Input Field
    * G Channel Input Field
    * B Channel Input Field
    * Hex (#) Color Input Field
* Confirm that manipulating the cursor along the color gradient square updates the color of the shape entity dynamically.
* Confirm that the user is able to tweak any of the RGB channels without closing the picker.
    * Using the increment/decrement arrows in the field input box.
    * Clicking the input box and directly altering the field value.
        * Input number between 0 and 255.  The range being inclusive.
        * Input number greater than 255.  Observe that the field is capped at 255.

Part 2:

Contrast the user interaction with the Shape's Entity Color field, to that of the Light's Light Color field which uses the set up previously utilized by the Shape's color field.  Which is preferred.

**Screenshots of Shape Color Field:**
    Note:  See above screenshots for visuals of the Light Color Field

Before:

![case4315_before](https://user-images.githubusercontent.com/28965411/34311733-4c4e2de4-e72d-11e7-9ede-f843a5872458.jpg)

After:

![case4315_after](https://user-images.githubusercontent.com/28965411/34311737-5613c8ac-e72d-11e7-9a18-3bfaffc16287.jpg)
