### PR TITLE
FB10621 "HIFI-Commerce Login" page title change to "Log in to continue"

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/NeedsLogIn.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/NeedsLogIn.qml
@@ -53,7 +53,7 @@ Item {
 
             // Title Bar text
             RalewaySemiBold {
-                text: "HIFI COMMERCE - LOGIN";
+                text: "Log in to continue";
                 // Text size
                 size: hifi.fontSizes.overlayTitle;
                 // Anchors


### PR DESCRIPTION
Based on https://highfidelity.fogbugz.com/f/cases/10621/

Test plan:   
Ensure title in "HIFI Commerce - Login" page changed to "Log in to continue" like here:

![image](https://user-images.githubusercontent.com/23638/34605649-6df709ac-f21d-11e7-90a0-da8798509871.png)
