### PR TITLE
WL#21669: Allow better keyboard navigation of prompt windows such as Window.prompt()

### DIFF
--- a/interface/resources/qml/controls-uit/Button.qml
+++ b/interface/resources/qml/controls-uit/Button.qml
@@ -32,6 +32,12 @@ Original.Button {
             Tablet.playSound(TabletEnums.ButtonHover);
         }
     }
+    
+    onFocusChanged: {
+        if (focus) {
+            Tablet.playSound(TabletEnums.ButtonHover);
+        }
+    }
 
     onClicked: {
         Tablet.playSound(TabletEnums.ButtonClick);

--- a/interface/resources/qml/controls-uit/Button.qml
+++ b/interface/resources/qml/controls-uit/Button.qml
@@ -57,7 +57,7 @@ Original.Button {
                             hifi.buttons.disabledColorStart[control.colorScheme]
                         } else if (control.pressed) {
                             hifi.buttons.pressedColor[control.color]
-                        } else if (control.hovered) {
+                        } else if (control.hovered || control.focus) {
                             hifi.buttons.hoveredColor[control.color]
                         } else {
                             hifi.buttons.colorStart[control.color]
@@ -71,7 +71,7 @@ Original.Button {
                             hifi.buttons.disabledColorFinish[control.colorScheme]
                         } else if (control.pressed) {
                             hifi.buttons.pressedColor[control.color]
-                        } else if (control.hovered) {
+                        } else if (control.hovered || control.focus) {
                             hifi.buttons.hoveredColor[control.color]
                         } else {
                             hifi.buttons.colorFinish[control.color]

--- a/interface/resources/qml/controls-uit/Button.qml
+++ b/interface/resources/qml/controls-uit/Button.qml
@@ -57,8 +57,10 @@ Original.Button {
                             hifi.buttons.disabledColorStart[control.colorScheme]
                         } else if (control.pressed) {
                             hifi.buttons.pressedColor[control.color]
-                        } else if (control.hovered || control.focus) {
+                        } else if (control.hovered) {
                             hifi.buttons.hoveredColor[control.color]
+                        }  else if (!control.hovered && control.focus) {
+                            hifi.buttons.focusedColor[control.color]
                         } else {
                             hifi.buttons.colorStart[control.color]
                         }
@@ -71,8 +73,10 @@ Original.Button {
                             hifi.buttons.disabledColorFinish[control.colorScheme]
                         } else if (control.pressed) {
                             hifi.buttons.pressedColor[control.color]
-                        } else if (control.hovered || control.focus) {
+                        } else if (control.hovered) {
                             hifi.buttons.hoveredColor[control.color]
+                        } else if (!control.hovered && control.focus) {
+                            hifi.buttons.focusedColor[control.color]
                         } else {
                             hifi.buttons.colorFinish[control.color]
                         }

--- a/interface/resources/qml/controls-uit/GlyphButton.qml
+++ b/interface/resources/qml/controls-uit/GlyphButton.qml
@@ -31,6 +31,12 @@ Original.Button {
         }
     }
 
+    onFocusChanged: {
+        if (focus) {
+            Tablet.playSound(TabletEnums.ButtonHover);
+        }
+    }
+
     onClicked: {
         Tablet.playSound(TabletEnums.ButtonClick);
     }
@@ -50,6 +56,8 @@ Original.Button {
                             hifi.buttons.pressedColor[control.color]
                         } else if (control.hovered) {
                             hifi.buttons.hoveredColor[control.color]
+                        } else if (!control.hovered && control.focus) {
+                            hifi.buttons.focusedColor[control.color]
                         } else {
                             hifi.buttons.colorStart[control.color]
                         }
@@ -64,6 +72,8 @@ Original.Button {
                             hifi.buttons.pressedColor[control.color]
                         } else if (control.hovered) {
                             hifi.buttons.hoveredColor[control.color]
+                        } else if (!control.hovered && control.focus) {
+                            hifi.buttons.focusedColor[control.color]
                         } else {
                             hifi.buttons.colorFinish[control.color]
                         }

--- a/interface/resources/qml/controls-uit/Table.qml
+++ b/interface/resources/qml/controls-uit/Table.qml
@@ -93,7 +93,7 @@ TableView {
             size: hifi.fontSizes.tableHeadingIcon
             anchors {
                 left: titleText.right
-                leftMargin: -hifi.fontSizes.tableHeadingIcon / 3 - (centerHeaderText ? 5 : 0)
+                leftMargin: -hifi.fontSizes.tableHeadingIcon / 3 - (centerHeaderText ? 15 : 10)
                 right: parent.right
                 rightMargin: hifi.dimensions.tablePadding
                 verticalCenter: titleText.verticalCenter

--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -102,7 +102,17 @@ ModalWindow {
             }
         });
 
-        fileTableView.forceActiveFocus();
+        focusTimer.start();
+    }
+    
+    Timer {
+        id: focusTimer
+        interval: 10
+        running: false
+        repeat: false
+        onTriggered: {
+            fileTableView.contentItem.forceActiveFocus();
+        }
     }
 
     Item {
@@ -122,7 +132,9 @@ ModalWindow {
             drag.target: root
             onClicked: {
                 d.clearSelection();
-                frame.forceActiveFocus();  // Defocus text field so that the keyboard gets hidden.
+                // Defocus text field so that the keyboard gets hidden.
+                // Clicking also breaks keyboard navigation apart from backtabbing to cancel 
+                frame.forceActiveFocus();
             }
         }
 
@@ -142,6 +154,12 @@ ModalWindow {
                 size: 30
                 enabled: fileTableModel.parentFolder && fileTableModel.parentFolder !== ""
                 onClicked: d.navigateUp();
+                KeyNavigation.up: fileTableView.contentItem
+                KeyNavigation.down: fileTableView.contentItem
+                KeyNavigation.tab: fileTableView.contentItem
+                KeyNavigation.backtab: fileTableView.contentItem
+                KeyNavigation.left: fileTableView.contentItem
+                KeyNavigation.right: fileTableView.contentItem
             }
 
             GlyphButton {
@@ -152,6 +170,12 @@ ModalWindow {
                 width: height
                 enabled: d.homeDestination ? true : false
                 onClicked: d.navigateHome();
+                KeyNavigation.up: fileTableView.contentItem
+                KeyNavigation.down: fileTableView.contentItem
+                KeyNavigation.tab: fileTableView.contentItem
+                KeyNavigation.backtab: fileTableView.contentItem
+                KeyNavigation.left: fileTableView.contentItem
+                KeyNavigation.right: fileTableView.contentItem
             }
         }
 
@@ -220,9 +244,15 @@ ModalWindow {
                         d.currentSelectionUrl = helper.pathToUrl(currentText);
                     }
                     fileTableModel.folder = folder;
-                    fileTableView.forceActiveFocus();
                 }
             }
+
+            KeyNavigation.up: fileTableView.contentItem
+            KeyNavigation.down: fileTableView.contentItem
+            KeyNavigation.tab: fileTableView.contentItem
+            KeyNavigation.backtab: fileTableView.contentItem
+            KeyNavigation.left: fileTableView.contentItem
+            KeyNavigation.right: fileTableView.contentItem
         }
 
         QtObject {
@@ -638,6 +668,8 @@ ModalWindow {
                     break;
                 }
             }
+            
+            KeyNavigation.tab: root.saveDialog ? currentSelection : openButton
         }
 
         TextField {
@@ -654,6 +686,10 @@ ModalWindow {
             activeFocusOnTab: !readOnly
             onActiveFocusChanged: if (activeFocus) { selectAll(); }
             onAccepted: okAction.trigger();
+            KeyNavigation.up: fileTableView.contentItem
+            KeyNavigation.down: openButton
+            KeyNavigation.tab: openButton
+            KeyNavigation.backtab: fileTableView.contentItem
         }
 
         FileTypeSelection {
@@ -664,8 +700,6 @@ ModalWindow {
                 right: parent.right
             }
             visible: !selectDirectory && filtersCount > 1
-            KeyNavigation.left: fileTableView
-            KeyNavigation.right: openButton
         }
 
         Keyboard {
@@ -693,18 +727,18 @@ ModalWindow {
                 color: hifi.buttons.blue
                 action: okAction
                 Keys.onReturnPressed: okAction.trigger()
-                KeyNavigation.up: selectionType
-                KeyNavigation.left: selectionType
                 KeyNavigation.right: cancelButton
+                KeyNavigation.up: root.saveDialog ? currentSelection : fileTableView.contentItem
+                KeyNavigation.tab: cancelButton
             }
 
             Button {
                 id: cancelButton
                 action: cancelAction
-                KeyNavigation.up: selectionType
-                KeyNavigation.left: openButton
-                KeyNavigation.right: fileTableView.contentItem
                 Keys.onReturnPressed: { cancelAction.trigger() }
+                KeyNavigation.left: openButton
+                KeyNavigation.up: root.saveDialog ? currentSelection : fileTableView.contentItem
+                KeyNavigation.backtab: openButton
             }
         }
 

--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -154,12 +154,11 @@ ModalWindow {
                 size: 30
                 enabled: fileTableModel.parentFolder && fileTableModel.parentFolder !== ""
                 onClicked: d.navigateUp();
-                KeyNavigation.up: fileTableView.contentItem
-                KeyNavigation.down: fileTableView.contentItem
-                KeyNavigation.tab: fileTableView.contentItem
-                KeyNavigation.backtab: fileTableView.contentItem
-                KeyNavigation.left: fileTableView.contentItem
-                KeyNavigation.right: fileTableView.contentItem
+                Keys.onReturnPressed: { d.navigateUp(); }
+                KeyNavigation.tab: homeButton
+                KeyNavigation.backtab: upButton
+                KeyNavigation.left: upButton
+                KeyNavigation.right: homeButton
             }
 
             GlyphButton {
@@ -170,12 +169,10 @@ ModalWindow {
                 width: height
                 enabled: d.homeDestination ? true : false
                 onClicked: d.navigateHome();
-                KeyNavigation.up: fileTableView.contentItem
-                KeyNavigation.down: fileTableView.contentItem
+                Keys.onReturnPressed: { d.navigateHome(); }
                 KeyNavigation.tab: fileTableView.contentItem
-                KeyNavigation.backtab: fileTableView.contentItem
-                KeyNavigation.left: fileTableView.contentItem
-                KeyNavigation.right: fileTableView.contentItem
+                KeyNavigation.backtab: upButton
+                KeyNavigation.left: upButton
             }
         }
 
@@ -505,7 +502,6 @@ ModalWindow {
             }
             headerVisible: !selectDirectory
             onDoubleClicked: navigateToRow(row);
-            focus: true
             Keys.onReturnPressed: navigateToCurrentRow();
             Keys.onEnterPressed: navigateToCurrentRow();
 
@@ -582,7 +578,7 @@ ModalWindow {
                 resizable: true
             }
             TableViewColumn {
-                id: fileMofifiedColumn
+                id: fileModifiedColumn
                 role: "fileModified"
                 title: "Date"
                 width: 0.3 * fileTableView.width
@@ -593,7 +589,7 @@ ModalWindow {
             TableViewColumn {
                 role: "fileSize"
                 title: "Size"
-                width: fileTableView.width - fileNameColumn.width - fileMofifiedColumn.width
+                width: fileTableView.width - fileNameColumn.width - fileModifiedColumn.width
                 movable: false
                 resizable: true
                 visible: !selectDirectory
@@ -668,7 +664,7 @@ ModalWindow {
                     break;
                 }
             }
-            
+
             KeyNavigation.tab: root.saveDialog ? currentSelection : openButton
         }
 

--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -704,7 +704,7 @@ ModalWindow {
                 KeyNavigation.up: selectionType
                 KeyNavigation.left: openButton
                 KeyNavigation.right: fileTableView.contentItem
-                Keys.onReturnPressed: { canceled(); root.enabled = false }
+                Keys.onReturnPressed: { cancelAction.trigger() }
             }
         }
 

--- a/interface/resources/qml/dialogs/MessageDialog.qml
+++ b/interface/resources/qml/dialogs/MessageDialog.qml
@@ -37,14 +37,14 @@ ModalWindow {
         return OffscreenUi.waitForMessageBoxResult(root);
     }
 
-    Keys.onRightPressed: if(defaultButton === OriginalDialogs.StandardButton.Yes) {
+    Keys.onRightPressed: if (defaultButton === OriginalDialogs.StandardButton.Yes) {
        yesButton.forceActiveFocus()
-    } else if(defaultButton === OriginalDialogs.StandardButton.Ok) {
+    } else if (defaultButton === OriginalDialogs.StandardButton.Ok) {
        okButton.forceActiveFocus()
     }
-    Keys.onTabPressed: if(defaultButton === OriginalDialogs.StandardButton.Yes) {
+    Keys.onTabPressed: if (defaultButton === OriginalDialogs.StandardButton.Yes) {
        yesButton.forceActiveFocus()
-    } else if(defaultButton === OriginalDialogs.StandardButton.Ok) {
+    } else if (defaultButton === OriginalDialogs.StandardButton.Ok) {
        okButton.forceActiveFocus()
     }
     property alias detailedText: detailedText.text

--- a/interface/resources/qml/dialogs/MessageDialog.qml
+++ b/interface/resources/qml/dialogs/MessageDialog.qml
@@ -37,6 +37,16 @@ ModalWindow {
         return OffscreenUi.waitForMessageBoxResult(root);
     }
 
+    Keys.onRightPressed: if(defaultButton === OriginalDialogs.StandardButton.Yes) {
+       yesButton.forceActiveFocus()
+    } else if(defaultButton === OriginalDialogs.StandardButton.Ok) {
+       okButton.forceActiveFocus()
+    }
+    Keys.onTabPressed: if(defaultButton === OriginalDialogs.StandardButton.Yes) {
+       yesButton.forceActiveFocus()
+    } else if(defaultButton === OriginalDialogs.StandardButton.Ok) {
+       okButton.forceActiveFocus()
+    }
     property alias detailedText: detailedText.text
     property alias text: mainTextContainer.text
     property alias informativeText: informativeTextContainer.text
@@ -47,7 +57,6 @@ ModalWindow {
     onIconChanged: updateIcon();
     property int defaultButton: OriginalDialogs.StandardButton.NoButton;
     property int clickedButton: OriginalDialogs.StandardButton.NoButton;
-    focus: defaultButton === OriginalDialogs.StandardButton.NoButton
 
     property int titleWidth: 0
     onTitleWidthChanged: d.resize();
@@ -134,16 +143,35 @@ ModalWindow {
             MessageDialogButton { dialog: root; text: qsTr("Reset"); button: OriginalDialogs.StandardButton.Reset; }
             MessageDialogButton { dialog: root; text: qsTr("Discard"); button: OriginalDialogs.StandardButton.Discard; }
             MessageDialogButton { dialog: root; text: qsTr("No to All"); button: OriginalDialogs.StandardButton.NoToAll; }
-            MessageDialogButton { dialog: root; text: qsTr("No"); button: OriginalDialogs.StandardButton.No; }
+            MessageDialogButton {
+                id: noButton
+                dialog: root
+                text: qsTr("No")
+                button: OriginalDialogs.StandardButton.No
+                KeyNavigation.left: yesButton
+                KeyNavigation.backtab: yesButton
+            }
             MessageDialogButton { dialog: root; text: qsTr("Yes to All"); button: OriginalDialogs.StandardButton.YesToAll; }
-            MessageDialogButton { dialog: root; text: qsTr("Yes"); button: OriginalDialogs.StandardButton.Yes; }
+            MessageDialogButton {
+                id: yesButton
+                dialog: root
+                text: qsTr("Yes") 
+                button: OriginalDialogs.StandardButton.Yes
+                KeyNavigation.right: noButton
+                KeyNavigation.tab: noButton
+            }
             MessageDialogButton { dialog: root; text: qsTr("Apply"); button: OriginalDialogs.StandardButton.Apply; }
             MessageDialogButton { dialog: root; text: qsTr("Ignore"); button: OriginalDialogs.StandardButton.Ignore; }
             MessageDialogButton { dialog: root; text: qsTr("Retry"); button: OriginalDialogs.StandardButton.Retry; }
             MessageDialogButton { dialog: root; text: qsTr("Save All"); button: OriginalDialogs.StandardButton.SaveAll; }
             MessageDialogButton { dialog: root; text: qsTr("Save"); button: OriginalDialogs.StandardButton.Save; }
             MessageDialogButton { dialog: root; text: qsTr("Open"); button: OriginalDialogs.StandardButton.Open; }
-            MessageDialogButton { dialog: root; text: qsTr("OK"); button: OriginalDialogs.StandardButton.Ok; }
+            MessageDialogButton {
+                id: okButton
+                dialog: root 
+                text: qsTr("OK")
+                button: OriginalDialogs.StandardButton.Ok
+            }
 
             Button {
                 id: moreButton
@@ -229,12 +257,6 @@ ModalWindow {
             case Qt.Key_Back:
                 event.accepted = true
                 root.click(OriginalDialogs.StandardButton.Cancel)
-                break
-
-            case Qt.Key_Enter:
-            case Qt.Key_Return:
-                event.accepted = true
-                root.click(root.defaultButton)
                 break
         }
     }

--- a/interface/resources/qml/dialogs/QueryDialog.qml
+++ b/interface/resources/qml/dialogs/QueryDialog.qml
@@ -200,9 +200,9 @@ ModalWindow {
         case Qt.Key_Enter:
             if (acceptButton.focus) {
                 acceptAction.trigger()
-            } else if(cancelButton.focus) {
+            } else if (cancelButton.focus) {
                 cancelAction.trigger()
-            } else if(comboBox.focus || comboBox.popup.focus) {
+            } else if (comboBox.focus || comboBox.popup.focus) {
                 comboBox.showList()
             }
             event.accepted = true;

--- a/interface/resources/qml/dialogs/QueryDialog.qml
+++ b/interface/resources/qml/dialogs/QueryDialog.qml
@@ -95,19 +95,19 @@ ModalWindow {
             TextField {
                 id: textResult
                 label: root.label
-                focus: items ? false : true
                 visible: items ? false : true
                 anchors {
                     left: parent.left;
                     right: parent.right;
                     bottom: parent.bottom
                 }
+                KeyNavigation.down: acceptButton
+                KeyNavigation.tab: acceptButton
             }
 
             ComboBox {
                 id: comboBox
                 label: root.label
-                focus: true
                 visible: items ? true : false
                 anchors {
                     left: parent.left
@@ -115,6 +115,8 @@ ModalWindow {
                     bottom: parent.bottom
                 }
                 model: items ? items : []
+                KeyNavigation.down: acceptButton
+                KeyNavigation.tab: acceptButton
             }
         }
 
@@ -135,7 +137,6 @@ ModalWindow {
 
         Flow {
             id: buttons
-            focus: true
             spacing: hifi.dimensions.contentSpacing.x
             onHeightChanged: d.resize(); onWidthChanged: d.resize();
             layoutDirection: Qt.RightToLeft
@@ -145,8 +146,21 @@ ModalWindow {
                 margins: 0
                 bottomMargin: hifi.dimensions.contentSpacing.y
             }
-            Button { action: cancelAction }
-            Button { action: acceptAction }
+            Button {
+                id: cancelButton
+                action: cancelAction
+                KeyNavigation.left: acceptButton
+                KeyNavigation.up: items ? comboBox : textResult
+                KeyNavigation.backtab: acceptButton
+            }
+            Button {
+                id: acceptButton
+                action: acceptAction
+                KeyNavigation.right: cancelButton
+                KeyNavigation.up: items ? comboBox : textResult
+                KeyNavigation.tab: cancelButton
+                KeyNavigation.backtab: items ? comboBox : textResult
+            }
         }
 
         Action {
@@ -184,7 +198,13 @@ ModalWindow {
 
         case Qt.Key_Return:
         case Qt.Key_Enter:
-            acceptAction.trigger()
+            if (acceptButton.focus) {
+                acceptAction.trigger()
+            } else if(cancelButton.focus) {
+                cancelAction.trigger()
+            } else if(comboBox.focus || comboBox.popup.focus) {
+                comboBox.showList()
+            }
             event.accepted = true;
             break;
         }
@@ -194,6 +214,10 @@ ModalWindow {
         keyboardEnabled = HMD.active;
         updateIcon();
         d.resize();
-        textResult.forceActiveFocus();
+        if (items) {
+            comboBox.forceActiveFocus()
+        } else {
+            textResult.forceActiveFocus()
+        }
     }
 }

--- a/interface/resources/qml/dialogs/messageDialog/MessageDialogButton.qml
+++ b/interface/resources/qml/dialogs/messageDialog/MessageDialogButton.qml
@@ -16,10 +16,21 @@ import "../../controls-uit"
 
 Button {
     property var dialog;
-    property int button: StandardButton.NoButton;
+    property int button: StandardButton.Ok;
 
-    color: dialog.defaultButton === button ? hifi.buttons.blue : hifi.buttons.white
-    focus: dialog.defaultButton === button
+    color: focus ? hifi.buttons.blue : hifi.buttons.white
     onClicked: dialog.click(button)
     visible: dialog.buttons & button
+    Keys.onPressed: {
+        if (!focus) {
+            return
+        }
+        switch (event.key) {
+        case Qt.Key_Enter:
+        case Qt.Key_Return:
+            event.accepted = true
+            dialog.click(button)
+            break
+        }
+    }
 }

--- a/interface/resources/qml/styles-uit/HifiConstants.qml
+++ b/interface/resources/qml/styles-uit/HifiConstants.qml
@@ -219,6 +219,7 @@ Item {
         readonly property var colorFinish: [ colors.lightGrayText, colors.blueAccent, "#94132e", colors.black, Qt.rgba(0, 0, 0, 0), Qt.rgba(0, 0, 0, 0), Qt.rgba(0, 0, 0, 0), Qt.rgba(0, 0, 0, 0) ]
         readonly property var hoveredColor: [ colorStart[white], colorStart[blue], colorStart[red], colorFinish[black], colorStart[none], colorStart[noneBorderless], colorStart[noneBorderlessWhite], colorStart[noneBorderlessGray] ]
         readonly property var pressedColor: [ colorFinish[white], colorFinish[blue], colorFinish[red], colorStart[black], colorStart[none], colorStart[noneBorderless], colorStart[noneBorderlessWhite], colorStart[noneBorderlessGray] ]
+        readonly property var focusedColor: [ colors.lightGray50, colors.blueAccent, colors.redAccent, colors.darkGray, colorStart[none], colorStart[noneBorderless], colorStart[noneBorderlessWhite], colorStart[noneBorderlessGray] ]
         readonly property var disabledColorStart: [ colorStart[white], colors.baseGrayHighlight]
         readonly property var disabledColorFinish: [ colorFinish[white], colors.baseGrayShadow]
         readonly property var disabledTextColor: [ colors.lightGrayText, colors.baseGrayShadow]

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -103,14 +103,14 @@ void WindowScriptingInterface::raiseMainWindow() {
 /// \param const QString& message message to display
 /// \return QScriptValue::UndefinedValue
 void WindowScriptingInterface::alert(const QString& message) {
-    OffscreenUi::asyncWarning("", message);
+    OffscreenUi::asyncWarning("", message, QMessageBox::Ok, QMessageBox::Ok);
 }
 
 /// Display a confirmation box with the options 'Yes' and 'No'
 /// \param const QString& message message to display
 /// \return QScriptValue `true` if 'Yes' was clicked, `false` otherwise
 QScriptValue WindowScriptingInterface::confirm(const QString& message) {
-    return QScriptValue((QMessageBox::Yes == OffscreenUi::question("", message, QMessageBox::Yes | QMessageBox::No)));
+    return QScriptValue((QMessageBox::Yes == OffscreenUi::question("", message, QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes)));
 }
 
 /// Display a prompt with a text box
@@ -353,7 +353,7 @@ QScriptValue WindowScriptingInterface::browseAssets(const QString& title, const 
     return result.isEmpty() ? QScriptValue::NullValue : QScriptValue(result);
 }
 
-/// Display a select asset dialog that lets the user select an asset from the Asset Server.  If `directory` is an invalid 
+/// Display a select asset dialog that lets the user select an asset from the Asset Server.  If `directory` is an invalid
 /// directory the browser will start at the root directory.
 /// \param const QString& title title of the window
 /// \param const QString& directory directory to start the asset browser at


### PR DESCRIPTION
Various fixes to allow some support for keyboard navigation in message boxes and dialogs such as:
`Window.alert`
`Window.confirm`
`Window.prompt`
`Window.save`
`Window.browse`

Also affects Interface menus such as bookmarks.
I started with `Window.prompt`, this only has two buttons added in the QML flow.
When getting to message boxes used for alerts I found that there is support for a number of buttons added dynamically using a QFlag int of StandardButtons.
As such I don't see how you can really be sure what order the buttons are in. At the moment it seems that only Ok and Yes/No is used, so I hard coded support for these.
Maybe grouping them together as the parameter will be better for long term support.

Also for prompts it seems okay to focus on the text box or combo box and allow navigation to the buttons. For a message box I was unsure if the button should have focus initially as they are not in a focused state in master. I made it require pressing tab/right to shift focus to the buttons for now.  

