### PR TITLE
Fix scaling of avatar submeshes attached to joints

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1766,7 +1766,6 @@ void Rig::copyJointsFromJointData(const QVector<JointData>& jointDataVec) {
     const AnimPoseVec& relativeDefaultPoses = _animSkeleton->getRelativeDefaultPoses();
     for (int i = 0; i < numJoints; i++) {
         const JointData& data = jointDataVec.at(i);
-        _internalPoseSet._relativePoses[i].scale() = Vectors::ONE;
         _internalPoseSet._relativePoses[i].rot() = rotations[i];
         if (data.translationIsDefaultPose) {
             _internalPoseSet._relativePoses[i].trans() = relativeDefaultPoses[i].trans();


### PR DESCRIPTION
Meshes in an avatar FBX may be attached to avatar joints and have non-1,1,1 local scales.