### PR TITLE
fix entity parenting crash

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1678,14 +1678,23 @@ void EntityTree::entityChanged(EntityItemPointer entity) {
     }
 }
 
+QVector<EntityItemWeakPointer> EntityTree::getEntitiesParentFixup() const {
+    QReadLocker locker(&_needsParentFixupLock);
+    return _needsParentFixup;
+}
+
+void EntityTree::setNeedsParentFixup(QVector<EntityItemWeakPointer> entitiesFixup) {
+    QWriteLocker locker(&_needsParentFixupLock);
+    _needsParentFixup = entitiesFixup;
+}
 
 void EntityTree::fixupNeedsParentFixups() {
     PROFILE_RANGE(simulation_physics, "FixupParents");
     MovingEntitiesOperator moveOperator;
 
-    QWriteLocker locker(&_needsParentFixupLock);
+    QVector<EntityItemWeakPointer> entitiesParentFixup = getEntitiesParentFixup();
 
-    QMutableVectorIterator<EntityItemWeakPointer> iter(_needsParentFixup);
+    QMutableVectorIterator<EntityItemWeakPointer> iter(entitiesParentFixup);
     while (iter.hasNext()) {
         EntityItemWeakPointer entityWP = iter.next();
         EntityItemPointer entity = entityWP.lock();
@@ -1748,6 +1757,8 @@ void EntityTree::fixupNeedsParentFixups() {
         PerformanceTimer perfTimer("recurseTreeWithOperator");
         recurseTreeWithOperator(&moveOperator);
     }
+
+    setNeedsParentFixup(entitiesParentFixup);
 }
 
 void EntityTree::deleteDescendantsOfAvatar(QUuid avatarID) {

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -385,6 +385,8 @@ private:
     void sendChallengeOwnershipPacket(const QString& certID, const QString& ownerKey, const EntityItemID& entityItemID, const SharedNodePointer& senderNode);
     void sendChallengeOwnershipRequestPacket(const QByteArray& certID, const QByteArray& text, const QByteArray& nodeToChallenge, const SharedNodePointer& senderNode);
     void validatePop(const QString& certID, const EntityItemID& entityItemID, const SharedNodePointer& senderNode, bool isRetryingValidation);
+    QVector<EntityItemWeakPointer> getEntitiesParentFixup() const;
+    void setNeedsParentFixup(QVector<EntityItemWeakPointer> entitiesFixup);
 
     std::shared_ptr<AvatarData> _myAvatar{ nullptr };
 };

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -385,8 +385,6 @@ private:
     void sendChallengeOwnershipPacket(const QString& certID, const QString& ownerKey, const EntityItemID& entityItemID, const SharedNodePointer& senderNode);
     void sendChallengeOwnershipRequestPacket(const QByteArray& certID, const QByteArray& text, const QByteArray& nodeToChallenge, const SharedNodePointer& senderNode);
     void validatePop(const QString& certID, const EntityItemID& entityItemID, const SharedNodePointer& senderNode, bool isRetryingValidation);
-    QVector<EntityItemWeakPointer> getEntitiesParentFixup() const;
-    void setNeedsParentFixup(QVector<EntityItemWeakPointer> entitiesFixup);
 
     std::shared_ptr<AvatarData> _myAvatar{ nullptr };
 };


### PR DESCRIPTION
This PR fixes the issue of the ```_needsParentFixupLock``` being clocked twice when ```EntityTree::fixupNeedsParentFixup``` function is called.