### PR TITLE
[Case 4315] Edit menu color picker OK button is hard to use in HMD

### DIFF
--- a/scripts/system/html/css/colpick.css
+++ b/scripts/system/html/css/colpick.css
@@ -26,6 +26,7 @@ colpick Color Picker / colpick.com
 /*Color selection box with gradients*/
 .colpick_color {
 	position: absolute;
+	touch-action: none;
 	left: 7px;
 	top: 7px;
 	width: 156px;
@@ -84,6 +85,7 @@ colpick Color Picker / colpick.com
 /*Vertical hue bar*/
 .colpick_hue {
 	position: absolute;
+	touch-action: none;
 	top: 6px;
 	left: 175px;
 	width: 19px;
@@ -94,6 +96,7 @@ colpick Color Picker / colpick.com
 /*Hue bar sliding indicator*/
 .colpick_hue_arrs {
 	position: absolute;
+	touch-action: none;
 	left: -8px;
 	width: 35px;
 	height: 7px;
@@ -101,6 +104,7 @@ colpick Color Picker / colpick.com
 }
 .colpick_hue_larr {
 	position:absolute;
+	touch-action: none;
 	width: 0; 
 	height: 0; 
 	border-top: 6px solid transparent;
@@ -109,6 +113,7 @@ colpick Color Picker / colpick.com
 }
 .colpick_hue_rarr {
 	position:absolute;
+	touch-action: none;
 	right:0;
 	width: 0; 
 	height: 0; 
@@ -119,6 +124,7 @@ colpick Color Picker / colpick.com
 /*New color box*/
 .colpick_new_color {
 	position: absolute;
+	touch-action: none;
 	left: 207px;
 	top: 6px;
 	width: 60px;
@@ -129,6 +135,7 @@ colpick Color Picker / colpick.com
 /*Current color box*/
 .colpick_current_color {
 	position: absolute;
+	touch-action: none;
 	left: 277px;
 	top: 6px;
 	width: 60px;
@@ -139,6 +146,7 @@ colpick Color Picker / colpick.com
 /*Input field containers*/
 .colpick_field, .colpick_hex_field  {
 	position: absolute;
+	touch-action: none;
 	height: 20px;
 	width: 60px;
 	overflow:hidden;
@@ -198,6 +206,7 @@ colpick Color Picker / colpick.com
 /*Text inputs*/
 .colpick_field input, .colpick_hex_field input {
 	position: absolute;
+	touch-action: none;
 	right: 11px;
 	margin: 0;
 	padding: 0;
@@ -217,6 +226,7 @@ colpick Color Picker / colpick.com
 /*Field up/down arrows*/
 .colpick_field_arrs {
 	position: absolute;
+	touch-action: none;
 	top: 0;
 	right: 0;
 	width: 9px;
@@ -225,6 +235,7 @@ colpick Color Picker / colpick.com
 }
 .colpick_field_uarr {
 	position: absolute;
+	touch-action: none;
 	top: 5px;
 	width: 0; 
 	height: 0; 
@@ -234,6 +245,7 @@ colpick Color Picker / colpick.com
 }
 .colpick_field_darr {
 	position: absolute;
+	touch-action: none;
 	bottom:5px;
 	width: 0; 
 	height: 0; 
@@ -244,6 +256,7 @@ colpick Color Picker / colpick.com
 /*Submit/Select button*/
 .colpick_submit {
 	position: absolute;
+	touch-action: none;
 	left: 207px;
 	top: 149px;
 	width: 130px;

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1040,9 +1040,9 @@ function loaded() {
                             elZoneAmbientLightURL.value = properties.ambientLight.ambientURL;
 
                             // Haze
-                            elZoneHazeModeInherit.checked  = (properties.hazeMode === 'inherit');
+                            elZoneHazeModeInherit.checked = (properties.hazeMode === 'inherit');
                             elZoneHazeModeDisabled.checked = (properties.hazeMode === 'disabled');
-                            elZoneHazeModeEnabled.checked  = (properties.hazeMode === 'enabled');
+                            elZoneHazeModeEnabled.checked = (properties.hazeMode === 'enabled');
 
                             elZoneHazeRange.value = properties.haze.hazeRange.toFixed(0);
                             elZoneHazeColor.style.backgroundColor = "rgb(" + 
@@ -1308,15 +1308,15 @@ function loaded() {
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
+            submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-color-control2').attr('active', 'true');
             },
             onHide: function(colpick) {
                 $('#property-color-control2').attr('active', 'false');
             },
-            onSubmit: function(hsb, hex, rgb, el) {
+            onChange: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
-                $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
             }
         }));
@@ -1332,15 +1332,15 @@ function loaded() {
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
+            submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-light-color').attr('active', 'true');
             },
             onHide: function(colpick) {
                 $('#property-light-color').attr('active', 'false');
             },
-            onSubmit: function(hsb, hex, rgb, el) {
+            onChange: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
-                $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
             }
         }));
@@ -1387,15 +1387,15 @@ function loaded() {
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
+            submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-text-text-color').attr('active', 'true');
             },
             onHide: function(colpick) {
                 $('#property-text-text-color').attr('active', 'false');
             },
-            onSubmit: function(hsb, hex, rgb, el) {
+            onChange: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
-                $(el).colpickHide();
                 $(el).attr('active', 'false');
                 emitColorPropertyUpdate('textColor', rgb.r, rgb.g, rgb.b);
             }
@@ -1411,15 +1411,15 @@ function loaded() {
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
+            submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-text-background-color').attr('active', 'true');
             },
             onHide: function(colpick) {
                 $('#property-text-background-color').attr('active', 'false');
             },
-            onSubmit: function(hsb, hex, rgb, el) {
+            onChange: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
-                $(el).colpickHide();
                 emitColorPropertyUpdate('backgroundColor', rgb.r, rgb.g, rgb.b);
             }
         }));
@@ -1436,15 +1436,15 @@ function loaded() {
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
+            submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-zone-key-light-color').attr('active', 'true');
             },
             onHide: function(colpick) {
                 $('#property-zone-key-light-color').attr('active', 'false');
             },
-            onSubmit: function(hsb, hex, rgb, el) {
+            onChange: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
-                $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b, 'keyLight');
             }
         }));
@@ -1505,15 +1505,15 @@ function loaded() {
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
+            submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-zone-haze-color').attr('active', 'true');
             },
             onHide: function(colpick) {
                 $('#property-zone-haze-color').attr('active', 'false');
             },
-            onSubmit: function(hsb, hex, rgb, el) {
+            onChange: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
-                $(el).colpickHide();
                 emitColorPropertyUpdate('hazeColor', rgb.r, rgb.g, rgb.b, 'haze');
             }
         }));
@@ -1530,15 +1530,15 @@ function loaded() {
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
+            submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-zone-haze-glare-color').attr('active', 'true');
             },
             onHide: function(colpick) {
                 $('#property-zone-haze-glare-color').attr('active', 'false');
             },
-            onSubmit: function(hsb, hex, rgb, el) {
+            onChange: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
-                $(el).colpickHide();
                 emitColorPropertyUpdate('hazeGlareColor', rgb.r, rgb.g, rgb.b, 'haze');
             }
         }));
@@ -1572,15 +1572,15 @@ function loaded() {
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
+            submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-zone-skybox-color').attr('active', 'true');
             },
             onHide: function(colpick) {
                 $('#property-zone-skybox-color').attr('active', 'false');
             },
-            onSubmit: function(hsb, hex, rgb, el) {
+            onChange: function(hsb, hex, rgb, el) {
                 $(el).css('background-color', '#' + hex);
-                $(el).colpickHide();
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b, 'skybox');
             }
         }));

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -653,16 +653,16 @@ function loaded() {
         var elZoneKeyLightDirectionY = document.getElementById("property-zone-key-light-direction-y");
 
         // Skybox
-        var elZoneSkyboxModeInherit  = document.getElementById("property-zone-skybox-mode-inherit");
+        var elZoneSkyboxModeInherit = document.getElementById("property-zone-skybox-mode-inherit");
         var elZoneSkyboxModeDisabled = document.getElementById("property-zone-skybox-mode-disabled");
-        var elZoneSkyboxModeEnabled  = document.getElementById("property-zone-skybox-mode-enabled");
+        var elZoneSkyboxModeEnabled = document.getElementById("property-zone-skybox-mode-enabled");
 
         // Ambient light
         var elCopySkyboxURLToAmbientURL = document.getElementById("copy-skybox-url-to-ambient-url");
 
-        var elZoneAmbientLightModeInherit  = document.getElementById("property-zone-ambient-light-mode-inherit");
+        var elZoneAmbientLightModeInherit = document.getElementById("property-zone-ambient-light-mode-inherit");
         var elZoneAmbientLightModeDisabled = document.getElementById("property-zone-ambient-light-mode-disabled");
-        var elZoneAmbientLightModeEnabled  = document.getElementById("property-zone-ambient-light-mode-enabled");
+        var elZoneAmbientLightModeEnabled = document.getElementById("property-zone-ambient-light-mode-enabled");
 
         var elZoneAmbientLightIntensity = document.getElementById("property-zone-key-ambient-intensity");
         var elZoneAmbientLightURL = document.getElementById("property-zone-key-ambient-url");
@@ -1013,9 +1013,9 @@ function loaded() {
 
                         } else if (properties.type === "Zone") {
                             // Key light
-                            elZoneKeyLightModeInherit.checked  = (properties.keyLightMode === 'inherit');
+                            elZoneKeyLightModeInherit.checked = (properties.keyLightMode === 'inherit');
                             elZoneKeyLightModeDisabled.checked = (properties.keyLightMode === 'disabled');
-                            elZoneKeyLightModeEnabled.checked  = (properties.keyLightMode === 'enabled');
+                            elZoneKeyLightModeEnabled.checked = (properties.keyLightMode === 'enabled');
 
                             elZoneKeyLightColor.style.backgroundColor = "rgb(" + properties.keyLight.color.red + "," + 
                                                    properties.keyLight.color.green + "," + properties.keyLight.color.blue + ")";
@@ -1027,14 +1027,14 @@ function loaded() {
                             elZoneKeyLightDirectionY.value = properties.keyLight.direction.y.toFixed(2);
 
                             // Skybox
-                            elZoneSkyboxModeInherit.checked  = (properties.skyboxMode === 'inherit');
+                            elZoneSkyboxModeInherit.checked = (properties.skyboxMode === 'inherit');
                             elZoneSkyboxModeDisabled.checked = (properties.skyboxMode === 'disabled');
-                            elZoneSkyboxModeEnabled.checked  = (properties.skyboxMode === 'enabled');
+                            elZoneSkyboxModeEnabled.checked = (properties.skyboxMode === 'enabled');
 
                             // Ambient light
-                            elZoneAmbientLightModeInherit.checked  = (properties.ambientLightMode === 'inherit');
+                            elZoneAmbientLightModeInherit.checked = (properties.ambientLightMode === 'inherit');
                             elZoneAmbientLightModeDisabled.checked = (properties.ambientLightMode === 'disabled');
-                            elZoneAmbientLightModeEnabled.checked  = (properties.ambientLightMode === 'enabled');
+                            elZoneAmbientLightModeEnabled.checked = (properties.ambientLightMode === 'enabled');
 
                             elZoneAmbientLightIntensity.value = properties.ambientLight.ambientIntensity.toFixed(2);
                             elZoneAmbientLightURL.value = properties.ambientLight.ambientURL;


### PR DESCRIPTION
* This removes the OK button which was hard to use in HMD mode in favor of having the color dynamically updating while utilizing the color picker.  For consistency, this change applies to both HMD & Desktop modes.
* Fixes issue where changing the color or hue via the color picker had input bleeding through and applied to the Edit menu in its context.
* Has various eslint/jshint fixes.

NOTE:  This was originally proposed along with other changes as PR #12058; however, it was closed in favor of submitting changes in more atomic PRs.  This is the initial atomic PR.  Known pre-existing issues found while addressing this case which will be addressed in the subsequent PRs are:

1. Color Picker original/initial color preview being black.
2. Color Picker not showing the old vs new color preview as it should
3. Color Picker original color restore not working.

**Testing**

Testing should be done in both Desktop & HMD modes.

Create or select an instance of a light, text, shape, and zone entity within the world.  Below is a listing of all known color fields:

* Light Color
* Text Color
* Text Background Color
* Shape Color
* Haze Key Light Color
* Haze Glaze Color
* Haze Glare Color

Each color field should:

- have its OK button removed.
- have the relevant color on the entity update dynamically as the user drags around the color picker hue & wheel areas.
- changing the color or hue via the color picker shouldn't scroll the Edit menu behind it


**_Before Example Light Color Field:_**
![case4315_lightcolor_before](https://user-images.githubusercontent.com/28965411/34362103-8f8ed086-ea3e-11e7-9d0b-b424c13df5ed.jpg)

**_After Example Light Color Field:_**
![case4315_lightcolor_afterok](https://user-images.githubusercontent.com/28965411/35305330-fa054f6a-0066-11e8-9516-69b38f3b2092.jpg)
