### PR TITLE
RC62: Fix for black screen when clicking Settings from Snap app

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletRoot.qml
+++ b/interface/resources/qml/hifi/tablet/TabletRoot.qml
@@ -106,7 +106,7 @@ Item {
         if (isWebPage) {
             var webUrl = tabletApps.get(currentApp).appWebUrl;
             var scriptUrl = tabletApps.get(currentApp).scriptUrl;
-            loadSource("TabletWebView.qml");
+            loadSource("hifi/tablet/TabletWebView.qml");
             loadWebUrl(webUrl, scriptUrl);
         } else {
         	loader.load(tabletApps.get(currentApp).appUrl);

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -121,7 +121,7 @@ function onMessage(message) {
                 || (!HMD.active && Settings.getValue("desktopTabletBecomesToolbar", true))) {
                 Desktop.show("hifi/dialogs/GeneralPreferencesDialog.qml", "GeneralPreferencesDialog");
             } else {
-                tablet.loadQMLOnTop("TabletGeneralPreferences.qml");
+                tablet.loadQMLOnTop("hifi/tablet/TabletGeneralPreferences.qml");
             }
             break;
         case 'captureStillAndGif':


### PR DESCRIPTION
QA Test plan:
In VR mode, the "settings" button on the snap app opens a black screen on the tablet.

1) Start interface with an HMD
2) Open snap app on tablet
3) Click "settings"
4) The tablet displays a black screen