### PR TITLE
Fix Security Pic Change dialog after QML security changes

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/SecurityImageChange.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/SecurityImageChange.qml
@@ -66,7 +66,7 @@ Item {
             source: "image://security/securityImage";
             cache: false;
             onVisibleChanged: {
-                commerce.getSecurityImage();
+                Commerce.getSecurityImage();
             }
         }
         Item {
@@ -194,7 +194,7 @@ Item {
                     securityImageSubmitButton.text = "Submitting...";
                     securityImageSubmitButton.enabled = false;
                     var securityImagePath = securityImageSelection.getImagePathFromImageID(securityImageSelection.getSelectedImageIndex())
-                    commerce.chooseSecurityImage(securityImagePath);
+                    Commerce.chooseSecurityImage(securityImagePath);
                 }
             }
         }


### PR DESCRIPTION
We must have missed this one during the big QML whitelisting change. Discovered while attempting to repro the grey security pic bug.

## Test Plan
1. Open the Wallet app and authenticate with your passphrase.
2. Go to the SECURITY tab, then click "CHANGE" next to "Security Pic"
3. Choose a new Security Pic, and press SUBMIT
4. Verify that you see the new Security Pic in the top right of the wallet.