### PR TITLE
Normalized diffuse & specular for directional, point and spot lights

### DIFF
--- a/libraries/render-utils/src/LightingModel.slh
+++ b/libraries/render-utils/src/LightingModel.slh
@@ -186,7 +186,7 @@ float specularDistribution(SurfaceData surface) {
     // Add geometric factors G1(n,l) and G1(n,v)
     float smithInvG1NdotL = evalSmithInvG1(surface.roughness4, surface.ndotl);
     denom *= surface.smithInvG1NdotV * smithInvG1NdotL;
-    // Don't divide by PI as it will be done later
+    // Don't divide by PI as this is part of the light normalization factor
     float power = surface.roughness4 / denom;
     return power;
 }
@@ -202,12 +202,11 @@ vec4 evalPBRShading(float metallic, vec3 fresnel, SurfaceData surface) {
     vec3 specular = fresnelColor * power * angleAttenuation;
     float diffuse = (1.0 - metallic) * angleAttenuation * (1.0 - fresnelColor.x);
 
-    diffuse /= 3.1415926;
-    // Diffuse is divided by PI but specular isn't because an infinitesimal volume light source
-    // has a multiplier of PI, says Naty Hoffman.
+    // We don't divided by PI, as the "normalized" equations state we should, because we decide, as Naty Hoffman, that
+    // we wish to have a similar color as raw albedo on a perfectly diffuse surface perpendicularly lit
+    // by a white light of intensity 1. But this is an arbitrary normalization of what light intensity "means".
     // (see http://blog.selfshadow.com/publications/s2013-shading-course/hoffman/s2013_pbs_physics_math_notes.pdf
     // page 23 paragraph "Punctual light sources")
-
     return vec4(specular, diffuse);
 }
 
@@ -222,9 +221,9 @@ vec4 evalPBRShadingDielectric(SurfaceData surface, float fresnel) {
     vec3 specular = vec3(fresnelScalar) * power * angleAttenuation;
     float diffuse = angleAttenuation * (1.0 - fresnelScalar);
 
-    diffuse /= 3.1415926;
-    // Diffuse is divided by PI but specular isn't because an infinitesimal volume light source
-    // has a multiplier of PI, says Naty Hoffman.
+    // We don't divided by PI, as the "normalized" equations state we should, because we decide, as Naty Hoffman, that
+    // we wish to have a similar color as raw albedo on a perfectly diffuse surface perpendicularly lit
+    // by a white light of intensity 1. But this is an arbitrary normalization of what light intensity "means".
     // (see http://blog.selfshadow.com/publications/s2013-shading-course/hoffman/s2013_pbs_physics_math_notes.pdf
     // page 23 paragraph "Punctual light sources")
     return vec4(specular, diffuse);
@@ -239,8 +238,9 @@ vec4 evalPBRShadingMetallic(SurfaceData surface, vec3 fresnel) {
     float power = specularDistribution(surface);
     vec3 specular = fresnelColor * power * angleAttenuation;
 
-    // Specular isn't divided by PI because an infinitesimal volume light source
-    // has a multiplier of PI, says Naty Hoffman.
+    // We don't divided by PI, as the "normalized" equations state we should, because we decide, as Naty Hoffman, that
+    // we wish to have a similar color as raw albedo on a perfectly diffuse surface perpendicularly lit
+    // by a white light of intensity 1. But this is an arbitrary normalization of what light intensity "means".
     // (see http://blog.selfshadow.com/publications/s2013-shading-course/hoffman/s2013_pbs_physics_math_notes.pdf
     // page 23 paragraph "Punctual light sources")
     return vec4(specular, 0.f);


### PR DESCRIPTION
This PR normalizes the light intensity of directional and local lights such as:
- for a light intensity of 1,
- and light color of pure white, 
a purely diffuse object lit perpendicularly by the light has a rendered color matching its albedo color / texture.

Simply put (hopefully):
- when authoring albedo textures, the OpenGL render of a non-metal purely diffuse quad face will match the albedo texture color when the quad is lit by a white light of intensity 1(if it is facing the light).

# Test case
The hifi_tests/engine/render/material test case screenshots has been updated in [hifi_tests PR #60](https://github.com/highfidelity/hifi_tests/pull/60).