### PR TITLE
11008 GoTo app does not focus on address bar when opened

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
@@ -72,10 +72,14 @@ StackView {
     Component { id: tabletWebView; TabletWebView {} }
     Component.onCompleted: {
         updateLocationText(false);
-        addressLine.focus = !HMD.active;
         root.parentChanged.connect(center);
         center();
         tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
+
+        Qt.callLater(function() {
+            addressBarDialog.keyboardEnabled = HMD.active;
+            addressLine.forceActiveFocus();
+        })
     }
     Component.onDestruction: {
         root.parentChanged.disconnect(center);


### PR DESCRIPTION
*** Test Plan *** 

1. Switch to desktop 
2. Open 'go to' app
3. Ensure address bar is auto-focused
5. Switch to VR
6. Open 'go to' app 
7. Ensure address bar is auto-focused and onscreen keyboard is visible
