### PR TITLE
WL#21654: Make the Asset Browser Sort Case Insensitive

### DIFF
--- a/interface/src/scripting/AssetMappingsScriptingInterface.cpp
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.cpp
@@ -33,7 +33,7 @@ AssetMappingsScriptingInterface::AssetMappingsScriptingInterface() {
     _proxyModel.setDynamicSortFilter(true);
     _proxyModel.setSortLocaleAware(true);
     _proxyModel.setFilterCaseSensitivity(Qt::CaseInsensitive);
-    _proxyModel.sort(Qt::SortOrder::AscendingOrder);
+    _proxyModel.sort(0);
 }
 
 void AssetMappingsScriptingInterface::setMapping(QString path, QString hash, QJSValue callback) {

--- a/interface/src/scripting/AssetMappingsScriptingInterface.cpp
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.cpp
@@ -31,7 +31,9 @@ AssetMappingsScriptingInterface::AssetMappingsScriptingInterface() {
     _proxyModel.setSourceModel(&_assetMappingModel);
     _proxyModel.setSortRole(Qt::DisplayRole);
     _proxyModel.setDynamicSortFilter(true);
-    _proxyModel.sort(0);
+    _proxyModel.setSortLocaleAware(true);
+    _proxyModel.setFilterCaseSensitivity(Qt::CaseInsensitive);
+    _proxyModel.sort(Qt::SortOrder::AscendingOrder);
 }
 
 void AssetMappingsScriptingInterface::setMapping(QString path, QString hash, QJSValue callback) {


### PR DESCRIPTION
**Test Plan:** Asset browser should now sort ignoring case, so asset.asset and Asset.asset should appear next to each other. Should work straight away for existing assets. Adding and removing new assets should be tested.