### PR TITLE
Fix model overlays not disappearing on visibility change

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -622,7 +622,7 @@ void Model::setLayeredInFront(bool isLayeredInFront, const render::ScenePointer&
         _isLayeredInFront = isLayeredInFront;
 
         bool isVisible = _isVisible;
-        bool isLayeredInHUD = _isLayeredInFront;
+        bool isLayeredInHUD = _isLayeredInHUD;
 
         render::Transaction transaction;
         foreach(auto item, _modelMeshRenderItemsMap.keys()) {
@@ -646,7 +646,7 @@ void Model::setLayeredInHUD(bool isLayeredInHUD, const render::ScenePointer& sce
         _isLayeredInHUD = isLayeredInHUD;
 
         bool isVisible = _isVisible;
-        bool isLayeredInFront = isLayeredInFront;
+        bool isLayeredInFront = _isLayeredInFront;
 
         render::Transaction transaction;
         foreach(auto item, _modelMeshRenderItemsMap.keys()) {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -594,47 +594,72 @@ void Model::calculateTriangleSets() {
     }
 }
 
-void Model::setVisibleInScene(bool newValue, const render::ScenePointer& scene) {
-    if (_isVisible != newValue) {
-        _isVisible = newValue;
+void Model::setVisibleInScene(bool isVisible, const render::ScenePointer& scene) {
+    if (_isVisible != isVisible) {
+        _isVisible = isVisible;
+
+        bool isLayeredInFront = _isLayeredInFront;
+        bool isLayeredInHUD = _isLayeredInHUD;
 
         render::Transaction transaction;
         foreach (auto item, _modelMeshRenderItemsMap.keys()) {
-            transaction.resetItem(item, _modelMeshRenderItemsMap[item]);
+            transaction.updateItem<ModelMeshPartPayload>(item, [isVisible, isLayeredInFront, isLayeredInHUD](ModelMeshPartPayload& data) {
+                data.setKey(isVisible, isLayeredInFront || isLayeredInHUD);
+            });
         }
         foreach(auto item, _collisionRenderItemsMap.keys()) {
-            transaction.resetItem(item, _collisionRenderItemsMap[item]);
+            transaction.updateItem<ModelMeshPartPayload>(item, [isVisible, isLayeredInFront, isLayeredInHUD](ModelMeshPartPayload& data) {
+                data.setKey(isVisible, isLayeredInFront || isLayeredInHUD);
+            });
         }
         scene->enqueueTransaction(transaction);
     }
 }
 
 
-void Model::setLayeredInFront(bool layered, const render::ScenePointer& scene) {
-    if (_isLayeredInFront != layered) {
-        _isLayeredInFront = layered;
+void Model::setLayeredInFront(bool isLayeredInFront, const render::ScenePointer& scene) {
+    if (_isLayeredInFront != isLayeredInFront) {
+        _isLayeredInFront = isLayeredInFront;
+
+        bool isVisible = _isVisible;
+        bool isLayeredInHUD = _isLayeredInFront;
 
         render::Transaction transaction;
         foreach(auto item, _modelMeshRenderItemsMap.keys()) {
-            transaction.resetItem(item, _modelMeshRenderItemsMap[item]);
+            transaction.updateItem<ModelMeshPartPayload>(item, [isVisible, isLayeredInFront, isLayeredInHUD](ModelMeshPartPayload& data) {
+                data.setKey(isVisible, isLayeredInFront || isLayeredInHUD);
+                data.setLayer(isLayeredInFront, isLayeredInHUD);
+            });
         }
         foreach(auto item, _collisionRenderItemsMap.keys()) {
-            transaction.resetItem(item, _collisionRenderItemsMap[item]);
+            transaction.updateItem<ModelMeshPartPayload>(item, [isVisible, isLayeredInFront, isLayeredInHUD](ModelMeshPartPayload& data) {
+                data.setKey(isVisible, isLayeredInFront || isLayeredInHUD);
+                data.setLayer(isLayeredInFront, isLayeredInHUD);
+            });
         }
         scene->enqueueTransaction(transaction);
     }
 }
 
-void Model::setLayeredInHUD(bool layered, const render::ScenePointer& scene) {
-    if (_isLayeredInHUD != layered) {
-        _isLayeredInHUD = layered;
+void Model::setLayeredInHUD(bool isLayeredInHUD, const render::ScenePointer& scene) {
+    if (_isLayeredInHUD != isLayeredInHUD) {
+        _isLayeredInHUD = isLayeredInHUD;
+
+        bool isVisible = _isVisible;
+        bool isLayeredInFront = isLayeredInFront;
 
         render::Transaction transaction;
         foreach(auto item, _modelMeshRenderItemsMap.keys()) {
-            transaction.resetItem(item, _modelMeshRenderItemsMap[item]);
+            transaction.updateItem<ModelMeshPartPayload>(item, [isVisible, isLayeredInFront, isLayeredInHUD](ModelMeshPartPayload& data) {
+                data.setKey(isVisible, isLayeredInFront || isLayeredInHUD);
+                data.setLayer(isLayeredInFront, isLayeredInHUD);
+            });
         }
         foreach(auto item, _collisionRenderItemsMap.keys()) {
-            transaction.resetItem(item, _collisionRenderItemsMap[item]);
+            transaction.updateItem<ModelMeshPartPayload>(item, [isVisible, isLayeredInFront, isLayeredInHUD](ModelMeshPartPayload& data) {
+                data.setKey(isVisible, isLayeredInFront || isLayeredInHUD);
+                data.setLayer(isLayeredInFront, isLayeredInHUD);
+            });
         }
         scene->enqueueTransaction(transaction);
     }

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -82,9 +82,9 @@ public:
     const QUrl& getURL() const { return _url; }
 
     // new Scene/Engine rendering support
-    void setVisibleInScene(bool newValue, const render::ScenePointer& scene);
-    void setLayeredInFront(bool layered, const render::ScenePointer& scene);
-    void setLayeredInHUD(bool layered, const render::ScenePointer& scene);
+    void setVisibleInScene(bool isVisible, const render::ScenePointer& scene);
+    void setLayeredInFront(bool isLayeredInFront, const render::ScenePointer& scene);
+    void setLayeredInHUD(bool isLayeredInHUD, const render::ScenePointer& scene);
     bool needsFixupInScene() const;
 
     bool needsReload() const { return _needsReload; }


### PR DESCRIPTION
Bug from https://github.com/highfidelity/hifi/pull/12026

Test plan:
- Play around with teleport.  The teleport pad at the end of the beam should appear and disappear at the right times, and should never get stuck with the wrong visibility.