### PR TITLE
WL 21664 - Window.innerHeight should not include the menu bar

### DIFF
--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -394,10 +394,6 @@ int WindowScriptingInterface::getInnerHeight() {
     return qApp->getDeviceSize().y;
 }
 
-int WindowScriptingInterface::getMenuHeight() {
-    return qApp->getPrimaryMenu()->geometry().height();
-}
-
 glm::vec2 WindowScriptingInterface::getDeviceSize() const {
     return qApp->getDeviceSize();
 }

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -176,10 +176,6 @@ bool  WindowScriptingInterface::isPointOnDesktopWindow(QVariant point) {
     return offscreenUi->isPointOnDesktopWindow(point);
 }
 
-glm::vec2 WindowScriptingInterface::getDeviceSize() const {
-    return qApp->getDeviceSize();
-}
-
 /// Makes sure that the reticle is visible, use this in blocking forms that require a reticle and
 /// might be in same thread as a script that sets the reticle to invisible
 void WindowScriptingInterface::ensureReticleVisible() const {
@@ -391,11 +387,19 @@ QString WindowScriptingInterface::checkVersion() {
 }
 
 int WindowScriptingInterface::getInnerWidth() {
-    return qApp->getWindow()->geometry().width();
+    return qApp->getDeviceSize().x;
 }
 
 int WindowScriptingInterface::getInnerHeight() {
-    return qApp->getWindow()->geometry().height();
+    return qApp->getDeviceSize().y;
+}
+
+int WindowScriptingInterface::getMenuHeight() {
+    return qApp->getPrimaryMenu()->geometry().height();
+}
+
+glm::vec2 WindowScriptingInterface::getDeviceSize() const {
+    return qApp->getDeviceSize();
 }
 
 int WindowScriptingInterface::getX() {

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -39,14 +39,12 @@ class WindowScriptingInterface : public QObject, public Dependency {
     Q_PROPERTY(int innerHeight READ getInnerHeight)
     Q_PROPERTY(int x READ getX)
     Q_PROPERTY(int y READ getY)
-    Q_PROPERTY(int menuHeight READ getMenuHeight)
 
 public:
     WindowScriptingInterface();
     ~WindowScriptingInterface();
     int getInnerWidth();
     int getInnerHeight();
-    int getMenuHeight();
     int getX();
     int getY();
 

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -1,5 +1,5 @@
 //
-//  WindowScriptingInterface.cpp
+//  WindowScriptingInterface.h
 //  interface/src/scripting
 //
 //  Created by Ryan Huffman on 4/29/14.

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -39,11 +39,14 @@ class WindowScriptingInterface : public QObject, public Dependency {
     Q_PROPERTY(int innerHeight READ getInnerHeight)
     Q_PROPERTY(int x READ getX)
     Q_PROPERTY(int y READ getY)
+    Q_PROPERTY(int menuHeight READ getMenuHeight)
+
 public:
     WindowScriptingInterface();
     ~WindowScriptingInterface();
     int getInnerWidth();
     int getInnerHeight();
+    int getMenuHeight();
     int getX();
     int getY();
 


### PR DESCRIPTION
> 2D overlays are positioned with respect to the drawable area (i.e., excluding the menu bar): an overlay positioned at 0,0 is drawn immediately underneath the menu bar.
> 
> Similarly for the values returned by Window.getDeviceSize() and Window.geometryChanged()
> 
> These are all pulled from 
> qApp->getWindow()->geometry()
> 
> Task:
> Fix the return back from Window.innerHeight, Window.getDeviceSize, and Window.geometryChanged to reflect the actual height minus the menu bar.
[Worklist 21664](https://worklist.net/21664)

## Test Plan
1. Install this PR
2. Enable Developer/Advanced Menu
3. Open the Console and Run `Window.innerHeight` and `JSON.stringify(Window.getDeviceSize())`
4. Confirm that the Y value is the size of the Interface window (Excluding Title & Menu Bar) on both results.
5. Run this: `Window.geometryChanged.connect(function(e) { print(JSON.stringify(e)); });` and start changing the size of the Window and comparing the console output to the actual size - confirm it's all correct.
6. Quickly run `Window.menuHeight` and confirm it prints the height of the Menu Bar.
7. Check the scripts [listed here](https://github.com/highfidelity/hifi/pull/12102#issuecomment-356032365) and ensure they're still running as expected with no strange results.

### On a 1920x1080 display, with Interface Maximized, your result for Y should be 996.
  