### PR TITLE
Cleanup and separate some uniform buffer slots

### DIFF
--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -23,8 +23,7 @@ using namespace render::entities;
 static uint8_t CUSTOM_PIPELINE_NUMBER = 0;
 static gpu::Stream::FormatPointer _vertexFormat;
 static std::weak_ptr<gpu::Pipeline> _texturedPipeline;
-// FIXME: This is interfering with the uniform buffers in DeferredLightingEffect.cpp, so use 11 to avoid collisions
-static int32_t PARTICLE_UNIFORM_SLOT { 11 };
+static int32_t PARTICLE_UNIFORM_SLOT { 0 };
 
 static ShapePipelinePointer shapePipelineFactory(const ShapePlumber& plumber, const ShapeKey& key) {
     auto texturedPipeline = _texturedPipeline.lock();

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -34,8 +34,7 @@ using namespace render::entities;
 
 static uint8_t CUSTOM_PIPELINE_NUMBER { 0 };
 static const int32_t PAINTSTROKE_TEXTURE_SLOT { 0 };
-// FIXME: This is interfering with the uniform buffers in DeferredLightingEffect.cpp, so use 11 to avoid collisions
-static const int32_t PAINTSTROKE_UNIFORM_SLOT { 11 };
+static const int32_t PAINTSTROKE_UNIFORM_SLOT { 0 };
 static gpu::Stream::FormatPointer polylineFormat;
 static gpu::PipelinePointer polylinePipeline;
 #ifdef POLYLINE_ENTITY_USE_FADE_EFFECT

--- a/libraries/graphics/src/graphics/Skybox.cpp
+++ b/libraries/graphics/src/graphics/Skybox.cpp
@@ -118,7 +118,7 @@ void Skybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum, const Sky
     batch.setModelTransform(Transform()); // only for Mac
 
     batch.setPipeline(thePipeline);
-    skybox.prepare(batch);
+    skybox.prepare(batch, SKYBOX_SKYMAP_SLOT, SKYBOX_CONSTANTS_SLOT);
     batch.draw(gpu::TRIANGLE_STRIP, 4);
 
     batch.setResourceTexture(SKYBOX_SKYMAP_SLOT, nullptr);

--- a/libraries/render-utils/src/DebugDeferredBuffer.cpp
+++ b/libraries/render-utils/src/DebugDeferredBuffer.cpp
@@ -57,8 +57,8 @@ enum TextureSlot {
 };
 
 enum ParamSlot {
-    CameraCorrection = 0,
-    DeferredFrameTransform,
+    DeferredFrameTransform = 0,
+    CameraCorrection,
     ShadowTransform
 };
 

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -64,19 +64,21 @@ enum DeferredShader_MapSlot {
     DEFERRED_BUFFER_DIFFUSED_CURVATURE_UNIT,
     SCATTERING_LUT_UNIT,
     SCATTERING_SPECULAR_UNIT,
+    NUM_MAP_SLOTS
 };
 enum DeferredShader_BufferSlot {
     DEFERRED_FRAME_TRANSFORM_BUFFER_SLOT = 0,
     CAMERA_CORRECTION_BUFFER_SLOT,
     SCATTERING_PARAMETERS_BUFFER_SLOT,
-    LIGHTING_MODEL_BUFFER_SLOT = render::ShapePipeline::Slot::LIGHTING_MODEL,
-    LIGHT_GPU_SLOT = render::ShapePipeline::Slot::LIGHT,
-    LIGHT_AMBIENT_SLOT = render::ShapePipeline::Slot::LIGHT_AMBIENT_BUFFER,
-    HAZE_MODEL_BUFFER_SLOT = render::ShapePipeline::Slot::HAZE_MODEL,
+    LIGHTING_MODEL_BUFFER_SLOT,
+    LIGHT_GPU_SLOT,
+    LIGHT_AMBIENT_SLOT,
+    HAZE_MODEL_BUFFER_SLOT,
     LIGHT_INDEX_GPU_SLOT,
     LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT,
     LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT,
     LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT,
+    NUM_BUFFER_SLOTS
 };
 
 static void loadLightProgram(const char* vertSource, const char* fragSource, bool lightVolume, gpu::PipelinePointer& program, LightLocationsPtr& locations);
@@ -651,26 +653,13 @@ void RenderDeferredCleanup::run(const render::RenderContextPointer& renderContex
     auto& batch = (*args->_batch);
     {
         // Probably not necessary in the long run because the gpu layer would unbound this texture if used as render target
-        batch.setResourceTexture(DEFERRED_BUFFER_COLOR_UNIT, nullptr);
-        batch.setResourceTexture(DEFERRED_BUFFER_NORMAL_UNIT, nullptr);
-        batch.setResourceTexture(DEFERRED_BUFFER_EMISSIVE_UNIT, nullptr);
-        batch.setResourceTexture(DEFERRED_BUFFER_DEPTH_UNIT, nullptr);
-        batch.setResourceTexture(DEFERRED_BUFFER_OBSCURANCE_UNIT, nullptr);
+        for (int i = 0; i < NUM_MAP_SLOTS; i++) {
+            batch.setResourceTexture(i, nullptr);
+        }
 
-        batch.setResourceTexture(DEFERRED_BUFFER_LINEAR_DEPTH_UNIT, nullptr);
-        batch.setResourceTexture(DEFERRED_BUFFER_CURVATURE_UNIT, nullptr);
-        batch.setResourceTexture(DEFERRED_BUFFER_DIFFUSED_CURVATURE_UNIT, nullptr);
-        batch.setResourceTexture(SCATTERING_LUT_UNIT, nullptr);
-        batch.setResourceTexture(SCATTERING_SPECULAR_UNIT, nullptr);
-
-        batch.setUniformBuffer(SCATTERING_PARAMETERS_BUFFER_SLOT, nullptr);
-        //     batch.setUniformBuffer(LIGHTING_MODEL_BUFFER_SLOT, nullptr);
-        batch.setUniformBuffer(DEFERRED_FRAME_TRANSFORM_BUFFER_SLOT, nullptr);
-
-        batch.setUniformBuffer(LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT, nullptr);
-        batch.setUniformBuffer(LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT, nullptr);
-        batch.setUniformBuffer(LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT, nullptr);
-
+        for (int i = 0; i < NUM_BUFFER_SLOTS; i++) {
+            batch.setUniformBuffer(i, nullptr);
+        }
     }
 }
 

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -1942,7 +1942,7 @@ void GeometryCache::renderGlowLine(gpu::Batch& batch, const glm::vec3& p1, const
     }
 
     // Compile the shaders
-    static const uint32_t LINE_DATA_SLOT = 1;
+    static const uint32_t LINE_DATA_SLOT = 0;
     static std::once_flag once;
     std::call_once(once, [&] {
         auto state = std::make_shared<gpu::State>();

--- a/libraries/render-utils/src/LightClusters.cpp
+++ b/libraries/render-utils/src/LightClusters.cpp
@@ -30,20 +30,21 @@
 
 enum LightClusterGridShader_MapSlot {
     DEFERRED_BUFFER_LINEAR_DEPTH_UNIT = 0,
-    DEFERRED_BUFFER_COLOR_UNIT = 1,
-    DEFERRED_BUFFER_NORMAL_UNIT = 2,
-    DEFERRED_BUFFER_EMISSIVE_UNIT = 3,
-    DEFERRED_BUFFER_DEPTH_UNIT = 4,
+    DEFERRED_BUFFER_COLOR_UNIT,
+    DEFERRED_BUFFER_NORMAL_UNIT,
+    DEFERRED_BUFFER_EMISSIVE_UNIT,
+    DEFERRED_BUFFER_DEPTH_UNIT,
+    NUM_MAP_SLOTS
 };
 
 enum LightClusterGridShader_BufferSlot {
     DEFERRED_FRAME_TRANSFORM_BUFFER_SLOT = 0,
-    CAMERA_CORRECTION_BUFFER_SLOT = 1,
-    LIGHT_GPU_SLOT = render::ShapePipeline::Slot::LIGHT,
-    LIGHT_INDEX_GPU_SLOT = 7,
-    LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT = 8,
-    LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT = 9,
-    LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT = 10,
+    CAMERA_CORRECTION_BUFFER_SLOT,
+    LIGHT_GPU_SLOT,
+    LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT,
+    LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT,
+    LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT,
+    NUM_BUFFER_SLOTS
 };
 
 FrustumGrid::FrustumGrid(const FrustumGrid& source) :
@@ -742,9 +743,6 @@ void DebugLightClusters::run(const render::RenderContextPointer& renderContext, 
         }
 
         batch.draw(gpu::TRIANGLE_STRIP, 4, 0);
-              
-        batch.setResourceTexture(DEFERRED_BUFFER_LINEAR_DEPTH_UNIT, nullptr);
-        batch.setUniformBuffer(DEFERRED_FRAME_TRANSFORM_BUFFER_SLOT, nullptr);
     }
 
     if (doDrawContent) {
@@ -758,9 +756,6 @@ void DebugLightClusters::run(const render::RenderContextPointer& renderContext, 
         }
 
         batch.draw(gpu::TRIANGLE_STRIP, 4, 0);
-              
-        batch.setResourceTexture(DEFERRED_BUFFER_LINEAR_DEPTH_UNIT, nullptr);
-        batch.setUniformBuffer(DEFERRED_FRAME_TRANSFORM_BUFFER_SLOT, nullptr);
     }
 
 
@@ -776,15 +771,13 @@ void DebugLightClusters::run(const render::RenderContextPointer& renderContext, 
         drawGridAndCleanBatch.drawInstanced(summedDims.x, gpu::LINES, 24, 0);
     }
 
-    drawGridAndCleanBatch.setUniformBuffer(LIGHT_GPU_SLOT, nullptr);
-    drawGridAndCleanBatch.setUniformBuffer(LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT, nullptr);
-    drawGridAndCleanBatch.setUniformBuffer(LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT, nullptr);
-    drawGridAndCleanBatch.setUniformBuffer(LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT, nullptr);
+    for (int i = 0; i < NUM_MAP_SLOTS; i++) {
+        drawGridAndCleanBatch.setResourceTexture(i, nullptr);
+    }
 
-    drawGridAndCleanBatch.setResourceTexture(DEFERRED_BUFFER_COLOR_UNIT, nullptr);
-    drawGridAndCleanBatch.setResourceTexture(DEFERRED_BUFFER_NORMAL_UNIT, nullptr);
-    drawGridAndCleanBatch.setResourceTexture(DEFERRED_BUFFER_EMISSIVE_UNIT, nullptr);
-    drawGridAndCleanBatch.setResourceTexture(DEFERRED_BUFFER_DEPTH_UNIT, nullptr);
+    for (int i = 0; i < NUM_BUFFER_SLOTS; i++) {
+        drawGridAndCleanBatch.setUniformBuffer(i, nullptr);
+    }
 
     args->_context->appendFrameBatch(batch);
     args->_context->appendFrameBatch(drawGridAndCleanBatch);


### PR DESCRIPTION
No real effect, just moving around some slots in a way that I think is clearer.

Test plan:
- General smoke test.  Things should render normally.  Try in domains with lots of content and interesting zones, like dev-welcome, etc.