### PR TITLE
RC63 hotfix: fixing lighting on scattering skin bug 11802

### DIFF
--- a/libraries/render-utils/src/LightAmbient.slh
+++ b/libraries/render-utils/src/LightAmbient.slh
@@ -99,7 +99,6 @@ void evalLightingAmbient(out vec3 diffuse, out vec3 specular, LightAmbient ambie
 
         // Diffuse from ambient
         diffuse = sphericalHarmonics_evalSphericalLight(getLightAmbientSphere(ambient), lowNormalCurvature.xyz).xyz;
-        diffuse /= 3.1415926;
         specular = vec3(0.0);
     }
 <@endif@>


### PR DESCRIPTION
FIx the scattering ambient lighting diffuse which was too dark (got divided by PI) compared to non 
scattering
## TEST PLAN and repro
https://highfidelity.manuscript.com/f/cases/11802/Photo-Real-Female-Avatar-has-hair-seaming-issues
