### PR TITLE
change ImageOverlay to use AnimatedImage instead of Image

### DIFF
--- a/interface/resources/qml/hifi/overlays/ImageOverlay.qml
+++ b/interface/resources/qml/hifi/overlays/ImageOverlay.qml
@@ -7,7 +7,7 @@ import "."
 Overlay {
     id: root
 
-    Image {
+    AnimatedImage {
         id: image
         property bool scaleFix: true
         property real xStart: 0


### PR DESCRIPTION
Use AnimatedImage instead of Image in ImageOverlay definition so that .gif files can be supported in image overlays. 

**Test Plan (New Behavior):**
- Open the console and paste in the following:
`var overlay = Overlays.addOverlay("image", {
    imageURL: "https://media.giphy.com/media/OGGwlV1RYgX2U/giphy.gif",
    x: 100,
    y: 100,
    width: 400, 
    height: 400,
    visible: true,
    alpha: 1.0
});`

- Confirm that you see the following animating on a loop in HMD and desktop mode:
https://user-images.githubusercontent.com/4313320/35070348-d77a713e-fb91-11e7-83ca-42cb7ec2befe.png


**Test Cases (Regression - ensure nothing existing is broken) :**
- Run cases 1816 and 1817 (Image Overlays for Snapshots with CTRL + S)
- Run test case 222 (Other image handling)
- Run test case 217

Note if there is anything that seems broken related to how images are displayed on client UI elements in both desktop and tablet modes.

