### PR TITLE
Fix a bug where hover events incorrectly propagate under popups

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -571,6 +571,7 @@ Rectangle {
             MouseArea {
                 anchors.fill: parent;
                 propagateComposedEvents: false;
+                hoverEnabled: true;
             }
 
             RalewayBold {

--- a/interface/resources/qml/hifi/commerce/common/CommerceLightbox.qml
+++ b/interface/resources/qml/hifi/commerce/common/CommerceLightbox.qml
@@ -45,6 +45,7 @@ Rectangle {
     MouseArea {
         anchors.fill: parent;
         propagateComposedEvents: false;
+        hoverEnabled: true;
     }
 
     Rectangle {

--- a/interface/resources/qml/hifi/commerce/common/FirstUseTutorial.qml
+++ b/interface/resources/qml/hifi/commerce/common/FirstUseTutorial.qml
@@ -44,6 +44,7 @@ Rectangle {
     MouseArea {
         anchors.fill: parent;
         propagateComposedEvents: false;
+        hoverEnabled: true;
     }
 
     Item {

--- a/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
+++ b/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
@@ -119,6 +119,7 @@ Rectangle {
     MouseArea {
         anchors.fill: parent;
         propagateComposedEvents: false;
+        hoverEnabled: true;
     }
 
     Image {

--- a/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
@@ -316,6 +316,7 @@ Item {
             MouseArea {
                 anchors.fill: parent;
                 propagateComposedEvents: false;
+                hoverEnabled: true;
             }
 
             RalewayBold {

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
@@ -66,6 +66,7 @@ Item {
     MouseArea {
         anchors.fill: parent;
         propagateComposedEvents: false;
+        hoverEnabled: true;
     }
     
     // This will cause a bug -- if you bring up passphrase selection in HUD mode while

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
@@ -34,6 +34,7 @@ Item {
     MouseArea {
         anchors.fill: parent;
         propagateComposedEvents: false;
+        hoverEnabled: true;
     }
 
     Connections {

--- a/interface/resources/qml/hifi/commerce/wallet/Security.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Security.qml
@@ -306,6 +306,7 @@ Item {
                 MouseArea {
                     anchors.fill: parent;
                     propagateComposedEvents: false;
+                    hoverEnabled: true;
                 }
 
                 RalewayBold {

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -394,6 +394,7 @@ Item {
         MouseArea {
             anchors.fill: parent;
             propagateComposedEvents: false;
+            hoverEnabled: true;
         }
 
         Image {

--- a/interface/resources/qml/hifi/commerce/wallet/sendMoney/SendMoney.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/sendMoney/SendMoney.qml
@@ -43,6 +43,7 @@ Item {
         width: parent.width;
         height: (root.shouldShowTopAndBottomOfWallet || root.shouldShowTopOfWallet) ? parent.height : parent.height - root.parentAppTitleBarHeight - root.parentAppNavBarHeight;
         propagateComposedEvents: false;
+        hoverEnabled: true;
     }
 
     Connections {
@@ -326,6 +327,7 @@ Item {
         MouseArea {
             anchors.fill: parent;
             propagateComposedEvents: false;
+            hoverEnabled: true;
         }
         
         ListModel {
@@ -477,6 +479,7 @@ Item {
                             enabled: connectionsList.currentIndex !== index;
                             anchors.fill: parent;
                             propagateComposedEvents: false;
+                            hoverEnabled: true;
                             onClicked: {
                                 connectionsList.currentIndex = index;
                             }
@@ -505,6 +508,7 @@ Item {
         MouseArea {
             anchors.fill: parent;
             propagateComposedEvents: false;
+            hoverEnabled: true;
         }
 
         Rectangle {
@@ -1059,6 +1063,7 @@ Item {
         MouseArea {
             anchors.fill: parent;
             propagateComposedEvents: false;
+            hoverEnabled: true;
         }
                 
         AnimatedImage {


### PR DESCRIPTION
When using Commerce features like the Wallet or Marketplace, UI elements that appear like popups appear. This PR prevents hover events from propagating to UI elements below those popups.