### PR TITLE
Model meta render item is only withTypeShape if visual geometry request fails

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1851,6 +1851,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     DependencyManager::get<EntityTreeRenderer>()->setSetPrecisionPickingOperator([&](unsigned int rayPickID, bool value) {
         DependencyManager::get<PickManager>()->setPrecisionPicking(rayPickID, value);
     });
+    EntityTreeRenderer::setRenderDebugHullsOperator([] {
+        return Menu::getInstance()->isOptionChecked(MenuOption::PhysicsShowHulls);
+    });
 
     // Preload Tablet sounds
     DependencyManager::get<TabletScriptingInterface>()->preloadSounds();

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -698,7 +698,7 @@ Menu::Menu() {
         addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowOwned,
             0, false, drawStatusConfig, SLOT(setShowNetwork(bool)));
     }
-    addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowHulls);
+    addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowHulls, 0, false, qApp->getEntities().data(), SIGNAL(setRenderDebugHulls()));
 
     // Developer > Ask to Reset Settings
     addCheckableActionToQMenuAndActionHash(developerMenu, MenuOption::AskToResetSettings, 0, false);

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -42,6 +42,7 @@
 
 size_t std::hash<EntityItemID>::operator()(const EntityItemID& id) const { return qHash(id); }
 std::function<bool()> EntityTreeRenderer::_entitiesShouldFadeFunction;
+std::function<bool()> EntityTreeRenderer::_renderDebugHullsOperator = [] { return false; };
 
 EntityTreeRenderer::EntityTreeRenderer(bool wantScripts, AbstractViewStateInterface* viewState,
                                             AbstractScriptingServicesInterface* scriptingServices) :

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -116,10 +116,14 @@ public:
     EntityItemPointer getEntity(const EntityItemID& id);
     void onEntityChanged(const EntityItemID& id);
 
+    static void setRenderDebugHullsOperator(std::function<bool()> renderDebugHullsOperator) { _renderDebugHullsOperator = renderDebugHullsOperator; }
+    static bool shouldRenderDebugHulls() { return _renderDebugHullsOperator(); }
+
 signals:
     void enterEntity(const EntityItemID& entityItemID);
     void leaveEntity(const EntityItemID& entityItemID);
     void collisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
+    void setRenderDebugHulls();
 
 public slots:
     void addingEntity(const EntityItemID& entityID);
@@ -255,6 +259,8 @@ private:
     static int _entitiesScriptEngineCount;
     static CalculateEntityLoadingPriority _calculateEntityLoadingPriorityFunc;
     static std::function<bool()> _entitiesShouldFadeFunction;
+
+    static std::function<bool()> _renderDebugHullsOperator;
 };
 
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -954,8 +954,23 @@ void RenderableModelEntityItem::copyAnimationJointDataToModel() {
 using namespace render;
 using namespace render::entities;
 
+ModelEntityRenderer::ModelEntityRenderer(const EntityItemPointer& entity) : Parent(entity) {
+    connect(DependencyManager::get<EntityTreeRenderer>().data(), &EntityTreeRenderer::setRenderDebugHulls, this, [&] {
+        _needsCollisionGeometryUpdate = true;
+        emit requestRenderUpdate();
+    });
+}
+
+void ModelEntityRenderer::setKey(bool didVisualGeometryRequestSucceed) {
+    if (didVisualGeometryRequestSucceed) {
+        _itemKey = ItemKey::Builder().withTypeMeta();
+    } else {
+        _itemKey = ItemKey::Builder().withTypeMeta().withTypeShape();
+    }
+}
+
 ItemKey ModelEntityRenderer::getKey() {
-    return ItemKey::Builder().withTypeMeta().withTypeShape();
+    return _itemKey;
 }
 
 uint32_t ModelEntityRenderer::metaFetchMetaSubItems(ItemIDs& subItems) { 
@@ -1209,7 +1224,10 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
     // Check for addition
     if (_hasModel && !(bool)_model) {
         model = std::make_shared<Model>(nullptr, entity.get());
-        connect(model.get(), &Model::setURLFinished, this, &ModelEntityRenderer::requestRenderUpdate);
+        connect(model.get(), &Model::setURLFinished, this, [&](bool didVisualGeometryRequestSucceed) {
+            setKey(didVisualGeometryRequestSucceed);
+            emit requestRenderUpdate();
+        });
         connect(model.get(), &Model::requestRenderUpdate, this, &ModelEntityRenderer::requestRenderUpdate);
         connect(entity.get(), &RenderableModelEntityItem::requestCollisionGeometryUpdate, this, &ModelEntityRenderer::flagForCollisionGeometryUpdate);
         model->setLoadingPriority(EntityTreeRenderer::getEntityLoadingPriority(*entity));
@@ -1275,7 +1293,7 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
         setCollisionMeshKey(entity->getCollisionMeshKey());
         _needsCollisionGeometryUpdate = false;
         ShapeType type = entity->getShapeType();
-        if (_showCollisionGeometry && type != SHAPE_TYPE_STATIC_MESH && type != SHAPE_TYPE_NONE) {
+        if (DependencyManager::get<EntityTreeRenderer>()->shouldRenderDebugHulls() && type != SHAPE_TYPE_STATIC_MESH && type != SHAPE_TYPE_NONE) {
             // NOTE: it is OK if _collisionMeshKey is nullptr
             model::MeshPointer mesh = collisionMeshCache.getMesh(_collisionMeshKey);
             // NOTE: the model will render the collisionGeometry if it has one
@@ -1342,20 +1360,11 @@ void ModelEntityRenderer::doRender(RenderArgs* args) {
     DETAILED_PROFILE_RANGE(render_detail, "MetaModelRender");
     DETAILED_PERFORMANCE_TIMER("RMEIrender");
 
-    ModelPointer model;
-    withReadLock([&]{
-        model = _model;
-    });
-
-    // If we don't have a model, or the model doesn't have visual geometry, render our bounding box as green wireframe
-    if (!model || (model && model->didVisualGeometryRequestFail())) {
-        static glm::vec4 greenColor(0.0f, 1.0f, 0.0f, 1.0f);
-        gpu::Batch& batch = *args->_batch;
-        batch.setModelTransform(getModelTransform()); // we want to include the scale as well
-        DependencyManager::get<GeometryCache>()->renderWireCubeInstance(args, batch, greenColor);
-        return;
-    }
-
+    // If the model doesn't have visual geometry, render our bounding box as green wireframe
+    static glm::vec4 greenColor(0.0f, 1.0f, 0.0f, 1.0f);
+    gpu::Batch& batch = *args->_batch;
+    batch.setModelTransform(getModelTransform()); // we want to include the scale as well
+    DependencyManager::get<GeometryCache>()->renderWireCubeInstance(args, batch, greenColor);
 
     // Enqueue updates for the next frame
 #if WANT_EXTRA_DEBUGGING
@@ -1366,12 +1375,6 @@ void ModelEntityRenderer::doRender(RenderArgs* args) {
 
     // Remap textures for the next frame to avoid flicker
     // remapTextures();
-
-    bool showCollisionGeometry = (bool)(args->_debugFlags & (int)RenderArgs::RENDER_DEBUG_HULLS);
-    if (showCollisionGeometry != _showCollisionGeometry) {
-        _showCollisionGeometry = showCollisionGeometry;
-        flagForCollisionGeometryUpdate();
-    }
 }
 
 void ModelEntityRenderer::mapJoints(const TypedEntityPointer& entity, const QStringList& modelJointNames) {

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -133,12 +133,13 @@ class ModelEntityRenderer : public TypedEntityRenderer<RenderableModelEntityItem
     friend class EntityRenderer;
 
 public:
-    ModelEntityRenderer(const EntityItemPointer& entity) : Parent(entity) {}
+    ModelEntityRenderer(const EntityItemPointer& entity);
 
 protected:
     virtual void removeFromScene(const ScenePointer& scene, Transaction& transaction) override;
     virtual void onRemoveFromSceneTyped(const TypedEntityPointer& entity) override;
 
+    void setKey(bool didVisualGeometryRequestSucceed);
     virtual ItemKey getKey() override;
     virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) override;
 
@@ -169,10 +170,9 @@ private:
     bool _hasTransitioned{ false };
 #endif
 
-    bool _needsJointSimulation{ false };
-    bool _showCollisionGeometry{ false };
-    bool _needsCollisionGeometryUpdate{ false };
-    const void* _collisionMeshKey{ nullptr };
+    bool _needsJointSimulation { false };
+    bool _needsCollisionGeometryUpdate { false };
+    const void* _collisionMeshKey { nullptr };
 
     // used on client side
     bool _jointMappingCompleted{ false };
@@ -185,6 +185,8 @@ private:
     bool _shouldHighlight { false };
     bool _animating { false };
     uint64_t _lastAnimated { 0 };
+
+    render::ItemKey _itemKey { render::ItemKey::Builder().withTypeMeta() };
 };
 
 } } // namespace 


### PR DESCRIPTION
Before, all model meta render items were withTypeShape(), which means were "rendering" an extra render item for every model, even though most of the time it did nothing.  Now, they are only withTypeShape() if they need to be (in order to render the green "model failed to load" cube).

Test plan:
- Create a model with a junk url ("asdf" for example).  A green cube should appear.
- Set the model's url to something valid, like http://hifi-content.s3.amazonaws.com/DomainContent/Welcome%20Area/Models/coffeeCup.fbx?2.  The green cube should disappear and the model should appear properly.
- Enable debug collision hulls (Developer -> Physics -> Draw Collision Shapes).
- Change the model's collision shape type to "Box".  It should be replaced by a blue box.
- Disable debug collision hulls.  The blue box should disappear and the model should reappear.