### PR TITLE
Don't manually highlight tablet buttons from swipeview.

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletButton.qml
+++ b/interface/resources/qml/hifi/tablet/TabletButton.qml
@@ -158,7 +158,6 @@ Item {
             gridView.currentIndex = buttonIndex
             tabletButton.isEntered = true;
             Tablet.playSound(TabletEnums.ButtonHover);
-
             if (tabletButton.isActive) {
                 tabletButton.state = "hover active state";
             } else {

--- a/interface/resources/qml/hifi/tablet/TabletButton.qml
+++ b/interface/resources/qml/hifi/tablet/TabletButton.qml
@@ -158,6 +158,7 @@ Item {
             gridView.currentIndex = buttonIndex
             tabletButton.isEntered = true;
             Tablet.playSound(TabletEnums.ButtonHover);
+
             if (tabletButton.isActive) {
                 tabletButton.state = "hover active state";
             } else {

--- a/interface/resources/qml/hifi/tablet/TabletHome.qml
+++ b/interface/resources/qml/hifi/tablet/TabletHome.qml
@@ -148,6 +148,18 @@ Item {
                             previousGridIndex = currentIndex
                         }
 
+                        onMovementStarted: {
+                            if (currentIndex < 0 || gridView.currentItem === undefined || gridView.contentItem.children.length - 1 < currentIndex) {
+                                return;
+                            }
+                            var button = gridView.contentItem.children[currentIndex].children[0];
+                            if (button.isActive) {
+                                button.state = "active state";
+                            } else {
+                                button.state = "base state";
+                            }
+                        }
+
                         cellWidth: width/3
                         cellHeight: cellWidth
                         flow: GridView.LeftToRight

--- a/interface/resources/qml/hifi/tablet/TabletHome.qml
+++ b/interface/resources/qml/hifi/tablet/TabletHome.qml
@@ -127,7 +127,7 @@ Item {
 
                     GridView {
                         id: gridView
-
+                        flickableDirection: Flickable.AutoFlickIfNeeded
                         keyNavigationEnabled: false
                         highlightFollowsCurrentItem: false
 

--- a/interface/resources/qml/hifi/tablet/TabletHome.qml
+++ b/interface/resources/qml/hifi/tablet/TabletHome.qml
@@ -144,22 +144,7 @@ Item {
                             bottomMargin: 0
                         }
 
-                        function setButtonState(buttonIndex, buttonstate) {
-                            if (buttonIndex < 0 || gridView.contentItem === undefined
-                                    || gridView.contentItem.children.length - 1 < buttonIndex) {
-                                return;
-                            }
-                            var itemat = gridView.contentItem.children[buttonIndex].children[0];
-                            if (itemat.isActive) {
-                                itemat.state = "active state";
-                            } else {
-                                itemat.state = buttonstate;
-                            }
-                        }
-
                         onCurrentIndexChanged: {
-                            setButtonState(previousGridIndex, "base state");
-                            setButtonState(currentIndex, "hover state");
                             previousGridIndex = currentIndex
                         }
 


### PR DESCRIPTION
Tablet button set the highlight mode themselves, so there is no reason for the tabletHome.qml to be manually setting the button highlighting.

Ticket - https://highfidelity.fogbugz.com/f/cases/11546/HMD-Multiple-tablet-buttons-become-highlighted-when-tablet-page-scrolls