### PR TITLE
RC62 - Oculus Touch: More accurate spin on thrown objects

### DIFF
--- a/plugins/oculus/src/OculusHelpers.cpp
+++ b/plugins/oculus/src/OculusHelpers.cpp
@@ -262,7 +262,7 @@ controller::Pose ovrControllerPoseToHandPose(
     pose.translation = toGlm(handPose.ThePose.Position);
     pose.translation += rotation * translationOffset;
     pose.rotation = rotation * rotationOffset;
-    pose.angularVelocity = toGlm(handPose.AngularVelocity);
+    pose.angularVelocity = rotation * toGlm(handPose.AngularVelocity);
     pose.velocity = toGlm(handPose.LinearVelocity);
     pose.valid = true;
     return pose;


### PR DESCRIPTION
The internal computation of angular velocity was incorrect.  Apparently, the ovrPoseStatef.AngularRotation is not in sensor frame but local to the controller rotation.

Same change as #12111 but rebased on the RC62 branch