### PR TITLE
Restore FPS threshold for increasing LOD after it decreased in heavy scenes

### DIFF
--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -168,7 +168,7 @@ float LODManager::getDesktopLODDecreaseFPS() const {
 }
 
 float LODManager::getDesktopLODIncreaseFPS() const {
-    return glm::max(((float)MSECS_PER_SECOND / _desktopMaxRenderTime) + INCREASE_LOD_GAP_FPS, MAX_LIKELY_DESKTOP_FPS);
+    return glm::min(((float)MSECS_PER_SECOND / _desktopMaxRenderTime) + INCREASE_LOD_GAP_FPS, MAX_LIKELY_DESKTOP_FPS);
 }
 
 void LODManager::setHMDLODDecreaseFPS(float fps) {
@@ -184,7 +184,7 @@ float LODManager::getHMDLODDecreaseFPS() const {
 }
 
 float LODManager::getHMDLODIncreaseFPS() const {
-    return glm::max(((float)MSECS_PER_SECOND / _hmdMaxRenderTime) + INCREASE_LOD_GAP_FPS, MAX_LIKELY_HMD_FPS);
+    return glm::min(((float)MSECS_PER_SECOND / _hmdMaxRenderTime) + INCREASE_LOD_GAP_FPS, MAX_LIKELY_HMD_FPS);
 }
 
 QString LODManager::getLODFeedbackText() {

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -25,7 +25,7 @@ const float DEFAULT_DESKTOP_MAX_RENDER_TIME = (float)MSECS_PER_SECOND / DEFAULT_
 const float DEFAULT_HMD_MAX_RENDER_TIME = (float)MSECS_PER_SECOND / DEFAULT_HMD_LOD_DOWN_FPS; // msec
 const float MAX_LIKELY_DESKTOP_FPS = 59.0f; // this is essentially, V-synch - 1 fps
 const float MAX_LIKELY_HMD_FPS = 74.0f; // this is essentially, V-synch - 1 fps
-const float INCREASE_LOD_GAP_FPS = 15.0f; // fps
+const float INCREASE_LOD_GAP_FPS = 10.0f; // fps
 
 // The default value DEFAULT_OCTREE_SIZE_SCALE means you can be 400 meters away from a 1 meter object in order to see it (which is ~20:20 vision).
 const float ADJUST_LOD_MAX_SIZE_SCALE = DEFAULT_OCTREE_SIZE_SCALE;


### PR DESCRIPTION
Fixing the get***LODIncreaseFPS functions evaluation of the threshold FPS for starting increasing LOD again

## TEST PLAN ##
In an heavy scene, once LOD has decreased to the minimum, it should increase again as soon as the fps reach 10HZ above the minimum FPS picked from 
THe behavior of the LOD manager can be monitored using the app "LOD.js" located in scripts/developer/utilities/render