### PR TITLE
Fix avatar texture loading

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
@@ -37,6 +37,16 @@ SkeletonModel::SkeletonModel(Avatar* owningAvatar, QObject* parent) :
 SkeletonModel::~SkeletonModel() {
 }
 
+void SkeletonModel::setURL(const QUrl& url) {
+    _texturesLoaded = false;
+    Model::setURL(url);
+}
+
+void SkeletonModel::setTextures(const QVariantMap& textures) {
+    _texturesLoaded = false;
+    Model::setTextures(textures);
+}
+
 void SkeletonModel::initJointStates() {
     const FBXGeometry& geometry = getFBXGeometry();
     glm::mat4 modelOffset = glm::scale(_scale) * glm::translate(_offset);
@@ -140,6 +150,13 @@ void SkeletonModel::simulate(float deltaTime, bool fullUpdate) {
         }
     } else {
         Parent::simulate(deltaTime, fullUpdate);
+    }
+
+    // FIXME: This texture loading logic should probably live in Avatar, to mirror RenderableModelEntityItem and ModelOverlay,
+    // but Avatars don't get updates in the same way
+    if (!_texturesLoaded && getGeometry() && getGeometry()->areTexturesLoaded()) {
+        _texturesLoaded = true;
+        updateRenderItems();
     }
 
     if (!isActive() || !_owningAvatar->isMyAvatar()) {

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
@@ -31,6 +31,9 @@ public:
     SkeletonModel(Avatar* owningAvatar, QObject* parent = nullptr);
     ~SkeletonModel();
 
+    Q_INVOKABLE void setURL(const QUrl& url) override;
+    Q_INVOKABLE void setTextures(const QVariantMap& textures) override;
+
     void initJointStates() override;
 
     void simulate(float deltaTime, bool fullUpdate = true) override;
@@ -115,8 +118,6 @@ protected:
 
     void computeBoundingShape();
 
-protected:
-
     bool getEyeModelPositions(glm::vec3& firstEyePosition, glm::vec3& secondEyePosition) const;
 
     Avatar* _owningAvatar;
@@ -128,6 +129,9 @@ protected:
     glm::vec3 _defaultEyeModelPosition;
 
     float _headClipDistance;  // Near clip distance to use if no separate head model
+
+private:
+    bool _texturesLoaded { false };
 };
 
 #endif // hifi_SkeletonModel_h

--- a/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
+++ b/libraries/render-utils/src/CauterizedMeshPartPayload.cpp
@@ -46,10 +46,7 @@ void CauterizedMeshPartPayload::bindTransform(gpu::Batch& batch, const render::S
         }
         batch.setModelTransform(_cauterizedTransform);
     } else {
-        if (_clusterBuffer) {
-            batch.setUniformBuffer(ShapePipeline::Slot::BUFFER::SKINNING, _clusterBuffer);
-        }
-        batch.setModelTransform(_transform);
+        ModelMeshPartPayload::bindTransform(batch, locations, renderMode);
     }
 }
 

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -480,23 +480,14 @@ ShapeKey ModelMeshPartPayload::getShapeKey() const {
 }
 
 void ModelMeshPartPayload::bindMesh(gpu::Batch& batch) {
-    if (!_isBlendShaped) {
-        batch.setIndexBuffer(gpu::UINT32, (_drawMesh->getIndexBuffer()._buffer), 0);
-        batch.setInputFormat((_drawMesh->getVertexFormat()));
-        batch.setInputStream(0, _drawMesh->getVertexStream());
+    batch.setIndexBuffer(gpu::UINT32, (_drawMesh->getIndexBuffer()._buffer), 0);
+    batch.setInputFormat((_drawMesh->getVertexFormat()));
+    if (_isBlendShaped && _blendedVertexBuffer) {
+        batch.setInputBuffer(0, _blendedVertexBuffer, 0, sizeof(glm::vec3));
+        batch.setInputBuffer(1, _blendedVertexBuffer, _drawMesh->getNumVertices() * sizeof(glm::vec3), sizeof(glm::vec3));
+        batch.setInputStream(2, _drawMesh->getVertexStream().makeRangedStream(2));
     } else {
-        batch.setIndexBuffer(gpu::UINT32, (_drawMesh->getIndexBuffer()._buffer), 0);
-        batch.setInputFormat((_drawMesh->getVertexFormat()));
-
-        if (_blendedVertexBuffer) {
-            batch.setInputBuffer(0, _blendedVertexBuffer, 0, sizeof(glm::vec3));
-            batch.setInputBuffer(1, _blendedVertexBuffer, _drawMesh->getNumVertices() * sizeof(glm::vec3), sizeof(glm::vec3));
-            batch.setInputStream(2, _drawMesh->getVertexStream().makeRangedStream(2));
-        } else {
-            batch.setIndexBuffer(gpu::UINT32, (_drawMesh->getIndexBuffer()._buffer), 0);
-            batch.setInputFormat((_drawMesh->getVertexFormat()));
-            batch.setInputStream(0, _drawMesh->getVertexStream());
-        }
+        batch.setInputStream(0, _drawMesh->getVertexStream());
     }
 }
 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -78,7 +78,7 @@ public:
 
     /// Sets the URL of the model to render.
     // Should only be called from the model's rendering thread to avoid access violations of changed geometry.
-    Q_INVOKABLE void setURL(const QUrl& url);
+    Q_INVOKABLE virtual void setURL(const QUrl& url);
     const QUrl& getURL() const { return _url; }
 
     // new Scene/Engine rendering support
@@ -136,7 +136,7 @@ public:
     const Geometry::Pointer& getCollisionGeometry() const { return _collisionGeometry; }
 
     const QVariantMap getTextures() const { assert(isLoaded()); return _renderGeometry->getTextures(); }
-    Q_INVOKABLE void setTextures(const QVariantMap& textures);
+    Q_INVOKABLE virtual void setTextures(const QVariantMap& textures);
 
     /// Provided as a convenience, will crash if !isLoaded()
     // And so that getGeometry() isn't chained everywhere


### PR DESCRIPTION
Like overlays and entities, avatars need to monitor for their textures loading in order to update their render items.

https://highfidelity.manuscript.com/f/cases/11054/Art3mis-Avatar-s-clothes-clip-into-body

Test plan:
- Start with the default wooden mannequin avatar.  Restart interface.
- Set your avatar to Yasmin.  You should not see splotches of her skin through her suit.
- Set your avatar to Art3mis.  You should not see splotches of her legs through her pants.
- Reload content several times.  Your avatar should continue to render correctly each time.
  