### PR TITLE
Fix concurrent access crash in avatar mixer

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -116,8 +116,9 @@ public:
     void setLastOtherAvatarEncodeTime(const QUuid& otherAvatar, const uint64_t& time);
 
     QVector<JointData>& getLastOtherAvatarSentJoints(QUuid otherAvatar) {
-        _lastOtherAvatarSentJoints[otherAvatar].resize(_avatar->getJointCount());
-        return _lastOtherAvatarSentJoints[otherAvatar];
+        auto& lastOtherAvatarSentJoints = _lastOtherAvatarSentJoints[otherAvatar];
+        lastOtherAvatarSentJoints.resize(_avatar->getJointCount());
+        return lastOtherAvatarSentJoints;
     }
 
     void queuePacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer node);

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -530,9 +530,13 @@ QByteArray AvatarData::toByteArray(AvatarDataDetail dataDetail, quint64 lastSent
 
         destinationBuffer += numValidityBytes; // Move pointer past the validity bytes
 
+        // sentJointDataOut and lastSentJointData might be the same vector
+        // build sentJointDataOut locally and then swap it at the end.
+        QVector<JointData> localSentJointDataOut;
         if (sentJointDataOut) {
-            sentJointDataOut->resize(_jointData.size()); // Make sure the destination is resized before using it
+            localSentJointDataOut.resize(numJoints); // Make sure the destination is resized before using it
         }
+
         float minRotationDOT = !distanceAdjust ? AVATAR_MIN_ROTATION_DOT : getDistanceBasedMinRotationDOT(viewerPosition);
 
         for (int i = 0; i < _jointData.size(); i++) {
@@ -552,8 +556,7 @@ QByteArray AvatarData::toByteArray(AvatarDataDetail dataDetail, quint64 lastSent
                         destinationBuffer += packOrientationQuatToSixBytes(destinationBuffer, data.rotation);
 
                         if (sentJointDataOut) {
-                            auto jointDataOut = *sentJointDataOut;
-                            jointDataOut[i].rotation = data.rotation;
+                            localSentJointDataOut[i].rotation = data.rotation;
                         }
 
                     }
@@ -602,8 +605,7 @@ QByteArray AvatarData::toByteArray(AvatarDataDetail dataDetail, quint64 lastSent
                             packFloatVec3ToSignedTwoByteFixed(destinationBuffer, data.translation, TRANSLATION_COMPRESSION_RADIX);
 
                         if (sentJointDataOut) {
-                            auto jointDataOut = *sentJointDataOut;
-                            jointDataOut[i].translation = data.translation;
+                            localSentJointDataOut[i].translation = data.translation;
                         }
 
                     }
@@ -645,6 +647,11 @@ QByteArray AvatarData::toByteArray(AvatarDataDetail dataDetail, quint64 lastSent
         int numBytes = destinationBuffer - startSection;
         if (outboundDataRateOut) {
             outboundDataRateOut->jointDataRate.increment(numBytes);
+        }
+
+        if (sentJointDataOut) {
+            // Push new sent joint data to sentJointDataOut
+            sentJointDataOut->swap(localSentJointDataOut);
         }
     }
 


### PR DESCRIPTION
`toByteArray` sometimes receives 2 separate pointers/refs to the same vectors and treats them as separate objects.
This PR makes sure we act on 2 separate objects and only commit the changes at the end