### PR TITLE
RC62 Pal volume slider fix

### DIFF
--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -520,7 +520,7 @@ Item {
     Slider {
         id: gainSlider
         // Size
-        width: thisNameCard.width - 20;
+        width: isMyCard ? thisNameCard.width - 20 : thisNameCard.width;
         height: 14
         // Anchors
         anchors.verticalCenter: nameCardVUMeter.verticalCenter;

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -50,7 +50,7 @@ Item {
         id: avatarImage
         visible: profileUrl !== "" && userName !== "";
         // Size
-        height: isMyCard ? 70 : 42;
+        height: isMyCard ? 84 : 42;
         width: visible ? height : 0;
         anchors.top: parent.top;
         anchors.topMargin: isMyCard ? 0 : 8;
@@ -520,7 +520,7 @@ Item {
     Slider {
         id: gainSlider
         // Size
-        width: thisNameCard.width;
+        width: thisNameCard.width - 20;
         height: 14
         // Anchors
         anchors.verticalCenter: nameCardVUMeter.verticalCenter;

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -28,7 +28,7 @@ Rectangle {
     // Properties
     property bool debug: false;
     property int myCardWidth: width - upperRightInfoContainer.width;
-    property int myCardHeight: 80;
+    property int myCardHeight: 100;
     property int rowHeight: 60;
     property int actionButtonWidth: 55;
     property int locationColumnWidth: 170;


### PR DESCRIPTION
This PR fix the master volume slider inside pal.

https://highfidelity.fogbugz.com/f/cases/11233/People-Tab-Set-Availability-box-overlaps-Master-Volume-Slider

# Test Plan

- Launch High Fidelity and select the People Tab. The _Set Availability_ box should not overlaps _Master Volume_ Slider.
 