### PR TITLE
Zone orientation effect on keylight, skybox and ambient light.

### DIFF
--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -241,7 +241,7 @@ void ZoneEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scen
     }
 #endif
 
-    updateKeyZoneItemFromEntity();
+    updateKeyZoneItemFromEntity(entity);
 
     if (keyLightChanged) {
         updateKeySunFromEntity(entity);
@@ -329,7 +329,7 @@ void ZoneEntityRenderer::updateKeySunFromEntity(const TypedEntityPointer& entity
     // Set the keylight
     sunLight->setColor(ColorUtils::toVec3(_keyLightProperties.getColor()));
     sunLight->setIntensity(_keyLightProperties.getIntensity());
-    sunLight->setDirection(_keyLightProperties.getDirection());
+    sunLight->setDirection(entity->getTransform().getRotation() * _keyLightProperties.getDirection());
 }
 
 void ZoneEntityRenderer::updateAmbientLightFromEntity(const TypedEntityPointer& entity) {
@@ -349,6 +349,8 @@ void ZoneEntityRenderer::updateAmbientLightFromEntity(const TypedEntityPointer& 
     } else {
         setAmbientURL(_ambientLightProperties.getAmbientURL());
     }
+
+    ambientLight->setTransform(entity->getTransform().getInverseMatrix());
 }
 
 void ZoneEntityRenderer::updateHazeFromEntity(const TypedEntityPointer& entity) {
@@ -378,7 +380,7 @@ void ZoneEntityRenderer::updateHazeFromEntity(const TypedEntityPointer& entity) 
     haze->setHazeKeyLightRangeFactor(graphics::Haze::convertHazeRangeToHazeRangeFactor(_hazeProperties.getHazeKeyLightRange()));
     haze->setHazeKeyLightAltitudeFactor(graphics::Haze::convertHazeAltitudeToHazeAltitudeFactor(_hazeProperties.getHazeKeyLightAltitude()));
 
-    haze->setZoneTransform(entity->getTransform().getMatrix());
+    haze->setTransform(entity->getTransform().getMatrix());
 }
 
 void ZoneEntityRenderer::updateKeyBackgroundFromEntity(const TypedEntityPointer& entity) {
@@ -390,7 +392,10 @@ void ZoneEntityRenderer::updateKeyBackgroundFromEntity(const TypedEntityPointer&
     setSkyboxURL(_skyboxProperties.getURL());
 }
 
-void ZoneEntityRenderer::updateKeyZoneItemFromEntity() {
+void ZoneEntityRenderer::updateKeyZoneItemFromEntity(const TypedEntityPointer& entity) {
+    // Update rotation values
+    editSkybox()->setOrientation(entity->getTransform().getRotation());
+
     /* TODO: Implement the sun model behavior / Keep this code here for reference, this is how we
     {
     // Set the stage

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.h
@@ -45,7 +45,7 @@ protected:
     virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) override;
 
 private:
-    void updateKeyZoneItemFromEntity();
+    void updateKeyZoneItemFromEntity(const TypedEntityPointer& entity);
     void updateKeySunFromEntity(const TypedEntityPointer& entity);
     void updateAmbientLightFromEntity(const TypedEntityPointer& entity);
     void updateHazeFromEntity(const TypedEntityPointer& entity);

--- a/libraries/graphics/src/graphics/Haze.cpp
+++ b/libraries/graphics/src/graphics/Haze.cpp
@@ -182,11 +182,11 @@ void Haze::setHazeBackgroundBlend(const float hazeBackgroundBlend) {
     }
 }
 
-void Haze::setZoneTransform(const glm::mat4& zoneTransform) {
+void Haze::setTransform(const glm::mat4& transform) {
     auto& params = _hazeParametersBuffer.get<Parameters>();
 
-    if (params.zoneTransform == zoneTransform) {
-        _hazeParametersBuffer.edit<Parameters>().zoneTransform = zoneTransform;
+    if (params.transform != transform) {
+        _hazeParametersBuffer.edit<Parameters>().transform = transform;
     }
 }
 

--- a/libraries/graphics/src/graphics/Haze.h
+++ b/libraries/graphics/src/graphics/Haze.h
@@ -92,7 +92,7 @@ namespace graphics {
 
         void setHazeBackgroundBlend(const float hazeBackgroundBlend);
 
-        void setZoneTransform(const glm::mat4& zoneTransform);
+        void setTransform(const glm::mat4& transform);
 
         using UniformBufferView = gpu::BufferView;
         UniformBufferView getHazeParametersBuffer() const { return _hazeParametersBuffer; }
@@ -113,7 +113,7 @@ namespace graphics {
                                   // bit 2 - set to activate directional light attenuation mode
                                   // bit 3 - set to blend between blend-in and blend-out colours
 
-            glm::mat4 zoneTransform;
+            glm::mat4 transform;
 
             // Amount of background (skybox) to display, overriding the haze effect for the background
             float hazeBackgroundBlend{ INITIAL_HAZE_BACKGROUND_BLEND };

--- a/libraries/graphics/src/graphics/Light.cpp
+++ b/libraries/graphics/src/graphics/Light.cpp
@@ -158,3 +158,9 @@ void Light::setAmbientMapNumMips(uint16_t numMips) {
     _ambientSchemaBuffer.edit().mapNumMips = (float)numMips;
 }
 
+void Light::setTransform(const glm::mat4& transform) {
+    if (_ambientSchemaBuffer.edit().transform != transform) {
+        _ambientSchemaBuffer.edit().transform = transform;
+    }
+}
+

--- a/libraries/graphics/src/graphics/Light.h
+++ b/libraries/graphics/src/graphics/Light.h
@@ -149,6 +149,8 @@ public:
     void setAmbientMapNumMips(uint16_t numMips);
     uint16_t getAmbientMapNumMips() const { return (uint16_t) _ambientSchemaBuffer->mapNumMips; }
 
+    void setTransform(const glm::mat4& transform);
+
     // Light Schema
     class LightSchema {
     public:
@@ -162,7 +164,9 @@ public:
         float mapNumMips { 0.0f };
         float spare1;
         float spare2;
+
         gpu::SphericalHarmonics ambientSphere;
+        glm::mat4 transform;
     };
 
     using LightSchemaBuffer = gpu::StructBuffer<LightSchema>;

--- a/libraries/graphics/src/graphics/Light.slh
+++ b/libraries/graphics/src/graphics/Light.slh
@@ -34,7 +34,9 @@ vec3 getLightIrradiance(Light l) { return lightIrradiance_getIrradiance(l.irradi
 // Light Ambient
 struct LightAmbient {
     vec4 _ambient;
+
     SphericalHarmonics _ambientSphere;
+    mat4 transform;
 };
 
 SphericalHarmonics getLightAmbientSphere(LightAmbient l) { return l._ambientSphere; }

--- a/libraries/graphics/src/graphics/Skybox.cpp
+++ b/libraries/graphics/src/graphics/Skybox.cpp
@@ -37,6 +37,12 @@ void Skybox::setCubemap(const gpu::TexturePointer& cubemap) {
     }
 }
 
+void Skybox::setOrientation(const glm::quat& orientation) {
+    // The zone rotations need to be negated
+    _orientation = orientation;
+    _orientation.w = -_orientation.w;
+}
+
 void Skybox::updateSchemaBuffer() const {
     auto blend = 0.0f;
     if (getCubemap() && getCubemap()->isDefined()) {
@@ -115,6 +121,10 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Sky
 
     Transform viewTransform;
     viewFrustum.evalViewTransform(viewTransform);
+
+    // Orientate view transform to be relative to zone
+    viewTransform.setRotation(skybox.getOrientation() * viewTransform.getRotation());
+
     batch.setProjectionTransform(projMat);
     batch.setViewTransform(viewTransform);
     batch.setModelTransform(Transform()); // only for Mac

--- a/libraries/graphics/src/graphics/Skybox.h
+++ b/libraries/graphics/src/graphics/Skybox.h
@@ -37,6 +37,9 @@ public:
     void setCubemap(const gpu::TexturePointer& cubemap);
     const gpu::TexturePointer& getCubemap() const { return _cubemap; }
 
+    void setOrientation(const glm::quat& orientation);
+    const glm::quat getOrientation() const { return _orientation; }
+
     virtual bool empty() { return _empty; }
     virtual void clear();
 
@@ -61,6 +64,8 @@ protected:
 
     mutable gpu::BufferView _schemaBuffer;
     gpu::TexturePointer _cubemap;
+    glm::quat _orientation;
+
     bool _empty{ true };
 };
 typedef std::shared_ptr<Skybox> SkyboxPointer;

--- a/libraries/render-utils/src/Haze.slh
+++ b/libraries/render-utils/src/Haze.slh
@@ -26,7 +26,7 @@ struct HazeParams {
     vec3 colorModulationFactor;
     int hazeMode;
 
-    mat4 zoneTransform;
+    mat4 transform;
     float backgroundBlend;
 
     float hazeRangeFactor;

--- a/libraries/render-utils/src/LightAmbient.slh
+++ b/libraries/render-utils/src/LightAmbient.slh
@@ -5,9 +5,6 @@
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-//
-
-
 
 <@func declareSkyboxMap()@>
 // declareSkyboxMap
@@ -15,7 +12,6 @@ uniform samplerCube skyboxMap;
 
 vec4 evalSkyboxLight(vec3 direction, float lod) {
     // textureQueryLevels is not available until #430, so we require explicit lod
-    // float mipmapLevel = lod * textureQueryLevels(skyboxMap);
     float filterLod = textureQueryLod(skyboxMap, direction).x;
     // Keep texture filtering LOD as limit to prevent aliasing on specular reflection
     lod = max(lod, filterLod);
@@ -28,15 +24,13 @@ vec4 evalSkyboxLight(vec3 direction, float lod) {
 vec3 fresnelSchlickAmbient(vec3 fresnelColor, float ndotd, float gloss) {
     float f = pow(1.0 - ndotd, 5.0);
     return fresnelColor + (max(vec3(gloss), fresnelColor) - fresnelColor) * f;
-//    return fresnelColor + (vec3(1.0) - fresnelColor) * f;
 }
 
 <@if supportAmbientMap@>
 <$declareSkyboxMap()$>
 <@endif@>
 
-vec3 evalAmbientSpecularIrradiance(LightAmbient ambient, SurfaceData surface) {
-    vec3 lightDir = -reflect(surface.eyeDir, surface.normal);
+vec3 evalAmbientSpecularIrradiance(LightAmbient ambient, SurfaceData surface, vec3 lightDir) {
     vec3 specularLight;
     <@if supportIfAmbientMapElseAmbientSphere@>
         if (getLightHasAmbientMap(ambient))
@@ -80,14 +74,21 @@ void evalLightingAmbient(out vec3 diffuse, out vec3 specular, LightAmbient ambie
 <@endif@>
     ) {
 
-    // Fresnel
+    // Rotate surface normal and eye direction
+    vec3 ambientSpaceSurfaceNormal = (ambient.transform * vec4(surface.normal,   0.0)).xyz;
+    vec3 ambientSpaceSurfaceEyeDir = (ambient.transform * vec4(surface.eyeDir,   0.0)).xyz;
+<@if supportScattering@>
+    vec3 ambientSpaceLowNormalCurvature = (ambient.transform * lowNormalCurvature).xyz;
+<@endif@>
+
     vec3 ambientFresnel = fresnelSchlickAmbient(fresnelF0, surface.ndotv, 1.0-surface.roughness);
 
-    // Diffuse from ambient
-    diffuse = (1.0 - metallic) * (vec3(1.0) - ambientFresnel) * sphericalHarmonics_evalSphericalLight(getLightAmbientSphere(ambient), surface.normal).xyz;
+    diffuse = (1.0 - metallic) * (vec3(1.0) - ambientFresnel) * 
+              sphericalHarmonics_evalSphericalLight(getLightAmbientSphere(ambient), ambientSpaceSurfaceNormal).xyz;
 
     // Specular highlight from ambient
-    specular = evalAmbientSpecularIrradiance(ambient, surface)  * ambientFresnel;
+    vec3 ambientSpaceLightDir = -reflect(ambientSpaceSurfaceEyeDir, ambientSpaceSurfaceNormal);
+    specular = evalAmbientSpecularIrradiance(ambient, surface, ambientSpaceLightDir)  * ambientFresnel;
 
 <@if supportScattering@>
     if (scattering * isScatteringEnabled() > 0.0) {
@@ -98,7 +99,7 @@ void evalLightingAmbient(out vec3 diffuse, out vec3 specular, LightAmbient ambie
         obscurance = min(obscurance, ambientOcclusion);
 
         // Diffuse from ambient
-        diffuse = sphericalHarmonics_evalSphericalLight(getLightAmbientSphere(ambient), lowNormalCurvature.xyz).xyz;
+        diffuse = sphericalHarmonics_evalSphericalLight(getLightAmbientSphere(ambient), ambientSpaceLowNormalCurvature).xyz;
 
         // Scattering ambient specular is the same as non scattering for now
         // TODO: we should use the same specular answer as for direct lighting

--- a/libraries/render-utils/src/model_translucent_fade.slf
+++ b/libraries/render-utils/src/model_translucent_fade.slf
@@ -1,25 +1,18 @@
 <@include gpu/Config.slh@>
 <$VERSION_HEADER$>
 //  Generated on <$_SCRIBE_DATE$>
-//
 //  model_translucent_fade.frag
-//  fragment shader
-//
 //  Created by Olivier Prat on 06/05/17.
 //  Copyright 2017 High Fidelity, Inc.
-//
 //  Distributed under the Apache License, Version 2.0.
-//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
-//
+//  See the accompanying file LICENSE
 
 <@include graphics/Material.slh@>
-
 <@include DeferredGlobalLight.slh@>
 
 <$declareEvalGlobalLightingAlphaBlendedWithHaze()$>
 
 <@include LightLocal.slh@>
-
 <@include gpu/Transform.slh@>
 <$declareStandardCameraTransform()$>
 


### PR DESCRIPTION
# Description
This PR implements rotates the keylight, skybox and ambient light by the zone orientation.
# Testing
1.  After installing the PR, verify that the local domain appears as before (to verify usage with older content).  
2.  Download the GitHub test repository from https://github.com/NissimHadar/hifi_tests.git - create and then checkout  the **hazeTests** branch.
3.  Run setup.bat in the tests/tools/autoTester folder. This will download the autoTester executable and required resources into tests/tools/autoTester/Release.

4.  Move to an empty area in a domain with full permissions (such as localhost/5000,5000,5000).

5.  Run script: tests/content/entity/zone/zoneOrientation/runAuto.js

tests/content/entity/zone/zoneOrientationwill now contain 30 images.  15 of these are the expected results named ExpectedImage_00000.jpg through ExpectedImage_00014.jpg.
The results are the 15 images named `hifi-snap-by........jpg. The images should match up (1st == 1st and so on).
