### PR TITLE
Fix the issue with not re-enabling preview after it was auto-disabled by wallet/marketplace

### DIFF
--- a/scripts/system/commerce/wallet.js
+++ b/scripts/system/commerce/wallet.js
@@ -561,14 +561,9 @@
                 openLoginWindow();
                 break;
             case 'disableHmdPreview':
-                isHmdPreviewDisabled = Menu.isOptionChecked("Disable Preview");
-                DesktopPreviewProvider.setPreviewDisabledReason("SECURE_SCREEN");
-                Menu.setIsOptionChecked("Disable Preview", true);
-                break;
+                break; // do nothing here, handled in marketplaces.js
             case 'maybeEnableHmdPreview':
-                DesktopPreviewProvider.setPreviewDisabledReason("USER");
-                Menu.setIsOptionChecked("Disable Preview", isHmdPreviewDisabled);
-                break;
+                break; // do nothing here, handled in marketplaces.js
             case 'passphraseReset':
                 onButtonClicked();
                 onButtonClicked();
@@ -643,11 +638,7 @@
     //   -Called when the TabletScriptingInterface::screenChanged() signal is emitted. The "type" argument can be either the string
     //    value of "Home", "Web", "Menu", "QML", or "Closed". The "url" argument is only valid for Web and QML.
     function onTabletScreenChanged(type, url) {
-        var onWalletScreenNow = (type === "QML" && url === WALLET_QML_SOURCE);
-        if (!onWalletScreenNow && onWalletScreen) {
-            DesktopPreviewProvider.setPreviewDisabledReason("USER");
-        }
-        onWalletScreen = onWalletScreenNow;
+        onWalletScreen = (type === "QML" && url === WALLET_QML_SOURCE);
         wireEventBridge(onWalletScreen);
         // Change button to active when window is first openend, false otherwise.
         if (button) {

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -112,6 +112,8 @@ var selectionDisplay = null; // for gridTool.js to ignore
 
     var referrerURL; // Used for updating Purchases QML
     var filterText; // Used for updating Purchases QML
+
+    var onWalletScreen = false;
     function onScreenChanged(type, url) {
         onMarketplaceScreen = type === "Web" && url.indexOf(MARKETPLACE_URL) !== -1;
         var onWalletScreenNow = url.indexOf(MARKETPLACE_WALLET_QML_PATH) !== -1;


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/11844/Disable-Preview-enabled-some-time-after-unchecking-the-Display-Disable-Preview-option

*** Issue description *** 

The issue was caused by interference between wallet.js and marketplaces.js in handling of 'disableHmdPreview'/'maybeEnableHmdPreview' events. The fix is based on moving preview-related code form wallet to marketplaces, because marketplaces seems to be 'superset' of wallet in terms of event handling. It is 'wired' to event bridge in at least 3 cases:

onMarketplaceScreen
onWalletScreen
onCommerceScreen (edited)

*** Test plan *** 

Test case 1:

1. Enter VR with enabled preview
2. Enter wallet. Preview should disable, wallet-specific 'disabled preview' image should appear
3. Type correct password, press submit
4. Ensure preview got re-enabled
5. Disable preview
6. Ensure standard (not wallet-specific) 'disabled preview' image appeared

Test case 2:
1. Enter VR with enabled preview
2. Enter wallet (wallet-specific 'disabled preview' image should appear)
3. Return to 'home' 
4. Ensure preview got re-enabled
6. Ensure standard (not wallet-specific) 'disabled preview' image appeared

Test case 3:

1. Enter VR with enabled preview
2. Enter wallet (wallet-specific 'disabled preview' image should appear)
3. Enable preview
4. Disable preview 
5. Ensure wallet-specific 'disabled preview' image is still shown
