### PR TITLE
Fix Interface first launch should show help

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -334,7 +334,7 @@ static const float MIRROR_FULLSCREEN_DISTANCE = 0.389f;
 static const quint64 TOO_LONG_SINCE_LAST_SEND_DOWNSTREAM_AUDIO_STATS = 1 * USECS_PER_SECOND;
 
 static const QString INFO_EDIT_ENTITIES_PATH = "html/edit-commands.html";
-static const QString INFO_HELP_PATH = "../../../html/tabletHelp.html";
+static const QString INFO_HELP_PATH = "html/tabletHelp.html";
 
 static const unsigned int THROTTLED_SIM_FRAMERATE = 15;
 static const int THROTTLED_SIM_FRAME_PERIOD_MS = MSECS_PER_SECOND / THROTTLED_SIM_FRAMERATE;
@@ -2660,7 +2660,8 @@ void Application::showHelp() {
     queryString.addQueryItem("defaultTab", defaultTab);
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
-    tablet->gotoWebScreen(INFO_HELP_PATH + "?" + queryString.toString());
+    tablet->gotoWebScreen(PathUtils::resourcesPath() + INFO_HELP_PATH + "?" + queryString.toString());
+    DependencyManager::get<HMDScriptingInterface>()->openTablet();
     //InfoView::show(INFO_HELP_PATH, false, queryString.toString());
 }
 


### PR DESCRIPTION
This PR fix the bug where the help screen doesn't appear when launching Interface for the first time. 

https://highfidelity.fogbugz.com/f/cases/11232/When-launching-for-the-first-time-in-VR-mode-help-screen-does-not-appear

# Test Plan
-Test case 161 (Steps 1 and 2): https://highfidelity.testrail.net/index.php?/cases/view/161
-Relaunch Interface (second time). The help screen should not appear this time.
-Test case 163 (Steps 1 and 2): https://highfidelity.testrail.net/index.php?/cases/view/163
-Relaunch Interface (second time). The help screen should not appear this time.
-Test case 165 (Steps 1 and 2): https://highfidelity.testrail.net/index.php?/cases/view/165
-Relaunch Interface (second time). The help screen should not appear this time.
-Test https://highfidelity.testrail.net/index.php?/cases/view/88&group_by=cases:section_id&group_order=asc&group_id=1498
(Make sure to clean install Interface during step 1 https://docs.highfidelity.com/build-guide/clean-installs)