### PR TITLE
Addressbar close fix

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -282,7 +282,7 @@ Menu::Menu() {
 
     // Navigate > Show Address Bar
     addActionToQMenuAndActionHash(navigateMenu, MenuOption::AddressBar, Qt::CTRL | Qt::Key_L,
-        dialogsManager.data(), SLOT(showAddressBar()));
+        dialogsManager.data(), SLOT(toggleAddressBar()));
 
     // Navigate > LocationBookmarks related menus -- Note: the LocationBookmarks class adds its own submenus here.
     auto locationBookmarks = DependencyManager::get<LocationBookmarks>();

--- a/interface/src/ui/AddressBarDialog.h
+++ b/interface/src/ui/AddressBarDialog.h
@@ -22,7 +22,7 @@ class AddressBarDialog : public OffscreenQmlDialog {
     Q_PROPERTY(bool backEnabled READ backEnabled NOTIFY backEnabledChanged)
     Q_PROPERTY(bool forwardEnabled READ forwardEnabled NOTIFY forwardEnabledChanged)
     Q_PROPERTY(bool useFeed READ useFeed WRITE setUseFeed NOTIFY useFeedChanged)
-    Q_PROPERTY(QString metaverseServerUrl READ metaverseServerUrl)
+    Q_PROPERTY(QString metaverseServerUrl READ metaverseServerUrl CONSTANT)
 
 public:
     AddressBarDialog(QQuickItem* parent = nullptr);

--- a/interface/src/ui/DialogsManager.cpp
+++ b/interface/src/ui/DialogsManager.cpp
@@ -58,7 +58,7 @@ void DialogsManager::showAddressBar() {
         hmd->openTablet();
     }
     qApp->setKeyboardFocusOverlay(hmd->getCurrentTabletScreenID());
-    emit addressBarShown(true);
+    setAddressBarVisible(true);
 }
 
 void DialogsManager::hideAddressBar() {
@@ -71,7 +71,7 @@ void DialogsManager::hideAddressBar() {
         hmd->closeTablet();
     }
     qApp->setKeyboardFocusOverlay(UNKNOWN_OVERLAY_ID);
-    emit addressBarShown(false);
+    setAddressBarVisible(false);
 }
 
 void DialogsManager::showFeed() {
@@ -155,6 +155,24 @@ void DialogsManager::hmdToolsClosed() {
     if (_hmdToolsDialog) {
         _hmdToolsDialog->hide();
     }
+}
+
+void DialogsManager::toggleAddressBar() {
+    auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
+    auto tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
+
+    const bool addressBarLoaded = tablet->isPathLoaded(TABLET_ADDRESS_DIALOG);
+
+    if (_addressBarVisible || addressBarLoaded) {
+        hideAddressBar();
+    } else {
+        showAddressBar();
+    }
+}
+
+void DialogsManager::setAddressBarVisible(bool addressBarVisible) {
+    _addressBarVisible = addressBarVisible;
+    emit addressBarShown(_addressBarVisible);
 }
 
 void DialogsManager::showTestingResults() {

--- a/interface/src/ui/DialogsManager.h
+++ b/interface/src/ui/DialogsManager.h
@@ -39,6 +39,7 @@ public:
     QPointer<OctreeStatsDialog> getOctreeStatsDialog() const { return _octreeStatsDialog; }
     QPointer<TestingDialog> getTestingDialog() const { return _testingDialog; }
     void emitAddressBarShown(bool visible) { emit addressBarShown(visible); }
+    void setAddressBarVisible(bool addressBarVisible);
 
 public slots:
     void showAddressBar();
@@ -52,6 +53,7 @@ public slots:
     void hmdTools(bool showTools);
     void showDomainConnectionDialog();
     void showTestingResults();
+    void toggleAddressBar();
     
     // Application Update
     void showUpdateDialog();
@@ -78,7 +80,7 @@ private:
     QPointer<OctreeStatsDialog> _octreeStatsDialog;
     QPointer<TestingDialog> _testingDialog;
     QPointer<DomainConnectionDialog> _domainConnectionDialog;
-    bool _closeAddressBar { false };
+    bool _addressBarVisible { false };
 };
 
 #endif // hifi_DialogsManager_h

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -72,6 +72,13 @@ Web3DOverlay::Web3DOverlay() {
     connect(this, &Web3DOverlay::requestWebSurface, this, &Web3DOverlay::buildWebSurface);
     connect(this, &Web3DOverlay::releaseWebSurface, this, &Web3DOverlay::destroyWebSurface);
     connect(this, &Web3DOverlay::resizeWebSurface, this, &Web3DOverlay::onResizeWebSurface);
+
+    //need to be intialized before Tablet 1st open
+    _webSurface = DependencyManager::get<OffscreenQmlSurfaceCache>()->acquire(_url);
+    _webSurface->getSurfaceContext()->setContextProperty("HMD", DependencyManager::get<HMDScriptingInterface>().data());
+    _webSurface->getSurfaceContext()->setContextProperty("Account", GlobalServicesScriptingInterface::getInstance());
+    _webSurface->getSurfaceContext()->setContextProperty("AddressManager", DependencyManager::get<AddressManager>().data());
+
 }
 
 Web3DOverlay::Web3DOverlay(const Web3DOverlay* Web3DOverlay) :

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -76,7 +76,9 @@ Web3DOverlay::Web3DOverlay() {
     //need to be intialized before Tablet 1st open
     _webSurface = DependencyManager::get<OffscreenQmlSurfaceCache>()->acquire(_url);
     _webSurface->getSurfaceContext()->setContextProperty("HMD", DependencyManager::get<HMDScriptingInterface>().data());
-    _webSurface->getSurfaceContext()->setContextProperty("Account", GlobalServicesScriptingInterface::getInstance());
+    _webSurface->getSurfaceContext()->setContextProperty("Account", AccountServicesScriptingInterface::getInstance()); // DEPRECATED - TO BE REMOVED
+    _webSurface->getSurfaceContext()->setContextProperty("GlobalServices", AccountServicesScriptingInterface::getInstance()); // DEPRECATED - TO BE REMOVED
+    _webSurface->getSurfaceContext()->setContextProperty("AccountServices", AccountServicesScriptingInterface::getInstance());
     _webSurface->getSurfaceContext()->setContextProperty("AddressManager", DependencyManager::get<AddressManager>().data());
 
 }
@@ -199,11 +201,6 @@ void Web3DOverlay::setupQmlSurface() {
 
         _webSurface->getSurfaceContext()->setContextProperty("offscreenFlags", flags);
         _webSurface->getSurfaceContext()->setContextProperty("AddressManager", DependencyManager::get<AddressManager>().data());
-
-        _webSurface->getSurfaceContext()->setContextProperty("Account", AccountServicesScriptingInterface::getInstance()); // DEPRECATED - TO BE REMOVED
-        _webSurface->getSurfaceContext()->setContextProperty("GlobalServices", AccountServicesScriptingInterface::getInstance()); // DEPRECATED - TO BE REMOVED
-        _webSurface->getSurfaceContext()->setContextProperty("AccountServices", AccountServicesScriptingInterface::getInstance());
-
         // in Qt 5.10.0 there is already an "Audio" object in the QML context
         // though I failed to find it (from QtMultimedia??). So..  let it be "AudioScriptingInterface"
         _webSurface->getSurfaceContext()->setContextProperty("AudioScriptingInterface", DependencyManager::get<AudioScriptingInterface>().data());


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/9223/The-Enter-key-does-not-close-the-address-bar-in-hmd

Test plan:

Open address bar pressing enter
Move focus out of address input field by clicking on empty space within Tablet
Press enter. Tablet should close