### PR TITLE
Don't call setQmlTabletRoot twice for Web3dOverlays RC62

### DIFF
--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -222,10 +222,6 @@ void Web3DOverlay::setupQmlSurface() {
 
         _webSurface->getSurfaceContext()->setContextProperty("pathToFonts", "../../");
 
-        tabletScriptingInterface->setQmlTabletRoot("com.highfidelity.interface.tablet.system", _webSurface.data());
-        // mark the TabletProxy object as cpp ownership.
-        QObject* tablet = tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system");
-        _webSurface->getSurfaceContext()->engine()->setObjectOwnership(tablet, QQmlEngine::CppOwnership);
         // Override min fps for tablet UI, for silky smooth scrolling
         setMaxFPS(90);
     }


### PR DESCRIPTION
```OffscreenQmlSurface``` calls ```TabletProxy::setQmlTabletRoot``` when it finishes loading a qml file. ```Web3doverlay``` call ```TabletProxy::setQmlTabletRoot``` when setting up a qmlSurface.  Since ```Web3dOverlay``` inherits from ```OffscreenQmlSurface``` this results  ```TabletProxy::setQmlTabletRoot``` being called twice and connecting the ```emitWebEvent``` twice. As a result any web app the uses the event bridge will perform any action twice. In this PR I am removing ```Web3dOverlay``` from calling ```TabletProxy::setQmlTabletRoot```  to prevent the issue above
  