### PR TITLE
Don't make links in txn history for highfidelity and marketplace

### DIFF
--- a/interface/src/commerce/Ledger.cpp
+++ b/interface/src/commerce/Ledger.cpp
@@ -137,9 +137,13 @@ QString hfcString(const QJsonValue& sentValue, const QJsonValue& receivedValue) 
     return result;
 }
 static const QString USER_PAGE_BASE_URL = NetworkingConstants::METAVERSE_SERVER_URL().toString() + "/users/";
+static const QStringList KNOWN_USERS(QStringList() << "highfidelity" << "marketplace");
 QString userLink(const QString& username) {
-    if (username.isEmpty()) {
+    if (username.isEmpty() ) {
         return QString("someone");
+    }
+    if (KNOWN_USERS.contains(username)) {
+        return username;
     }
     return QString("<a href=\"%1%2\">%2</a>").arg(USER_PAGE_BASE_URL, username);
 }

--- a/interface/src/commerce/Ledger.cpp
+++ b/interface/src/commerce/Ledger.cpp
@@ -139,7 +139,7 @@ QString hfcString(const QJsonValue& sentValue, const QJsonValue& receivedValue) 
 static const QString USER_PAGE_BASE_URL = NetworkingConstants::METAVERSE_SERVER_URL().toString() + "/users/";
 static const QStringList KNOWN_USERS(QStringList() << "highfidelity" << "marketplace");
 QString userLink(const QString& username) {
-    if (username.isEmpty() ) {
+    if (username.isEmpty()) {
         return QString("someone");
     }
     if (KNOWN_USERS.contains(username)) {


### PR DESCRIPTION
For instance, when you receive you seeding, there is no need to have the highfidelity user that sent it to you be a link to that very uninteresting user page in the metaverse.  Same for marketplace.