### PR TITLE
Some improvements to the log window

### DIFF
--- a/interface/resources/styles/log_dialog.qss
+++ b/interface/resources/styles/log_dialog.qss
@@ -67,7 +67,7 @@ QPushButton#revealLogButton {
     font-size: 11px;
 }
 
-QPushButton#showAllButton {
+QPushButton#allLogsButton {
     font-family: Helvetica, Arial, sans-serif;
     background-color: #333333;
     color: #BBBBBB;
@@ -112,4 +112,11 @@ QComboBox::drop-down {
 QComboBox::down-arrow {
     image: url(:/styles/filter.png);
     border-width: 0px;
+}
+
+QLabel#messageCount {
+    font-family: Helvetica, Arial, sans-serif;
+    text-align: center;
+    color: #3d3d3d;
+    font-size: 11px;
 }

--- a/interface/src/ui/BaseLogDialog.cpp
+++ b/interface/src/ui/BaseLogDialog.cpp
@@ -29,8 +29,8 @@ const int SEARCH_TOGGLE_BUTTON_WIDTH = 50;
 const int SEARCH_TEXT_WIDTH = 240;
 const int TIME_STAMP_LENGTH = 16;
 const int FONT_WEIGHT = 75;
-const QColor HIGHLIGHT_COLOR = QColor("#3366CC");
-const QColor BOLD_COLOR = QColor("#445c8c");
+const QColor HIGHLIGHT_COLOR = QColor("#00B4EF");
+const QColor BOLD_COLOR = QColor("#1080B8");
 const QString BOLD_PATTERN = "\\[\\d*\\/.*:\\d*:\\d*\\]";
 
 BaseLogDialog::BaseLogDialog(QWidget* parent) : QDialog(parent, Qt::Window) {
@@ -182,6 +182,7 @@ void BaseLogDialog::updateSelection() {
 Highlighter::Highlighter(QTextDocument* parent) : QSyntaxHighlighter(parent) {
     boldFormat.setFontWeight(FONT_WEIGHT);
     boldFormat.setForeground(BOLD_COLOR);
+    keywordFormat.setFontWeight(FONT_WEIGHT);
     keywordFormat.setForeground(HIGHLIGHT_COLOR);
 }
 

--- a/interface/src/ui/LogDialog.cpp
+++ b/interface/src/ui/LogDialog.cpp
@@ -15,11 +15,12 @@
 #include <QPushButton>
 #include <QComboBox>
 #include <QPlainTextEdit>
+#include <Qlabel>
 
 #include <shared/AbstractLoggerInterface.h>
 
 const int REVEAL_BUTTON_WIDTH = 122;
-const int CLEAR_FILTER_BUTTON_WIDTH = 80;
+const int ALL_LOGS_BUTTON_WIDTH = 90;
 const int MARGIN_LEFT = 25;
 const int DEBUG_CHECKBOX_WIDTH = 70;
 const int INFO_CHECKBOX_WIDTH = 65;
@@ -142,6 +143,11 @@ LogDialog::LogDialog(QWidget* parent, AbstractLoggerInterface* logger) : BaseLog
     _filterDropdown->addItem("qml");
     connect(_filterDropdown, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &LogDialog::handleFilterDropdownChanged);
 
+    _leftPad += COMBOBOX_WIDTH + MARGIN_LEFT + MARGIN_LEFT;
+    _messageCount = new QLabel("", this);
+    _messageCount->setObjectName("messageCount");
+    _messageCount->show();
+
     _extraDebuggingBox = new QCheckBox("Extra debugging", this);
     if (_logger->extraDebugging()) {
         _extraDebuggingBox->setCheckState(Qt::Checked);
@@ -149,12 +155,13 @@ LogDialog::LogDialog(QWidget* parent, AbstractLoggerInterface* logger) : BaseLog
     _extraDebuggingBox->show();
     connect(_extraDebuggingBox, &QCheckBox::stateChanged, this, &LogDialog::handleExtraDebuggingCheckbox);
 
-    _clearFilterButton = new QPushButton("Clear Filters", this);
+    _allLogsButton = new QPushButton("All Messages", this);
     // set object name for css styling
-    _clearFilterButton->setObjectName("showAllButton");
-    _clearFilterButton->show();
-    connect(_clearFilterButton, &QPushButton::clicked, this, &LogDialog::handleClearFilterButton);
-    handleClearFilterButton();
+
+    _allLogsButton->setObjectName("allLogsButton");
+    _allLogsButton->show();
+    connect(_allLogsButton, &QPushButton::clicked, this, &LogDialog::handleAllLogsButton);
+    handleAllLogsButton();
 
     auto windowGeometry = _windowGeometry.get();
     if (windowGeometry.isValid()) {
@@ -168,11 +175,15 @@ void LogDialog::resizeEvent(QResizeEvent* event) {
         ELEMENT_MARGIN,
         REVEAL_BUTTON_WIDTH,
         ELEMENT_HEIGHT);
-    _clearFilterButton->setGeometry(width() - ELEMENT_MARGIN - CLEAR_FILTER_BUTTON_WIDTH,
+    _allLogsButton->setGeometry(width() - ELEMENT_MARGIN - ALL_LOGS_BUTTON_WIDTH,
         THIRD_ROW,
-        CLEAR_FILTER_BUTTON_WIDTH,
+        ALL_LOGS_BUTTON_WIDTH,
         ELEMENT_HEIGHT);
-    _extraDebuggingBox->setGeometry(width() - ELEMENT_MARGIN - COMBOBOX_WIDTH - ELEMENT_MARGIN - CLEAR_FILTER_BUTTON_WIDTH,
+    _extraDebuggingBox->setGeometry(width() - ELEMENT_MARGIN - COMBOBOX_WIDTH - ELEMENT_MARGIN - ALL_LOGS_BUTTON_WIDTH,
+        THIRD_ROW,
+        COMBOBOX_WIDTH,
+        ELEMENT_HEIGHT);
+    _messageCount->setGeometry(_leftPad,
         THIRD_ROW,
         COMBOBOX_WIDTH,
         ELEMENT_HEIGHT);
@@ -187,13 +198,13 @@ void LogDialog::handleRevealButton() {
     _logger->locateLog();
 }
 
-void LogDialog::handleClearFilterButton() {
+void LogDialog::handleAllLogsButton() {
     _logger->setExtraDebugging(false);
     _extraDebuggingBox->setCheckState(Qt::Unchecked);
-    _logger->setDebugPrint(false);
-    _debugPrintBox->setCheckState(Qt::Unchecked);
-    _logger->setInfoPrint(false);
-    _infoPrintBox->setCheckState(Qt::Unchecked);
+    _logger->setDebugPrint(true);
+    _debugPrintBox->setCheckState(Qt::Checked);
+    _logger->setInfoPrint(true);
+    _infoPrintBox->setCheckState(Qt::Checked);
     _logger->setCriticalPrint(true);
     _criticalPrintBox->setCheckState(Qt::Checked);
     _logger->setWarningPrint(true);
@@ -270,40 +281,67 @@ void LogDialog::appendLogLine(QString logLine) {
         if (logLine.contains(DEBUG_TEXT, Qt::CaseSensitive)) {
             if (_logger->debugPrint()) {
                 _logTextBox->appendPlainText(logLine.trimmed());
+                _count++;
+                updateMessageCount();
             }
         } else if (logLine.contains(INFO_TEXT, Qt::CaseSensitive)) {
             if (_logger->infoPrint()) {
                 _logTextBox->appendPlainText(logLine.trimmed());
+                _count++;
+                updateMessageCount();
             } 
         } else if (logLine.contains(CRITICAL_TEXT, Qt::CaseSensitive)) {
             if (_logger->criticalPrint()) {
                 _logTextBox->appendPlainText(logLine.trimmed());
+                _count++;
+                updateMessageCount();
             }
         } else if (logLine.contains(WARNING_TEXT, Qt::CaseSensitive)) {
             if (_logger->warningPrint()) {
                 _logTextBox->appendPlainText(logLine.trimmed());
+                _count++;
+                updateMessageCount();
             }
         } else if (logLine.contains(SUPPRESS_TEXT, Qt::CaseSensitive)) {
             if (_logger->suppressPrint()) {
                 _logTextBox->appendPlainText(logLine.trimmed());
+                _count++;
+                updateMessageCount();
             }
         } else if (logLine.contains(FATAL_TEXT, Qt::CaseSensitive)) {
             if (_logger->fatalPrint()) {
                 _logTextBox->appendPlainText(logLine.trimmed());
+                _count++;
+                updateMessageCount();
             }
         } else {
-            if (_logger->unknownPrint()) {
+            if (_logger->unknownPrint() && logLine.trimmed() != "") {
                 _logTextBox->appendPlainText(logLine.trimmed());
+                _count++;
+                updateMessageCount();
             }
         }
     }
 }
 
 void LogDialog::printLogFile() {
+    _count = 0;
     _logTextBox->clear();
     QString log = getCurrentLog();
     QStringList logList = log.split('\n');
     for (const auto& message : logList) {
         appendLogLine(message);
     }
+    updateMessageCount();
+}
+
+void LogDialog::updateMessageCount() {
+    _countLabel = QString::number(_count);
+    if (_count != 1) {
+        _countLabel.append("  log messages");
+    }
+    else {
+        _countLabel.append("  log message");
+    }
+    _messageCount->setText(_countLabel);
 }

--- a/interface/src/ui/LogDialog.cpp
+++ b/interface/src/ui/LogDialog.cpp
@@ -15,7 +15,7 @@
 #include <QPushButton>
 #include <QComboBox>
 #include <QPlainTextEdit>
-#include <Qlabel>
+#include <QLabel>
 
 #include <shared/AbstractLoggerInterface.h>
 

--- a/interface/src/ui/LogDialog.h
+++ b/interface/src/ui/LogDialog.h
@@ -18,6 +18,7 @@
 class QCheckBox;
 class QPushButton;
 class QComboBox;
+class QLabel;
 class QResizeEvent;
 class AbstractLoggerInterface;
 
@@ -41,19 +42,21 @@ private slots:
     void handleFatalPrintBox(int);
     void handleUnknownPrintBox(int);
     void handleFilterDropdownChanged(int);
-    void handleClearFilterButton();
+    void handleAllLogsButton();
+    void printLogFile();
 
 protected:
     void resizeEvent(QResizeEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
 
     QString getCurrentLog() override;
-    void printLogFile();
+    void updateMessageCount();
+    
 
 private:
     QCheckBox* _extraDebuggingBox;
     QPushButton* _revealLogButton;
-    QPushButton* _clearFilterButton;
+    QPushButton* _allLogsButton;
     QCheckBox* _debugPrintBox;
     QCheckBox* _infoPrintBox;
     QCheckBox* _criticalPrintBox;
@@ -62,10 +65,12 @@ private:
     QCheckBox* _fatalPrintBox;
     QCheckBox* _unknownPrintBox;
     QComboBox* _filterDropdown;
+    QLabel* _messageCount;
     QString _filterSelection;
-
+    QString _countLabel;
     AbstractLoggerInterface* _logger;
     Setting::Handle<QRect> _windowGeometry;
+    int _count = 0;
 };
 
 #endif // hifi_LogDialog_h

--- a/libraries/shared/src/shared/AbstractLoggerInterface.h
+++ b/libraries/shared/src/shared/AbstractLoggerInterface.h
@@ -50,8 +50,8 @@ signals:
 
 private:
     bool _extraDebugging{ false };
-    bool _debugPrint{ false };
-    bool _infoPrint{ false };
+    bool _debugPrint{ true };
+    bool _infoPrint{ true };
     bool _criticalPrint{ true };
     bool _warningPrint{ true };
     bool _suppressPrint{ true };


### PR DESCRIPTION
-Renamed button "Clear Filters" to "All Messages"
-Changed search result matching text to a more visible color
-Made Date/Time text more visible
-Added count of current messages in window
-Set window to show all messages with no filtering upon first opening

-------TEST PLAN------
-Open the log window (CTRL + SHIFT +L)
-All checkboxes except "EXTRA DEBUGGING" should be checked. Search bar should be empty and "No secondary filter..." should be selected in filter drop-down on top-left. All messages should be printing. The number of messages should be displayed.
-clear all check boxes. The log window should be empty. The message count should say "0 log messages"
-click "INFO" and the checkbox should be selected. All messages labeled INFO should show if there are any. Only messages with INFO should be printing. Check that the count is correct.
-click "INFO" again to remove the check
-click "WARNING" and the checkbox should be selected. All messages labeled WARNING should show if there are any. Only messages with WARNING should be printing.
-click "WARNING" again to remove the check
-click "SUPPRESS" and the checkbox should be selected. All messages labeled SUPPRESS should show if there are any. Only messages with SUPPRESS should be printing.
-click "SUPPRESS" again to remove the check
-click "FATAL" and the checkbox should be selected. All messages labeled FATAL should show if there are any. Only messages with FATAL should be printing.
-click "FATAL" again to remove the check
-click "UNKNOWN" and the checkbox should be selected. All messages labeled UNKNOWN should show if there are any. Only messages with UNKNOWN should be printing.
-click "UNKNOWN" again to remove the check
-click "CRITICAL" again and the checkbox should be selected again. All messages labeled CRITICAL should show if there are any. Only messages with CRITICAL should be printing.
-clear the CRITICAL check box and click "DEBUG". All messages labeled DEBUG should show. Only messages with DEBUG should be printing.
-click "EXTRA DEBUGGING" and a lot more DEBUG messages should begin printing
-select "hifi.shared" from the secondary filter drop-down. Only DEBUG messages with type [hifi.shared] should be shown and printing.
-select "No secondary filter..." again from the secondary filter drop-down. All messages labeled DEBUG should show again.
-select "hifi.shared" from the secondary filter drop-down again.
-click "All Messages". All check boxes should be checked except "EXTRA DEBUGGING". Search bar should be empty and "No secondary filter..." should be selected in filter drop-down on top-right. All messages should be printing. Count should increment with new messages.
-type a word from one of the messages into the search
-any instances of the word should be bolded in bright blue. Using the Prev and Next buttons allows you to scan through all instances of the word. Only messages with the word you typed should be printing.
-deleting the search term should remove all highlights