### PR TITLE
FB11511 - position of log windows should be persistent between invocations of interface

### DIFF
--- a/interface/src/ui/LogDialog.cpp
+++ b/interface/src/ui/LogDialog.cpp
@@ -38,7 +38,7 @@ const QString FATAL_TEXT = "[FATAL]";
 const QString SUPPRESS_TEXT = "[SUPPRESS]";
 const QString UNKNOWN_TEXT = "[UNKNOWN]";
 
-LogDialog::LogDialog(QWidget* parent, AbstractLoggerInterface* logger) : BaseLogDialog(parent) {
+LogDialog::LogDialog(QWidget* parent, AbstractLoggerInterface* logger) : BaseLogDialog(parent), _windowGeometry("logDialogGeometry", QRect()) {
     _logger = logger;
     setWindowTitle("Log");
 
@@ -155,6 +155,11 @@ LogDialog::LogDialog(QWidget* parent, AbstractLoggerInterface* logger) : BaseLog
     _clearFilterButton->show();
     connect(_clearFilterButton, &QPushButton::clicked, this, &LogDialog::handleClearFilterButton);
     handleClearFilterButton();
+
+    auto windowGeometry = _windowGeometry.get();
+    if (windowGeometry.isValid()) {
+        setGeometry(windowGeometry);
+    }
 }
 
 void LogDialog::resizeEvent(QResizeEvent* event) {
@@ -171,6 +176,11 @@ void LogDialog::resizeEvent(QResizeEvent* event) {
         THIRD_ROW,
         COMBOBOX_WIDTH,
         ELEMENT_HEIGHT);
+}
+
+void LogDialog::closeEvent(QCloseEvent* event) {
+    BaseLogDialog::closeEvent(event);
+    _windowGeometry.set(geometry());
 }
 
 void LogDialog::handleRevealButton() {

--- a/interface/src/ui/LogDialog.h
+++ b/interface/src/ui/LogDialog.h
@@ -13,6 +13,7 @@
 #define hifi_LogDialog_h
 
 #include "BaseLogDialog.h"
+#include <SettingHandle.h>
 
 class QCheckBox;
 class QPushButton;
@@ -44,6 +45,8 @@ private slots:
 
 protected:
     void resizeEvent(QResizeEvent* event) override;
+    void closeEvent(QCloseEvent* event) override;
+
     QString getCurrentLog() override;
     void printLogFile();
 
@@ -62,6 +65,7 @@ private:
     QString _filterSelection;
 
     AbstractLoggerInterface* _logger;
+    Setting::Handle<QRect> _windowGeometry;
 };
 
 #endif // hifi_LogDialog_h

--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -227,7 +227,7 @@ bool QmlWindowClass::isVisible() {
 glm::vec2 QmlWindowClass::getPosition() {
     if (QThread::currentThread() != thread()) {
         vec2 result;
-        BLOCKING_INVOKE_METHOD(this, "getPosition", Q_RETURN_ARG(vec2, result));
+        BLOCKING_INVOKE_METHOD(this, "getPosition", Q_RETURN_ARG(glm::vec2, result));
         return result;
     }
 
@@ -241,7 +241,7 @@ glm::vec2 QmlWindowClass::getPosition() {
 
 void QmlWindowClass::setPosition(const glm::vec2& position) {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setPosition", Q_ARG(vec2, position));
+        QMetaObject::invokeMethod(this, "setPosition", Q_ARG(const glm::vec2&, position));
         return;
     }
 
@@ -262,7 +262,7 @@ glm::vec2 toGlm(const QSizeF& size) {
 glm::vec2 QmlWindowClass::getSize() {
     if (QThread::currentThread() != thread()) {
         vec2 result;
-        BLOCKING_INVOKE_METHOD(this, "getSize", Q_RETURN_ARG(vec2, result));
+        BLOCKING_INVOKE_METHOD(this, "getSize", Q_RETURN_ARG(glm::vec2, result));
         return result;
     }
 
@@ -275,7 +275,7 @@ glm::vec2 QmlWindowClass::getSize() {
 
 void QmlWindowClass::setSize(const glm::vec2& size) {
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setSize", Q_ARG(vec2, size));
+        QMetaObject::invokeMethod(this, "setSize", Q_ARG(const glm::vec2&, size));
         return;
     }
 

--- a/scripts/developer/debugging/debugWindow.js
+++ b/scripts/developer/debugging/debugWindow.js
@@ -22,14 +22,37 @@ if (scripts.length >= 2) {
 // Set up the qml ui
 var qml = Script.resolvePath('debugWindow.qml');
 
+var HMD_DEBUG_WINDOW_GEOMETRY_KEY = 'hmdDebugWindowGeometry';
+var hmdDebugWindowGeometryValue = Settings.getValue(HMD_DEBUG_WINDOW_GEOMETRY_KEY)
+
+var windowWidth = 400;
+var windowHeight = 900;
+
+var hasPosition = false;
+var windowX = 0;
+var windowY = 0;
+
+if (hmdDebugWindowGeometryValue !== '') {
+    var geometry = JSON.parse(hmdDebugWindowGeometryValue);
+
+    windowWidth = geometry.width
+    windowHeight = geometry.height
+    windowX = geometry.x
+    windowY = geometry.y
+    hasPosition = true;
+}
+
 var window = new OverlayWindow({
     title: 'Debug Window',
     source: qml,
-    width: 400, height: 900,
+    width: windowWidth, height: windowHeight,
 });
 
-window.setPosition(25, 50);
-window.closed.connect(function() { Script.stop(); });
+if (hasPosition) {
+    window.setPosition(windowX, windowY);
+}
+
+window.closed.connect(function () { Script.stop(); });
 
 var getFormattedDate = function() {
     var date = new Date();
@@ -65,6 +88,14 @@ ScriptDiscoveryService.clearDebugWindow.connect(function() {
 });
 
 Script.scriptEnding.connect(function () {
+    var geometry = JSON.stringify({
+        x: window.position.x,
+        y: window.position.y,
+        width: window.size.x,
+        height: window.size.y
+    })
+
+    Settings.setValue(HMD_DEBUG_WINDOW_GEOMETRY_KEY, geometry);
     window.close();
 })
 


### PR DESCRIPTION
**Test plan**

1. Open log window
2. Resize/move it
3. Close it. 
4. Open HMD-friendly log window
5. Resize/move it
6. Restart interface
7. Ensure log / HMD-friendly log windows remember their positions