### PR TITLE
Fix a number of bugs caused by the binary resources migration

### DIFF
--- a/interface/resources/styles/global.qss
+++ b/interface/resources/styles/global.qss
@@ -41,14 +41,14 @@ QSpinBox, QDoubleSpinBox {
 
 QDoubleSpinBox::up-arrow,
 QSpinBox::up-arrow {
-    background-image: url(styles/up.svg);
+    background-image: url(:/styles/up.svg);
     background-repeat: no-repeat;
     background-position: center center;
 }
 
 QDoubleSpinBox::down-arrow,
 QSpinBox::down-arrow {
-    background-image: url(styles/down.svg);
+    background-image: url(:/styles/down.svg);
     background-repeat: no-repeat;
     background-position: center center;
 }
@@ -88,7 +88,7 @@ QSlider {
 
 QSlider::groove:horizontal {
     border: none;
-    background-image: url(styles/slider-bg.svg);
+    background-image: url(:/styles/slider-bg.svg);
     background-repeat: no-repeat;
     background-position: center center;
 }
@@ -96,7 +96,7 @@ QSlider::groove:horizontal {
 QSlider::handle:horizontal {
     width: 18px;
     height: 18px;
-    background-image: url(styles/slider-handle.svg);
+    background-image: url(:/styles/slider-handle.svg);
     background-repeat: no-repeat;
     background-position: center center;
 }
@@ -107,7 +107,7 @@ QPushButton#closeButton {
     border-width: 1px;
     border-radius: 0;
     background-color: #fff;
-    background-image: url(styles/close.svg);
+    background-image: url(:/styles/close.svg);
     background-repeat: no-repeat;
     background-position: center center;
 }

--- a/interface/resources/styles/import_dialog.qss
+++ b/interface/resources/styles/import_dialog.qss
@@ -63,17 +63,17 @@ QPushButton#cancelButton {
 }
 
 #backButton {
-    background-image: url(icons/backButton.svg);
+    background-image: url(:/icons/backButton.svg);
     border-radius: 0px;
 }
 
 #forwardButton {
-	background-image: url(icons/forwardButton.svg);
+	background-image: url(:/icons/forwardButton.svg);
     border-radius: 0px;
 }
 
 #toParentButton {
-	background-image: url(icons/toParentButton.svg);
+	background-image: url(:/icons/toParentButton.svg);
     border-radius: 0px;
 }
 

--- a/interface/resources/styles/log_dialog.qss
+++ b/interface/resources/styles/log_dialog.qss
@@ -22,7 +22,7 @@ QLineEdit {
 }
 
 QPushButton#searchButton {
-    background: url(styles/search.svg);
+    background: url(:/styles/search.svg);
     background-repeat: none;
     background-position: left center;
     background-origin: content;
@@ -55,7 +55,7 @@ QPushButton#searchPrevButton {
 
 QPushButton#revealLogButton {
     font-family: Helvetica, Arial, sans-serif;
-    background: url(styles/txt-file.svg);
+    background: url(:/styles/txt-file.svg);
     background-repeat: none;
     background-position: left center;
     background-origin: content;
@@ -86,11 +86,11 @@ QCheckBox {
 }
 
 QCheckBox::indicator:unchecked {
-    image: url(styles/unchecked.svg);
+    image: url(:/styles/unchecked.svg);
 }
 
 QCheckBox::indicator:checked {
-    image: url(styles/checked.svg);
+    image: url(:/styles/checked.svg);
 }
 
 QComboBox {
@@ -110,6 +110,6 @@ QComboBox::drop-down {
 }
 
 QComboBox::down-arrow {
-    image: url(styles/filter.png);
+    image: url(:/styles/filter.png);
     border-width: 0px;
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2724,7 +2724,7 @@ void Application::showHelp() {
     queryString.addQueryItem("defaultTab", defaultTab);
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet(SYSTEM_TABLET));
-    tablet->gotoWebScreen(PathUtils::resourcesPath() + INFO_HELP_PATH + "?" + queryString.toString());
+    tablet->gotoWebScreen(PathUtils::resourcesUrl() + INFO_HELP_PATH + "?" + queryString.toString());
     DependencyManager::get<HMDScriptingInterface>()->openTablet();
     //InfoView::show(INFO_HELP_PATH, false, queryString.toString());
 }

--- a/interface/src/ui/BaseLogDialog.cpp
+++ b/interface/src/ui/BaseLogDialog.cpp
@@ -39,7 +39,6 @@ BaseLogDialog::BaseLogDialog(QWidget* parent) : QDialog(parent, Qt::Window) {
 
     QFile styleSheet(PathUtils::resourcesPath() + "styles/log_dialog.qss");
     if (styleSheet.open(QIODevice::ReadOnly)) {
-        QDir::setCurrent(PathUtils::resourcesPath());
         setStyleSheet(styleSheet.readAll());
     }
 

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -168,7 +168,7 @@ bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& 
                 _contextOverlay->setColorPulse(CONTEXT_OVERLAY_UNHOVERED_COLORPULSE);
                 _contextOverlay->setIgnoreRayIntersection(false);
                 _contextOverlay->setDrawInFront(true);
-                _contextOverlay->setURL(PathUtils::resourcesPath() + "images/inspect-icon.png");
+                _contextOverlay->setURL(PathUtils::resourcesUrl() + "images/inspect-icon.png");
                 _contextOverlay->setIsFacingAvatar(true);
                 _contextOverlayID = qApp->getOverlays().addOverlay(_contextOverlay);
             }

--- a/libraries/render/src/render/Engine.cpp
+++ b/libraries/render/src/render/Engine.cpp
@@ -45,8 +45,8 @@ void Engine::load() {
     auto config = getConfiguration();
     const QString configFile= "config/render.json";
 
-    QUrl path(PathUtils::resourcesPath() + configFile);
-    QFile file(path.toString());
+    QString path(PathUtils::resourcesPath() + configFile);
+    QFile file(path);
     if (!file.exists()) {
         qWarning() << "Engine configuration file" << path << "does not exist";
     } else if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {


### PR DESCRIPTION
* QSS stylesheets need to use absolute paths (and despite the field being called `url` seem to need the QFile version of a QRC path (`:/`) rather than the QUrl version (`qrc:///`)
* The help dialog was passing a resource path rather than a resource URL to the tablet, which requires URLs
* The context overlay interface was using a path rather than a URL for the information icon overlay image
* The render engine was incorrectly encapsulating a resource path as a resource URL, which failed to load the render JSON configuration

## Testing

* The log dialog should now show icons, such as check boxes next to the log levels, when displaying (does not work in master)
* Right clicking on objects in world should correctly reveal the information icon (does not work in master)
* The Developer / Graphics... settings dialog should now show additional options besides `None` for the shadows and ambient occlusion dropdowns
* The help toolbar/tablet button should no longer show an error page when bringing up the help dialog.