### PR TITLE
Fix for rigidly bound mesh not being properly cauterized.

### DIFF
--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -238,9 +238,9 @@ void CauterizedModel::updateRenderItems() {
                     renderTransform = modelTransform;
                     if (clusterTransformsCauterized.size() == 1) {
 #if defined(SKIN_DQ)
-                        Transform transform(clusterTransforms[0].getRotation(),
-                                            clusterTransforms[0].getScale(),
-                                            clusterTransforms[0].getTranslation());
+                        Transform transform(clusterTransformsCauterized[0].getRotation(),
+                                            clusterTransformsCauterized[0].getScale(),
+                                            clusterTransformsCauterized[0].getTranslation());
                         renderTransform = modelTransform.worldTransform(Transform(transform));
 #else
                         renderTransform = modelTransform.worldTransform(Transform(clusterTransformsCauterized[0]));


### PR DESCRIPTION
For example, sometimes in first person view, you can see the back of your avatar's eyes or the brim of your avatar's hat.