### PR TITLE
RC62: Fix animation crash, make last frame inclusive

### DIFF
--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -267,9 +267,9 @@ void ModelEntityItem::updateFrameCount() {
     if (!getAnimationHold() && getAnimationIsPlaying()) {
         float deltaTime = (float)interval / (float)USECS_PER_SECOND;
         _currentFrame += (deltaTime * getAnimationFPS());
-        if (_currentFrame > getAnimationLastFrame()) {
-            if (getAnimationLoop()) {
-                _currentFrame = getAnimationFirstFrame() + (int)(glm::floor(_currentFrame - getAnimationFirstFrame())) % (updatedFrameCount - 1);
+        if (_currentFrame > getAnimationLastFrame() + 1) {
+            if (getAnimationLoop() && getAnimationFirstFrame() != getAnimationLastFrame()) {
+                _currentFrame = getAnimationFirstFrame() + (int)(_currentFrame - getAnimationFirstFrame()) % updatedFrameCount;
             } else {
                 _currentFrame = getAnimationLastFrame();
             }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/11410/CRASH-Setting-first-frame-and-last-frame-of-an-animation-to-the-same-value-crashes-all-users-in-domain

Test plan:
- Create a model entity (http://hifi-content.s3.amazonaws.com/DomainContent/Welcome%20Area/production/models/Flag-Hifi.fbx?2)
- Give it an animation (http://hifi-content.s3.amazonaws.com/DomainContent/Welcome%20Area/production/models/Flag-Hifi.fbx?2)
- The animation should play normally
- Set the first frame to something like 50 and the last frame to the same number.  It should not crash.  The animation should be paused.
- Set the last frame to first frame + 1.  Two frames should play.
- [Animation test rail](https://highfidelity.testrail.net/index.php?/tests/view/33492&group_by=cases:section_id&group_order=asc&group_id=1471)