### PR TITLE
Add Window browseChanged signal as replacement for openFileChanged

### DIFF
--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -277,7 +277,8 @@ void WindowScriptingInterface::browseAsync(const QString& title, const QString& 
         if (!result.isEmpty()) {
             setPreviousBrowseLocation(QFileInfo(result).absolutePath());
         }
-        emit openFileChanged(result);
+        emit browseChanged(result);
+        emit openFileChanged(result); // Deprecated signal; to be removed in due course.
     });
 }
 

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -197,18 +197,19 @@ public slots:
 
     /**jsdoc
      * Prompt the user to choose a file. Displays a non-modal dialog that navigates the directory tree. A
-     * {@link Window.openFileChanged|openFileChanged} signal is emitted when a file is chosen; no signal is emitted if the user
+     * {@link Window.browseChanged|browseChanged} signal is emitted when a file is chosen; no signal is emitted if the user
      * cancels the dialog.
+     * @deprecated A deprecated {@link Window.openFileChanged|openFileChanged} signal is also emitted when a file is chosen.
      * @function Window.browseAsync
      * @param {string} title="" - The title to display at the top of the dialog.
      * @param {string} directory="" - The initial directory to start browsing at.
      * @param {string} nameFilter="" - The types of files to display. Examples: <code>"*.json"</code> and
      *     <code>"Images (*.png *.jpg *.svg)"</code>. All files are displayed if a filter isn't specified.
      * @example <caption>Ask the user to choose an image file without waiting for the answer.</caption>
-     * function onOpenFileChanged(filename) {
+     * function onBrowseChanged(filename) {
      *     print("File: " + filename);
      * }
-     * Window.openFileChanged.connect(onOpenFileChanged);
+     * Window.browseChanged.connect(onBrowseChanged);
      *
      * Window.browseAsync("Select Image File", Paths.resources, "Images (*.png *.jpg *.svg)");
      * print("Script continues without waiting");
@@ -654,7 +655,16 @@ signals:
 
     /**jsdoc
      * Triggered when the user chooses a file in a {@link Window.browseAsync|browseAsync} dialog.
+     * @function Window.browseChanged
+     * @param {string} filename - The path and name of the file the user chose in the dialog.
+     * @returns {Signal}
+     */
+    void browseChanged(QString filename);
+
+    /**jsdoc
+     * Triggered when the user chooses a file in a {@link Window.browseAsync|browseAsync} dialog.
      * @function Window.openFileChanged
+     * @deprecated This signal is being replaced with {@link Window.browseChanged|browseChanged} and will be removed.
      * @param {string} filename - The path and name of the file the user chose in the dialog.
      * @returns {Signal}
      */

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -448,7 +448,7 @@ var toolBar = (function () {
         });
 
         addButton("importEntitiesButton", "assets-01.svg", function() {
-            Window.openFileChanged.connect(onFileOpenChanged);
+            Window.browseChanged.connect(onFileOpenChanged);
             Window.browseAsync("Select Model to Import", "", "*.json");
         });
 
@@ -1497,7 +1497,7 @@ function onFileOpenChanged(filename) {
     // disconnect the event, otherwise the requests will stack up
     try {
         // Not all calls to onFileOpenChanged() connect an event.
-        Window.openFileChanged.disconnect(onFileOpenChanged);
+        Window.browseChanged.disconnect(onFileOpenChanged);
     } catch (e) {
         // Ignore.
     }
@@ -1549,7 +1549,7 @@ function handeMenuEvent(menuItem) {
         }
     } else if (menuItem === "Import Entities" || menuItem === "Import Entities from URL") {
         if (menuItem === "Import Entities") {
-            Window.openFileChanged.connect(onFileOpenChanged);
+            Window.browseChanged.connect(onFileOpenChanged);
             Window.browseAsync("Select Model to Import", "", "*.json");
         } else {
             Window.promptTextChanged.connect(onPromptTextChanged);


### PR DESCRIPTION
When the user selects a file in the Window.browseAsync() dialog a new Window.browseChanged() signal is emitted in addition to the old, now deprecated Window.openFileChanged() signal. The new signal's name matches the browseAsync() function call, similar to how other Window signals match their function calls.