### PR TITLE
Fix security image index clear after back nav

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/SecurityImageSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/SecurityImageSelection.qml
@@ -99,6 +99,10 @@ Item {
     function initModel() {
         gridModel.initModel();
     }
+
+    function resetSelection() {
+        securityImageGrid.currentIndex = -1;
+    }
     //
     // FUNCTION DEFINITIONS END
     //

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -348,6 +348,7 @@ Item {
                 width: 200;
                 text: "Back"
                 onClicked: {
+                    securityImageSelection.resetSelection();
                     root.activeView = "step_1";
                 }
             }
@@ -516,6 +517,7 @@ Item {
                 width: 200;
                 text: "Back"
                 onClicked: {
+                    securityImageSelection.resetSelection();
                     root.lastPage = "step_3";
                     root.activeView = "step_2";
                 }


### PR DESCRIPTION
## Test Plan
1. Select the "Wallet" button from the tablet/toolbar
2. Select the "Set up" button on step one of the wallet set up wizard
3. Attempt to select the next button before select a security picture
4. Select a security picture from the group provided (don't press NEXT), then click the back button.
5. Click the "Set Up Wallet" button
6. Verify that no security image is selected and that the "NEXT" button is greyed out.
7. Select a security image, then press NEXT
8. Press the "BACK" button
9. Verify that no security image is selected and that the "NEXT" button is greyed out.