### PR TITLE
Don't trigger a backtrace exception on quitting while in HMD

### DIFF
--- a/interface/src/Application_render.cpp
+++ b/interface/src/Application_render.cpp
@@ -55,7 +55,7 @@ void Application::paintGL() {
         // If a display plugin loses it's underlying support, it
         // needs to be able to signal us to not use it
         if (!displayPlugin->beginFrameRender(_renderFrameCount)) {
-            updateDisplayMode();
+            QMetaObject::invokeMethod(this, "updateDisplayMode");
             return;
         }
     }


### PR DESCRIPTION
A frequent crash from backtrace appears to derive from `Application::updateDisplayMode` being called from `Application::paintGL`.  This happens when the `DisplayPlugin::beginFrameRender` call returns false.  This code was originally written when `paintGL` was called from the main thread.  Now that rendering has been moved to it's own thread, the rare case of `beginFrameRender` returning false now triggers an exception because `updateDisplayMode` is _only_ allowed to be called from the main thread.

As far as I can discover, `beginFrameRender` only returns false in one situation: when the HMD display plugin (OpenVR or Oculus) detects that a quit has been requested by the VR API.  

## Testing

With the master build, if you run Interface and are using Vive or Oculus, and then close the application _though the VR runtime_ (i.e. SteamVR overlay or Oculus home) then it will likely trigger a crash and a new backtrace entry.  This build should not trigger a crash on such an exit.  

