### PR TITLE
Trying to fix AMD crash in QML rendering

### DIFF
--- a/libraries/gl/src/gl/Context.h
+++ b/libraries/gl/src/gl/Context.h
@@ -47,6 +47,7 @@ namespace gl {
         Context(const Context& other);
 
     public:
+        static bool enableDebugLogger();
         Context();
         Context(QWindow* window);
         void release();

--- a/libraries/gl/src/gl/OffscreenGLCanvas.h
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.h
@@ -17,7 +17,7 @@
 
 class QOpenGLContext;
 class QOffscreenSurface;
-class QOpenGLDebugLogger;
+class QOpenGLDebugMessage;
 
 class OffscreenGLCanvas : public QObject {
 public:
@@ -32,6 +32,9 @@ public:
     }
     QObject* getContextObject();
     
+private slots:
+    void onMessageLogged(const QOpenGLDebugMessage &debugMessage);
+
 protected:
     std::once_flag _reportOnce;
     QOpenGLContext* _context{ nullptr };

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -543,6 +543,7 @@ void OffscreenQmlSurface::cleanup() {
 
 void OffscreenQmlSurface::render() {
 #if !defined(DISABLE_QML)
+
     if (nsightActive()) {
         return;
     }
@@ -565,6 +566,7 @@ void OffscreenQmlSurface::render() {
     glBindTexture(GL_TEXTURE_2D, texture);
     glGenerateMipmap(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, 0);
+    glFinish();
 
 
     {

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -566,19 +566,22 @@ void OffscreenQmlSurface::render() {
     glBindTexture(GL_TEXTURE_2D, texture);
     glGenerateMipmap(GL_TEXTURE_2D);
     glBindTexture(GL_TEXTURE_2D, 0);
-    glFinish();
 
 
     {
         // If the most recent texture was unused, we can directly recycle it
-        if (_latestTextureAndFence.first) {
-            offscreenTextures.releaseTexture(_latestTextureAndFence);
-            _latestTextureAndFence = { 0, 0 };
-        }
-
-        _latestTextureAndFence = { texture, glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0) };
+        auto fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
         // Fence will be used in another thread / context, so a flush is required
         glFlush();
+
+        {
+            Lock lock(_latestTextureAndFenceMutex);
+            if (_latestTextureAndFence.first) {
+                offscreenTextures.releaseTexture(_latestTextureAndFence);
+                _latestTextureAndFence = { 0, 0 };
+            }
+            _latestTextureAndFence = { texture, fence};
+        }
     }
 
     _quickWindow->resetOpenGLState();
@@ -590,13 +593,21 @@ void OffscreenQmlSurface::render() {
 bool OffscreenQmlSurface::fetchTexture(TextureAndFence& textureAndFence) {
     textureAndFence = { 0, 0 };
 
+    // Lock free early check
     if (0 == _latestTextureAndFence.first) {
         return false;
     }
 
     // Ensure writes to the latest texture are complete before before returning it for reading
-    textureAndFence = _latestTextureAndFence;
-    _latestTextureAndFence = { 0, 0 };
+    {
+        Lock lock(_latestTextureAndFenceMutex);
+        // Double check inside the lock
+        if (0 == _latestTextureAndFence.first) {
+            return false;
+        }
+        textureAndFence = _latestTextureAndFence;
+        _latestTextureAndFence = { 0, 0 };
+    }
     return true;
 }
 
@@ -815,10 +826,13 @@ void OffscreenQmlSurface::resize(const QSize& newSize_, bool forceResize) {
 
         // Release hold on the textures of the old size
         if (uvec2() != _size) {
-            // If the most recent texture was unused, we can directly recycle it
-            if (_latestTextureAndFence.first) {
-                offscreenTextures.releaseTexture(_latestTextureAndFence);
-                _latestTextureAndFence = { 0, 0 };
+            {
+                Lock lock(_latestTextureAndFenceMutex);
+                // If the most recent texture was unused, we can directly recycle it
+                if (_latestTextureAndFence.first) {
+                    offscreenTextures.releaseTexture(_latestTextureAndFence);
+                    _latestTextureAndFence = { 0, 0 };
+                }
             }
             offscreenTextures.releaseSize(_size);
         }

--- a/libraries/ui/src/ui/OffscreenQmlSurface.h
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.h
@@ -167,6 +167,9 @@ public slots:
     bool handlePointerEvent(const PointerEvent& event, class QTouchDevice& device, bool release = false);
 
 private:
+    using Mutex = std::mutex;
+    using Lock = std::unique_lock<std::mutex>;
+
     QQuickWindow* _quickWindow { nullptr };
     QQmlContext* _qmlContext { nullptr };
     QQuickItem* _rootItem { nullptr };
@@ -188,6 +191,7 @@ private:
 #endif
     
     // Texture management
+    Mutex _latestTextureAndFenceMutex;
     TextureAndFence _latestTextureAndFence { 0, 0 };
 
     bool _render { false };


### PR DESCRIPTION
This resolves a potential race condition in accessing the textures and fences protecting QML surface textures.  Because the QML rendering happens on the main thread, but batch generation of rendering commands is on another thread, the calls to `OffscreenQmlSurface::render` and `OffscreenQmlSurface::fetchTexture` will now occur on different threads.  However, the structure containing the texture and fence were not thread safe and so fences could theoretically be lost.  

## Testing

Repeatedly launch the application and connect to dev-welcome on an AMD / i5 system.  The master build will often crash, usually within a minute or so of startup.  This build should not crash on AMD/i5.