### PR TITLE
RC63 Hotfix: HMD low LOD threshold changed: 45 --> 34

### DIFF
--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -20,7 +20,7 @@
 #include <render/Args.h>
 
 const float DEFAULT_DESKTOP_LOD_DOWN_FPS = 30.0f;
-const float DEFAULT_HMD_LOD_DOWN_FPS = 42.0f;
+const float DEFAULT_HMD_LOD_DOWN_FPS = 34.0f;
 const float DEFAULT_DESKTOP_MAX_RENDER_TIME = (float)MSECS_PER_SECOND / DEFAULT_DESKTOP_LOD_DOWN_FPS; // msec
 const float DEFAULT_HMD_MAX_RENDER_TIME = (float)MSECS_PER_SECOND / DEFAULT_HMD_LOD_DOWN_FPS; // msec
 const float MAX_LIKELY_DESKTOP_FPS = 59.0f; // this is essentially, V-synch - 1 fps

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -20,7 +20,7 @@
 #include <render/Args.h>
 
 const float DEFAULT_DESKTOP_LOD_DOWN_FPS = 30.0f;
-const float DEFAULT_HMD_LOD_DOWN_FPS = 45.0f;
+const float DEFAULT_HMD_LOD_DOWN_FPS = 42.0f;
 const float DEFAULT_DESKTOP_MAX_RENDER_TIME = (float)MSECS_PER_SECOND / DEFAULT_DESKTOP_LOD_DOWN_FPS; // msec
 const float DEFAULT_HMD_MAX_RENDER_TIME = (float)MSECS_PER_SECOND / DEFAULT_HMD_LOD_DOWN_FPS; // msec
 const float MAX_LIKELY_DESKTOP_FPS = 59.0f; // this is essentially, V-synch - 1 fps


### PR DESCRIPTION
We think having the low-LOD threshold close to 45Hz (which happens to be the low FPS "mode" for oculus) causes the client LOD to NOT recover in a timely fashion, even when it should, because one of the measured values used to determine LOD is the time to "present" which can be kept artificially near 22msec when Oculus is locked in 45FPS mode.

### TEST PLAN
In a rich domain (avatar island)
Make sure that the Setting/LOD/ HMD FPS value is 35

While experiencing the domain (in HMD) and observing the present and render framerate from stats (the '/' key)

observe that the LOD nottification message is not appearing as much as in current stable
and also that the effect of LOD (culling small objects) is recovered from when looking at less expensive view in the domain.

THe goal of this pr is to simply change the default value that trigger the LOD system so it doesn;t works against the HMD time warp system which is also trying to run at 45Hz too. By selecting an value under 45Hz the LOD manager should do the correct thing.