### PR TITLE
RC63: Bug fix for incorrect positioned eyes on other peoples avatars

### DIFF
--- a/libraries/shared/src/BitVectorHelpers.h
+++ b/libraries/shared/src/BitVectorHelpers.h
@@ -12,14 +12,14 @@
 #ifndef hifi_BitVectorHelpers_h
 #define hifi_BitVectorHelpers_h
 
-size_t calcBitVectorSize(int numBits) {
+int calcBitVectorSize(int numBits) {
     return ((numBits - 1) >> 3) + 1;
 }
 
 // func should be of type bool func(int index)
 template <typename F>
-size_t writeBitVector(uint8_t* destinationBuffer, int numBits, const F& func) {
-    size_t totalBytes = ((numBits - 1) >> 3) + 1;
+int writeBitVector(uint8_t* destinationBuffer, int numBits, const F& func) {
+    int totalBytes = calcBitVectorSize(numBits);
     uint8_t* cursor = destinationBuffer;
     uint8_t byte = 0;
     uint8_t bit = 0;
@@ -34,13 +34,19 @@ size_t writeBitVector(uint8_t* destinationBuffer, int numBits, const F& func) {
             bit = 0;
         }
     }
+    // write the last byte, if necessary
+    if (bit != 0) {
+        *cursor++ = byte;
+    }
+
+    assert((int)(cursor - destinationBuffer) == totalBytes);
     return totalBytes;
 }
 
 // func should be of type 'void func(int index, bool value)'
 template <typename F>
-size_t readBitVector(const uint8_t* sourceBuffer, int numBits, const F& func) {
-    size_t totalBytes = ((numBits - 1) >> 3) + 1;
+int readBitVector(const uint8_t* sourceBuffer, int numBits, const F& func) {
+    int totalBytes = calcBitVectorSize(numBits);
     const uint8_t* cursor = sourceBuffer;
     uint8_t bit = 0;
 

--- a/tests/shared/src/BitVectorHelperTests.cpp
+++ b/tests/shared/src/BitVectorHelperTests.cpp
@@ -1,0 +1,80 @@
+//
+// BitVectorHelperTests.cpp
+// tests/shared/src
+//
+// Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "BitVectorHelperTests.h"
+
+#include <SharedLogging.h>
+
+#include "../QTestExtensions.h"
+#include <QtCore/QDebug>
+#include <StreamUtils.h>
+#include <glm/glm.hpp>
+#include <BitVectorHelpers.h>
+
+QTEST_MAIN(BitVectorHelperTests)
+
+const int BITS_IN_BYTE = 8;
+
+void BitVectorHelperTests::sizeTest() {
+    std::vector<int> sizes = {0, 6, 7, 8, 30, 31, 32, 33, 87, 88, 89, 90, 90, 91, 92, 93};
+    for (auto& size : sizes) {
+        const int oldWay = (int)ceil((float)size / (float)BITS_IN_BYTE);
+        const int newWay = (int)calcBitVectorSize(size);
+        QCOMPARE(oldWay, newWay);
+    }
+}
+
+static void readWriteHelper(const std::vector<bool>& src) {
+
+    int numBits = (int)src.size();
+    int numBytes = calcBitVectorSize(numBits);
+    uint8_t* bytes = new uint8_t[numBytes];
+    memset(bytes, numBytes, sizeof(uint8_t));
+    int numBytesWritten = writeBitVector(bytes, numBits, [&](int i) {
+        return src[i];
+    });
+    QCOMPARE(numBytesWritten, numBytes);
+
+    std::vector<bool> dst;
+    int numBytesRead = readBitVector(bytes, numBits, [&](int i, bool value) {
+        dst.push_back(value);
+    });
+    QCOMPARE(numBytesRead, numBytes);
+
+    QCOMPARE(numBits, (int)src.size());
+    QCOMPARE(numBits, (int)dst.size());
+    for (int i = 0; i < numBits; i++) {
+        bool a = src[i];
+        bool b = dst[i];
+        QCOMPARE(a, b);
+    }
+}
+
+void BitVectorHelperTests::readWriteTest() {
+    std::vector<int> sizes = {0, 6, 7, 8, 30, 31, 32, 33, 87, 88, 89, 90, 90, 91, 92, 93};
+
+    for (auto& size : sizes) {
+        std::vector<bool> allTrue(size, true);
+        std::vector<bool> allFalse(size, false);
+        std::vector<bool> evenSet;
+        evenSet.reserve(size);
+        std::vector<bool> oddSet;
+        oddSet.reserve(size);
+        for (int i = 0; i < size; i++) {
+            bool isOdd = (i & 0x1) > 0;
+            evenSet.push_back(!isOdd);
+            oddSet.push_back(isOdd);
+        }
+        readWriteHelper(allTrue);
+        readWriteHelper(allFalse);
+        readWriteHelper(evenSet);
+        readWriteHelper(oddSet);
+    }
+}

--- a/tests/shared/src/BitVectorHelperTests.h
+++ b/tests/shared/src/BitVectorHelperTests.h
@@ -1,0 +1,23 @@
+//
+// BitVectorHelperTests.h
+// tests/shared/src
+//
+// Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_BitVectorHelperTests_h
+#define hifi_BitVectorHelperTests_h
+
+#include <QtTest/QtTest>
+
+class BitVectorHelperTests : public QObject {
+    Q_OBJECT
+private slots:
+    void sizeTest();
+    void readWriteTest();
+};
+
+#endif // hifi_BitVectorHelperTests_h


### PR DESCRIPTION
There was a bug in writeBitVector(), where the last byte was not consistently written into the destination buffer. A unit test was added to verify that writeBitVector() and readBitVector() are correct.