### PR TITLE
Fix MacOS Security Pic visibility; fix incorrect button state when changing pic

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/Security.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Security.qml
@@ -193,7 +193,7 @@ Item {
                 color: hifi.colors.white;
             }
 
-            // "Change Passphrase" button
+            // "Change Security Pic" button
             HifiControlsUit.Button {
                 id: changeSecurityImageButton;
                 color: hifi.buttons.blue;

--- a/interface/resources/qml/hifi/commerce/wallet/SecurityImageChange.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/SecurityImageChange.qml
@@ -34,13 +34,11 @@ Item {
             securityImageChangePageSecurityImage.source = "image://security/securityImage";
             if (exists) { // Success submitting new security image
                 if (root.justSubmitted) {
-                    root.resetSubmitButton();
                     sendSignalToWallet({method: "walletSecurity_changeSecurityImageSuccess"});
                     root.justSubmitted = false;
                 }
             } else if (root.justSubmitted) {
                 // Error submitting new security image.
-                root.resetSubmitButton();
                 root.justSubmitted = false;
             }
         }
@@ -180,7 +178,8 @@ Item {
             // "Submit" button
             HifiControlsUit.Button {
                 id: securityImageSubmitButton;
-                enabled: securityImageSelection.currentIndex !== -1;
+                text: root.justSubmitted ? "Submitting..." : "Submit";
+                enabled: securityImageSelection.currentIndex !== -1 && !root.justSubmitted;
                 color: hifi.buttons.blue;
                 colorScheme: hifi.colorSchemes.dark;
                 anchors.top: parent.top;
@@ -188,11 +187,8 @@ Item {
                 anchors.right: parent.right;
                 anchors.rightMargin: 20;
                 width: 150;
-                text: "Submit";
                 onClicked: {
                     root.justSubmitted = true;
-                    securityImageSubmitButton.text = "Submitting...";
-                    securityImageSubmitButton.enabled = false;
                     var securityImagePath = securityImageSelection.getImagePathFromImageID(securityImageSelection.getSelectedImageIndex())
                     Commerce.chooseSecurityImage(securityImagePath);
                 }
@@ -204,11 +200,6 @@ Item {
     //
 
     signal sendSignalToWallet(var msg);
-
-    function resetSubmitButton() {
-        securityImageSubmitButton.enabled = true;
-        securityImageSubmitButton.text = "Submit";
-    }
 
     function initModel() {
         securityImageSelection.initModel();

--- a/interface/resources/qml/hifi/commerce/wallet/SecurityImageSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/SecurityImageSelection.qml
@@ -24,7 +24,7 @@ Item {
     HifiConstants { id: hifi; }
 
     id: root;
-    property int currentIndex: securityImageGrid.currentIndex;
+    property alias currentIndex: securityImageGrid.currentIndex;
     
     // This will cause a bug -- if you bring up security image selection in HUD mode while
     // in HMD while having HMD preview enabled, then move, then finish passphrase selection,
@@ -98,6 +98,7 @@ Item {
 
     function initModel() {
         gridModel.initModel();
+        securityImageGrid.currentIndex = -1;
     }
 
     function resetSelection() {

--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -591,8 +591,8 @@ void Wallet::chooseSecurityImage(const QString& filename) {
     if (_securityImage) {
         delete _securityImage;
     }
-    QString path = qApp->applicationDirPath();
-    path.append("/resources/qml/hifi/commerce/wallet/");
+    QString path = PathUtils::resourcesPath();
+    path.append("/qml/hifi/commerce/wallet/");
     path.append(filename);
 
     // now create a new security image pixmap


### PR DESCRIPTION
## Test Plan
**On a MacOS machine:**
1. Open the Wallet app and authenticate your Wallet
2. Go to the Security tab
3. Next to "SECURITY PIC", click "CHANGE"
4. Select a new security pic, and click "SUBMIT"
5. Verify that you see your new security pic show up in the top right of the Wallet app
6. Next to "SECURITY PIC", click "CHANGE"
7. Verify that the "SUBMIT" button is greyed out and that no security pic in the grid is selected
8. Select a new security pic, and click "SUBMIT"
9. Verify that you see your new security pic show up in the top right of the Wallet app