### PR TITLE
Fix black flashing on transparent objects

### DIFF
--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -335,11 +335,13 @@ void DrawDeferred::run(const RenderContextPointer& renderContext, const Inputs& 
         // Setup lighting model for all items;
         batch.setUniformBuffer(render::ShapePipeline::Slot::LIGHTING_MODEL, lightingModel->getParametersBuffer());
 
-        // Setup haze iff curretn zone has haze
+        // Setup haze iff current zone has haze
         auto hazeStage = args->_scene->getStage<HazeStage>();
         if (hazeStage && hazeStage->_currentFrame._hazes.size() > 0) {
             graphics::HazePointer hazePointer = hazeStage->getHaze(hazeStage->_currentFrame._hazes.front());
-            batch.setUniformBuffer(render::ShapePipeline::Slot::HAZE_MODEL, hazePointer->getHazeParametersBuffer());
+            if (hazePointer) {
+                batch.setUniformBuffer(render::ShapePipeline::Slot::HAZE_MODEL, hazePointer->getHazeParametersBuffer());
+            }
         }
 
         // From the lighting model define a global shapKey ORED with individiual keys

--- a/libraries/render/src/render/ShapePipeline.cpp
+++ b/libraries/render/src/render/ShapePipeline.cpp
@@ -87,7 +87,7 @@ void ShapePlumber::addPipeline(const Filter& filter, const gpu::ShaderPointer& p
     slotBindings.insert(gpu::Shader::Binding(std::string("skyboxMap"), Slot::MAP::LIGHT_AMBIENT));
     slotBindings.insert(gpu::Shader::Binding(std::string("fadeMaskMap"), Slot::MAP::FADE_MASK));
     slotBindings.insert(gpu::Shader::Binding(std::string("fadeParametersBuffer"), Slot::BUFFER::FADE_PARAMETERS));
-    slotBindings.insert(gpu::Shader::Binding(std::string("hazeParametersBuffer"), Slot::BUFFER::HAZE_MODEL));
+    slotBindings.insert(gpu::Shader::Binding(std::string("hazeBuffer"), Slot::BUFFER::HAZE_MODEL));
 
     gpu::Shader::makeProgram(*program, slotBindings);
 


### PR DESCRIPTION
We were setting "hazeParametersBuffer" instead of "hazeBuffer."  Might also fix/workaround a somewhat rare haze crash.

Test plan:
- In the default content set, transparent entities (teleporter models, the lights, the windows, etc.) should render correctly, and not flash black or get messed up when you rotate your view and move around.
- Try in blue, wikiplanet, and a few other domains (if they're up and on the same protocol version).