### PR TITLE
Make zones, lights, and particles not grabbable when created in edit.js

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -225,7 +225,7 @@ function adjustPositionPerBoundingBox(position, direction, registration, dimensi
 
 var TOOLS_PATH = Script.resolvePath("assets/images/tools/");
 var GRABBABLE_ENTITIES_MENU_CATEGORY = "Edit";
-var GRABBABLE_ENTITIES_MENU_ITEM = "Create Entities As Grabbable";
+var GRABBABLE_ENTITIES_MENU_ITEM = "Create Entities As Grabbable (except Zones, Particles, and Lights)";
 
 var toolBar = (function () {
     var EDIT_SETTING = "io.highfidelity.isEditing"; // for communication with other scripts
@@ -280,7 +280,7 @@ var toolBar = (function () {
             position = grid.snapToSurface(grid.snapToGrid(position, false, dimensions), dimensions);
             properties.position = position;
             if (Menu.isOptionChecked(GRABBABLE_ENTITIES_MENU_ITEM) &&
-                !(properties.type === "Zone" || properties.type === "Light")) {
+                !(properties.type === "Zone" || properties.type === "Light" || properties.type === "ParticleEffect")) {
                 properties.userData = JSON.stringify({ grabbableKey: { grabbable: true } });
             } else {
                 properties.userData = JSON.stringify({ grabbableKey: { grabbable: false } });

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -279,13 +279,11 @@ var toolBar = (function () {
 
             position = grid.snapToSurface(grid.snapToGrid(position, false, dimensions), dimensions);
             properties.position = position;
-            if (Menu.isOptionChecked(GRABBABLE_ENTITIES_MENU_ITEM)) {
+            if (Menu.isOptionChecked(GRABBABLE_ENTITIES_MENU_ITEM) &&
+                !(properties.type === "Zone" || properties.type === "Light")) {
                 properties.userData = JSON.stringify({ grabbableKey: { grabbable: true } });
-            }
-
-            if (properties.type === "Zone" || properties.type === "Light") {
+            } else {
                 properties.userData = JSON.stringify({ grabbableKey: { grabbable: false } });
-                properties.dynamic = false;
             }
 
             entityID = Entities.addEntity(properties);

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -239,6 +239,7 @@ var toolBar = (function () {
         var dimensions = properties.dimensions ? properties.dimensions : DEFAULT_DIMENSIONS;
         var position = getPositionToCreateEntity();
         var entityID = null;
+
         if (position !== null && position !== undefined) {
             var direction;
             if (Camera.mode === "entity" || Camera.mode === "independent") {
@@ -281,6 +282,12 @@ var toolBar = (function () {
             if (Menu.isOptionChecked(GRABBABLE_ENTITIES_MENU_ITEM)) {
                 properties.userData = JSON.stringify({ grabbableKey: { grabbable: true } });
             }
+
+            if (properties.type === "Zone" || properties.type === "Light") {
+                properties.userData = JSON.stringify({ grabbableKey: { grabbable: false } });
+                properties.dynamic = false;
+            }
+
             entityID = Entities.addEntity(properties);
 
             if (properties.type === "ParticleEffect") {


### PR DESCRIPTION
**FB Case 10583**
By default, lights, zones, and particle effects should not be created as grabbable. This PR changes the functionality for these types of entities only and updates the menu in Interface to reflect which entities _will_ be made grabbable if 'Create Entities as Grabbable' (Advanced Menus on) is checked.

Test plan:
- Run Create Tab test plan 6766 and confirm that the cube creation still follows the expected behavior as written in that test plan
- Run Create Tab test plans 6768, 6769, and 6771 and confirm that instead of user data showing `userData {1} section with grabbableKey {1} grabbable: true ` for the Zone, Particles, and Light entity types, it shows as `userData {1} section with grabbableKey {1} grabbable: false`
- Confirm that with Advanced Menus enabled, the 'Create Entities as Grabbable' menu item now reads Create Entities as Grabbable (except Zones, Particles, and Lights)

I have created FB Case 11214 to reflect changes to the test cases with the new expected behavior per this PR
  