### PR TITLE
fixing teleport module for sit script

### DIFF
--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -411,7 +411,7 @@ Script.include("/~/system/libraries/controllers.js");
         var data = parseJSON(props.userData);
         if (data !== undefined && data.seat !== undefined) {
             var avatarUuid = Uuid.fromString(data.seat.user);
-            if (Uuid.isNull(avatarUuid) || !AvatarList.getAvatar(avatarUuid)) {
+            if (Uuid.isNull(avatarUuid) || !AvatarList.getAvatar(avatarUuid).sessionUUID) {
                 return TARGET.SEAT;
             } else {
                 return TARGET.INVALID;


### PR DESCRIPTION
The teleport module does not check if the sit script user is a valid user. 

ticket - https://highfidelity.fogbugz.com/f/cases/11378/Chair-unusable-after-Switching-domains-crashing-and-re-entering-on-HMD