### PR TITLE
Expose functionality to enable entity scripts to check ownership verification on avatar entities

### DIFF
--- a/interface/src/scripting/WalletScriptingInterface.cpp
+++ b/interface/src/scripting/WalletScriptingInterface.cpp
@@ -37,14 +37,11 @@ void WalletScriptingInterface::setWalletStatus(const uint& status) {
     emit DependencyManager::get<Wallet>()->walletStatusResult(status);
 }
 
-void WalletScriptingInterface::proveAvatarEntityOwnershipVerification(const QUuid& entityID) {
+void WalletScriptingInterface::proveEntityOwnershipVerification(const QUuid& entityID) {
     EntityItemProperties entityProperties = DependencyManager::get<EntityScriptingInterface>()->getEntityProperties(entityID, _entityPropertyFlags);
     if (!entityID.isNull() && entityProperties.getMarketplaceID().length() > 0) {
-        if (!entityProperties.getClientOnly()) {
-            qCDebug(entities) << "Failed to prove ownership of:" << entityID << "is not an avatar entity";
-            emit DependencyManager::get<ContextOverlayInterface>()->ownershipVerificationFailed(entityID);
-            return;
-        }
         DependencyManager::get<ContextOverlayInterface>()->requestOwnershipVerification(entityID);
+    } else {
+        qCDebug(entities) << "Failed to prove ownership of:" << entityID << "is null or not a marketplace item";
     }
 }

--- a/interface/src/scripting/WalletScriptingInterface.cpp
+++ b/interface/src/scripting/WalletScriptingInterface.cpp
@@ -16,7 +16,6 @@ CheckoutProxy::CheckoutProxy(QObject* qmlObject, QObject* parent) : QmlWrapper(q
 }
 
 WalletScriptingInterface::WalletScriptingInterface() {
-    _contextOverlayInterface = DependencyManager::get<ContextOverlayInterface>();
 
     _entityPropertyFlags += PROP_POSITION;
     _entityPropertyFlags += PROP_ROTATION;
@@ -43,9 +42,9 @@ void WalletScriptingInterface::proveAvatarEntityOwnershipVerification(const QUui
     if (!entityID.isNull() && entityProperties.getMarketplaceID().length() > 0) {
         if (!entityProperties.getClientOnly()) {
             qCDebug(entities) << "Failed to prove ownership of:" << entityID << "is not an avatar entity";
-            emit _contextOverlayInterface->ownershipVerificationFailed(entityID);
+            emit DependencyManager::get<ContextOverlayInterface>()->ownershipVerificationFailed(entityID);
             return;
         }
-        _contextOverlayInterface->requestOwnershipVerification(entityID);
+        DependencyManager::get<ContextOverlayInterface>()->requestOwnershipVerification(entityID);
     }
 }

--- a/interface/src/scripting/WalletScriptingInterface.h
+++ b/interface/src/scripting/WalletScriptingInterface.h
@@ -34,8 +34,6 @@ class WalletScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
 
     Q_PROPERTY(uint walletStatus READ getWalletStatus WRITE setWalletStatus NOTIFY walletStatusChanged)
-    QSharedPointer<ContextOverlayInterface> _contextOverlayInterface;
-
 
 public:
     WalletScriptingInterface();

--- a/interface/src/scripting/WalletScriptingInterface.h
+++ b/interface/src/scripting/WalletScriptingInterface.h
@@ -40,7 +40,7 @@ public:
 
     Q_INVOKABLE void refreshWalletStatus();
     Q_INVOKABLE uint getWalletStatus() { return _walletStatus; }
-    Q_INVOKABLE void proveEntityOwnershipVerification(const QUuid& entityID);
+    Q_INVOKABLE void proveAvatarEntityOwnershipVerification(const QUuid& entityID);
     // setWalletStatus() should never be made Q_INVOKABLE. If it were,
     //     scripts could cause the Wallet to incorrectly report its status.
     void setWalletStatus(const uint& status);
@@ -51,7 +51,6 @@ signals:
 
 private:
     uint _walletStatus;
-    EntityPropertyFlags _entityPropertyFlags;
 };
 
 #endif // hifi_WalletScriptingInterface_h

--- a/interface/src/scripting/WalletScriptingInterface.h
+++ b/interface/src/scripting/WalletScriptingInterface.h
@@ -40,7 +40,7 @@ public:
 
     Q_INVOKABLE void refreshWalletStatus();
     Q_INVOKABLE uint getWalletStatus() { return _walletStatus; }
-    Q_INVOKABLE void proveAvatarEntityOwnershipVerification(const QUuid& entityID);
+    Q_INVOKABLE void proveEntityOwnershipVerification(const QUuid& entityID);
     // setWalletStatus() should never be made Q_INVOKABLE. If it were,
     //     scripts could cause the Wallet to incorrectly report its status.
     void setWalletStatus(const uint& status);

--- a/interface/src/scripting/WalletScriptingInterface.h
+++ b/interface/src/scripting/WalletScriptingInterface.h
@@ -48,6 +48,8 @@ public:
 signals:
     void walletStatusChanged();
     void walletNotSetup();
+    void ownershipVerificationSuccess(const QUuid& entityID);
+    void ownershipVerificationFailed(const QUuid& entityID);
 
 private:
     uint _walletStatus;

--- a/interface/src/scripting/WalletScriptingInterface.h
+++ b/interface/src/scripting/WalletScriptingInterface.h
@@ -21,6 +21,7 @@
 #include <OffscreenUi.h>
 #include "Application.h"
 #include "commerce/Wallet.h"
+#include "ui/overlays/ContextOverlayInterface.h"
 
 class CheckoutProxy : public QmlWrapper {
     Q_OBJECT
@@ -33,12 +34,15 @@ class WalletScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
 
     Q_PROPERTY(uint walletStatus READ getWalletStatus WRITE setWalletStatus NOTIFY walletStatusChanged)
+    QSharedPointer<ContextOverlayInterface> _contextOverlayInterface;
+
 
 public:
     WalletScriptingInterface();
 
     Q_INVOKABLE void refreshWalletStatus();
     Q_INVOKABLE uint getWalletStatus() { return _walletStatus; }
+    Q_INVOKABLE void proveAvatarEntityOwnershipVerification(const QUuid& entityID);
     // setWalletStatus() should never be made Q_INVOKABLE. If it were,
     //     scripts could cause the Wallet to incorrectly report its status.
     void setWalletStatus(const uint& status);
@@ -49,6 +53,7 @@ signals:
 
 private:
     uint _walletStatus;
+    EntityPropertyFlags _entityPropertyFlags;
 };
 
 #endif // hifi_WalletScriptingInterface_h

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -267,21 +267,10 @@ void ContextOverlayInterface::contextOverlays_hoverLeaveEntity(const EntityItemI
     }
 }
 
-void ContextOverlayInterface::proveAvatarEntityOwnershipVerification(const QUuid& entityItemID) {
-    EntityItemProperties entityProperties = _entityScriptingInterface->getEntityProperties(entityItemID, _entityPropertyFlags);
-    _entityMarketplaceID = entityProperties.getMarketplaceID();
-    if (!entityItemID.isNull() && _entityMarketplaceID.length() > 0) {
-        if (!entityProperties.getClientOnly()) {
-            qCDebug(entities) << "Failed to prove ownership of:" << entityItemID << "is not an avatar entity";
-            emit ownershipVerificationFailed(entityItemID);
-            return;
-        }
-        setLastInspectedEntity(entityItemID);
-        requestOwnershipVerification();
-    }
-}
+void ContextOverlayInterface::requestOwnershipVerification(const QUuid& entityID) {
 
-void ContextOverlayInterface::requestOwnershipVerification() {
+    setLastInspectedEntity(entityID);
+
     EntityItemProperties entityProperties = _entityScriptingInterface->getEntityProperties(_lastInspectedEntity, _entityPropertyFlags);
 
     auto nodeList = DependencyManager::get<NodeList>();
@@ -381,7 +370,7 @@ void ContextOverlayInterface::openInspectionCertificate() {
         _hmdScriptingInterface->openTablet();
 
         setLastInspectedEntity(_currentEntityWithContextOverlay);
-        requestOwnershipVerification();
+        requestOwnershipVerification(_lastInspectedEntity);
     }
 }
 

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -299,14 +299,11 @@ void ContextOverlayInterface::requestOwnershipVerification(const QUuid& entityID
                     if (networkReply->error() == QNetworkReply::NoError) {
                         if (!jsonObject["invalid_reason"].toString().isEmpty()) {
                             qCDebug(entities) << "invalid_reason not empty";
-                        }
-                        else if (jsonObject["transfer_status"].toArray().first().toString() == "failed") {
+                        } else if (jsonObject["transfer_status"].toArray().first().toString() == "failed") {
                             qCDebug(entities) << "'transfer_status' is 'failed'";
-                        }
-                        else if (jsonObject["transfer_status"].toArray().first().toString() == "pending") {
+                        } else if (jsonObject["transfer_status"].toArray().first().toString() == "pending") {
                             qCDebug(entities) << "'transfer_status' is 'pending'";
-                        }
-                        else {
+                        } else {
                             QString ownerKey = jsonObject["transfer_recipient_key"].toString();
 
                             QByteArray certID = entityProperties.getCertificateID().toUtf8();
@@ -332,25 +329,21 @@ void ContextOverlayInterface::requestOwnershipVerification(const QUuid& entityID
                             if (thread() != QThread::currentThread()) {
                                 QMetaObject::invokeMethod(this, "startChallengeOwnershipTimer");
                                 return;
-                            }
-                            else {
+                            } else {
                                 startChallengeOwnershipTimer();
                             }
                         }
-                    }
-                    else {
+                    } else {
                         qCDebug(entities) << "Call to" << networkReply->url() << "failed with error" << networkReply->error() <<
                             "More info:" << networkReply->readAll();
                     }
 
                     networkReply->deleteLater();
                 });
-            }
-            else {
+            } else {
                 qCWarning(context_overlay) << "Couldn't get Entity Server!";
             }
-        }
-        else {
+        } else {
             auto ledger = DependencyManager::get<Ledger>();
             _challengeOwnershipTimeoutTimer.stop();
             emit ledger->updateCertificateStatus(entityProperties.getCertificateID(), (uint)(ledger->CERTIFICATE_STATUS_STATIC_VERIFICATION_FAILED));

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -347,7 +347,7 @@ void ContextOverlayInterface::requestOwnershipVerification(const QUuid& entityID
             auto ledger = DependencyManager::get<Ledger>();
             _challengeOwnershipTimeoutTimer.stop();
             emit ledger->updateCertificateStatus(entityProperties.getCertificateID(), (uint)(ledger->CERTIFICATE_STATUS_STATIC_VERIFICATION_FAILED));
-            emit ownershipVerificationFailed(_lastInspectedEntity);
+            emit DependencyManager::get<WalletScriptingInterface>()->ownershipVerificationFailed(_lastInspectedEntity);
             qCDebug(context_overlay) << "Entity" << _lastInspectedEntity << "failed static certificate verification!";
         }
     }
@@ -404,7 +404,7 @@ void ContextOverlayInterface::startChallengeOwnershipTimer() {
     connect(&_challengeOwnershipTimeoutTimer, &QTimer::timeout, this, [=]() {
         qCDebug(entities) << "Ownership challenge timed out for" << _lastInspectedEntity;
         emit ledger->updateCertificateStatus(entityProperties.getCertificateID(), (uint)(ledger->CERTIFICATE_STATUS_VERIFICATION_TIMEOUT));
-        emit ownershipVerificationFailed(_lastInspectedEntity);
+        emit DependencyManager::get<WalletScriptingInterface>()->ownershipVerificationFailed(_lastInspectedEntity);
     });
 
     _challengeOwnershipTimeoutTimer.start(5000);
@@ -429,9 +429,9 @@ void ContextOverlayInterface::handleChallengeOwnershipReplyPacket(QSharedPointer
 
     if (verificationSuccess) {
         emit ledger->updateCertificateStatus(certID, (uint)(ledger->CERTIFICATE_STATUS_VERIFICATION_SUCCESS));
-        emit ownershipVerificationSuccess(_lastInspectedEntity);
+        emit DependencyManager::get<WalletScriptingInterface>()->ownershipVerificationSuccess(_lastInspectedEntity);
     } else {
         emit ledger->updateCertificateStatus(certID, (uint)(ledger->CERTIFICATE_STATUS_OWNER_VERIFICATION_FAILED));
-        emit ownershipVerificationFailed(_lastInspectedEntity);
+        emit DependencyManager::get<WalletScriptingInterface>()->ownershipVerificationFailed(_lastInspectedEntity);
     }
 }

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -189,7 +189,6 @@ bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& 
     return false;
 }
 
-
 bool ContextOverlayInterface::contextOverlayFilterPassed(const EntityItemID& entityItemID) {
     EntityItemProperties entityProperties = _entityScriptingInterface->getEntityProperties(entityItemID, _entityPropertyFlags);
     Setting::Handle<bool> _settingSwitch{ "commerce", true };

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -267,10 +267,15 @@ void ContextOverlayInterface::contextOverlays_hoverLeaveEntity(const EntityItemI
     }
 }
 
-void ContextOverlayInterface::requestEntityOwnershipVerification(const QUuid& entityItemID) {
+void ContextOverlayInterface::proveAvatarEntityOwnershipVerification(const QUuid& entityItemID) {
     EntityItemProperties entityProperties = _entityScriptingInterface->getEntityProperties(entityItemID, _entityPropertyFlags);
     _entityMarketplaceID = entityProperties.getMarketplaceID();
     if (!entityItemID.isNull() && _entityMarketplaceID.length() > 0) {
+        if (!entityProperties.getClientOnly()) {
+            qCDebug(entities) << "Failed to prove ownership of:" << entityItemID << "is not an avatar entity";
+            emit ownershipVerificationFailed(entityItemID);
+            return;
+        }
         setLastInspectedEntity(entityItemID);
         requestOwnershipVerification();
     }

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -168,7 +168,7 @@ bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& 
                 _contextOverlay->setColorPulse(CONTEXT_OVERLAY_UNHOVERED_COLORPULSE);
                 _contextOverlay->setIgnoreRayIntersection(false);
                 _contextOverlay->setDrawInFront(true);
-                _contextOverlay->setURL(PathUtils::resourcesPath() + "images/inspect-icon.png");
+                _contextOverlay->setURL(PathUtils::resourcesUrl() + "images/inspect-icon.png");
                 _contextOverlay->setIsFacingAvatar(true);
                 _contextOverlayID = qApp->getOverlays().addOverlay(_contextOverlay);
             }
@@ -188,6 +188,7 @@ bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& 
     }
     return false;
 }
+
 
 bool ContextOverlayInterface::contextOverlayFilterPassed(const EntityItemID& entityItemID) {
     EntityItemProperties entityProperties = _entityScriptingInterface->getEntityProperties(entityItemID, _entityPropertyFlags);
@@ -266,6 +267,112 @@ void ContextOverlayInterface::contextOverlays_hoverLeaveEntity(const EntityItemI
     }
 }
 
+bool ContextOverlayInterface::getLastInspectedEntityWasValid() {
+    if (!_lastInspectedEntity.isNull() && !_lastInspectedValidEntity.isNull()) {
+        return _lastInspectedEntity == _lastInspectedValidEntity;
+    }
+    return false;
+}
+
+void ContextOverlayInterface::requestEntityOwnershipVerification(const QUuid& entityItemID) {
+    EntityItemProperties entityProperties = _entityScriptingInterface->getEntityProperties(entityItemID, _entityPropertyFlags);
+    _entityMarketplaceID = entityProperties.getMarketplaceID();
+    if (!entityItemID.isNull() && _entityMarketplaceID.length() > 0) {
+        setLastInspectedEntity(entityItemID);
+        requestOwnershipVerification();
+    }
+}
+
+void ContextOverlayInterface::requestOwnershipVerification() {
+    EntityItemProperties entityProperties = _entityScriptingInterface->getEntityProperties(_lastInspectedEntity, _entityPropertyFlags);
+
+    auto nodeList = DependencyManager::get<NodeList>();
+
+    if (entityProperties.getClientOnly()) {
+        if (entityProperties.verifyStaticCertificateProperties()) {
+            SharedNodePointer entityServer = nodeList->soloNodeOfType(NodeType::EntityServer);
+
+            if (entityServer) {
+                QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
+                QNetworkRequest networkRequest;
+                networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+                networkRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+                QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL();
+                requestURL.setPath("/api/v1/commerce/proof_of_purchase_status/transfer");
+                QJsonObject request;
+                request["certificate_id"] = entityProperties.getCertificateID();
+                networkRequest.setUrl(requestURL);
+
+                QNetworkReply* networkReply = NULL;
+                networkReply = networkAccessManager.put(networkRequest, QJsonDocument(request).toJson());
+
+                connect(networkReply, &QNetworkReply::finished, [=]() {
+                    QJsonObject jsonObject = QJsonDocument::fromJson(networkReply->readAll()).object();
+                    jsonObject = jsonObject["data"].toObject();
+
+                    if (networkReply->error() == QNetworkReply::NoError) {
+                        if (!jsonObject["invalid_reason"].toString().isEmpty()) {
+                            qCDebug(entities) << "invalid_reason not empty";
+                        }
+                        else if (jsonObject["transfer_status"].toArray().first().toString() == "failed") {
+                            qCDebug(entities) << "'transfer_status' is 'failed'";
+                        }
+                        else if (jsonObject["transfer_status"].toArray().first().toString() == "pending") {
+                            qCDebug(entities) << "'transfer_status' is 'pending'";
+                        }
+                        else {
+                            QString ownerKey = jsonObject["transfer_recipient_key"].toString();
+
+                            QByteArray certID = entityProperties.getCertificateID().toUtf8();
+                            QByteArray text = DependencyManager::get<EntityTreeRenderer>()->getTree()->computeNonce(certID, ownerKey);
+                            QByteArray nodeToChallengeByteArray = entityProperties.getOwningAvatarID().toRfc4122();
+
+                            int certIDByteArraySize = certID.length();
+                            int textByteArraySize = text.length();
+                            int nodeToChallengeByteArraySize = nodeToChallengeByteArray.length();
+
+                            auto challengeOwnershipPacket = NLPacket::create(PacketType::ChallengeOwnershipRequest,
+                                certIDByteArraySize + textByteArraySize + nodeToChallengeByteArraySize + 3 * sizeof(int),
+                                true);
+                            challengeOwnershipPacket->writePrimitive(certIDByteArraySize);
+                            challengeOwnershipPacket->writePrimitive(textByteArraySize);
+                            challengeOwnershipPacket->writePrimitive(nodeToChallengeByteArraySize);
+                            challengeOwnershipPacket->write(certID);
+                            challengeOwnershipPacket->write(text);
+                            challengeOwnershipPacket->write(nodeToChallengeByteArray);
+                            nodeList->sendPacket(std::move(challengeOwnershipPacket), *entityServer);
+
+                            // Kickoff a 10-second timeout timer that marks the cert if we don't get an ownership response in time
+                            if (thread() != QThread::currentThread()) {
+                                QMetaObject::invokeMethod(this, "startChallengeOwnershipTimer");
+                                return;
+                            }
+                            else {
+                                startChallengeOwnershipTimer();
+                            }
+                        }
+                    }
+                    else {
+                        qCDebug(entities) << "Call to" << networkReply->url() << "failed with error" << networkReply->error() <<
+                            "More info:" << networkReply->readAll();
+                    }
+
+                    networkReply->deleteLater();
+                });
+            }
+            else {
+                qCWarning(context_overlay) << "Couldn't get Entity Server!";
+            }
+        }
+        else {
+            auto ledger = DependencyManager::get<Ledger>();
+            _challengeOwnershipTimeoutTimer.stop();
+            emit ledger->updateCertificateStatus(entityProperties.getCertificateID(), (uint)(ledger->CERTIFICATE_STATUS_STATIC_VERIFICATION_FAILED));
+            qCDebug(context_overlay) << "Entity" << _lastInspectedEntity << "failed static certificate verification!";
+        }
+    }
+}
+
 static const QString INSPECTION_CERTIFICATE_QML_PATH = "hifi/commerce/inspectionCertificate/InspectionCertificate.qml";
 void ContextOverlayInterface::openInspectionCertificate() {
     // lets open the tablet to the inspection certificate QML
@@ -275,87 +382,7 @@ void ContextOverlayInterface::openInspectionCertificate() {
         _hmdScriptingInterface->openTablet();
 
         setLastInspectedEntity(_currentEntityWithContextOverlay);
-
-        EntityItemProperties entityProperties = _entityScriptingInterface->getEntityProperties(_lastInspectedEntity, _entityPropertyFlags);
-
-        auto nodeList = DependencyManager::get<NodeList>();
-
-        if (entityProperties.getClientOnly()) {
-            if (entityProperties.verifyStaticCertificateProperties()) {
-                SharedNodePointer entityServer = nodeList->soloNodeOfType(NodeType::EntityServer);
-
-                if (entityServer) {
-                    QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
-                    QNetworkRequest networkRequest;
-                    networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
-                    networkRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-                    QUrl requestURL = NetworkingConstants::METAVERSE_SERVER_URL();
-                    requestURL.setPath("/api/v1/commerce/proof_of_purchase_status/transfer");
-                    QJsonObject request;
-                    request["certificate_id"] = entityProperties.getCertificateID();
-                    networkRequest.setUrl(requestURL);
-
-                    QNetworkReply* networkReply = NULL;
-                    networkReply = networkAccessManager.put(networkRequest, QJsonDocument(request).toJson());
-
-                    connect(networkReply, &QNetworkReply::finished, [=]() {
-                        QJsonObject jsonObject = QJsonDocument::fromJson(networkReply->readAll()).object();
-                        jsonObject = jsonObject["data"].toObject();
-
-                        if (networkReply->error() == QNetworkReply::NoError) {
-                            if (!jsonObject["invalid_reason"].toString().isEmpty()) {
-                                qCDebug(entities) << "invalid_reason not empty";
-                            } else if (jsonObject["transfer_status"].toArray().first().toString() == "failed") {
-                                qCDebug(entities) << "'transfer_status' is 'failed'";
-                            } else if (jsonObject["transfer_status"].toArray().first().toString() == "pending") {
-                                qCDebug(entities) << "'transfer_status' is 'pending'";
-                            } else {
-                                QString ownerKey = jsonObject["transfer_recipient_key"].toString();
-
-                                QByteArray certID = entityProperties.getCertificateID().toUtf8();
-                                QByteArray text = DependencyManager::get<EntityTreeRenderer>()->getTree()->computeNonce(certID, ownerKey);
-                                QByteArray nodeToChallengeByteArray = entityProperties.getOwningAvatarID().toRfc4122();
-
-                                int certIDByteArraySize = certID.length();
-                                int textByteArraySize = text.length();
-                                int nodeToChallengeByteArraySize = nodeToChallengeByteArray.length();
-
-                                auto challengeOwnershipPacket = NLPacket::create(PacketType::ChallengeOwnershipRequest,
-                                    certIDByteArraySize + textByteArraySize + nodeToChallengeByteArraySize + 3 * sizeof(int),
-                                    true);
-                                challengeOwnershipPacket->writePrimitive(certIDByteArraySize);
-                                challengeOwnershipPacket->writePrimitive(textByteArraySize);
-                                challengeOwnershipPacket->writePrimitive(nodeToChallengeByteArraySize);
-                                challengeOwnershipPacket->write(certID);
-                                challengeOwnershipPacket->write(text);
-                                challengeOwnershipPacket->write(nodeToChallengeByteArray);
-                                nodeList->sendPacket(std::move(challengeOwnershipPacket), *entityServer);
-
-                                // Kickoff a 10-second timeout timer that marks the cert if we don't get an ownership response in time
-                                if (thread() != QThread::currentThread()) {
-                                    QMetaObject::invokeMethod(this, "startChallengeOwnershipTimer");
-                                    return;
-                                } else {
-                                    startChallengeOwnershipTimer();
-                                }
-                            }
-                        } else {
-                            qCDebug(entities) << "Call to" << networkReply->url() << "failed with error" << networkReply->error() <<
-                                "More info:" << networkReply->readAll();
-                        }
-
-                        networkReply->deleteLater();
-                    });
-                } else {
-                    qCWarning(context_overlay) << "Couldn't get Entity Server!";
-                }
-            } else {
-                auto ledger = DependencyManager::get<Ledger>();
-                _challengeOwnershipTimeoutTimer.stop();
-                emit ledger->updateCertificateStatus(entityProperties.getCertificateID(), (uint)(ledger->CERTIFICATE_STATUS_STATIC_VERIFICATION_FAILED));
-                qCDebug(context_overlay) << "Entity" << _lastInspectedEntity << "failed static certificate verification!";
-            }
-        }
+        requestOwnershipVerification();
     }
 }
 
@@ -421,6 +448,7 @@ void ContextOverlayInterface::handleChallengeOwnershipReplyPacket(QSharedPointer
 
     if (verificationSuccess) {
         emit ledger->updateCertificateStatus(certID, (uint)(ledger->CERTIFICATE_STATUS_VERIFICATION_SUCCESS));
+        _lastInspectedValidEntity = _lastInspectedEntity;
     } else {
         emit ledger->updateCertificateStatus(certID, (uint)(ledger->CERTIFICATE_STATUS_OWNER_VERIFICATION_FAILED));
     }

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -57,6 +57,7 @@ public:
     bool getIsInMarketplaceInspectionMode() { return _isInMarketplaceInspectionMode; }
     void setIsInMarketplaceInspectionMode(bool mode) { _isInMarketplaceInspectionMode = mode; }
     void requestOwnershipVerification(const QUuid& entityID);
+    EntityPropertyFlags getEntityPropertyFlags() { return _entityPropertyFlags; }
 
 signals:
     void contextOverlayClicked(const QUuid& currentEntityWithContextOverlay);

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -84,7 +84,7 @@ private:
         MAX_SELECTION_COUNT = 16
     };
     bool _verboseLogging{ true };
-    bool _enabled{ true };
+    bool _enabled { true };
     EntityItemID _currentEntityWithContextOverlay{};
     EntityItemID _lastInspectedEntity{};
     QString _entityMarketplaceID;

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -26,6 +26,7 @@
 #include "ui/overlays/Overlays.h"
 #include "scripting/HMDScriptingInterface.h"
 #include "scripting/SelectionScriptingInterface.h"
+#include "scripting/WalletScriptingInterface.h"
 
 #include "EntityTree.h"
 #include "ContextOverlayLogging.h"
@@ -61,8 +62,6 @@ public:
 
 signals:
     void contextOverlayClicked(const QUuid& currentEntityWithContextOverlay);
-    void ownershipVerificationSuccess(const QUuid& entityID);
-    void ownershipVerificationFailed(const QUuid& entityID);
 
 public slots:
     bool createOrDestroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -36,21 +36,20 @@
 class ContextOverlayInterface : public QObject, public Dependency {
     Q_OBJECT
 
-        Q_PROPERTY(QUuid entityWithContextOverlay READ getCurrentEntityWithContextOverlay WRITE setCurrentEntityWithContextOverlay)
-        Q_PROPERTY(bool enabled READ getEnabled WRITE setEnabled)
-        Q_PROPERTY(bool isInMarketplaceInspectionMode READ getIsInMarketplaceInspectionMode WRITE setIsInMarketplaceInspectionMode)
+    Q_PROPERTY(QUuid entityWithContextOverlay READ getCurrentEntityWithContextOverlay WRITE setCurrentEntityWithContextOverlay)
+    Q_PROPERTY(bool enabled READ getEnabled WRITE setEnabled)
+    Q_PROPERTY(bool isInMarketplaceInspectionMode READ getIsInMarketplaceInspectionMode WRITE setIsInMarketplaceInspectionMode)
 
-        QSharedPointer<EntityScriptingInterface> _entityScriptingInterface;
+    QSharedPointer<EntityScriptingInterface> _entityScriptingInterface;
     EntityPropertyFlags _entityPropertyFlags;
     QSharedPointer<HMDScriptingInterface> _hmdScriptingInterface;
     QSharedPointer<TabletScriptingInterface> _tabletScriptingInterface;
     QSharedPointer<SelectionScriptingInterface> _selectionScriptingInterface;
-    OverlayID _contextOverlayID{ UNKNOWN_OVERLAY_ID };
-    std::shared_ptr<Image3DOverlay> _contextOverlay{ nullptr };
+    OverlayID _contextOverlayID { UNKNOWN_OVERLAY_ID };
+    std::shared_ptr<Image3DOverlay> _contextOverlay { nullptr };
 public:
     ContextOverlayInterface();
     Q_INVOKABLE QUuid getCurrentEntityWithContextOverlay() { return _currentEntityWithContextOverlay; }
-    Q_INVOKABLE bool getLastInspectedEntityWasValid();
     Q_INVOKABLE void requestEntityOwnershipVerification(const QUuid& entityID);
     void setCurrentEntityWithContextOverlay(const QUuid& entityID) { _currentEntityWithContextOverlay = entityID; }
     void setLastInspectedEntity(const QUuid& entityID) { _challengeOwnershipTimeoutTimer.stop(); _lastInspectedEntity = entityID; }
@@ -61,8 +60,10 @@ public:
 
 signals:
     void contextOverlayClicked(const QUuid& currentEntityWithContextOverlay);
+    void ownershipVerificationSuccess(const QUuid& entityID);
+    void ownershipVerificationFailed(const QUuid& entityID);
 
-    public slots:
+public slots:
     bool createOrDestroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
     bool destroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
     bool destroyContextOverlay(const EntityItemID& entityItemID);
@@ -73,7 +74,7 @@ signals:
     void contextOverlays_hoverLeaveEntity(const EntityItemID& entityID, const PointerEvent& event);
     bool contextOverlayFilterPassed(const EntityItemID& entityItemID);
 
-    private slots:
+private slots:
     void handleChallengeOwnershipReplyPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
 
 private:
@@ -85,7 +86,6 @@ private:
     bool _enabled{ true };
     EntityItemID _currentEntityWithContextOverlay{};
     EntityItemID _lastInspectedEntity{};
-    EntityItemID _lastInspectedValidEntity{};
     QString _entityMarketplaceID;
     bool _contextOverlayJustClicked { false };
 

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -50,7 +50,7 @@ class ContextOverlayInterface : public QObject, public Dependency {
 public:
     ContextOverlayInterface();
     Q_INVOKABLE QUuid getCurrentEntityWithContextOverlay() { return _currentEntityWithContextOverlay; }
-    Q_INVOKABLE void requestEntityOwnershipVerification(const QUuid& entityID);
+    Q_INVOKABLE void proveAvatarEntityOwnershipVerification(const QUuid& entityID);
     void setCurrentEntityWithContextOverlay(const QUuid& entityID) { _currentEntityWithContextOverlay = entityID; }
     void setLastInspectedEntity(const QUuid& entityID) { _challengeOwnershipTimeoutTimer.stop(); _lastInspectedEntity = entityID; }
     void setEnabled(bool enabled);

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -50,13 +50,13 @@ class ContextOverlayInterface : public QObject, public Dependency {
 public:
     ContextOverlayInterface();
     Q_INVOKABLE QUuid getCurrentEntityWithContextOverlay() { return _currentEntityWithContextOverlay; }
-    Q_INVOKABLE void proveAvatarEntityOwnershipVerification(const QUuid& entityID);
     void setCurrentEntityWithContextOverlay(const QUuid& entityID) { _currentEntityWithContextOverlay = entityID; }
     void setLastInspectedEntity(const QUuid& entityID) { _challengeOwnershipTimeoutTimer.stop(); _lastInspectedEntity = entityID; }
     void setEnabled(bool enabled);
     bool getEnabled() { return _enabled; }
     bool getIsInMarketplaceInspectionMode() { return _isInMarketplaceInspectionMode; }
     void setIsInMarketplaceInspectionMode(bool mode) { _isInMarketplaceInspectionMode = mode; }
+    void requestOwnershipVerification(const QUuid& entityID);
 
 signals:
     void contextOverlayClicked(const QUuid& currentEntityWithContextOverlay);
@@ -92,7 +92,6 @@ private:
     bool _isInMarketplaceInspectionMode { false };
 
     void openInspectionCertificate();
-    void requestOwnershipVerification();
     void openMarketplace();
     void enableEntityHighlight(const EntityItemID& entityItemID);
     void disableEntityHighlight(const EntityItemID& entityItemID);

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -33,24 +33,25 @@
 /**jsdoc
 * @namespace ContextOverlay
 */
-class ContextOverlayInterface : public QObject, public Dependency  {
+class ContextOverlayInterface : public QObject, public Dependency {
     Q_OBJECT
 
-    Q_PROPERTY(QUuid entityWithContextOverlay READ getCurrentEntityWithContextOverlay WRITE setCurrentEntityWithContextOverlay)
-    Q_PROPERTY(bool enabled READ getEnabled WRITE setEnabled)
-    Q_PROPERTY(bool isInMarketplaceInspectionMode READ getIsInMarketplaceInspectionMode WRITE setIsInMarketplaceInspectionMode)
-    QSharedPointer<EntityScriptingInterface> _entityScriptingInterface;
+        Q_PROPERTY(QUuid entityWithContextOverlay READ getCurrentEntityWithContextOverlay WRITE setCurrentEntityWithContextOverlay)
+        Q_PROPERTY(bool enabled READ getEnabled WRITE setEnabled)
+        Q_PROPERTY(bool isInMarketplaceInspectionMode READ getIsInMarketplaceInspectionMode WRITE setIsInMarketplaceInspectionMode)
+
+        QSharedPointer<EntityScriptingInterface> _entityScriptingInterface;
     EntityPropertyFlags _entityPropertyFlags;
     QSharedPointer<HMDScriptingInterface> _hmdScriptingInterface;
     QSharedPointer<TabletScriptingInterface> _tabletScriptingInterface;
     QSharedPointer<SelectionScriptingInterface> _selectionScriptingInterface;
-    OverlayID _contextOverlayID { UNKNOWN_OVERLAY_ID };
-    std::shared_ptr<Image3DOverlay> _contextOverlay { nullptr };
+    OverlayID _contextOverlayID{ UNKNOWN_OVERLAY_ID };
+    std::shared_ptr<Image3DOverlay> _contextOverlay{ nullptr };
 public:
-
     ContextOverlayInterface();
-
     Q_INVOKABLE QUuid getCurrentEntityWithContextOverlay() { return _currentEntityWithContextOverlay; }
+    Q_INVOKABLE bool getLastInspectedEntityWasValid();
+    Q_INVOKABLE void requestEntityOwnershipVerification(const QUuid& entityID);
     void setCurrentEntityWithContextOverlay(const QUuid& entityID) { _currentEntityWithContextOverlay = entityID; }
     void setLastInspectedEntity(const QUuid& entityID) { _challengeOwnershipTimeoutTimer.stop(); _lastInspectedEntity = entityID; }
     void setEnabled(bool enabled);
@@ -61,7 +62,7 @@ public:
 signals:
     void contextOverlayClicked(const QUuid& currentEntityWithContextOverlay);
 
-public slots:
+    public slots:
     bool createOrDestroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
     bool destroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
     bool destroyContextOverlay(const EntityItemID& entityItemID);
@@ -72,7 +73,7 @@ public slots:
     void contextOverlays_hoverLeaveEntity(const EntityItemID& entityID, const PointerEvent& event);
     bool contextOverlayFilterPassed(const EntityItemID& entityItemID);
 
-private slots:
+    private slots:
     void handleChallengeOwnershipReplyPacket(QSharedPointer<ReceivedMessage> packet, SharedNodePointer sendingNode);
 
 private:
@@ -80,17 +81,18 @@ private:
     enum {
         MAX_SELECTION_COUNT = 16
     };
-
-    bool _verboseLogging { true };
-    bool _enabled { true };
+    bool _verboseLogging{ true };
+    bool _enabled{ true };
     EntityItemID _currentEntityWithContextOverlay{};
     EntityItemID _lastInspectedEntity{};
+    EntityItemID _lastInspectedValidEntity{};
     QString _entityMarketplaceID;
     bool _contextOverlayJustClicked { false };
 
     bool _isInMarketplaceInspectionMode { false };
 
     void openInspectionCertificate();
+    void requestOwnershipVerification();
     void openMarketplace();
     void enableEntityHighlight(const EntityItemID& entityItemID);
     void disableEntityHighlight(const EntityItemID& entityItemID);


### PR DESCRIPTION
Provides a route for entity client scripts to request that an avatar prove ownership of an (unmodified) avatar entity and emits a signal if the avatar entity passes or fails static certification and ownership verification. Some logic moved around in ContextOverlayInterface to not require mouse/laser inspection before requesting ownership verification. Still need to add failure reasons to signals when verification doesn't pass.

Test plan incoming. 