### PR TITLE
Fix toolbar is visible on HMD mode

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7357,6 +7357,7 @@ void Application::updateThreadPoolCount() const {
 }
 
 void Application::updateSystemTabletMode() {
+    if (!_settingsLoaded) return;
     qApp->setProperty(hifi::properties::HMD, isHMDMode());
     if (isHMDMode()) {
         DependencyManager::get<TabletScriptingInterface>()->setToolbarMode(getHmdTabletBecomesToolbarSetting());

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7357,12 +7357,13 @@ void Application::updateThreadPoolCount() const {
 }
 
 void Application::updateSystemTabletMode() {
-    if (!_settingsLoaded) return;
-    qApp->setProperty(hifi::properties::HMD, isHMDMode());
-    if (isHMDMode()) {
-        DependencyManager::get<TabletScriptingInterface>()->setToolbarMode(getHmdTabletBecomesToolbarSetting());
-    } else {
-        DependencyManager::get<TabletScriptingInterface>()->setToolbarMode(getDesktopTabletBecomesToolbarSetting());
+    if (_settingsLoaded) {
+        qApp->setProperty(hifi::properties::HMD, isHMDMode());
+        if (isHMDMode()) {
+            DependencyManager::get<TabletScriptingInterface>()->setToolbarMode(getHmdTabletBecomesToolbarSetting());
+        } else {
+            DependencyManager::get<TabletScriptingInterface>()->setToolbarMode(getDesktopTabletBecomesToolbarSetting());
+        }
     }
 }
 


### PR DESCRIPTION

This PR fix the bug where the toolbar appears when interface is started on HMD mode.

https://highfidelity.manuscript.com/f/cases/11094/In-VR-mode-toolbar-is-visible-in-addition-to-tablet-until-desktop-mode-is-entered-at-least-once

# Test Plan

- Start interface.exe in HMD mode and make sure the toolbar doesn't appear.
- Change to desktop mode. The toolbar should now appear.
- Change again to HMD mode. The toolbar should not appear.
- Start interface.exe in Desktop mode and make sure the toolbar appear.
- Change again to HMD mode. The toolbar should not appear.
- Change to desktop mode. The toolbar should now appear.
 