### PR TITLE
Fix for deadlock triggering while loading QML engine

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2404,7 +2404,9 @@ void Application::initializeUi() {
         tabletScriptingInterface->getTablet(SYSTEM_TABLET);
     }
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    DeadlockWatchdogThread::pause();
     offscreenUi->create();
+    DeadlockWatchdogThread::resume();
 
     auto surfaceContext = offscreenUi->getSurfaceContext();
 


### PR DESCRIPTION
A number of traces of dumps from [deadlock related crashes](https://highfidelity.sp.backtrace.io/dashboard/highfidelity/project/Interface/group/b22555e405e2817d262404287d604c50cadca20ad7080ac4cdf55dd92c9c2727) appear to be deep inside the QML/QWebEngine code and occur because of a long delay in loading of the user's fonts. 

This PR suspends the deadlock thread during the initial QML desktop load, which should be the only time the font database is populated like this.  

## Testing

Dunno, install a ridiculous number of fonts on an i5 machine and see if it crashes on load in master, then doesn't crash in this build?


