### PR TITLE
RC63: Bug fix for twisted knees on some avatars.

### DIFF
--- a/libraries/render-utils/src/Skinning.slh
+++ b/libraries/render-utils/src/Skinning.slh
@@ -39,12 +39,12 @@ mat4 dualQuatToMat4(vec4 real, vec4 dual) {
                      twoRealXZ - twoRealYW,
                      0.0);
     vec4 col1 = vec4(twoRealXY - twoRealZW,
-                     1 - twoRealXSq - twoRealZSq,
+                     1.0 - twoRealXSq - twoRealZSq,
                      twoRealYZ + twoRealXW,
                      0.0);
     vec4 col2 = vec4(twoRealXZ + twoRealYW,
                      twoRealYZ - twoRealXW,
-                     1 - twoRealXSq - twoRealYSq,
+                     1.0 - twoRealXSq - twoRealYSq,
                      0.0);
     vec4 col3 = vec4(2.0 * (-dual.w * real.x + dual.x * real.w - dual.y * real.z + dual.z * real.y),
                      2.0 * (-dual.w * real.y + dual.x * real.z + dual.y * real.w - dual.z * real.x),


### PR DESCRIPTION
The FBXReader inverse bind pose calculation can sometimes introduce floating point fuzz into
the bottom row of the matrix.  The Transform class checks this bottom row before doing decomposition
into translation, rotation and scale.  If it detects that this row is not exactly (0, 0, 0, 1) it aborts.
And returns identity.  To guarantee that it preforms the decomposition correctly slam the row to (0, 0, 0, 1),
before conversion to a Transform instance.

(cherry picked from commit 991ba7f1951db5043dd8fbf73ba6403b193f38eb)