### PR TITLE
Removal of hips offset shifting from AnimInverseKinematics node

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -3238,8 +3238,6 @@ bool MyAvatar::pinJoint(int index, const glm::vec3& position, const glm::quat& o
     slamPosition(position);
     setWorldOrientation(orientation);
 
-    _skeletonModel->getRig().setMaxHipsOffsetLength(0.05f);
-
     auto it = std::find(_pinnedJoints.begin(), _pinnedJoints.end(), index);
     if (it == _pinnedJoints.end()) {
         _pinnedJoints.push_back(index);
@@ -3259,12 +3257,6 @@ bool MyAvatar::clearPinOnJoint(int index) {
     auto it = std::find(_pinnedJoints.begin(), _pinnedJoints.end(), index);
     if (it != _pinnedJoints.end()) {
         _pinnedJoints.erase(it);
-
-        auto hipsIndex = getJointIndex("Hips");
-        if (index == hipsIndex) {
-            _skeletonModel->getRig().setMaxHipsOffsetLength(FLT_MAX);
-        }
-
         return true;
     }
     return false;

--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -43,8 +43,6 @@ static AnimPose computeHipsInSensorFrame(MyAvatar* myAvatar, bool isFlying) {
         AnimPose result = AnimPose(worldToSensorMat * avatarTransform.getMatrix() * Matrices::Y_180);
         result.scale() = glm::vec3(1.0f, 1.0f, 1.0f);
         return result;
-    } else {
-        DebugDraw::getInstance().removeMarker("pinnedHips");
     }
 
     glm::mat4 hipsMat = myAvatar->deriveBodyFromHMDSensor();

--- a/libraries/animation/src/AnimInverseKinematics.h
+++ b/libraries/animation/src/AnimInverseKinematics.h
@@ -57,8 +57,6 @@ public:
 
     void clearIKJointLimitHistory();
 
-    void setMaxHipsOffsetLength(float maxLength);
-
     float getMaxErrorOnLastSolve() { return _maxErrorOnLastSolve; }
 
     enum class SolutionSource {
@@ -92,7 +90,6 @@ protected:
     void blendToPoses(const AnimPoseVec& targetPoses, const AnimPoseVec& underPose, float blendFactor);
     void preconditionRelativePosesToAvoidLimbLock(const AnimContext& context, const std::vector<IKTarget>& targets);
     void setSecondaryTargets(const AnimContext& context);
-    AnimPose applyHipsOffset() const;
 
     // used to pre-compute information about each joint influeced by a spline IK target.
     struct SplineJointInfo {
@@ -111,7 +108,6 @@ protected:
     void clearConstraints();
     void initConstraints();
     void initLimitCenterPoses();
-    glm::vec3 computeHipsOffset(const std::vector<IKTarget>& targets, const AnimPoseVec& underPoses, float dt, glm::vec3 prevHipsOffset) const;
 
     // no copies
     AnimInverseKinematics(const AnimInverseKinematics&) = delete;
@@ -150,9 +146,6 @@ protected:
 
     mutable std::map<int, std::vector<SplineJointInfo>> _splineJointInfoMap;
 
-    // experimental data for moving hips during IK
-    glm::vec3 _hipsOffset { Vectors::ZERO };
-    float _maxHipsOffsetLength{ FLT_MAX };
     int _headIndex { -1 };
     int _hipsIndex { -1 };
     int _hipsParentIndex { -1 };

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -372,18 +372,6 @@ void Rig::clearIKJointLimitHistory() {
     }
 }
 
-void Rig::setMaxHipsOffsetLength(float maxLength) {
-    _maxHipsOffsetLength = maxLength;
-    auto ikNode = getAnimInverseKinematicsNode();
-    if (ikNode) {
-        ikNode->setMaxHipsOffsetLength(_maxHipsOffsetLength);
-    }
-}
-
-float Rig::getMaxHipsOffsetLength() const {
-    return _maxHipsOffsetLength;
-}
-
 float Rig::getIKErrorOnLastSolve() const {
     float result = 0.0f;
 

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -346,7 +346,6 @@ protected:
     bool _enabledAnimations { true };
 
     mutable uint32_t _jointNameWarningCount { 0 };
-    float _maxHipsOffsetLength { 1.0f };
 
     bool _enableDebugDrawIKTargets { false };
     bool _enableDebugDrawIKConstraints { false };


### PR DESCRIPTION
With the addition of the hips IK target, the hips offset shifting code is no longer necessary.
This PR should not effect any behavior, but it removes this unused code from the animation system.