### PR TITLE
Fix sortOrder param on tablet buttons

### DIFF
--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -83,7 +83,8 @@ TabletButtonProxy* TabletButtonListModel::addButton(const QVariant& properties) 
     int insertButtonUsingIndex = computeNewButtonIndex(newTabletButtonProperties);
     auto newTabletButtonProxy = QSharedPointer<TabletButtonProxy>(new TabletButtonProxy(newTabletButtonProperties));
     beginResetModel();
-    if (insertButtonUsingIndex < _buttons.size()) {
+    int buttonCount = (int)_buttons.size();
+    if (insertButtonUsingIndex < buttonCount) {
         _buttons.insert(_buttons.begin() + insertButtonUsingIndex, newTabletButtonProxy);
     } else {
         _buttons.push_back(newTabletButtonProxy);

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -76,21 +76,21 @@ QVariant TabletButtonListModel::data(const QModelIndex& index, int role) const {
 }
 
 TabletButtonProxy* TabletButtonListModel::addButton(const QVariant& properties) {
-    QVariantMap newTabletButtonProperties = properties.toMap();
-    if (newTabletButtonProperties.find(BUTTON_SORT_ORDER_KEY) == newTabletButtonProperties.end()) {
-        newTabletButtonProperties[BUTTON_SORT_ORDER_KEY] = DEFAULT_BUTTON_SORT_ORDER;
+    QVariantMap newProperties = properties.toMap();
+    if (newProperties.find(BUTTON_SORT_ORDER_KEY) == newProperties.end()) {
+        newProperties[BUTTON_SORT_ORDER_KEY] = DEFAULT_BUTTON_SORT_ORDER;
     }
-    int insertButtonUsingIndex = computeNewButtonIndex(newTabletButtonProperties);
-    auto newTabletButtonProxy = QSharedPointer<TabletButtonProxy>(new TabletButtonProxy(newTabletButtonProperties));
+    int index = computeNewButtonIndex(newProperties);
+    auto button = QSharedPointer<TabletButtonProxy>(new TabletButtonProxy(newProperties));
     beginResetModel();
-    int buttonCount = (int)_buttons.size();
-    if (insertButtonUsingIndex < buttonCount) {
-        _buttons.insert(_buttons.begin() + insertButtonUsingIndex, newTabletButtonProxy);
+    int numButtons = (int)_buttons.size();
+    if (index < numButtons) {
+        _buttons.insert(_buttons.begin() + index, button);
     } else {
-        _buttons.push_back(newTabletButtonProxy);
+        _buttons.push_back(button);
     }
     endResetModel();
-    return newTabletButtonProxy.data();
+    return button.data();
 }
 
 void TabletButtonListModel::removeButton(TabletButtonProxy* button) {
@@ -105,17 +105,17 @@ void TabletButtonListModel::removeButton(TabletButtonProxy* button) {
 }
 
 int TabletButtonListModel::computeNewButtonIndex(const QVariantMap& newButtonProperties) {
-    int buttonCount = (int)_buttons.size();
+    int numButtons = (int)_buttons.size();
     int newButtonSortOrder = newButtonProperties[BUTTON_SORT_ORDER_KEY].toInt();
-    if (newButtonSortOrder == DEFAULT_BUTTON_SORT_ORDER) return buttonCount;
-    for (int i = 0; i < buttonCount; i++) {
+    if (newButtonSortOrder == DEFAULT_BUTTON_SORT_ORDER) return numButtons;
+    for (int i = 0; i < numButtons; i++) {
         QVariantMap tabletButtonProperties = _buttons[i]->getProperties();
         int tabletButtonSortOrder = tabletButtonProperties[BUTTON_SORT_ORDER_KEY].toInt();
         if (newButtonSortOrder <= tabletButtonSortOrder) {
             return i;
         }
     }
-    return buttonCount;
+    return numButtons;
 }
 
 TabletButtonsProxyModel::TabletButtonsProxyModel(QObject *parent)

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -115,6 +115,7 @@ protected:
     friend class TabletProxy;
     TabletButtonProxy* addButton(const QVariant& properties);
     void removeButton(TabletButtonProxy* button);
+    int computeNewButtonIndex(const QVariantMap& newButtonProperties);
     using List = std::list<QSharedPointer<TabletButtonProxy>>;
     static QHash<int, QByteArray> _roles;
     static Qt::ItemFlags _flags;

--- a/scripts/developer/tests/dynamics/dynamicsTests.js
+++ b/scripts/developer/tests/dynamics/dynamicsTests.js
@@ -22,8 +22,7 @@
 
     var button = tablet.addButton({
         icon: Script.resolvePath("dynamicsTests.svg"),
-        text: "Dynamics",
-        sortOrder: 15
+        text: "Dynamics"
     });
 
 

--- a/scripts/developer/utilities/render/debugHighlight.js
+++ b/scripts/developer/utilities/render/debugHighlight.js
@@ -32,8 +32,7 @@
     var button = tablet.addButton({
         text: TABLET_BUTTON_NAME,
         icon: ICON_URL,
-        activeIcon: ACTIVE_ICON_URL,
-        sortOrder: 1
+        activeIcon: ACTIVE_ICON_URL
     });
 
     var hasEventBridge = false;

--- a/scripts/developer/utilities/render/lod.js
+++ b/scripts/developer/utilities/render/lod.js
@@ -30,8 +30,7 @@
     var button = tablet.addButton({
         text: TABLET_BUTTON_NAME,
         icon: ICON_URL,
-        activeIcon: ACTIVE_ICON_URL,
-        sortOrder: 1
+        activeIcon: ACTIVE_ICON_URL
     });
 
     var hasEventBridge = false;

--- a/scripts/developer/utilities/render/luci.js
+++ b/scripts/developer/utilities/render/luci.js
@@ -31,8 +31,7 @@
     var button = tablet.addButton({
         text: TABLET_BUTTON_NAME,
         icon: ICON_URL,
-        activeIcon: ACTIVE_ICON_URL,
-        sortOrder: 1
+        activeIcon: ACTIVE_ICON_URL
     });
 
     var hasEventBridge = false;

--- a/scripts/system/chat.js
+++ b/scripts/system/chat.js
@@ -945,8 +945,7 @@
         tabletButton = tablet.addButton({
             icon: tabletButtonIcon,
             activeIcon: tabletButtonActiveIcon,
-            text: tabletButtonName,
-            sortOrder: 0
+            text: tabletButtonName
         });
 
         Messages.subscribe(channelName);

--- a/scripts/system/generalSettings.js
+++ b/scripts/system/generalSettings.js
@@ -37,8 +37,7 @@
         tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
         button = tablet.addButton({
             icon: "icons/tablet-icons/goto-i.svg",
-            text: buttonName,
-            sortOrder: 8
+            text: buttonName
         });
     }
 

--- a/scripts/system/goto.js
+++ b/scripts/system/goto.js
@@ -41,8 +41,7 @@ if (Settings.getValue("HUDUIEnabled")) {
     button = tablet.addButton({
         icon: "icons/tablet-icons/goto-i.svg",
         activeIcon: "icons/tablet-icons/goto-a.svg",
-        text: buttonName,
-        sortOrder: 8
+        text: buttonName
     });
 }
 

--- a/scripts/system/run.js
+++ b/scripts/system/run.js
@@ -10,8 +10,7 @@
     var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
     var button = tablet.addButton({
         icon: Script.resolvePath("assets/images/run.svg"),
-        text: "RUN",
-        sortOrder: 15
+        text: "RUN"
     });
 
     function onClicked() {

--- a/scripts/system/tablet-users.js
+++ b/scripts/system/tablet-users.js
@@ -37,8 +37,7 @@
     var button = tablet.addButton({
         icon: "icons/tablet-icons/users-i.svg",
         activeIcon: "icons/tablet-icons/users-a.svg",
-        text: "USERS",
-        sortOrder: 11
+        text: "USERS"
     });
 
     var onUsersScreen = false;

--- a/unpublishedScripts/marketplace/clap/clapApp.js
+++ b/unpublishedScripts/marketplace/clap/clapApp.js
@@ -31,8 +31,7 @@ var activeButton = tablet.addButton({
     icon: whiteIcon,
     activeIcon: blackIcon,
     text: APP_NAME,
-    isActive: isActive,
-    sortOrder: 11
+    isActive: isActive
 });
 
 if (isActive) {

--- a/unpublishedScripts/marketplace/skyboxChanger/skyboxchanger.js
+++ b/unpublishedScripts/marketplace/skyboxChanger/skyboxchanger.js
@@ -32,8 +32,7 @@
     var button = tablet.addButton({
         icon: ICONS.icon,
         activeIcon: ICONS.activeIcon,
-        text: TABLET_BUTTON_NAME,
-        sortOrder: 1
+        text: TABLET_BUTTON_NAME
     });
 
     var hasEventBridge = false;


### PR DESCRIPTION
This PR reinstates the button parameter sortOrder. 
The desired behavior is to keep the default apps ordered on the toolbar by their sortOrder value with every non-default app added to their right.
If sortOrder is not specified, it will default to 100 and that button will always be added to the right. 
This PR also eliminates this parameter from all non-default app scripts in order to achieve the desired behavior.

https://highfidelity.fogbugz.com/f/cases/11460/Tablet-Toolbar-Icon-without-SortOrder-are-being-given-random-order

# Test Plan
(Test on desktop and HMD modes)
- Launch High Fidelity and make sure that only the scripts **controllerScripts.js** and **defaultScripts.js** are loaded. The buttons on the toolbar/tablet should be ordered by their sortOrder values:
**AUDIO, ENTER VR, MENU, BUBBLE, SNAP, HELP, PEOPLE, GOTO, MARKET, CREATE, WALLET, EMOTE**
- Load the following scripts: **system/fingerPaint.js, system/run.js, system/mod.js** and **system/chat.js**. New buttons should be added to the right of the toolbar/tablet.
- Relaunch High Fidelity and make sure that the default app buttons are situated to the left in the same order as before (first step). The non-default app buttons should be located to the right of the toolbar/tablet (their order might vary from the order in which they were added since now it will depend on the order in which they are loaded). 