### PR TITLE
Remove OpenVR custom reprojection hack

### DIFF
--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -15,23 +15,6 @@
 
 const float TARGET_RATE_OpenVr = 90.0f;  // FIXME: get from sdk tracked device property? This number is vive-only.
 
-namespace gl {
-    class OffscreenContext;
-}
-class OpenVrSubmitThread;
-class OffscreenGLCanvas;
-static const size_t COMPOSITING_BUFFER_SIZE = 3;
-
-struct CompositeInfo {
-    using Queue = std::queue<CompositeInfo>;
-    using Array = std::array<CompositeInfo, COMPOSITING_BUFFER_SIZE>;
-    
-    gpu::TexturePointer texture;
-    uint32_t textureID { 0 };
-    glm::mat4 pose;
-    void* fence{ 0 };
-};
-
 class OpenVrDisplayPlugin : public HmdDisplayPlugin {
     using Parent = HmdDisplayPlugin;
 public:
@@ -44,10 +27,9 @@ public:
     void init() override;
 
     float getTargetFrameRate() const override;
-    bool hasAsyncReprojection() const override { return _asyncReprojectionActive; }
+    bool hasAsyncReprojection() const override { return true; }
 
     void customizeContext() override;
-    void uncustomizeContext() override;
 
     // Stereo specific methods
     void resetSensors() override;
@@ -58,9 +40,6 @@ public:
     void unsuppressKeyboard() override;
     bool isKeyboardVisible() override;
 
-    // Possibly needs an additional thread for VR submission
-    int getRequiredThreadCount() const override;
-
     QString getPreferredAudioInDevice() const override;
     QString getPreferredAudioOutDevice() const override;
 
@@ -69,7 +48,6 @@ protected:
     void internalDeactivate() override;
     void updatePresentPose() override;
 
-    void compositeLayers() override;
     void hmdPresent() override;
     bool isHmdMounted() const override;
     void postPreview() override;
@@ -79,16 +57,7 @@ private:
     std::atomic<vr::EDeviceActivityLevel> _hmdActivityLevel { vr::k_EDeviceActivityLevel_Unknown };
     std::atomic<uint32_t> _keyboardSupressionCount{ 0 };
     static const char* NAME;
-
     vr::HmdMatrix34_t _lastGoodHMDPose;
+    vr::Compositor_FrameTiming _frameTiming;
     mat4 _sensorResetMat;
-    bool _threadedSubmit { true };
-
-    CompositeInfo::Array _compositeInfos;
-    size_t _renderingIndex { 0 };
-    std::shared_ptr<OpenVrSubmitThread> _submitThread;
-    std::shared_ptr<gl::OffscreenContext> _submitCanvas;
-    friend class OpenVrSubmitThread;
-
-    bool _asyncReprojectionActive { false };
 };


### PR DESCRIPTION
Originally OpenVR didn't support async reprojection on all platforms, and so we developed our own custom threaded reprojection solution.  However, the OpenVR API and drivers have advanced to parity with the Oculus drivers and the reprojection system should no longer be needed.  Furthermore, the target framerate for the Vive HMD (or Oculus HMD through OpenVR) should be a 'live' representation of whether the reprojection flag is enabled for the most recent frame.  

## Testing

Run Interface with a Vive HMD on nVidia and AMD, both on i5 and I7.  Verify that there is no stuttering of the display or latency in head movement (subject to the limitations of the platform, i.e. no MORE stuttering than would exist on the same hardware on master)