### PR TITLE
RC63 Hotfix: Fix haze parameters uniform buffer size

### DIFF
--- a/libraries/graphics/src/graphics/Haze.h
+++ b/libraries/graphics/src/graphics/Haze.h
@@ -117,13 +117,14 @@ namespace graphics {
 
             // Amount of background (skybox) to display, overriding the haze effect for the background
             float hazeBackgroundBlend{ INITIAL_HAZE_BACKGROUND_BLEND };
-
             // The haze attenuation exponents used by both fragment and directional light attenuation
             float hazeRangeFactor{ convertHazeRangeToHazeRangeFactor(INITIAL_HAZE_RANGE) };
             float hazeHeightFactor{ convertHazeAltitudeToHazeAltitudeFactor(INITIAL_HAZE_HEIGHT) };
-
             float hazeKeyLightRangeFactor{ convertHazeRangeToHazeRangeFactor(INITIAL_KEY_LIGHT_RANGE) };
+
             float hazeKeyLightAltitudeFactor{ convertHazeAltitudeToHazeAltitudeFactor(INITIAL_KEY_LIGHT_ALTITUDE) };
+            // Padding required to align the structure to sizeof(vec4)
+            vec3 __padding;
 
             Parameters() {}
         };


### PR DESCRIPTION
Hotfix for Haze buffer allocation size.  May fix the AMD OpenGL crashes. 

Test plan:
- Test on AMD video card and see if crash goes away.
- Make sure to visit domains with and without haze.
- Test on Nvidia cards as well.