### PR TITLE
Remove dangerous "Use Anim Pre and Post Rotations" menu item

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -574,8 +574,6 @@ Menu::Menu() {
         avatar.get(), SLOT(setEnableMeshVisible(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::DisableEyelidAdjustment, 0, false);
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::TurnWithHead, 0, false);
-    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::UseAnimPreAndPostRotations, 0, true,
-        avatar.get(), SLOT(setUseAnimPreAndPostRotations(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::EnableInverseKinematics, 0, true,
         avatar.get(), SLOT(setEnableInverseKinematics(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::RenderSensorToWorldMatrix, 0, false,

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -194,7 +194,6 @@ namespace MenuOption {
     const QString TurnWithHead = "Turn using Head";
     const QString UseAudioForMouth = "Use Audio for Mouth";
     const QString UseCamera = "Use Camera";
-    const QString UseAnimPreAndPostRotations = "Use Anim Pre and Post Rotations";
     const QString VelocityFilter = "Velocity Filter";
     const QString VisibleToEveryone = "Everyone";
     const QString VisibleToFriends = "Friends";

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1061,11 +1061,6 @@ void MyAvatar::setEnableMeshVisible(bool isEnabled) {
     _skeletonModel->setVisibleInScene(isEnabled, qApp->getMain3DScene());
 }
 
-void MyAvatar::setUseAnimPreAndPostRotations(bool isEnabled) {
-    AnimClip::usePreAndPostPoseFromAnim = isEnabled;
-    reset(true);
-}
-
 void MyAvatar::setEnableInverseKinematics(bool isEnabled) {
     _skeletonModel->getRig().setEnableInverseKinematics(isEnabled);
 }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -594,7 +594,6 @@ public slots:
 
     bool getEnableMeshVisible() const { return _skeletonModel->isVisible(); }
     void setEnableMeshVisible(bool isEnabled);
-    void setUseAnimPreAndPostRotations(bool isEnabled);
     void setEnableInverseKinematics(bool isEnabled);
 
     QUrl getAnimGraphOverrideUrl() const;  // thread-safe

--- a/libraries/animation/src/AnimClip.cpp
+++ b/libraries/animation/src/AnimClip.cpp
@@ -13,8 +13,6 @@
 #include "AnimationLogging.h"
 #include "AnimUtil.h"
 
-bool AnimClip::usePreAndPostPoseFromAnim = true;
-
 AnimClip::AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag, bool mirrorFlag) :
     AnimNode(AnimNode::Type::Clip, id),
     _startFrame(startFrame),
@@ -138,14 +136,8 @@ void AnimClip::copyFromNetworkAnim() {
             if (skeletonJoint >= 0 && skeletonJoint < skeletonJointCount) {
 
                 AnimPose preRot, postRot;
-                if (usePreAndPostPoseFromAnim) {
-                    preRot = animSkeleton.getPreRotationPose(animJoint);
-                    postRot = animSkeleton.getPostRotationPose(animJoint);
-                } else {
-                    // In order to support Blender, which does not have preRotation FBX support, we use the models defaultPose as the reference frame for the animations.
-                    preRot = AnimPose(glm::vec3(1.0f), _skeleton->getRelativeBindPose(skeletonJoint).rot(), glm::vec3());
-                    postRot = AnimPose::identity;
-                }
+                preRot = animSkeleton.getPreRotationPose(animJoint);
+                postRot = animSkeleton.getPostRotationPose(animJoint);
 
                 // cancel out scale
                 preRot.scale() = glm::vec3(1.0f);

--- a/libraries/animation/src/AnimClip.h
+++ b/libraries/animation/src/AnimClip.h
@@ -25,8 +25,6 @@ class AnimClip : public AnimNode {
 public:
     friend class AnimTests;
 
-    static bool usePreAndPostPoseFromAnim;
-
     AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag, bool mirrorFlag);
     virtual ~AnimClip() override;
 

--- a/libraries/animation/src/AnimInverseKinematics.cpp
+++ b/libraries/animation/src/AnimInverseKinematics.cpp
@@ -1255,7 +1255,7 @@ void AnimInverseKinematics::initConstraints() {
     //                     /       /
     //                 O--O    O--O
 
-    loadDefaultPoses(_skeleton->getRelativeBindPoses());
+    loadDefaultPoses(_skeleton->getRelativeDefaultPoses());
 
     int numJoints = (int)_defaultRelativePoses.size();
 

--- a/libraries/animation/src/AnimManipulator.cpp
+++ b/libraries/animation/src/AnimManipulator.cpp
@@ -33,7 +33,7 @@ AnimManipulator::~AnimManipulator() {
 }
 
 const AnimPoseVec& AnimManipulator::evaluate(const AnimVariantMap& animVars, const AnimContext& context, float dt, Triggers& triggersOut) {
-    return overlay(animVars, context, dt, triggersOut, _skeleton->getRelativeBindPoses());
+    return overlay(animVars, context, dt, triggersOut, _skeleton->getRelativeDefaultPoses());
 }
 
 const AnimPoseVec& AnimManipulator::overlay(const AnimVariantMap& animVars, const AnimContext& context, float dt, Triggers& triggersOut, const AnimPoseVec& underPoses) {

--- a/libraries/animation/src/AnimSkeleton.cpp
+++ b/libraries/animation/src/AnimSkeleton.cpp
@@ -56,14 +56,6 @@ int AnimSkeleton::getChainDepth(int jointIndex) const {
     }
 }
 
-const AnimPose& AnimSkeleton::getAbsoluteBindPose(int jointIndex) const {
-    return _absoluteBindPoses[jointIndex];
-}
-
-const AnimPose& AnimSkeleton::getRelativeBindPose(int jointIndex) const {
-    return _relativeBindPoses[jointIndex];
-}
-
 const AnimPose& AnimSkeleton::getRelativeDefaultPose(int jointIndex) const {
     return _relativeDefaultPoses[jointIndex];
 }
@@ -164,8 +156,6 @@ void AnimSkeleton::buildSkeletonFromJoints(const std::vector<FBXJoint>& joints) 
     _joints = joints;
     _jointsSize = (int)joints.size();
     // build a cache of bind poses
-    _absoluteBindPoses.reserve(_jointsSize);
-    _relativeBindPoses.reserve(_jointsSize);
 
     // build a chache of default poses
     _absoluteDefaultPoses.reserve(_jointsSize);
@@ -191,28 +181,6 @@ void AnimSkeleton::buildSkeletonFromJoints(const std::vector<FBXJoint>& joints) 
             _absoluteDefaultPoses.push_back(_absoluteDefaultPoses[parentIndex] * relDefaultPose);
         } else {
             _absoluteDefaultPoses.push_back(relDefaultPose);
-        }
-
-        // build relative and absolute bind poses
-        if (_joints[i].bindTransformFoundInCluster) {
-            // Use the FBXJoint::bindTransform, which is absolute model coordinates
-            // i.e. not relative to it's parent.
-            AnimPose absoluteBindPose(_joints[i].bindTransform);
-            _absoluteBindPoses.push_back(absoluteBindPose);
-            if (parentIndex >= 0) {
-                AnimPose inverseParentAbsoluteBindPose = _absoluteBindPoses[parentIndex].inverse();
-                _relativeBindPoses.push_back(inverseParentAbsoluteBindPose * absoluteBindPose);
-            } else {
-                _relativeBindPoses.push_back(absoluteBindPose);
-            }
-        } else {
-            // use default transform instead
-            _relativeBindPoses.push_back(relDefaultPose);
-            if (parentIndex >= 0) {
-                _absoluteBindPoses.push_back(_absoluteBindPoses[parentIndex] * relDefaultPose);
-            } else {
-                _absoluteBindPoses.push_back(relDefaultPose);
-            }
         }
     }
 
@@ -251,8 +219,6 @@ void AnimSkeleton::dump(bool verbose) const {
         qCDebug(animation) << "    {";
         qCDebug(animation) << "        index =" << i;
         qCDebug(animation) << "        name =" << getJointName(i);
-        qCDebug(animation) << "        absBindPose =" << getAbsoluteBindPose(i);
-        qCDebug(animation) << "        relBindPose =" << getRelativeBindPose(i);
         qCDebug(animation) << "        absDefaultPose =" << getAbsoluteDefaultPose(i);
         qCDebug(animation) << "        relDefaultPose =" << getRelativeDefaultPose(i);
         if (verbose) {
@@ -287,8 +253,6 @@ void AnimSkeleton::dump(const AnimPoseVec& poses) const {
         qCDebug(animation) << "    {";
         qCDebug(animation) << "        index =" << i;
         qCDebug(animation) << "        name =" << getJointName(i);
-        qCDebug(animation) << "        absBindPose =" << getAbsoluteBindPose(i);
-        qCDebug(animation) << "        relBindPose =" << getRelativeBindPose(i);
         qCDebug(animation) << "        absDefaultPose =" << getAbsoluteDefaultPose(i);
         qCDebug(animation) << "        relDefaultPose =" << getRelativeDefaultPose(i);
         qCDebug(animation) << "        pose =" << poses[i];

--- a/libraries/animation/src/AnimSkeleton.h
+++ b/libraries/animation/src/AnimSkeleton.h
@@ -30,13 +30,6 @@ public:
     int getNumJoints() const;
     int getChainDepth(int jointIndex) const;
 
-    // absolute pose, not relative to parent
-    const AnimPose& getAbsoluteBindPose(int jointIndex) const;
-
-    // relative to parent pose
-    const AnimPose& getRelativeBindPose(int jointIndex) const;
-    const AnimPoseVec& getRelativeBindPoses() const { return _relativeBindPoses; }
-
     // the default poses are the orientations of the joints on frame 0.
     const AnimPose& getRelativeDefaultPose(int jointIndex) const;
     const AnimPoseVec& getRelativeDefaultPoses() const { return _relativeDefaultPoses; }
@@ -72,8 +65,6 @@ protected:
 
     std::vector<FBXJoint> _joints;
     int _jointsSize { 0 };
-    AnimPoseVec _absoluteBindPoses;
-    AnimPoseVec _relativeBindPoses;
     AnimPoseVec _relativeDefaultPoses;
     AnimPoseVec _absoluteDefaultPoses;
     AnimPoseVec _relativePreRotationPoses;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1050,16 +1050,6 @@ void Rig::updateAnimations(float deltaTime, const glm::mat4& rootTransform, cons
     }
 }
 
-void Rig::inverseKinematics(int endIndex, glm::vec3 targetPosition, const glm::quat& targetRotation, float priority,
-                            const QVector<int>& freeLineage, glm::mat4 rootTransform) {
-    ASSERT(false);
-}
-
-bool Rig::restoreJointPosition(int jointIndex, float fraction, float priority, const QVector<int>& freeLineage) {
-    ASSERT(false);
-    return false;
-}
-
 float Rig::getLimbLength(int jointIndex, const QVector<int>& freeLineage,
                          const glm::vec3 scale, const QVector<FBXJoint>& fbxJoints) const {
     ASSERT(false);

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -179,7 +179,7 @@ void Rig::restoreRoleAnimation(const QString& role) {
             } else {
                 qCWarning(animation) << "Rig::restoreRoleAnimation could not find role " << role;
             }
-            
+
             auto statesIter = _roleAnimStates.find(role);
             if (statesIter != _roleAnimStates.end()) {
                 _roleAnimStates.erase(statesIter);
@@ -1049,42 +1049,6 @@ void Rig::updateAnimations(float deltaTime, const glm::mat4& rootTransform, cons
         _externalPoseSet = _internalPoseSet;
     }
 }
-
-float Rig::getLimbLength(int jointIndex, const QVector<int>& freeLineage,
-                         const glm::vec3 scale, const QVector<FBXJoint>& fbxJoints) const {
-    ASSERT(false);
-    return 1.0f;
-}
-
-glm::quat Rig::setJointRotationInBindFrame(int jointIndex, const glm::quat& rotation, float priority) {
-    ASSERT(false);
-    return glm::quat();
-}
-
-glm::vec3 Rig::getJointDefaultTranslationInConstrainedFrame(int jointIndex) {
-    ASSERT(false);
-    return glm::vec3();
-}
-
-glm::quat Rig::setJointRotationInConstrainedFrame(int jointIndex, glm::quat targetRotation, float priority, float mix) {
-    ASSERT(false);
-    return glm::quat();
-}
-
-bool Rig::getJointRotationInConstrainedFrame(int jointIndex, glm::quat& quatOut) const {
-    ASSERT(false);
-    return false;
-}
-
-void Rig::clearJointStatePriorities() {
-    ASSERT(false);
-}
-
-glm::quat Rig::getJointDefaultRotationInParentFrame(int jointIndex) {
-    ASSERT(false);
-    return glm::quat();
-}
-
 
 void Rig::updateFromEyeParameters(const EyeParameters& params) {
     updateEyeJoint(params.leftEyeJointIndex, params.modelTranslation, params.modelRotation, params.eyeLookAt, params.eyeSaccade);

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -173,10 +173,6 @@ public:
     void updateAnimations(float deltaTime, const glm::mat4& rootTransform, const glm::mat4& rigToWorldTransform);
 
     // legacy
-    void inverseKinematics(int endIndex, glm::vec3 targetPosition, const glm::quat& targetRotation, float priority,
-                           const QVector<int>& freeLineage, glm::mat4 rootTransform);
-
-    // legacy
     bool restoreJointPosition(int jointIndex, float fraction, float priority, const QVector<int>& freeLineage);
 
     // legacy

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -172,32 +172,6 @@ public:
     // Regardless of who started the animations or how many, update the joints.
     void updateAnimations(float deltaTime, const glm::mat4& rootTransform, const glm::mat4& rigToWorldTransform);
 
-    // legacy
-    bool restoreJointPosition(int jointIndex, float fraction, float priority, const QVector<int>& freeLineage);
-
-    // legacy
-    float getLimbLength(int jointIndex, const QVector<int>& freeLineage,
-                        const glm::vec3 scale, const QVector<FBXJoint>& fbxJoints) const;
-
-    // legacy
-    glm::quat setJointRotationInBindFrame(int jointIndex, const glm::quat& rotation, float priority);
-
-    // legacy
-    glm::vec3 getJointDefaultTranslationInConstrainedFrame(int jointIndex);
-
-    // legacy
-    glm::quat setJointRotationInConstrainedFrame(int jointIndex, glm::quat targetRotation,
-                                                 float priority, float mix = 1.0f);
-
-    // legacy
-    bool getJointRotationInConstrainedFrame(int jointIndex, glm::quat& rotOut) const;
-
-    // legacy
-    glm::quat getJointDefaultRotationInParentFrame(int jointIndex);
-
-    // legacy
-    void clearJointStatePriorities();
-
     void updateFromControllerParameters(const ControllerParameters& params, float dt);
     void updateFromEyeParameters(const EyeParameters& params);
 
@@ -341,7 +315,7 @@ protected:
         float firstFrame;
         float lastFrame;
     };
-    
+
     struct RoleAnimState {
        RoleAnimState() {}
        RoleAnimState(const QString& roleId, const QString& urlIn, float fpsIn, bool loopIn, float firstFrameIn, float lastFrameIn) :

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
@@ -241,16 +241,8 @@ bool SkeletonModel::getLeftShoulderPosition(glm::vec3& position) const {
     return getJointPositionInWorldFrame(getLastFreeJointIndex(getLeftHandJointIndex()), position);
 }
 
-float SkeletonModel::getLeftArmLength() const {
-    return getLimbLength(getLeftHandJointIndex());
-}
-
 bool SkeletonModel::getRightShoulderPosition(glm::vec3& position) const {
     return getJointPositionInWorldFrame(getLastFreeJointIndex(getRightHandJointIndex()), position);
-}
-
-float SkeletonModel::getRightArmLength() const {
-    return getLimbLength(getRightHandJointIndex());
 }
 
 bool SkeletonModel::getHeadPosition(glm::vec3& headPosition) const {

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
@@ -237,20 +237,12 @@ bool SkeletonModel::getRightHandPosition(glm::vec3& position) const {
     return getJointPositionInWorldFrame(getRightHandJointIndex(), position);
 }
 
-bool SkeletonModel::restoreLeftHandPosition(float fraction, float priority) {
-    return restoreJointPosition(getLeftHandJointIndex(), fraction, priority);
-}
-
 bool SkeletonModel::getLeftShoulderPosition(glm::vec3& position) const {
     return getJointPositionInWorldFrame(getLastFreeJointIndex(getLeftHandJointIndex()), position);
 }
 
 float SkeletonModel::getLeftArmLength() const {
     return getLimbLength(getLeftHandJointIndex());
-}
-
-bool SkeletonModel::restoreRightHandPosition(float fraction, float priority) {
-    return restoreJointPosition(getRightHandJointIndex(), fraction, priority);
 }
 
 bool SkeletonModel::getRightShoulderPosition(glm::vec3& position) const {

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
@@ -57,22 +57,12 @@ public:
     /// \return true whether or not the position was found
     bool getRightHandPosition(glm::vec3& position) const;
 
-    /// Restores some fraction of the default position of the left hand.
-    /// \param fraction the fraction of the default position to restore
-    /// \return whether or not the left hand joint was found
-    bool restoreLeftHandPosition(float fraction = 1.0f, float priority = 1.0f);
-
     /// Gets the position of the left shoulder.
     /// \return whether or not the left shoulder joint was found
     bool getLeftShoulderPosition(glm::vec3& position) const;
 
     /// Returns the extended length from the left hand to its last free ancestor.
     float getLeftArmLength() const;
-
-    /// Restores some fraction of the default position of the right hand.
-    /// \param fraction the fraction of the default position to restore
-    /// \return whether or not the right hand joint was found
-    bool restoreRightHandPosition(float fraction = 1.0f, float priority = 1.0f);
 
     /// Gets the position of the right shoulder.
     /// \return whether or not the right shoulder joint was found

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
@@ -68,9 +68,6 @@ public:
     /// \return whether or not the right shoulder joint was found
     bool getRightShoulderPosition(glm::vec3& position) const;
 
-    /// Returns the extended length from the right hand to its first free ancestor.
-    float getRightArmLength() const;
-
     /// Returns the position of the head joint.
     /// \return whether or not the head was found
     bool getHeadPosition(glm::vec3& headPosition) const;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1259,19 +1259,6 @@ void Model::updateClusterMatrices() {
     }
 }
 
-void Model::inverseKinematics(int endIndex, glm::vec3 targetPosition, const glm::quat& targetRotation, float priority) {
-    const FBXGeometry& geometry = getFBXGeometry();
-    const QVector<int>& freeLineage = geometry.joints.at(endIndex).freeLineage;
-    glm::mat4 parentTransform = glm::scale(_scale) * glm::translate(_offset);
-    _rig.inverseKinematics(endIndex, targetPosition, targetRotation, priority, freeLineage, parentTransform);
-}
-
-bool Model::restoreJointPosition(int jointIndex, float fraction, float priority) {
-    const FBXGeometry& geometry = getFBXGeometry();
-    const QVector<int>& freeLineage = geometry.joints.at(jointIndex).freeLineage;
-    return _rig.restoreJointPosition(jointIndex, fraction, priority, freeLineage);
-}
-
 float Model::getLimbLength(int jointIndex) const {
     const FBXGeometry& geometry = getFBXGeometry();
     const QVector<int>& freeLineage = geometry.joints.at(jointIndex).freeLineage;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1259,12 +1259,6 @@ void Model::updateClusterMatrices() {
     }
 }
 
-float Model::getLimbLength(int jointIndex) const {
-    const FBXGeometry& geometry = getFBXGeometry();
-    const QVector<int>& freeLineage = geometry.joints.at(jointIndex).freeLineage;
-    return _rig.getLimbLength(jointIndex, freeLineage, _scale, geometry.joints);
-}
-
 bool Model::maybeStartBlender() {
     if (isLoaded()) {
         const FBXGeometry& fbxGeometry = getFBXGeometry();

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -366,10 +366,6 @@ protected:
     void computeMeshPartLocalBounds();
     virtual void updateRig(float deltaTime, glm::mat4 parentTransform);
 
-    /// Computes and returns the extended length of the limb terminating at the specified joint and starting at the joint's
-    /// first free ancestor.
-    float getLimbLength(int jointIndex) const;
-
     /// Allow sub classes to force invalidating the bboxes
     void invalidCalculatedMeshBoxes() {
         _triangleSetsValid = false;

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -199,8 +199,6 @@ public:
     /// Returns the index of the parent of the indexed joint, or -1 if not found.
     int getParentJointIndex(int jointIndex) const;
 
-    void inverseKinematics(int jointIndex, glm::vec3 position, const glm::quat& rotation, float priority);
-
     /// Returns the extents of the model in its bind pose.
     Extents getBindExtents() const;
 
@@ -367,12 +365,6 @@ protected:
 
     void computeMeshPartLocalBounds();
     virtual void updateRig(float deltaTime, glm::mat4 parentTransform);
-
-    /// Restores the indexed joint to its default position.
-    /// \param fraction the fraction of the default position to apply (i.e., 0.25f to slerp one fourth of the way to
-    /// the original position
-    /// \return true if the joint was found
-    bool restoreJointPosition(int jointIndex, float fraction = 1.0f, float priority = 0.0f);
 
     /// Computes and returns the extended length of the limb terminating at the specified joint and starting at the joint's
     /// first free ancestor.


### PR DESCRIPTION
The `Developer > Avatar > Use Anim Pre and Post Rotations` menu item has been removed.  Disabling this menu item could cause hard to diagnose avatar bugs, it has been defaulted to true for more than a year.  Also, some internal legacy code from Rig and Model have been removed.