### PR TITLE
Added option to select snapshot filename in scripts.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6934,10 +6934,10 @@ void Application::loadAvatarBrowser() const {
     DependencyManager::get<HMDScriptingInterface>()->openTablet();
 }
 
-void Application::takeSnapshot(bool notify, bool includeAnimated, float aspectRatio) {
-    postLambdaEvent([notify, includeAnimated, aspectRatio, this] {
+void Application::takeSnapshot(bool notify, bool includeAnimated, float aspectRatio, const QString& filename) {
+    postLambdaEvent([notify, includeAnimated, aspectRatio, filename, this] {
         // Get a screenshot and save it
-        QString path = Snapshot::saveSnapshot(getActiveDisplayPlugin()->getScreenshot(aspectRatio));
+        QString path = Snapshot::saveSnapshot(getActiveDisplayPlugin()->getScreenshot(aspectRatio), filename);
         // If we're not doing an animated snapshot as well...
         if (!includeAnimated) {
             // Tell the dependency manager that the capture of the still snapshot has taken place.
@@ -6949,9 +6949,9 @@ void Application::takeSnapshot(bool notify, bool includeAnimated, float aspectRa
     });
 }
 
-void Application::takeSecondaryCameraSnapshot() {
-    postLambdaEvent([this] {
-        QString snapshotPath = Snapshot::saveSnapshot(getActiveDisplayPlugin()->getSecondaryCameraScreenshot());
+void Application::takeSecondaryCameraSnapshot(const QString& filename) {
+    postLambdaEvent([filename, this] {
+        QString snapshotPath = Snapshot::saveSnapshot(getActiveDisplayPlugin()->getSecondaryCameraScreenshot(), filename);
         emit DependencyManager::get<WindowScriptingInterface>()->stillSnapshotTaken(snapshotPath, true);
     });
 }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -266,8 +266,10 @@ public:
 
     float getGameLoopRate() const { return _gameLoopCounter.rate(); }
 
-    void takeSnapshot(bool notify, bool includeAnimated = false, float aspectRatio = 0.0f);
-    void takeSecondaryCameraSnapshot();
+    // Note that takeSnapshot has a default value, as this method is used internally.
+    void takeSnapshot(bool notify, bool includeAnimated = false, float aspectRatio = 0.0f, const QString& filename = "");
+    void takeSecondaryCameraSnapshot(const QString& filename);
+
     void shareSnapshot(const QString& filename, const QUrl& href = QUrl(""));
 
     graphics::SkyboxPointer getDefaultSkybox() const { return _defaultSkybox; }

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -430,12 +430,12 @@ bool WindowScriptingInterface::setDisplayTexture(const QString& name) {
     return  qApp->getActiveDisplayPlugin()->setDisplayTexture(name);   // Plugins that don't know how, answer false.
 }
 
-void WindowScriptingInterface::takeSnapshot(bool notify, bool includeAnimated, float aspectRatio) {
-    qApp->takeSnapshot(notify, includeAnimated, aspectRatio);
+void WindowScriptingInterface::takeSnapshot(bool notify, bool includeAnimated, float aspectRatio, const QString& filename) {
+    qApp->takeSnapshot(notify, includeAnimated, aspectRatio, filename);
 }
 
-void WindowScriptingInterface::takeSecondaryCameraSnapshot() {
-    qApp->takeSecondaryCameraSnapshot();
+void WindowScriptingInterface::takeSecondaryCameraSnapshot(const QString& filename) {
+    qApp->takeSecondaryCameraSnapshot(filename);
 }
 
 void WindowScriptingInterface::shareSnapshot(const QString& path, const QUrl& href) {

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -357,13 +357,13 @@ public slots:
      * var aspect = 1920 / 1080;
      * Window.takeSnapshot(notify, animated, aspect);
      */
-    void takeSnapshot(bool notify = true, bool includeAnimated = false, float aspectRatio = 0.0f);
+    void takeSnapshot(bool notify = true, bool includeAnimated = false, float aspectRatio = 0.0f, const QString& filename = "");
 
     /**jsdoc
      * Takes a still snapshot of the current view from the secondary camera that can be set up through the {@link Render} API.
      * @function Window.takeSecondaryCameraSnapshot
      */
-    void takeSecondaryCameraSnapshot();
+    void takeSecondaryCameraSnapshot(const QString& filename = "");
 
     /**jsdoc
      * Emit a {@link Window.connectionAdded|connectionAdded} or a {@link Window.connectionError|connectionError} signal that

--- a/interface/src/ui/Snapshot.cpp
+++ b/interface/src/ui/Snapshot.cpp
@@ -73,9 +73,9 @@ SnapshotMetaData* Snapshot::parseSnapshotData(QString snapshotPath) {
     return data;
 }
 
-QString Snapshot::saveSnapshot(QImage image) {
+QString Snapshot::saveSnapshot(QImage image, const QString& filename) {
 
-    QFile* snapshotFile = savedFileForSnapshot(image, false);
+    QFile* snapshotFile = savedFileForSnapshot(image, false, filename);
 
     // we don't need the snapshot file, so close it, grab its filename and delete it
     snapshotFile->close();
@@ -92,7 +92,7 @@ QTemporaryFile* Snapshot::saveTempSnapshot(QImage image) {
     return static_cast<QTemporaryFile*>(savedFileForSnapshot(image, true));
 }
 
-QFile* Snapshot::savedFileForSnapshot(QImage & shot, bool isTemporary) {
+QFile* Snapshot::savedFileForSnapshot(QImage & shot, bool isTemporary, const QString& userSelectedFilename) {
 
     // adding URL to snapshot
     QUrl currentURL = DependencyManager::get<AddressManager>()->currentShareableAddress();
@@ -104,7 +104,15 @@ QFile* Snapshot::savedFileForSnapshot(QImage & shot, bool isTemporary) {
 
     QDateTime now = QDateTime::currentDateTime();
 
-    QString filename = FILENAME_PATH_FORMAT.arg(username, now.toString(DATETIME_FORMAT));
+    // If user has requested specific filename then use it, else create the filename
+	// 'jpg" is appended, as the image is saved in jpg format.  This is the case for all snapshots
+	//       (see definition of FILENAME_PATH_FORMAT)
+    QString filename;
+    if (userSelectedFilename != "") {
+        filename = userSelectedFilename + ".jpg";
+    } else {
+        filename = FILENAME_PATH_FORMAT.arg(username, now.toString(DATETIME_FORMAT));
+    }
 
     const int IMAGE_QUALITY = 100;
 

--- a/interface/src/ui/Snapshot.h
+++ b/interface/src/ui/Snapshot.h
@@ -37,7 +37,7 @@ class Snapshot : public QObject, public Dependency {
     Q_OBJECT
     SINGLETON_DEPENDENCY
 public:
-    static QString saveSnapshot(QImage image);
+    static QString saveSnapshot(QImage image, const QString& filename);
     static QTemporaryFile* saveTempSnapshot(QImage image);
     static SnapshotMetaData* parseSnapshotData(QString snapshotPath);
 
@@ -51,7 +51,7 @@ public slots:
     Q_INVOKABLE QString getSnapshotsLocation();
     Q_INVOKABLE void setSnapshotsLocation(const QString& location);
 private:
-    static QFile* savedFileForSnapshot(QImage & image, bool isTemporary);
+    static QFile* savedFileForSnapshot(QImage & image, bool isTemporary, const QString& userSelectedFilename = "");
 };
 
 #endif // hifi_Snapshot_h


### PR DESCRIPTION
# Description
The Window,takeSnapshot() and Window.takeSecondarySnapshot() scripting commands now accept an optional filename.  If this filename is present then the snapshot will be saved as `<filename>.jpg`.
# Tests
Work In Progress
# User Documentation
Work In Progress
