### PR TITLE
Fix the Space Bubble button flash behavior; Rate limit sound

### DIFF
--- a/scripts/system/bubble.js
+++ b/scripts/system/bubble.js
@@ -16,6 +16,8 @@
     var button;
     // Used for animating and disappearing the bubble
     var bubbleOverlayTimestamp;
+    // Used for rate limiting the bubble sound
+    var lastBubbleSoundTimestamp = 0;
     // Used for flashing the HUD button upon activation
     var bubbleButtonFlashState = false;
     // Affects bubble height
@@ -38,6 +40,7 @@
 
     var BUBBLE_VISIBLE_DURATION_MS = 3000;
     var BUBBLE_RAISE_ANIMATION_DURATION_MS = 750;
+    var BUBBLE_SOUND_RATE_LIMIT_MS = 15000;
 
     // Hides the bubble model overlay and resets the button flash state
     function hideOverlays() {
@@ -49,11 +52,15 @@
 
     // Make the bubble overlay visible, set its position, and play the sound
     function createOverlays() {
-        Audio.playSound(bubbleActivateSound, {
-            position: { x: MyAvatar.position.x, y: MyAvatar.position.y, z: MyAvatar.position.z },
-            localOnly: true,
-            volume: 0.2
-        });
+        var nowTimestamp = Date.now();
+        if (nowTimestamp - lastBubbleSoundTimestamp >= BUBBLE_SOUND_RATE_LIMIT_MS) {
+            Audio.playSound(bubbleActivateSound, {
+                position: { x: MyAvatar.position.x, y: MyAvatar.position.y, z: MyAvatar.position.z },
+                localOnly: true,
+                volume: 0.2
+            });
+            lastBubbleSoundTimestamp = nowTimestamp;
+        }
         hideOverlays();
         if (updateConnected === true) {
             updateConnected = false;
@@ -79,7 +86,7 @@
             },
             visible: true
         });
-        bubbleOverlayTimestamp = Date.now();
+        bubbleOverlayTimestamp = nowTimestamp;
         Script.update.connect(update);
         updateConnected = true;
 

--- a/scripts/system/bubble.js
+++ b/scripts/system/bubble.js
@@ -18,8 +18,6 @@
     var bubbleOverlayTimestamp;
     // Used for flashing the HUD button upon activation
     var bubbleButtonFlashState = false;
-    // Used for flashing the HUD button upon activation
-    var bubbleButtonTimestamp;
     // Affects bubble height
     var BUBBLE_HEIGHT_SCALE = 0.15;
     // The bubble model itself
@@ -36,6 +34,7 @@
     var bubbleActivateSound = SoundCache.getSound(Script.resolvePath("assets/sounds/bubble.wav"));
     // Is the update() function connected?
     var updateConnected = false;
+    var bubbleFlashTimer = false;
 
     var BUBBLE_VISIBLE_DURATION_MS = 3000;
     var BUBBLE_RAISE_ANIMATION_DURATION_MS = 750;
@@ -81,9 +80,16 @@
             visible: true
         });
         bubbleOverlayTimestamp = Date.now();
-        bubbleButtonTimestamp = bubbleOverlayTimestamp;
         Script.update.connect(update);
         updateConnected = true;
+
+        // Flash button
+        if (!bubbleFlashTimer) {
+            bubbleFlashTimer = Script.setInterval(function () {
+                writeButtonProperties(bubbleButtonFlashState);
+                bubbleButtonFlashState = !bubbleButtonFlashState;
+            }, 500);
+        }
     }
 
     // Called from the C++ scripting interface to show the bubble overlay
@@ -103,12 +109,6 @@
         var delay = (timestamp - bubbleOverlayTimestamp);
         var overlayAlpha = 1.0 - (delay / BUBBLE_VISIBLE_DURATION_MS);
         if (overlayAlpha > 0) {
-            // Flash button
-            if ((timestamp - bubbleButtonTimestamp) >= BUBBLE_VISIBLE_DURATION_MS) {
-                writeButtonProperties(bubbleButtonFlashState);
-                bubbleButtonTimestamp = timestamp;
-                bubbleButtonFlashState = !bubbleButtonFlashState;
-            }
 
             if (delay < BUBBLE_RAISE_ANIMATION_DURATION_MS) {
                 Overlays.editOverlay(bubbleOverlay, {
@@ -157,8 +157,11 @@
                 Script.update.disconnect(update);
                 updateConnected = false;
             }
-            var bubbleActive = Users.getIgnoreRadiusEnabled();
-            writeButtonProperties(bubbleActive);
+            if (bubbleFlashTimer) {
+                Script.clearTimeout(bubbleFlashTimer);
+                bubbleFlashTimer = false;
+            }
+            writeButtonProperties(Users.getIgnoreRadiusEnabled());
         }
     }
 
@@ -166,6 +169,10 @@
     // NOTE: the c++ calls this with just the first param -- we added a second
     // just for not logging the initial state of the bubble when we startup.
     function onBubbleToggled(enabled, doNotLog) {
+        if (bubbleFlashTimer) {
+            Script.clearTimeout(bubbleFlashTimer);
+            bubbleFlashTimer = false;
+        }
         writeButtonProperties(enabled);
         if (doNotLog !== true) {
             UserActivityLogger.bubbleToggled(enabled);
@@ -200,6 +207,10 @@
     // Cleanup the tablet button and overlays when script is stopped
     Script.scriptEnding.connect(function () {
         button.clicked.disconnect(Users.toggleIgnoreRadius);
+        if (bubbleFlashTimer) {
+            Script.clearTimeout(bubbleFlashTimer);
+            bubbleFlashTimer = false;
+        }
         if (tablet) {
             tablet.removeButton(button);
         }


### PR DESCRIPTION
The bubble button is supposed to flash on and off upon activation. Fixes [MS11365](https://highfidelity.manuscript.com/f/cases/11365/Bubble-icon-does-not-flash-when-bubble-is-activated).

Also, the sound is really annoying when it plays too often. Fix that, and address [MS7338](https://highfidelity.manuscript.com/f/cases/7338/Limit-the-times-the-bubble-audio-plays). Finally.

## Test Plan
1. In desktop mode, enable your Space Bubble. Verify that the Space Bubble icon flashes when you click on the icon to enable it (since it brings up the bubble and plays the sound when you first turn it on).
2. Have another avatar walk into your Space Bubble. Verify that the Space Bubble icon flashes when your Bubble is activated.
3. Have that avatar leave your Space Bubble.
4. Have that avatar enter your Space Bubble. As soon as your Space Bubble is activated, click on the BUBBLE icon to turn off your Bubble. Verify that the other avatar appears very close to you and that the BUBBLE Icon stops flashing.
5. Have that avatar rapidly enter and leave your Space Bubble. Verify that the sound doesn't play every time the Bubble is activated, but that it only plays, at minimum, once every 15 seconds.