### PR TITLE
RC63 GoTo fix for HMD

### DIFF
--- a/interface/resources/qml/hifi/Feed.qml
+++ b/interface/resources/qml/hifi/Feed.qml
@@ -33,6 +33,7 @@ Column {
     property int labelSize: 20;
 
     property string metaverseServerUrl: '';
+    property string protocol: '';
     property string actions: 'snapshot';
     // sendToScript doesn't get wired until after everything gets created. So we have to queue fillDestinations on nextTick.
     property string labelText: actions;
@@ -102,7 +103,7 @@ Column {
             'include_actions=' + actions,
             'restriction=' + (Account.isLoggedIn() ? 'open,hifi' : 'open'),
             'require_online=true',
-            'protocol=' + encodeURIComponent(Window.protocolSignature()),
+            'protocol=' + protocol,
             'page=' + pageNumber
         ];
         var url = metaverseBase + 'user_stories?' + options.join('&');

--- a/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
@@ -54,6 +54,7 @@ StackView {
             console.debug('TabletAddressDialog::fromScript: refreshFeeds', 'feeds = ', feeds);
 
             feeds.forEach(function(feed) {
+                feed.protocol = encodeURIComponent(message.protocolSignature);
                 Qt.callLater(feed.fillDestinations);
             });
 

--- a/scripts/system/tablet-goto.js
+++ b/scripts/system/tablet-goto.js
@@ -100,7 +100,7 @@
             button.editProperties({isActive: shouldActivateButton});
             wireEventBridge(true);
             messagesWaiting(false);
-            tablet.sendToQml({ method: 'refreshFeeds' })
+            tablet.sendToQml({ method: 'refreshFeeds', protocolSignature: Window.protocolSignature() })
 
         } else {
             shouldActivateButton = false;


### PR DESCRIPTION
This PR fix a bug where Places and Recent Snaps are not visible in GoTo app while in HMD mode

https://highfidelity.fogbugz.com/f/cases/11714/HMD-Places-and-Recent-Snaps-are-not-visible-in-GoTo-app

# Test Plan
- Launch Interface in HMD mode, open the tablet and click on GOTO. The Address Bar, Places and Recent Snaps should now be visible.
- Repeat in desktop mode.