### PR TITLE
Fix deleting entities with children depth > 1 

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1344,7 +1344,7 @@ function recursiveDelete(entities, childrenList, deletedIDs) {
         var entityID = entities[i];
         var children = Entities.getChildrenIDs(entityID);
         var grandchildrenList = [];
-        recursiveDelete(children, grandchildrenList);
+        recursiveDelete(children, grandchildrenList, deletedIDs);
         var initialProperties = Entities.getEntityProperties(entityID);
         childrenList.push({
             entityID: entityID,


### PR DESCRIPTION
Fixes Fogbugz Case 11839 where entities that had 'grandchildren' entities would not delete. 

**Test Plan**
Create three entities such that A is the parent of B, which is the parent of C
Select A
Delete A
All children should delete in addition to A

Import http://mpassets.highfidelity.com/3c6e7cf9-494b-427e-a1b3-87877f99012b-v1/whiteboard_v2.json

Grab the top level entity for the whiteboard (Whiteboard, file wbFrameNew_framed.fbx) and delete
All should delete