### PR TITLE
FB11241 Changing options in menu causes the title “Menu” to change to…

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
@@ -22,7 +22,6 @@ Item {
         anchors.fill: parent
         id: d
         objectName: "stack"
-        initialItem: topMenu
 
         property var menuStack: []
         property var topMenu: null;


### PR DESCRIPTION
… “root”

note: fix is based on removing duplicated top-level menu entry from stack view

**Test plan**

1. Switch to desktop
2. Open tablet
3. Go to 'Edit' menu
4. Click on 'Edit' at the top to return back to 'Menu' 
5. Ensure 'Menu' still has 'Menu' as the title
6. Repeat the same steps for VR mode

Bonus: 

Original steps to reproduce:

1. Select the “Menu” item from the tablet/toolbar
2. Select the “tools” link in the menu
3. Select the “Notifications” link in the tools section
4. Enable / disable different items in the notifications section. (This step is vague, but most items were switched to the opposite state to cause the defect)
5. Select the title “Notification” to navigate back to the “tool” menu
6. Select the title “tool” to navigate back to the main menu page of the “Menu” app
7. Ensure Title displays “Menu”