### PR TITLE
Destroy PointerManager before PickManager

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2093,6 +2093,11 @@ void Application::cleanupBeforeQuit() {
     DependencyManager::destroy<AudioInjectorManager>();
     DependencyManager::destroy<AudioScriptingInterface>();
 
+    // The PointerManager must be destroyed before the PickManager because when a Pointer is deleted,
+    // it accesses the PickManager to delete its associated Pick
+    DependencyManager::destroy<PointerManager>();
+    DependencyManager::destroy<PickManager>();
+
     qCDebug(interfaceapp) << "Application::cleanupBeforeQuit() complete";
 }
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/11412/crash-on-exit-involving-LaserPointer

Test plan:
- Shouldn't crash on shutdown.  Try several times.