### PR TITLE
Page indicator visible only when pages more than one

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletHome.qml
+++ b/interface/resources/qml/hifi/tablet/TabletHome.qml
@@ -224,6 +224,7 @@ Item {
         PageIndicator {
             id: pageIndicator
             currentIndex: swipeView.currentIndex
+            visible: swipeView.count > 1
 
             delegate: Item {
                 width: 15


### PR DESCRIPTION
Test plan:

- Create > 12 apps. Make sure page indicator is visible
- Remove apps to make them  less or equal 12. Make sure page indicator non visible