### PR TITLE
Support for stereo audio input/mic

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -439,7 +439,7 @@ void Agent::executeScript() {
             encodedBuffer = audio;
         }
 
-        AbstractAudioInterface::emitAudioPacket(encodedBuffer.data(), encodedBuffer.size(), audioSequenceNumber,
+        AbstractAudioInterface::emitAudioPacket(encodedBuffer.data(), encodedBuffer.size(), audioSequenceNumber, false, 
             audioTransform, scriptedAvatar->getWorldPosition(), glm::vec3(0),
             packetType, _selectedCodecName);
     });

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -275,9 +275,13 @@ int AudioMixerClientData::parseData(ReceivedMessage& message) {
             if (micStreamIt == _audioStreams.end()) {
                 // we don't have a mic stream yet, so add it
 
-                // read the channel flag to see if our stream is stereo or not
+                // hop past the sequence number that leads the packet
                 message.seek(sizeof(quint16));
 
+                // pull the codec string from the packet
+                auto codecString = message.readString();
+
+                // read the channel flag to see if our stream is stereo or not
                 quint8 channelFlag;
                 message.readPrimitive(&channelFlag);
 
@@ -285,7 +289,7 @@ int AudioMixerClientData::parseData(ReceivedMessage& message) {
 
                 auto avatarAudioStream = new AvatarAudioStream(isStereo, AudioMixer::getStaticJitterFrames());
                 avatarAudioStream->setupCodec(_codec, _selectedCodecName, AudioConstants::MONO);
-                qCDebug(audio) << "creating new AvatarAudioStream... codec:" << _selectedCodecName;
+                qCDebug(audio) << "creating new AvatarAudioStream... codec:" << _selectedCodecName << "channels:" << (channelFlag + 1);
 
                 connect(avatarAudioStream, &InboundAudioStream::mismatchedAudioCodec,
                         this, &AudioMixerClientData::handleMismatchAudioFormat);

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -579,6 +579,7 @@ void AudioMixerClientData::setupCodec(CodecPluginPointer codec, const QString& c
     auto avatarAudioStream = getAvatarAudioStream();
     if (avatarAudioStream) {
         avatarAudioStream->setupCodec(codec, codecName, avatarAudioStream->isStereo() ? AudioConstants::STEREO : AudioConstants::MONO);
+        qCDebug(audio) << "setting AvatarAudioStream... codec:" << _selectedCodecName << "isStereo:" << avatarAudioStream->isStereo();
     }
 
 #if INJECTORS_SUPPORT_CODECS

--- a/assignment-client/src/audio/AvatarAudioStream.cpp
+++ b/assignment-client/src/audio/AvatarAudioStream.cpp
@@ -11,6 +11,7 @@
 
 #include <udt/PacketHeaders.h>
 
+#include "AudioLogging.h"
 #include "AvatarAudioStream.h"
 
 AvatarAudioStream::AvatarAudioStream(bool isStereo, int numStaticJitterFrames) :
@@ -41,6 +42,15 @@ int AvatarAudioStream::parseStreamProperties(PacketType type, const QByteArray& 
             _ringBuffer.resizeForFrameSize(isStereo
                                            ? AudioConstants::NETWORK_FRAME_SAMPLES_STEREO
                                            : AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
+            // restart the codec
+            if (_codec) {
+                if (_decoder) {
+                    _codec->releaseDecoder(_decoder);
+                }
+                _decoder = _codec->createDecoder(AudioConstants::SAMPLE_RATE, isStereo ? AudioConstants::STEREO : AudioConstants::MONO);
+            }
+            qCDebug(audio) << "resetting AvatarAudioStream... codec:" << _selectedCodecName << "isStereo:" << isStereo;
+
             _isStereo = isStereo;
         }
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1079,7 +1079,7 @@ void AudioClient::handleAudioInput(QByteArray& audioBuffer) {
         encodedBuffer = audioBuffer;
     }
 
-    emitAudioPacket(encodedBuffer.data(), encodedBuffer.size(), _outgoingAvatarAudioSequenceNumber,
+    emitAudioPacket(encodedBuffer.data(), encodedBuffer.size(), _outgoingAvatarAudioSequenceNumber, _isStereoInput,
             audioTransform, avatarBoundingBoxCorner, avatarBoundingBoxScale,
             packetType, _selectedCodecName);
     _stats.sentPacket();

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1610,7 +1610,7 @@ void AudioClient::outputNotify() {
     }
 }
 
-bool AudioClient::switchOutputToAudioDevice(const QAudioDeviceInfo& outputDeviceInfo, bool isShutdownRequest) {
+bool AudioClient::switchOutputToAudioDevice(const QAudioDeviceInfo outputDeviceInfo, bool isShutdownRequest) {
     qCDebug(audioclient) << "AudioClient::switchOutputToAudioDevice() outputDeviceInfo: [" << outputDeviceInfo.deviceName() << "]";
     bool supportedFormat = false;
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1427,7 +1427,7 @@ void AudioClient::outputFormatChanged() {
     _receivedAudioStream.outputFormatChanged(_outputFormat.sampleRate(), OUTPUT_CHANNEL_COUNT);
 }
 
-bool AudioClient::switchInputToAudioDevice(const QAudioDeviceInfo& inputDeviceInfo, bool isShutdownRequest) {
+bool AudioClient::switchInputToAudioDevice(const QAudioDeviceInfo inputDeviceInfo, bool isShutdownRequest) {
     qCDebug(audioclient) << __FUNCTION__ << "inputDeviceInfo: [" << inputDeviceInfo.deviceName() << "]";
     bool supportedFormat = false;
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1382,7 +1382,16 @@ void AudioClient::setIsStereoInput(bool isStereoInput) {
             _desiredInputFormat.setChannelCount(1);
         }
 
-        // change in channel count for desired input format, restart the input device
+        // restart the codec
+        if (_codec) {
+            if (_encoder) {
+                _codec->releaseEncoder(_encoder);
+            }
+            _encoder = _codec->createEncoder(AudioConstants::SAMPLE_RATE, _isStereoInput ? AudioConstants::STEREO : AudioConstants::MONO);
+        }
+        qCDebug(audioclient) << "Reset Codec:" << _selectedCodecName << "isStereoInput:" << _isStereoInput;
+
+        // restart the input device
         switchInputToAudioDevice(_inputDeviceInfo);
     }
 }

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -782,7 +782,7 @@ void AudioClient::selectAudioFormat(const QString& selectedCodecName) {
 
     _selectedCodecName = selectedCodecName;
 
-    qCDebug(audioclient) << "Selected Codec:" << _selectedCodecName;
+    qCDebug(audioclient) << "Selected Codec:" << _selectedCodecName << "isStereoInput:" << _isStereoInput;
 
     // release any old codec encoder/decoder first...
     if (_codec && _encoder) {
@@ -797,7 +797,7 @@ void AudioClient::selectAudioFormat(const QString& selectedCodecName) {
         if (_selectedCodecName == plugin->getName()) {
             _codec = plugin;
             _receivedAudioStream.setupCodec(plugin, _selectedCodecName, AudioConstants::STEREO);
-            _encoder = plugin->createEncoder(AudioConstants::SAMPLE_RATE, AudioConstants::MONO);
+            _encoder = plugin->createEncoder(AudioConstants::SAMPLE_RATE, _isStereoInput ? AudioConstants::STEREO : AudioConstants::MONO);
             qCDebug(audioclient) << "Selected Codec Plugin:" << _codec.get();
             break;
         }

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -378,7 +378,7 @@ private:
 
     void handleLocalEchoAndReverb(QByteArray& inputByteArray);
 
-    bool switchInputToAudioDevice(const QAudioDeviceInfo& inputDeviceInfo, bool isShutdownRequest = false);
+    bool switchInputToAudioDevice(const QAudioDeviceInfo inputDeviceInfo, bool isShutdownRequest = false);
     bool switchOutputToAudioDevice(const QAudioDeviceInfo& outputDeviceInfo, bool isShutdownRequest = false);
 
     // Callback acceleration dependent calculations

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -379,7 +379,7 @@ private:
     void handleLocalEchoAndReverb(QByteArray& inputByteArray);
 
     bool switchInputToAudioDevice(const QAudioDeviceInfo inputDeviceInfo, bool isShutdownRequest = false);
-    bool switchOutputToAudioDevice(const QAudioDeviceInfo& outputDeviceInfo, bool isShutdownRequest = false);
+    bool switchOutputToAudioDevice(const QAudioDeviceInfo outputDeviceInfo, bool isShutdownRequest = false);
 
     // Callback acceleration dependent calculations
     int calculateNumberOfInputCallbackBytes(const QAudioFormat& format) const;

--- a/libraries/audio/src/AbstractAudioInterface.cpp
+++ b/libraries/audio/src/AbstractAudioInterface.cpp
@@ -19,7 +19,7 @@
 
 #include "AudioConstants.h"
 
-void AbstractAudioInterface::emitAudioPacket(const void* audioData, size_t bytes, quint16& sequenceNumber,
+void AbstractAudioInterface::emitAudioPacket(const void* audioData, size_t bytes, quint16& sequenceNumber, bool isStereo,
                                              const Transform& transform, glm::vec3 avatarBoundingBoxCorner, glm::vec3 avatarBoundingBoxScale,
                                              PacketType packetType, QString codecName) {
     static std::mutex _mutex;
@@ -29,9 +29,6 @@ void AbstractAudioInterface::emitAudioPacket(const void* audioData, size_t bytes
     if (audioMixer && audioMixer->getActiveSocket()) {
         Locker lock(_mutex);
         auto audioPacket = NLPacket::create(packetType);
-
-        // FIXME - this is not a good way to determine stereoness with codecs.... 
-        quint8 isStereo = bytes == AudioConstants::NETWORK_FRAME_BYTES_STEREO ? 1 : 0;
 
         // write sequence number
         auto sequence = sequenceNumber++;
@@ -48,7 +45,8 @@ void AbstractAudioInterface::emitAudioPacket(const void* audioData, size_t bytes
             audioPacket->writePrimitive(numSilentSamples);
         } else {
             // set the mono/stereo byte
-            audioPacket->writePrimitive(isStereo);
+            quint8 channelFlag = isStereo ? 1 : 0;
+            audioPacket->writePrimitive(channelFlag);
         }
 
         // pack the three float positions

--- a/libraries/audio/src/AbstractAudioInterface.h
+++ b/libraries/audio/src/AbstractAudioInterface.h
@@ -29,7 +29,7 @@ class AbstractAudioInterface : public QObject {
 public:
     AbstractAudioInterface(QObject* parent = 0) : QObject(parent) {};
     
-    static void emitAudioPacket(const void* audioData, size_t bytes, quint16& sequenceNumber,
+    static void emitAudioPacket(const void* audioData, size_t bytes, quint16& sequenceNumber, bool isStereo,
                                 const Transform& transform, glm::vec3 avatarBoundingBoxCorner, glm::vec3 avatarBoundingBoxScale,
                                 PacketType packetType, QString codecName = QString(""));
 


### PR DESCRIPTION
This PR adds the plumbing for stereo avatar audio streams, using audio codecs.

By default, a stereo input device gets downmixed to mono, streamed to the audio-mixer using a mono codec, and rendered as an HRTF point-source located at the avatar.

With this PR, you can explicitly enable the "isStereoInput" property on a stereo input device. This will disable downmixing, stream to the audio-mixer using a stereo codec, and render as "head locked" stereo that bypasses the HRTF.

A checkbox/GUI for this feature can be added in a future PR.