### PR TITLE
Add "pitch" property to allow pitch shifting an audio effect

### DIFF
--- a/libraries/audio/src/AudioInjector.cpp
+++ b/libraries/audio/src/AudioInjector.cpp
@@ -427,28 +427,11 @@ AudioInjectorPointer AudioInjector::playSound(SharedSoundPointer sound, const fl
     options.stereo = sound->isStereo();
     options.position = position;
     options.volume = volume;
+    options.pitch = 1.0f / stretchFactor;
 
     QByteArray samples = sound->getByteArray();
-    if (stretchFactor == 1.0f) {
-        return playSoundAndDelete(samples, options);
-    }
 
-    const int standardRate = AudioConstants::SAMPLE_RATE;
-    const int resampledRate = standardRate * stretchFactor;
-    const int channelCount = sound->isStereo() ? 2 : 1;
-
-    AudioSRC resampler(standardRate, resampledRate, channelCount);
-
-    const int nInputFrames = samples.size() / (channelCount * sizeof(int16_t));
-    const int maxOutputFrames = resampler.getMaxOutput(nInputFrames);
-    QByteArray resampled(maxOutputFrames * channelCount * sizeof(int16_t), '\0');
-
-    int nOutputFrames = resampler.render(reinterpret_cast<const int16_t*>(samples.data()),
-                                         reinterpret_cast<int16_t*>(resampled.data()),
-                                         nInputFrames);
-
-    Q_UNUSED(nOutputFrames);
-    return playSoundAndDelete(resampled, options);
+    return playSoundAndDelete(samples, options);
 }
 
 AudioInjectorPointer AudioInjector::playSoundAndDelete(const QByteArray& buffer, const AudioInjectorOptions options) {
@@ -460,7 +443,6 @@ AudioInjectorPointer AudioInjector::playSoundAndDelete(const QByteArray& buffer,
 
     return sound;
 }
-
 
 AudioInjectorPointer AudioInjector::playSound(const QByteArray& buffer, const AudioInjectorOptions options) {
 

--- a/libraries/audio/src/AudioInjectorOptions.cpp
+++ b/libraries/audio/src/AudioInjectorOptions.cpp
@@ -26,7 +26,8 @@ AudioInjectorOptions::AudioInjectorOptions() :
     ambisonic(false),
     ignorePenumbra(false),
     localOnly(false),
-    secondOffset(0.0f)
+    secondOffset(0.0f),
+    pitch(1.0f)
 {
 
 }
@@ -40,6 +41,7 @@ QScriptValue injectorOptionsToScriptValue(QScriptEngine* engine, const AudioInje
     obj.setProperty("ignorePenumbra", injectorOptions.ignorePenumbra);
     obj.setProperty("localOnly", injectorOptions.localOnly);
     obj.setProperty("secondOffset", injectorOptions.secondOffset);
+    obj.setProperty("pitch", injectorOptions.pitch);
     return obj;
 }
 
@@ -86,6 +88,12 @@ void injectorOptionsFromScriptValue(const QScriptValue& object, AudioInjectorOpt
                 injectorOptions.secondOffset = it.value().toNumber();
             } else {
                 qCWarning(audio) << "Audio injector options: secondOffset is not a number";
+            }
+        } else if (it.name() == "pitch") {
+            if (it.value().isNumber()) {
+                injectorOptions.pitch = it.value().toNumber();
+            } else {
+                qCWarning(audio) << "Audio injector options: pitch is not a number";
             }
         } else {
             qCWarning(audio) << "Unknown audio injector option:" << it.name();

--- a/libraries/audio/src/AudioInjectorOptions.h
+++ b/libraries/audio/src/AudioInjectorOptions.h
@@ -29,6 +29,7 @@ public:
     bool ignorePenumbra;
     bool localOnly;
     float secondOffset;
+    float pitch;    // multiplier, where 2.0f shifts up one octave
 };
 
 Q_DECLARE_METATYPE(AudioInjectorOptions);


### PR DESCRIPTION
This PR adds a "pitch" property to AudioInjectorOptions. A value other than default (1.0) will cause playSound() to pitch shift the audio up or down by an arbitrary factor, up to 4 octaves.

NOTES:
 - This is implemented by resampling, so there will be a corresponding change to the duration.
 - This is implemented when the injector is created. Once an injector is running, dynamic changes will have no effect.
