### PR TITLE
Prevent deadlock crashes when building shaders at startup

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -318,7 +318,7 @@ static QTimer pingTimer;
 static bool DISABLE_WATCHDOG = true;
 #else
 static const QString DISABLE_WATCHDOG_FLAG{ "HIFI_DISABLE_WATCHDOG" };
-static bool DISABLE_WATCHDOG = QProcessEnvironment::systemEnvironment().contains(DISABLE_WATCHDOG_FLAG);
+static bool DISABLE_WATCHDOG = nsightActive() || QProcessEnvironment::systemEnvironment().contains(DISABLE_WATCHDOG_FLAG);
 #endif
 
 #if defined(USE_GLES)
@@ -415,20 +415,26 @@ public:
         *crashTrigger = 0xDEAD10CC;
     }
 
+    static void withPause(const std::function<void()>& lambda) {
+        pause();
+        lambda();
+        resume();
+    }
     static void pause() {
         _paused = true;
     }
 
     static void resume() {
-        _paused = false;
+        // Update the heartbeat BEFORE resuming the checks
         updateHeartbeat();
+        _paused = false;
     }
 
     void run() override {
         while (!_quit) {
             QThread::sleep(HEARTBEAT_UPDATE_INTERVAL_SECS);
             // Don't do heartbeat detection under nsight
-            if (nsightActive() || _paused) {
+            if (_paused) {
                 continue;
             }
             uint64_t lastHeartbeat = _heartbeat; // sample atomic _heartbeat, because we could context switch away and have it updated on us
@@ -2283,29 +2289,22 @@ void Application::initializeGL() {
     initDisplay();
     qCDebug(interfaceapp, "Initialized Display.");
 
-#ifdef Q_OS_OSX
-    // FIXME: on mac os the shaders take up to 1 minute to compile, so we pause the deadlock watchdog thread.
-    DeadlockWatchdogThread::pause();
-#endif
-
-    // Set up the render engine
-    render::CullFunctor cullFunctor = LODManager::shouldRender;
-    static const QString RENDER_FORWARD = "HIFI_RENDER_FORWARD";
-    _renderEngine->addJob<UpdateSceneTask>("UpdateScene");
+    // FIXME: on low end systems os the shaders take up to 1 minute to compile, so we pause the deadlock watchdog thread.
+    DeadlockWatchdogThread::withPause([&] {
+        // Set up the render engine
+        render::CullFunctor cullFunctor = LODManager::shouldRender;
+        static const QString RENDER_FORWARD = "HIFI_RENDER_FORWARD";
+        _renderEngine->addJob<UpdateSceneTask>("UpdateScene");
 #ifndef Q_OS_ANDROID
-    _renderEngine->addJob<SecondaryCameraRenderTask>("SecondaryCameraJob", cullFunctor, !DISABLE_DEFERRED);
+        _renderEngine->addJob<SecondaryCameraRenderTask>("SecondaryCameraJob", cullFunctor, !DISABLE_DEFERRED);
 #endif
-    _renderEngine->addJob<RenderViewTask>("RenderMainView", cullFunctor, !DISABLE_DEFERRED, render::ItemKey::TAG_BITS_0, render::ItemKey::TAG_BITS_0);
+        _renderEngine->addJob<RenderViewTask>("RenderMainView", cullFunctor, !DISABLE_DEFERRED, render::ItemKey::TAG_BITS_0, render::ItemKey::TAG_BITS_0);
+        _renderEngine->load();
+        _renderEngine->registerScene(_main3DScene);
 
-    _renderEngine->load();
-    _renderEngine->registerScene(_main3DScene);
-
-    // Now that OpenGL is initialized, we are sure we have a valid context and can create the various pipeline shaders with success.
-    DependencyManager::get<GeometryCache>()->initializeShapePipelines();
-
-#ifdef Q_OS_OSX
-    DeadlockWatchdogThread::resume();
-#endif
+        // Now that OpenGL is initialized, we are sure we have a valid context and can create the various pipeline shaders with success.
+        DependencyManager::get<GeometryCache>()->initializeShapePipelines();
+    });
 
     _offscreenContext = new OffscreenGLCanvas();
     _offscreenContext->setObjectName("MainThreadContext");


### PR DESCRIPTION
Examining the deadlocks on backtrace shows a number of deadlock crashes at application startup while deep inside the GPU driver.  We already have logic that disables the deadlock code during shader compilation on OSX, but it appears based on the evidence that we need this on Windows as well.  

## Testing

This should not change application behavior other than to remove the crash, which would likely occur on a lower end machine under high load during Interface startup.  I can't think of any simple way to force this situation or crash, so a simple test of application startup and basic rendering should suffice.  