### PR TITLE
Move key logic from onClicked to onReleased

### DIFF
--- a/interface/resources/qml/controls-uit/Key.qml
+++ b/interface/resources/qml/controls-uit/Key.qml
@@ -45,18 +45,6 @@ Item {
             }
         }
 
-        onClicked: {
-            mouse.accepted = true;
-            Tablet.playSound(TabletEnums.ButtonClick);
-
-            webEntity.synthesizeKeyPress(glyph);
-            webEntity.synthesizeKeyPress(glyph, mirrorText);
-
-            if (toggle) {
-                toggled = !toggled;
-            }
-        }
-
         onDoubleClicked: {
             mouse.accepted = true;
         }
@@ -94,6 +82,14 @@ Item {
 
         onReleased: {
             if (containsMouse) {
+                Tablet.playSound(TabletEnums.ButtonClick);
+
+                webEntity.synthesizeKeyPress(glyph);
+                webEntity.synthesizeKeyPress(glyph, mirrorText);
+
+                if (toggle) {
+                    toggled = !toggled;
+                }
                 keyItem.state = "mouseOver";
             } else {
                 if (toggled) {


### PR DESCRIPTION
If you clicked quickly with the lasers, the second click was never being registered by the QML onClicked.  This works around the issue.

Test plan:
- In HMD, bring up the keyboard on the tablet.  Use your lasers on the keyboard.  The keys should register properly, even if you click quickly.