### PR TITLE
[Case 10865] Make Asset Browser multi-select work with Ctrl/Cmd/Shift+Click

### DIFF
--- a/interface/resources/qml/controls-uit/Tree.qml
+++ b/interface/resources/qml/controls-uit/Tree.qml
@@ -202,8 +202,4 @@ TreeView {
     }
 
     onDoubleClicked: isExpanded(index) ? collapse(index) : expand(index)
-
-    onClicked: {
-        selectionModel.setCurrentIndex(index, ItemSelectionModel.ClearAndSelect);
-    }
 }

--- a/interface/resources/qml/hifi/AssetServer.qml
+++ b/interface/resources/qml/hifi/AssetServer.qml
@@ -694,7 +694,7 @@ Windows.ScrollingWindow {
                         }
                     }
                 }
-            }
+            }// End_OF( itemLoader )
 
             Rectangle {
                 id: treeLabelToolTip
@@ -731,50 +731,59 @@ Windows.ScrollingWindow {
                     showTimer.stop();
                     treeLabelToolTip.visible = false;
                 }
-            }
+            }// End_OF( treeLabelToolTip )
             
             MouseArea {
                 propagateComposedEvents: true
                 anchors.fill: parent
                 acceptedButtons: Qt.RightButton
                 onClicked: {
-                    if (!HMD.active) {  // Popup only displays properly on desktop
-                        var index = treeView.indexAt(mouse.x, mouse.y);
-                        treeView.selection.setCurrentIndex(index, 0x0002);
-                        contextMenu.currentIndex = index;
-                        contextMenu.popup();
+                    if (treeView.selection.hasSelection && !HMD.active) {  // Popup only displays properly on desktop
+                        // Only display the popup if the click triggered within
+                        // the selection.
+                        var clickedIndex = treeView.indexAt(mouse.x, mouse.y);
+                        var displayContextMenu = false;
+                        for ( var i = 0; i < selectedItems; ++i) {
+                            var currentSelectedIndex = treeView.selection.selectedIndexes[i];
+                            if (clickedIndex === currentSelectedIndex) {
+                                contextMenu.popup();
+                                break;
+                            }
+                        }
                     }
                 }
             }
-                
+
             Menu {
                 id: contextMenu
                 title: "Edit"
                 property var url: ""
-                property var currentIndex: null
 
                 MenuItem {
                     text: "Copy URL"
+                    enabled: (selectedItems == 1)
                     onTriggered: {
-                        copyURLToClipboard(contextMenu.currentIndex);
+                        copyURLToClipboard(treeView.selection.currentIndex);
                     }
                 }
 
                 MenuItem {
                     text: "Rename"
+                    enabled: (selectedItems == 1)
                     onTriggered: {
-                        renameFile(contextMenu.currentIndex);
+                        renameFile(treeView.selection.currentIndex);
                     }
                 }
 
                 MenuItem {
                     text: "Delete"
+                    enabled: (selectedItems > 0)
                     onTriggered: {
-                        deleteFile(contextMenu.currentIndex);
+                        deleteFile();
                     }
                 }
-            }
-        }
+            }// End_OF( contextMenu )
+        }// End_OF( treeView )
 
         Row {
             id: infoRow
@@ -885,7 +894,7 @@ Windows.ScrollingWindow {
                                             "Baking compresses and optimizes files for faster network transfer and display. We recommend you bake your content to reduce initial load times for your visitors.");
                     }
             } 
-        }
+        }// End_OF( infoRow )
 
         HifiControls.ContentSection {
             id: uploadSection
@@ -945,7 +954,7 @@ Windows.ScrollingWindow {
                     }
                 }
             }
-        }
+        }// End_OF( uploadSection )
     }
 }
 

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -39,7 +39,7 @@ Rectangle {
     property var assetProxyModel: Assets.proxyModel;
     property var assetMappingsModel: Assets.mappingModel;
     property var currentDirectory;
-    property var selectedItems: treeView.selection.selectedIndexes.length;
+    property var selectedItemCount: treeView.selection.selectedIndexes.length;
 
     Settings {
         category: "Overlay.AssetServer"
@@ -76,17 +76,17 @@ Rectangle {
         });
     }
 
-    function doDeleteFile(path) {
-        console.log("Deleting " + path);
+    function doDeleteFile(paths) {
+        console.log("Deleting " + paths);
 
-        Assets.deleteMappings(path, function(err) {
+        Assets.deleteMappings(paths, function(err) {
             if (err) {
-                console.log("Asset browser - error deleting path: ", path, err);
+                console.log("Asset browser - error deleting paths: ", paths, err);
 
-                box = errorMessageBox("There was an error deleting:\n" + path + "\n" + err);
+                box = errorMessageBox("There was an error deleting:\n" + paths + "\n" + err);
                 box.selected.connect(reload);
             } else {
-                console.log("Asset browser - finished deleting path: ", path);
+                console.log("Asset browser - finished deleting paths: ", paths);
                 reload();
             }
         });
@@ -146,7 +146,7 @@ Rectangle {
     function canAddToWorld(path) {
         var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i];
         
-        if (selectedItems > 1) {
+        if (selectedItemCount > 1) {
             return false;
         }
 
@@ -156,7 +156,7 @@ Rectangle {
     }
     
     function canRename() {    
-        if (treeView.selection.hasSelection && selectedItems == 1) {
+        if (treeView.selection.hasSelection && selectedItemCount == 1) {
             return true;
         } else {
             return false;
@@ -334,29 +334,28 @@ Rectangle {
         });
     }
     function deleteFile(index) {
-        var path = [];
+        var paths = [];
         
         if (!index) {
-            for (var i = 0; i < selectedItems; i++) {
-                 treeView.selection.setCurrentIndex(treeView.selection.selectedIndexes[i], 0x100);
-                 index = treeView.selection.currentIndex;
-                 path[i] = assetProxyModel.data(index, 0x100);                  
+            for (var i = 0; i < selectedItemCount; ++i) {
+                 index = treeView.selection.selectedIndexes[i];
+                 paths[i] = assetProxyModel.data(index, 0x100);
             }
         }
         
-        if (!path) {
+        if (!paths) {
             return;
         }
 
         var modalMessage = "";
-        var items = selectedItems.toString();
+        var items = selectedItemCount.toString();
         var isFolder = assetProxyModel.data(treeView.selection.currentIndex, 0x101);
         var typeString = isFolder ? 'folder' : 'file';
         
-        if (selectedItems > 1) {
+        if (selectedItemCount > 1) {
             modalMessage = "You are about to delete " + items + " items \nDo you want to continue?";
         } else {
-            modalMessage = "You are about to delete the following " + typeString + ":\n" + path + "\nDo you want to continue?";
+            modalMessage = "You are about to delete the following " + typeString + ":\n" + paths + "\nDo you want to continue?";
         }
 
         var object = tabletRoot.messageBox({
@@ -368,7 +367,7 @@ Rectangle {
         });
         object.selected.connect(function(button) {
             if (button === OriginalDialogs.StandardButton.Yes) {
-                doDeleteFile(path);
+                doDeleteFile(paths);
             }
         });
     }
@@ -693,7 +692,7 @@ Rectangle {
                         }
                     }
                 }
-            }
+            }// End_OF( itemLoader )
 
             Rectangle {
                 id: treeLabelToolTip
@@ -730,50 +729,59 @@ Rectangle {
                     showTimer.stop();
                     treeLabelToolTip.visible = false;
                 }
-            }
+            }// End_OF( treeLabelToolTip )
             
             MouseArea {
                 propagateComposedEvents: true
                 anchors.fill: parent
                 acceptedButtons: Qt.RightButton
                 onClicked: {
-                    if (!HMD.active) {  // Popup only displays properly on desktop
-                        var index = treeView.indexAt(mouse.x, mouse.y);
-                        treeView.selection.setCurrentIndex(index, 0x0002);
-                        contextMenu.currentIndex = index;
-                        contextMenu.popup();
+                    if (treeView.selection.hasSelection && !HMD.active) {  // Popup only displays properly on desktop
+                        // Only display the popup if the click triggered within
+                        // the selection.
+                        var clickedIndex = treeView.indexAt(mouse.x, mouse.y);
+                        var displayContextMenu = false;
+                        for ( var i = 0; i < selectedItemCount; ++i) {
+                            var currentSelectedIndex = treeView.selection.selectedIndexes[i];
+                            if (clickedIndex === currentSelectedIndex) {
+                                contextMenu.popup();
+                                break;
+                            }
+                        }
                     }
                 }
             }
-                
+
             Menu {
                 id: contextMenu
                 title: "Edit"
                 property var url: ""
-                property var currentIndex: null
 
                 MenuItem {
                     text: "Copy URL"
+                    enabled: (selectedItemCount == 1)
                     onTriggered: {
-                        copyURLToClipboard(contextMenu.currentIndex);
+                        copyURLToClipboard(treeView.selection.currentIndex);
                     }
                 }
 
                 MenuItem {
                     text: "Rename"
+                    enabled: (selectedItemCount == 1)
                     onTriggered: {
-                        renameFile(contextMenu.currentIndex);
+                        renameFile(treeView.selection.currentIndex);
                     }
                 }
 
                 MenuItem {
                     text: "Delete"
+                    enabled: (selectedItemCount > 0)
                     onTriggered: {
-                        deleteFile(contextMenu.currentIndex);
+                        deleteFile();
                     }
                 }
-            }
-        }
+            }// End_OF( contextMenu )
+        }// End_OF( treeView )
 
         Row {
             id: infoRow
@@ -786,8 +794,8 @@ Rectangle {
 
                 function makeText() {
                     var numPendingBakes = assetMappingsModel.numPendingBakes;
-                    if (selectedItems > 1 || numPendingBakes === 0) {
-                        return selectedItems + " items selected";
+                    if (selectedItemCount > 1 || numPendingBakes === 0) {
+                        return selectedItemCount + " items selected";
                     } else {
                         return numPendingBakes + " bakes pending"
                     }
@@ -884,7 +892,7 @@ Rectangle {
                                             "Baking compresses and optimizes files for faster network transfer and display. We recommend you bake your content to reduce initial load times for your visitors.");
                     }
             } 
-        }
+        }// End_OF( infoRow )
 
         HifiControls.TabletContentSection {
             id: uploadSection
@@ -961,7 +969,7 @@ Rectangle {
                     }
                 }
             }
-        }
+        }// End_OF( uploadSection )
     }
 }
 


### PR DESCRIPTION
This fixes [FogBugz Case #10865](https://highfidelity.fogbugz.com/f/cases/10865/Asset-Browser-Improvement-Make-the-asset-browser-multi-select-work-like-any-other-app) which was wrapped into FogBugz Case #7734; however, is being addressed separately for simplicity.


NOTE: This should be tested on Windows & Mac to cover the bases.  Desktop mode appears to be the only mode at present where the Asset Browser is accessible.  In HMD mode, the Asset Browser isn't displayed when navigating via the Tablet (Menu->Edit->Asset Browser), it's just a black screen.

- The following should be tested with Ctrl+Click selection and Shift+Click when testing multi-selection.
    - Expected Behavior for Ctrl+Click:  The click row should be added to the selection if it wasn't previously selected.  If the item was previously selected, then the row should be removed from the selection.  Any item aside from the clicked item isn't influenced.
    - Expected Behavior for Shift+Click:  The selection should be updated such that all items between the current item selected and the clicked item are selected or un-selected, depending on the state of the clicked item. Multiple items can be selected by dragging the mouse over them.

**Testing**

- Open the Asset Browser within the interface
- Create a scratch directory within the Asset Browser and upload a few asset files to your scratch directory.
- Select 1 file within your directory.  Notice _if_ that file is an <code>.obj</code> or <code>.fbx</code> file that the Add To World, Rename, & Delete buttons are available/enabled; _otherwise_, only the Rename & Delete buttons are available/enabled.
    - Right Click on the selected file.  Notice that the Rename, Copy URL, & Delete options within the context menu are available/enabled.
    - Right Click outside of the selection.  Notice that nothing unexpected is selected nor is the context menu displayed.  If the menu, was up prior to right clicking outside of the selection, notice that the context menu is dismissed without any option taken.
- Select 2 or more files within your directory.  Notice that _only_ the Delete button is available/enabled.
    - Right Click on the selection.  Notice that _only_ the Delete option is available/enabled.
    - Right Click outside of the selection.  Notice that nothing unexpected is selected nor is the context menu displayed.  If the menu, was up prior to right clicking outside of the selection, notice that the context menu is dismissed without any option taken.
