### PR TITLE
Fix social media sharing buttons on Snapshot app

### DIFF
--- a/interface/resources/qml/controls/TabletWebScreen.qml
+++ b/interface/resources/qml/controls/TabletWebScreen.qml
@@ -41,9 +41,9 @@ Item {
         onNewViewRequestedCallback: {
             // desktop is not defined for web-entities or tablet
             if (typeof desktop !== "undefined") {
-                desktop.openBrowserWindow(request, profile);
+                desktop.openBrowserWindow(request, webViewCoreProfile);
             } else {
-                tabletRoot.openBrowserWindow(request, profile);
+                tabletRoot.openBrowserWindow(request, webViewCoreProfile);
             }
         }
 


### PR DESCRIPTION
This has been broken since _August_ and yet I somehow missed that...Making this RC63 because apparently it doesn't matter that much 😜 

## Test Plan
Perform the steps below in Desktop mode, then in HMD mode.
1. Go to a shareable domain (i.e. `start`)
2. Take a still snapshot
3. Attempt to share the still snapshot to Twitter. Verify that the Twitter window appears. Close the Twitter window.
4. Attempt to share the still snapshot to Facebook. Verify that the Facebook window appears. Close the Facebook window.
5. Open the PAL, then click on your profile picture in the top left corner. Verify that you see a Web browser open to your profile page.
6. Click on the "Tweet" button towards the top right of the window. Verify that you see a Twitter window.
7. Perform a quick smoke test of anywhere else you can think of that opens a browser window in-world (I can't think of anything else right now). Verify that clicking links works from within that browser window.