### PR TITLE
Fix Purchases sorting (again); Fix (i) icon loading

### DIFF
--- a/interface/resources/qml/hifi/commerce/common/SortableListModel.qml
+++ b/interface/resources/qml/hifi/commerce/common/SortableListModel.qml
@@ -22,7 +22,7 @@ ListModel {
     function swap(a, b) {
         if (a < b) {
             move(a, b, 1);
-            move (b - 1, a, 1);
+            move(b - 1, a, 1);
         } else if (a > b) {
             move(b, a, 1);
             move(a - 1, b, 1);
@@ -34,16 +34,17 @@ ListModel {
             var piv = get(pivot)[sortColumnName];
             swap(pivot, end - 1);
             var store = begin;
+            var i;
 
-            for (var i = begin; i < end - 1; ++i) {
+            for (i = begin; i < end - 1; ++i) {
                 var currentElement = get(i)[sortColumnName];
                 if (isSortingDescending) {
-                    if (currentElement < piv) {
+                    if (currentElement > piv) {
                         swap(store, i);
                         ++store;
                     }
                 } else {
-                    if (currentElement > piv) {
+                    if (currentElement < piv) {
                         swap(store, i);
                         ++store;
                     }
@@ -56,16 +57,17 @@ ListModel {
             var piv = get(pivot)[sortColumnName].toLowerCase();
             swap(pivot, end - 1);
             var store = begin;
+            var i;
 
-            for (var i = begin; i < end - 1; ++i) {
+            for (i = begin; i < end - 1; ++i) {
                 var currentElement = get(i)[sortColumnName].toLowerCase();
                 if (isSortingDescending) {
-                    if (currentElement < piv) {
+                    if (currentElement > piv) {
                         swap(store, i);
                         ++store;
                     }
                 } else {
-                    if (currentElement > piv) {
+                    if (currentElement < piv) {
                         swap(store, i);
                         ++store;
                     }

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -317,6 +317,7 @@ Rectangle {
 
             HifiControlsUit.TextField {
                 id: filterBar;
+                property string previousText: "";
                 colorScheme: hifi.colorSchemes.faintGray;
                 hasClearButton: true;
                 hasRoundedBorder: true;
@@ -329,6 +330,8 @@ Rectangle {
 
                 onTextChanged: {
                     buildFilteredPurchasesModel();
+                    purchasesContentsList.positionViewAtIndex(0, ListView.Beginning)
+                    filterBar.previousText = filterBar.text;
                 }
 
                 onAccepted: {
@@ -647,7 +650,8 @@ Rectangle {
 
     function sortByDate() {
         filteredPurchasesModel.sortColumnName = "purchase_date";
-        filteredPurchasesModel.isSortingDescending = false;
+        filteredPurchasesModel.isSortingDescending = true;
+        filteredPurchasesModel.valuesAreNumerical = true;
         filteredPurchasesModel.quickSort();
     }
 
@@ -677,7 +681,7 @@ Rectangle {
             }
         }
 
-        if (sameItemCount !== tempPurchasesModel.count || filterBar.text !== "") {
+        if (sameItemCount !== tempPurchasesModel.count || filterBar.text !== filterBar.previousText) {
             filteredPurchasesModel.clear();
             for (var i = 0; i < tempPurchasesModel.count; i++) {
                 filteredPurchasesModel.append(tempPurchasesModel.get(i));

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -168,8 +168,8 @@ bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& 
                 _contextOverlay->setColorPulse(CONTEXT_OVERLAY_UNHOVERED_COLORPULSE);
                 _contextOverlay->setIgnoreRayIntersection(false);
                 _contextOverlay->setDrawInFront(true);
-                _contextOverlay->setURL(PathUtils::resourcesPath() + "images/inspect-icon.png");
                 _contextOverlay->setIsFacingAvatar(true);
+                _contextOverlay->setURL(PathUtils::resourcesUrl() + "images/inspect-icon.png");
                 _contextOverlayID = qApp->getOverlays().addOverlay(_contextOverlay);
             }
             _contextOverlay->setWorldPosition(contextOverlayPosition);


### PR DESCRIPTION
This PR accomplishes a few things:
1. Ensures that the order of My Purchases is correctly sorted (most recent purchase first)
2. Fixes the bug caused by #12238 where sorting was being done on a string when it should have been done on a number
3. Ensures that filtering My Purchases causes the Purchases listview to jump to the top (instead of confusingly being in the middle)
4. Fixes the (i) inspection icon