### PR TITLE
Add Window.protocolSignature() as a replacement for location.protocolVersion()

### DIFF
--- a/interface/resources/qml/hifi/Feed.qml
+++ b/interface/resources/qml/hifi/Feed.qml
@@ -102,7 +102,7 @@ Column {
             'include_actions=' + actions,
             'restriction=' + (Account.isLoggedIn() ? 'open,hifi' : 'open'),
             'require_online=true',
-            'protocol=' + encodeURIComponent(AddressManager.protocolVersion()),
+            'protocol=' + encodeURIComponent(Window.protocolSignature()),
             'page=' + pageNumber
         ];
         var url = metaverseBase + 'user_stories?' + options.join('&');

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -573,8 +573,7 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
         }
     };
     reportAndQuit("--protocolVersion", [&](FILE* fp) {
-        DependencyManager::set<AddressManager>();
-        auto version = DependencyManager::get<AddressManager>()->protocolVersion();
+        auto version = protocolVersionsSignatureBase64();
         fputs(version.toLatin1().data(), fp);
     });
     reportAndQuit("--version", [&](FILE* fp) {

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -390,6 +390,10 @@ QString WindowScriptingInterface::checkVersion() {
     return QCoreApplication::applicationVersion();
 }
 
+QString WindowScriptingInterface::protocolVersion() {
+    return protocolVersionsSignatureBase64();
+}
+
 int WindowScriptingInterface::getInnerWidth() {
     return qApp->getDeviceSize().x;
 }

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -390,7 +390,7 @@ QString WindowScriptingInterface::checkVersion() {
     return QCoreApplication::applicationVersion();
 }
 
-QString WindowScriptingInterface::protocolVersion() {
+QString WindowScriptingInterface::protocolSignature() {
     return protocolVersionsSignatureBase64();
 }
 

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -306,6 +306,13 @@ public slots:
     QString checkVersion();
 
     /**jsdoc
+     * Get Interface's protocol version.
+     * @function Window.protocolVersion
+     * @returns {string} A string uniquely identifying the version of the metaverse protocol that Interface is using.
+     */
+    QString protocolVersion();
+
+    /**jsdoc
      * Copies text to the operating system's clipboard.
      * @function Window.copyToClipboard
      * @param {string} text - The text to copy to the operating system's clipboard.

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -306,11 +306,11 @@ public slots:
     QString checkVersion();
 
     /**jsdoc
-     * Get Interface's protocol version.
-     * @function Window.protocolVersion
+     * Get the signature for Interface's protocol version.
+     * @function Window.protocolSignature
      * @returns {string} A string uniquely identifying the version of the metaverse protocol that Interface is using.
      */
-    QString protocolVersion();
+    QString protocolSignature();
 
     /**jsdoc
      * Copies text to the operating system's clipboard.

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -73,7 +73,7 @@ public:
      * Get Interface's protocol version.
      * @function location.protocolVersion
      * @returns {string} A string uniquely identifying the version of the metaverse protocol that Interface is using.
-     * @deprecated This function is deprecated and will removed. Use {@link Window.protocolVersion} instead.
+     * @deprecated This function is deprecated and will be removed. Use {@link Window.protocolSignature} instead.
      */
     Q_INVOKABLE QString protocolVersion();
 

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -73,6 +73,7 @@ public:
      * Get Interface's protocol version.
      * @function location.protocolVersion
      * @returns {string} A string uniquely identifying the version of the metaverse protocol that Interface is using.
+     * @deprecated This function is deprecated and will removed. Use {@link Window.protocolVersion} instead.
      */
     Q_INVOKABLE QString protocolVersion();
 

--- a/scripts/system/tablet-goto.js
+++ b/scripts/system/tablet-goto.js
@@ -136,7 +136,7 @@
             'include_actions=' + actions,
             'restriction=' + (Account.isLoggedIn() ? 'open,hifi' : 'open'),
             'require_online=true',
-            'protocol=' + encodeURIComponent(location.protocolVersion()),
+            'protocol=' + encodeURIComponent(Window.protocolVersion()),
             'per_page=' + count
         ];
         var url = Account.metaverseServerURL + '/api/v1/user_stories?' + options.join('&');

--- a/scripts/system/tablet-goto.js
+++ b/scripts/system/tablet-goto.js
@@ -136,7 +136,7 @@
             'include_actions=' + actions,
             'restriction=' + (Account.isLoggedIn() ? 'open,hifi' : 'open'),
             'require_online=true',
-            'protocol=' + encodeURIComponent(Window.protocolVersion()),
+            'protocol=' + encodeURIComponent(Window.protocolSignature()),
             'per_page=' + count
         ];
         var url = Account.metaverseServerURL + '/api/v1/user_stories?' + options.join('&');

--- a/unpublishedScripts/marketplace/camera-move/app-camera-move.js
+++ b/unpublishedScripts/marketplace/camera-move/app-camera-move.js
@@ -133,7 +133,7 @@ var DEBUG_INFO = {
     Reticle: {
         supportsScale: 'scale' in Reticle,
     },
-    protocolVersion: Window.protocolVersion(),
+    protocolVersion: Window.protocolSignature(),
 };
 
 var globalState = {

--- a/unpublishedScripts/marketplace/camera-move/app-camera-move.js
+++ b/unpublishedScripts/marketplace/camera-move/app-camera-move.js
@@ -133,7 +133,7 @@ var DEBUG_INFO = {
     Reticle: {
         supportsScale: 'scale' in Reticle,
     },
-    protocolVersion: location.protocolVersion,
+    protocolVersion: Window.protocolVersion(),
 };
 
 var globalState = {

--- a/unpublishedScripts/marketplace/camera-move/modules/custom-settings-app/CustomSettingsApp.js
+++ b/unpublishedScripts/marketplace/camera-move/modules/custom-settings-app/CustomSettingsApp.js
@@ -52,7 +52,7 @@ function CustomSettingsApp(options) {
 
     this.extraParams = Object.assign(options.extraParams || {}, {
         customSettingsVersion: CustomSettingsApp.version+'',
-        protocolVersion: location.protocolVersion && location.protocolVersion()
+        protocolVersion: Window.protocolVersion && Window.protocolVersion()
     });
 
     var params = {

--- a/unpublishedScripts/marketplace/camera-move/modules/custom-settings-app/CustomSettingsApp.js
+++ b/unpublishedScripts/marketplace/camera-move/modules/custom-settings-app/CustomSettingsApp.js
@@ -52,7 +52,7 @@ function CustomSettingsApp(options) {
 
     this.extraParams = Object.assign(options.extraParams || {}, {
         customSettingsVersion: CustomSettingsApp.version+'',
-        protocolVersion: Window.protocolVersion && Window.protocolVersion()
+        protocolVersion: Window.protocolSignature && Window.protocolSignature()
     });
 
     var params = {


### PR DESCRIPTION
A new Window.protocolVersion() API function is provided in addition to the old, deprecated location.protocolVersion() API function.