### PR TITLE
Set ambient mode to inherit if no URLs have been entered.

### DIFF
--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -162,28 +162,31 @@ void ZoneEntityRenderer::doRender(RenderArgs* args) {
     }
 
     if (_visible) {
-        // Finally, push the light visible in the frame
+        // Finally, push the lights visible in the frame
+        //
+        // If component is disabled then push component off state
+        // else if component is enabled then push current state
+        // (else mode is inherit, the value from the parent zone will be used
+        //
         if (_keyLightMode == COMPONENT_MODE_DISABLED) {
             _stage->_currentFrame.pushSunLight(_stage->getSunOffLight());
         } else if (_keyLightMode == COMPONENT_MODE_ENABLED) {
             _stage->_currentFrame.pushSunLight(_sunIndex);
         }
 
-        // The background only if the mode is not inherit
         if (_skyboxMode == COMPONENT_MODE_DISABLED) {
             _backgroundStage->_currentFrame.pushBackground(INVALID_INDEX);
         } else if (_skyboxMode == COMPONENT_MODE_ENABLED) {
             _backgroundStage->_currentFrame.pushBackground(_backgroundIndex);
         }
 
-        // The ambient light only if it has a valid texture to render with
         if (_ambientLightMode == COMPONENT_MODE_DISABLED) {
             _stage->_currentFrame.pushAmbientLight(_stage->getAmbientOffLight());
         } else if (_ambientLightMode == COMPONENT_MODE_ENABLED) {
             _stage->_currentFrame.pushAmbientLight(_ambientIndex);
         }
 
-        // Haze only if the mode is not inherit
+        // Haze only if the mode is not inherit, as the model deals with on/off
         if (_hazeMode != COMPONENT_MODE_INHERIT) {
             _hazeStage->_currentFrame.pushHaze(_hazeIndex);
         }


### PR DESCRIPTION
# Description
This PR corrects the behaviour when no ambient URL AND no skybox URL have been defined.  In this case - the ambient mode should be set to Inherit, as this is the old behaviour.
# Testing
The first stage of testing requires the creation of content using the released version 7607.  The models.json.gz files should be stored in different folders, named 1, 2, 3 and so on.
After creating each domain - the file can be found in `~/High Fidelity/assignment-client/entities/`.
1.  Delete all content from the domain.  This may be done by  Market->Environments->Empty Domain Set.  This is domain #1.
![1](https://user-images.githubusercontent.com/29026026/34853555-462de118-f6e9-11e7-8df1-b6c605563847.PNG)
2.  Add a sphere - leave all values as default.  This is domain #2.
![2](https://user-images.githubusercontent.com/29026026/34853580-6183d472-f6e9-11e7-9c3b-3410f601be5f.PNG)
3.  Add a default zone - leave all values as default.  This is domain #3
![3](https://user-images.githubusercontent.com/29026026/34853654-c72c56aa-f6e9-11e7-8a48-d4cedea56774.PNG)
4.  Set the ambient URL to `http://hifi-content.s3.amazonaws.com/DomainContent/baked/island/Sky_Day-Sun-Mid-photo.ktx`.  This is domain #4.
![4](https://user-images.githubusercontent.com/29026026/34853888-173d0c4c-f6eb-11e7-867d-8ad9fd4e69a5.PNG)
5.  Set the Background Mode to Skybox.  This is domain #5
![5](https://user-images.githubusercontent.com/29026026/34853933-57d9641c-f6eb-11e7-8be1-12e1e04488c7.PNG)
6.  Set the Skybox URL to `http://hifi-content.s3.amazonaws.com/DomainContent/baked/island/Sky_Day-Sun-Mid-photo.ktx`.  This is domain #6.
![6](https://user-images.githubusercontent.com/29026026/34854190-fe5e1ab6-f6ec-11e7-9903-96f312a6c9dd.PNG)
7.  Delete the Ambient URL - this is domain #7. (Same image as 6).
8.  Set the ambient URL to `http://hifi-content.s3.amazonaws.com/DomainContent/baked/hideout/SKY-Fullmoon-w-Sea.jpg`
![8](https://user-images.githubusercontent.com/29026026/34854217-28688f12-f6ed-11e7-80fd-1afc174c2679.PNG)
9.  Delete the ambient URL and set the ambient intensity to 3.0.  This is zone #9.
![9](https://user-images.githubusercontent.com/29026026/34965386-8410692a-fa08-11e7-8db9-99d656e27cb0.PNG)
10.  Delete the skybox URL.  This is zone #10.
![10](https://user-images.githubusercontent.com/29026026/34965404-a2b28836-fa08-11e7-9e55-396ab9e43d5c.PNG)

To verify that the content can be read correctly, perform the following steps for each of the domains that have been created:

1.  Close Interface
2.  Stop the Server
3.  Copy the next models.json.gz to the `~/High Fidelity - PR12147/assignment-client/entities/` folder
4.  Start the Server
5.  Start Interface (i.e. Go Home)
6.  Verify the content looks like that described above.  Note that you may need to turn left/right until you see the sphere.