### PR TITLE
Add a link to My Purchases from Wallet Home

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
@@ -197,14 +197,36 @@ Item {
             anchors.topMargin: 26;
             anchors.left: parent.left;
             anchors.leftMargin: 20;
-            anchors.right: parent.right;
-            anchors.rightMargin: 30;
+            width: paintedWidth;
             height: 30;
             // Text size
             size: 22;
             // Style
             color: hifi.colors.baseGrayHighlight;
         }
+
+        RalewaySemiBold {
+            id: myPurchasesLink;
+            text: '<font color="#0093C5"><a href="#myPurchases">My Purchases</a></font>';
+            // Anchors
+            anchors.top: parent.top;
+            anchors.topMargin: 26;
+            anchors.right: parent.right;
+            anchors.rightMargin: 20;
+            width: paintedWidth;
+            height: 30;
+            y: 4;
+            // Text size
+            size: 18;
+            // Style
+            color: hifi.colors.baseGrayHighlight;
+            horizontalAlignment: Text.AlignRight;
+
+            onLinkActivated: {
+                sendSignalToWallet({method: 'goToPurchases_fromWalletHome'});
+            }
+        }
+
         ListModel {
             id: tempTransactionHistoryModel;
         }

--- a/scripts/system/commerce/wallet.js
+++ b/scripts/system/commerce/wallet.js
@@ -103,6 +103,7 @@
             case 'transactionHistory_linkClicked':
                 tablet.gotoWebScreen(message.marketplaceLink, MARKETPLACES_INJECT_SCRIPT_URL);
                 break;
+            case 'goToPurchases_fromWalletHome':
             case 'goToPurchases':
                 tablet.pushOntoStack(MARKETPLACE_PURCHASES_QML_PATH);
                 break;


### PR DESCRIPTION
See title of PR.

## Test Plan
1. Using Desktop/HUD mode, open the Wallet app and login/authenticate. Verify that the "WALLET" icon turns white/active.
2. Click the "My Purchases" link to the right of "Recent Activity".
3. Verify that you are taken to My Purchases. Verify that the WALLET HUD icon is no longer active. Verify that the MARKET HUD icon is now active.