### PR TITLE
Fix resource loading from source tree

### DIFF
--- a/libraries/shared/src/PathUtils.cpp
+++ b/libraries/shared/src/PathUtils.cpp
@@ -29,7 +29,6 @@
 #include <mach-o/dyld.h>
 #endif
 
-
 #include "shared/GlobalAppProperties.h"
 #include "SharedUtil.h"
 
@@ -41,8 +40,15 @@ QString TEMP_DIR_FORMAT { "%1-%2-%3" };
 #if defined(Q_OS_OSX)
 static bool USE_SOURCE_TREE_RESOURCES = true;
 #else
-static const QString USE_SOURCE_TREE_RESOURCES_FLAG("HIFI_USE_SOURCE_TREE_RESOURCES");
-static bool USE_SOURCE_TREE_RESOURCES = QProcessEnvironment::systemEnvironment().contains(USE_SOURCE_TREE_RESOURCES_FLAG);
+static bool USE_SOURCE_TREE_RESOURCES() {
+    static bool result = false;
+    static std::once_flag once;
+    std::call_once(once, [&] {
+        const QString USE_SOURCE_TREE_RESOURCES_FLAG("HIFI_USE_SOURCE_TREE_RESOURCES");
+        result = QProcessEnvironment::systemEnvironment().contains(USE_SOURCE_TREE_RESOURCES_FLAG);
+    });
+    return result;
+}
 #endif
 #endif
 
@@ -77,7 +83,7 @@ const QString& PathUtils::resourcesPath() {
 #endif
         
 #if !defined(Q_OS_ANDROID) && defined(DEV_BUILD)
-        if (USE_SOURCE_TREE_RESOURCES) {
+        if (USE_SOURCE_TREE_RESOURCES()) {
             // For dev builds, optionally load content from the Git source tree
             staticResourcePath = projectRootPath() + "/interface/resources/";
         }
@@ -100,7 +106,7 @@ const QString& PathUtils::resourcesUrl() {
 #endif
 
 #if !defined(Q_OS_ANDROID) && defined(DEV_BUILD)
-        if (USE_SOURCE_TREE_RESOURCES) {
+        if (USE_SOURCE_TREE_RESOURCES()) {
             // For dev builds, optionally load content from the Git source tree
             staticResourcePath = QUrl::fromLocalFile(projectRootPath() + "/interface/resources/").toString();
         }


### PR DESCRIPTION
Because `PathUtils::resourcesUrl` and `PathUtils::resourcesPath` can be used in static initialization (as when `PathUtils::resourcesUrl` is used indirectly through the `HIFI_DEF_QML` macro), they might be called before the static `USE_SOURCE_TREE_RESOURCES` boolean was initialized.  By changing `USE_SOURCE_TREE_RESOURCES` to a static function it ensures that the correct value will be returned even during static initialization.  

## Testing

No QA required, this is a dev-only feature.