### PR TITLE
Fix the text filter in My Purchases

### DIFF
--- a/interface/resources/qml/hifi/commerce/common/SortableListModel.qml
+++ b/interface/resources/qml/hifi/commerce/common/SortableListModel.qml
@@ -17,6 +17,7 @@ ListModel {
     id: root;
     property string sortColumnName: "";
     property bool isSortingDescending: true;
+    property bool valuesAreNumerical: false;
 
     function swap(a, b) {
         if (a < b) {
@@ -29,26 +30,51 @@ ListModel {
     }
 
     function partition(begin, end, pivot) {
-        var piv = get(pivot)[sortColumnName];
-        swap(pivot, end - 1);
-        var store = begin;
+        if (valuesAreNumerical) {
+            var piv = get(pivot)[sortColumnName];
+            swap(pivot, end - 1);
+            var store = begin;
 
-        for (var i = begin; i < end - 1; ++i) {
-            if (isSortingDescending) {
-                if (get(i)[sortColumnName] < piv) {
-                    swap(store, i);
-                    ++store;
-                }
-            } else {
-                if (get(i)[sortColumnName] > piv) {
-                    swap(store, i);
-                    ++store;
+            for (var i = begin; i < end - 1; ++i) {
+                var currentElement = get(i)[sortColumnName];
+                if (isSortingDescending) {
+                    if (currentElement < piv) {
+                        swap(store, i);
+                        ++store;
+                    }
+                } else {
+                    if (currentElement > piv) {
+                        swap(store, i);
+                        ++store;
+                    }
                 }
             }
-        }
-        swap(end - 1, store);
+            swap(end - 1, store);
 
-        return store;
+            return store;
+        } else {
+            var piv = get(pivot)[sortColumnName].toLowerCase();
+            swap(pivot, end - 1);
+            var store = begin;
+
+            for (var i = begin; i < end - 1; ++i) {
+                var currentElement = get(i)[sortColumnName].toLowerCase();
+                if (isSortingDescending) {
+                    if (currentElement < piv) {
+                        swap(store, i);
+                        ++store;
+                    }
+                } else {
+                    if (currentElement > piv) {
+                        swap(store, i);
+                        ++store;
+                    }
+                }
+            }
+            swap(end - 1, store);
+
+            return store;
+        }
     }
 
     function qsort(begin, end) {

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -677,7 +677,7 @@ Rectangle {
             }
         }
 
-        if (sameItemCount !== tempPurchasesModel.count) {
+        if (sameItemCount !== tempPurchasesModel.count || filterBar.text !== "") {
             filteredPurchasesModel.clear();
             for (var i = 0; i < tempPurchasesModel.count; i++) {
                 filteredPurchasesModel.append(tempPurchasesModel.get(i));


### PR DESCRIPTION
This was never working. Oops.

## Test Plan
1. Log into an account that has lots of Purchases made. Authenticate your wallet.
2. Open My Purchases
3. Experiment with the filter bar. Type in stuff. Filter your purchases. Make sure the results that show in My Purchases make sense with the filter you've used. For example, try typing gibberish and ensure nothing shows up. Another example: If you have both "Beach Ball" and "Balls & Marbles" in your Purchases, try typing in "ball" and verify that both items show up.