### PR TITLE
[Case 4315] Fixes ColorPicker Color Preview functionality

### DIFF
--- a/scripts/system/html/css/colpick.css
+++ b/scripts/system/html/css/colpick.css
@@ -279,7 +279,7 @@ colpick Color Picker / colpick.com
 }
 
 /*full layout with no submit button*/
-.colpick_full_ns  .colpick_submit, .colpick_full_ns .colpick_current_color{
+.colpick_full_ns  .colpick_submit {
 	display:none;
 }
 .colpick_full_ns .colpick_new_color {
@@ -320,11 +320,11 @@ colpick Color Picker / colpick.com
 }
 
 /*rgbhex layout, no submit button*/
-.colpick_rgbhex_ns  .colpick_submit, .colpick_rgbhex_ns .colpick_current_color{
+.colpick_rgbhex_ns  .colpick_submit {
 	display:none;
 }
 .colpick_rgbhex_ns .colpick_new_color{
-	width:68px;
+	width:34px;
 	border: 1px solid #8f8f8f;
 }
 .colpick_rgbhex_ns .colpick_rgb_r {
@@ -379,7 +379,7 @@ colpick Color Picker / colpick.com
 }
 
 /*hex layout, no submit button*/
-.colpick_hex_ns  .colpick_submit, .colpick_hex_ns .colpick_current_color {
+.colpick_hex_ns  .colpick_submit {
 	display:none;
 }
 .colpick_hex_ns .colpick_hex_field {

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -170,7 +170,7 @@ For usage and examples: colpick.com/plugin
                 $(document).on('mouseup touchend',current,upHue);
                 $(document).on('mousemove touchmove',current,moveHue);
                 
-                var pageY = ((ev.type == 'touchstart') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
+                var pageY = ((ev.type === 'touchstart') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
                     current.cal.data('colpick')
                         .fields.eq(4).val(parseInt(360 * (current.cal.data('colpick').height -
@@ -181,7 +181,7 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             moveHue = function (ev) {
-                var pageY = ((ev.type == 'touchmove') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
+                var pageY = ((ev.type === 'touchmove') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
                     ev.data.cal.data('colpick')
                         .fields.eq(4).val(parseInt(360 * (ev.data.cal.data('colpick').height -
@@ -212,7 +212,7 @@ For usage and examples: colpick.com/plugin
                 $(document).on('mousemove touchmove',current,moveSelector);
 
                 var pageX,pageY;
-                if (ev.type == 'touchstart') {
+                if (ev.type === 'touchstart') {
                     pageX = ev.originalEvent.changedTouches[0].pageX,
                     pageY = ev.originalEvent.changedTouches[0].pageY;
                 } else {
@@ -232,7 +232,7 @@ For usage and examples: colpick.com/plugin
             },
             moveSelector = function (ev) {
                 var pageX,pageY;
-                if (ev.type == 'touchmove') {
+                if (ev.type === 'touchmove') {
                     pageX = ev.originalEvent.changedTouches[0].pageX,
                     pageY = ev.originalEvent.changedTouches[0].pageY;
                 } else {
@@ -282,7 +282,7 @@ For usage and examples: colpick.com/plugin
                     left -= calW;
                 }
                 cal.css({left: left + 'px', top: top + 'px'});
-                if (cal.data('colpick').onShow.apply(this, [cal.get(0)]) != false) {
+                if (cal.data('colpick').onShow.apply(this, [cal.get(0)]) !== false) {
                     cal.show();
                 }
                 // Hide when user clicks outside
@@ -292,13 +292,13 @@ For usage and examples: colpick.com/plugin
                 });
             },
             hide = function (ev) {
-                if (ev.data.cal.data('colpick').onHide.apply(this, [ev.data.cal.get(0)]) != false) {
+                if (ev.data.cal.data('colpick').onHide.apply(this, [ev.data.cal.get(0)]) !== false) {
                     ev.data.cal.hide();
                 }
                 $('html').off('mousedown', hide);
             },
             getViewport = function () {
-                var m = document.compatMode == 'CSS1Compat';
+                var m = document.compatMode === 'CSS1Compat';
                 return {
                     l : window.pageXOffset || (m ? document.documentElement.scrollLeft : document.body.scrollLeft),
                     w : window.innerWidth || (m ? document.documentElement.clientWidth : document.body.clientWidth)
@@ -351,9 +351,9 @@ For usage and examples: colpick.com/plugin
                 // Set color
                 if (typeof opt.color === 'string') {
                     opt.color = hexToHsb(opt.color);
-                } else if (opt.color.r != undefined && opt.color.g != undefined && opt.color.b != undefined) {
+                } else if (opt.color.r !== undefined && opt.color.g !== undefined && opt.color.b !== undefined) {
                     opt.color = rgbToHsb(opt.color);
-                } else if (opt.color.h != undefined && opt.color.s != undefined && opt.color.b != undefined) {
+                } else if (opt.color.h !== undefined && opt.color.s !== undefined && opt.color.b !== undefined) {
                     opt.color = fixHSB(opt.color);
                 } else {
                     return this;
@@ -373,7 +373,7 @@ For usage and examples: colpick.com/plugin
                         // Add class according to layout
                         cal.addClass('colpick_'+options.layout+(options.submit?'':' colpick_'+options.layout+'_ns'));
                         // Add class if the color scheme is not default
-                        if (options.colorScheme != 'light') {
+                        if (options.colorScheme !== 'light') {
                             cal.addClass('colpick_'+options.colorScheme);
                         }
                         // Setup submit button
@@ -466,9 +466,9 @@ For usage and examples: colpick.com/plugin
                 setCurrent = (typeof setCurrent === "undefined") ? 1 : setCurrent;
                 if (typeof col === 'string') {
                     col = hexToHsb(col);
-                } else if (col.r != undefined && col.g != undefined && col.b != undefined) {
+                } else if (col.r !== undefined && col.g !== undefined && col.b !== undefined) {
                     col = rgbToHsb(col);
-                } else if (col.h != undefined && col.s != undefined && col.b != undefined) {
+                } else if (col.h !== undefined && col.s !== undefined && col.b !== undefined) {
                     col = fixHSB(col);
                 } else {
                     return this;

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -519,11 +519,11 @@ For usage and examples: colpick.com/plugin
         var max = Math.max(rgb.r, rgb.g, rgb.b);
         var delta = max - min;
         hsb.b = max;
-        hsb.s = max != 0 ? 255 * delta / max : 0;
-        if (hsb.s != 0) {
-            if (rgb.r == max) {
+        hsb.s = max != 0 ? 255 * delta / max : 0; // eslint-disable-line eqeqeq
+        if (hsb.s != 0) { // eslint-disable-line eqeqeq
+            if (rgb.r == max) { // eslint-disable-line eqeqeq
                 hsb.h = (rgb.g - rgb.b) / delta;
-            } else if (rgb.g == max) {
+            } else if (rgb.g == max) { // eslint-disable-line eqeqeq
                 hsb.h = 2 + (rgb.b - rgb.r) / delta;
             } else {
                 hsb.h = 4 + (rgb.r - rgb.g) / delta;
@@ -544,13 +544,13 @@ For usage and examples: colpick.com/plugin
         var h = hsb.h;
         var s = hsb.s*255/100;
         var v = hsb.b*255/100;
-        if (s == 0) {
+        if (s == 0) { // eslint-disable-line eqeqeq
             rgb.r = rgb.g = rgb.b = v;
         } else {
             var t1 = v;
             var t2 = (255-s)*v/255;
             var t3 = (t1-t2)*(h%60)/60;
-            if (h==360) {
+            if (h==360) { // eslint-disable-line eqeqeq
                 h = 0;
             }
             if (h<60) {
@@ -578,7 +578,7 @@ For usage and examples: colpick.com/plugin
             rgb.b.toString(16)
         ];
         $.each(hex, function (nr, val) {
-            if (val.length == 1) {
+            if (val.length == 1) { // eslint-disable-line eqeqeq
                 hex[nr] = '0' + val;
             }
         });

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -6,6 +6,8 @@ under the MIT and GPL licenses
 For usage and examples: colpick.com/plugin
  */
 
+/* global console, document, Element, EventBridge, jQuery, navigator, window, _ $ */
+
 (function ($) {
     var colpick = function () {
         var

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -25,15 +25,15 @@ For usage and examples: colpick.com/plugin
                 submitText: 'OK',
                 height: 156
             },
-            //Fill the inputs of the plugin
-            fillRGBFields = function  (hsb, cal) {
+            // Fill the inputs of the plugin
+            fillRGBFields = function (hsb, cal) {
                 var rgb = hsbToRgb(hsb);
                 $(cal).data('colpick').fields
                     .eq(1).val(rgb.r).end()
                     .eq(2).val(rgb.g).end()
                     .eq(3).val(rgb.b).end();
             },
-            fillHSBFields = function  (hsb, cal) {
+            fillHSBFields = function (hsb, cal) {
                 $(cal).data('colpick').fields
                     .eq(4).val(Math.round(hsb.h)).end()
                     .eq(5).val(Math.round(hsb.s)).end()
@@ -42,7 +42,7 @@ For usage and examples: colpick.com/plugin
             fillHexFields = function (hsb, cal) {
                 $(cal).data('colpick').fields.eq(0).val(hsbToHex(hsb));
             },
-            //Set the round selector position
+            // Set the round selector position
             setSelector = function (hsb, cal) {
                 $(cal).data('colpick').selector.css('backgroundColor', '#' + hsbToHex({h: hsb.h, s: 100, b: 100}));
                 $(cal).data('colpick').selectorIndic.css({
@@ -50,18 +50,18 @@ For usage and examples: colpick.com/plugin
                     top: parseInt($(cal).data('colpick').height * (100-hsb.b)/100, 10)
                 });
             },
-            //Set the hue selector position
+            // Set the hue selector position
             setHue = function (hsb, cal) {
                 $(cal).data('colpick').hue.css('top', parseInt($(cal).data('colpick').height - $(cal).data('colpick').height * hsb.h/360, 10));
             },
-            //Set current and new colors
+            // Set current and new colors
             setCurrentColor = function (hsb, cal) {
                 $(cal).data('colpick').currentColor.css('backgroundColor', '#' + hsbToHex(hsb));
             },
             setNewColor = function (hsb, cal) {
                 $(cal).data('colpick').newColor.css('backgroundColor', '#' + hsbToHex(hsb));
             },
-            //Called when the new color is changed
+            // Called when the new color is changed
             change = function (ev) {
                 var cal = $(this).parent().parent(), col;
                 if (this.parentNode.className.indexOf('_hex') > 0) {
@@ -93,7 +93,7 @@ For usage and examples: colpick.com/plugin
                 setNewColor(col, cal.get(0));
                 cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el, 0]);
             },
-            //Change style on blur and on focus of inputs
+            // Change style on blur and on focus of inputs
             blur = function (ev) {
                 $(this).parent().removeClass('colpick_focus');
             },
@@ -101,7 +101,7 @@ For usage and examples: colpick.com/plugin
                 $(this).parent().parent().data('colpick').fields.parent().removeClass('colpick_focus');
                 $(this).parent().addClass('colpick_focus');
             },
-            //Increment/decrement arrows functions
+            // Increment/decrement arrows functions
             downIncrement = function (ev) {
                 ev.preventDefault ? ev.preventDefault() : ev.returnValue = false;
                 var field = $(this).parent().find('input').focus();
@@ -130,7 +130,7 @@ For usage and examples: colpick.com/plugin
                 $(document).off('mousemove', moveIncrement);
                 return false;
             },
-            //Hue slider functions
+            // Hue slider functions
             downHue = function (ev) {
                 ev.preventDefault ? ev.preventDefault() : ev.returnValue = false;
                 var current = {
@@ -143,7 +143,7 @@ For usage and examples: colpick.com/plugin
                 var pageY = ((ev.type == 'touchstart') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
                     current.cal.data('colpick')
-                    .fields.eq(4).val(parseInt(360*(current.cal.data('colpick').height - (pageY - current.y))/current.cal.data('colpick').height, 10))
+                        .fields.eq(4).val(parseInt(360*(current.cal.data('colpick').height - (pageY - current.y))/current.cal.data('colpick').height, 10))
                         .get(0),
                     [current.cal.data('colpick').livePreview]
                 );
@@ -153,7 +153,7 @@ For usage and examples: colpick.com/plugin
                 var pageY = ((ev.type == 'touchmove') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
                     ev.data.cal.data('colpick')
-                    .fields.eq(4).val(parseInt(360*(ev.data.cal.data('colpick').height - Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageY - ev.data.y))))/ev.data.cal.data('colpick').height, 10))
+                        .fields.eq(4).val(parseInt(360*(ev.data.cal.data('colpick').height - Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageY - ev.data.y))))/ev.data.cal.data('colpick').height, 10))
                         .get(0),
                     [ev.data.preview]
                 );
@@ -166,7 +166,7 @@ For usage and examples: colpick.com/plugin
                 $(document).off('mousemove touchmove',moveHue);
                 return false;
             },
-            //Color selector functions
+            // Color selector functions
             downSelector = function (ev) {
                 ev.preventDefault ? ev.preventDefault() : ev.returnValue = false;
                 var current = {
@@ -179,7 +179,7 @@ For usage and examples: colpick.com/plugin
                 $(document).on('mousemove touchmove',current,moveSelector);
 
                 var payeX,pageY;
-                if(ev.type == 'touchstart') {
+                if (ev.type == 'touchstart') {
                     pageX = ev.originalEvent.changedTouches[0].pageX,
                     pageY = ev.originalEvent.changedTouches[0].pageY;
                 } else {
@@ -189,16 +189,16 @@ For usage and examples: colpick.com/plugin
 
                 change.apply(
                     current.cal.data('colpick').fields
-                    .eq(6).val(parseInt(100*(current.cal.data('colpick').height - (pageY - current.pos.top))/current.cal.data('colpick').height, 10)).end()
-                    .eq(5).val(parseInt(100*(pageX - current.pos.left)/current.cal.data('colpick').height, 10))
-                    .get(0),
+                        .eq(6).val(parseInt(100*(current.cal.data('colpick').height - (pageY - current.pos.top))/current.cal.data('colpick').height, 10)).end()
+                        .eq(5).val(parseInt(100*(pageX - current.pos.left)/current.cal.data('colpick').height, 10))
+                        .get(0),
                     [current.preview]
                 );
                 return false;
             },
             moveSelector = function (ev) {
                 var payeX,pageY;
-                if(ev.type == 'touchmove') {
+                if (ev.type == 'touchmove') {
                     pageX = ev.originalEvent.changedTouches[0].pageX,
                     pageY = ev.originalEvent.changedTouches[0].pageY;
                 } else {
@@ -208,9 +208,9 @@ For usage and examples: colpick.com/plugin
 
                 change.apply(
                     ev.data.cal.data('colpick').fields
-                    .eq(6).val(parseInt(100*(ev.data.cal.data('colpick').height - Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageY - ev.data.pos.top))))/ev.data.cal.data('colpick').height, 10)).end()
-                    .eq(5).val(parseInt(100*(Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageX - ev.data.pos.left))))/ev.data.cal.data('colpick').height, 10))
-                    .get(0),
+                        .eq(6).val(parseInt(100*(ev.data.cal.data('colpick').height - Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageY - ev.data.pos.top))))/ev.data.cal.data('colpick').height, 10)).end()
+                        .eq(5).val(parseInt(100*(Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageX - ev.data.pos.left))))/ev.data.cal.data('colpick').height, 10))
+                        .get(0),
                     [ev.data.preview]
                 );
                 return false;
@@ -222,7 +222,7 @@ For usage and examples: colpick.com/plugin
                 $(document).off('mousemove touchmove',moveSelector);
                 return false;
             },
-            //Submit button
+            // Submit button
             clickSubmit = function (ev) {
                 var cal = $(this).parent();
                 var col = cal.data('colpick').color;
@@ -230,7 +230,7 @@ For usage and examples: colpick.com/plugin
                 setCurrentColor(col, cal.get(0));
                 cal.data('colpick').onSubmit(col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el);
             },
-            //Show/hide the color picker
+            // Show/hide the color picker
             show = function (ev) {
                 // Prevent the trigger of any direct parent
                 ev.stopPropagation();
@@ -248,9 +248,11 @@ For usage and examples: colpick.com/plugin
                 if (cal.data('colpick').onShow.apply(this, [cal.get(0)]) != false) {
                     cal.show();
                 }
-                //Hide when user clicks outside
+                // Hide when user clicks outside
                 $('html').mousedown({cal:cal}, hide);
-                cal.mousedown(function(ev){ev.stopPropagation();})
+                cal.mousedown(function(ev){
+                    ev.stopPropagation();
+                });
             },
             hide = function (ev) {
                 if (ev.data.cal.data('colpick').onHide.apply(this, [ev.data.cal.get(0)]) != false) {
@@ -265,7 +267,7 @@ For usage and examples: colpick.com/plugin
                     w : window.innerWidth || (m ? document.documentElement.clientWidth : document.body.clientWidth)
                 };
             },
-            //Fix the values if the user enters a negative or high value
+            // Fix the values if the user enters a negative or high value
             fixHSB = function (hsb) {
                 return {
                     h: Math.min(360, Math.max(0, hsb.h)),
@@ -309,8 +311,8 @@ For usage and examples: colpick.com/plugin
         return {
             init: function (opt) {
                 opt = $.extend({}, defaults, opt||{});
-                //Set color
-                if (typeof opt.color == 'string') {
+                // Set color
+                if (typeof opt.color === 'string') {
                     opt.color = hexToHsb(opt.color);
                 } else if (opt.color.r != undefined && opt.color.g != undefined && opt.color.b != undefined) {
                     opt.color = rgbToHsb(opt.color);
@@ -320,44 +322,44 @@ For usage and examples: colpick.com/plugin
                     return this;
                 }
                 
-                //For each selected DOM element
+                // For each selected DOM element
                 return this.each(function () {
-                    //If the element does not have an ID
+                    // If the element does not have an ID
                     if (!$(this).data('colpickId')) {
                         var options = $.extend({}, opt);
                         options.origColor = opt.color;
-                        //Generate and assign a random ID
+                        // Generate and assign a random ID
                         var id = 'collorpicker_' + parseInt(Math.random() * 1000);
                         $(this).data('colpickId', id);
-                        //Set the tpl's ID and get the HTML
+                        // Set the tpl's ID and get the HTML
                         var cal = $(tpl).attr('id', id);
-                        //Add class according to layout
+                        // Add class according to layout
                         cal.addClass('colpick_'+options.layout+(options.submit?'':' colpick_'+options.layout+'_ns'));
-                        //Add class if the color scheme is not default
-                        if(options.colorScheme != 'light') {
+                        // Add class if the color scheme is not default
+                        if (options.colorScheme != 'light') {
                             cal.addClass('colpick_'+options.colorScheme);
                         }
-                        //Setup submit button
+                        // Setup submit button
                         cal.find('div.colpick_submit').html(options.submitText).click(clickSubmit);
-                        //Setup input fields
+                        // Setup input fields
                         options.fields = cal.find('input').change(change).blur(blur).focus(focus);
                         cal.find('div.colpick_field_arrs').mousedown(downIncrement).end().find('div.colpick_current_color').click(restoreOriginal);
-                        //Setup hue selector
+                        // Setup hue selector
                         options.selector = cal.find('div.colpick_color').on('mousedown touchstart',downSelector);
                         options.selectorIndic = options.selector.find('div.colpick_selector_outer');
-                        //Store parts of the plugin
+                        // Store parts of the plugin
                         options.el = this;
                         options.hue = cal.find('div.colpick_hue_arrs');
                         huebar = options.hue.parent();
-                        //Paint the hue bar
+                        // Paint the hue bar
                         var UA = navigator.userAgent.toLowerCase();
                         var isIE = navigator.appName === 'Microsoft Internet Explorer';
                         var IEver = isIE ? parseFloat( UA.match( /msie ([0-9]{1,}[\.0-9]{0,})/ )[1] ) : 0;
                         var ngIE = ( isIE && IEver < 10 );
                         var stops = ['#ff0000','#ff0080','#ff00ff','#8000ff','#0000ff','#0080ff','#00ffff','#00ff80','#00ff00','#80ff00','#ffff00','#ff8000','#ff0000'];
-                        if(ngIE) {
+                        if (ngIE) {
                             var i, div;
-                            for(i=0; i<=11; i++) {
+                            for (i=0; i<=11; i++) {
                                 div = $('<div></div>').attr('style','height:8.333333%; filter:progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='+stops[i]+', endColorstr='+stops[i+1]+'); -ms-filter: "progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='+stops[i]+', endColorstr='+stops[i+1]+')";');
                                 huebar.append(div);
                             }
@@ -368,7 +370,7 @@ For usage and examples: colpick.com/plugin
                         cal.find('div.colpick_hue').on('mousedown touchstart',downHue);
                         options.newColor = cal.find('div.colpick_new_color');
                         options.currentColor = cal.find('div.colpick_current_color');
-                        //Store options and fill with default color
+                        // Store options and fill with default color
                         cal.data('colpick', options);
                         fillRGBFields(options.color, cal.get(0));
                         fillHSBFields(options.color, cal.get(0));
@@ -377,7 +379,7 @@ For usage and examples: colpick.com/plugin
                         setSelector(options.color, cal.get(0));
                         setCurrentColor(options.color, cal.get(0));
                         setNewColor(options.color, cal.get(0));
-                        //Append to body if flat=false, else show in place
+                        // Append to body if flat=false, else show in place
                         if (options.flat) {
                             cal.appendTo(this).show();
                             cal.css({
@@ -394,7 +396,7 @@ For usage and examples: colpick.com/plugin
                     }
                 });
             },
-            //Shows the picker
+            // Shows the picker
             showPicker: function() {
                 return this.each( function () {
                     if ($(this).data('colpickId')) {
@@ -402,7 +404,7 @@ For usage and examples: colpick.com/plugin
                     }
                 });
             },
-            //Hides the picker
+            // Hides the picker
             hidePicker: function() {
                 return this.each( function () {
                     if ($(this).data('colpickId')) {
@@ -410,10 +412,10 @@ For usage and examples: colpick.com/plugin
                     }
                 });
             },
-            //Sets a color as new and current (default)
+            // Sets a color as new and current (default)
             setColor: function(col, setCurrent) {
                 setCurrent = (typeof setCurrent === "undefined") ? 1 : setCurrent;
-                if (typeof col == 'string') {
+                if (typeof col === 'string') {
                     col = hexToHsb(col);
                 } else if (col.r != undefined && col.g != undefined && col.b != undefined) {
                     col = rgbToHsb(col);
@@ -435,7 +437,7 @@ For usage and examples: colpick.com/plugin
                         
                         setNewColor(col, cal.get(0));
                         cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el, 1]);
-                        if(setCurrent) {
+                        if (setCurrent) {
                             setCurrentColor(col, cal.get(0));
                         }
                     }
@@ -443,7 +445,7 @@ For usage and examples: colpick.com/plugin
             }
         };
     }();
-    //Color space convertions
+    // Color space convertions
     var hexToRgb = function (hex) {
         var hex = parseInt(((hex.indexOf('#') > -1) ? hex.substring(1) : hex), 16);
         return {r: hex >> 16, g: (hex & 0x00FF00) >> 8, b: (hex & 0x0000FF)};
@@ -459,12 +461,20 @@ For usage and examples: colpick.com/plugin
         hsb.b = max;
         hsb.s = max != 0 ? 255 * delta / max : 0;
         if (hsb.s != 0) {
-            if (rgb.r == max) hsb.h = (rgb.g - rgb.b) / delta;
-            else if (rgb.g == max) hsb.h = 2 + (rgb.b - rgb.r) / delta;
-            else hsb.h = 4 + (rgb.r - rgb.g) / delta;
-        } else hsb.h = -1;
+            if (rgb.r == max) {
+                hsb.h = (rgb.g - rgb.b) / delta;
+            } else if (rgb.g == max) {
+                hsb.h = 2 + (rgb.b - rgb.r) / delta;
+            } else {
+                hsb.h = 4 + (rgb.r - rgb.g) / delta;
+            }
+        } else {
+            hsb.h = -1;
+        }
         hsb.h *= 60;
-        if (hsb.h < 0) hsb.h += 360;
+        if (hsb.h < 0) {
+            hsb.h += 360;
+        }
         hsb.s *= 100/255;
         hsb.b *= 100/255;
         return hsb;
@@ -474,20 +484,30 @@ For usage and examples: colpick.com/plugin
         var h = hsb.h;
         var s = hsb.s*255/100;
         var v = hsb.b*255/100;
-        if(s == 0) {
+        if (s == 0) {
             rgb.r = rgb.g = rgb.b = v;
         } else {
             var t1 = v;
             var t2 = (255-s)*v/255;
             var t3 = (t1-t2)*(h%60)/60;
-            if(h==360) h = 0;
-            if(h<60) {rgb.r=t1;    rgb.b=t2; rgb.g=t2+t3}
-            else if(h<120) {rgb.g=t1; rgb.b=t2;    rgb.r=t1-t3}
-            else if(h<180) {rgb.g=t1; rgb.r=t2;    rgb.b=t2+t3}
-            else if(h<240) {rgb.b=t1; rgb.r=t2;    rgb.g=t1-t3}
-            else if(h<300) {rgb.b=t1; rgb.g=t2;    rgb.r=t2+t3}
-            else if(h<360) {rgb.r=t1; rgb.g=t2;    rgb.b=t1-t3}
-            else {rgb.r=0; rgb.g=0;    rgb.b=0}
+            if (h==360) {
+                h = 0;
+            }
+            if (h<60) {
+                rgb.r=t1; rgb.b=t2; rgb.g=t2+t3;
+            } else if (h<120) {
+                rgb.g=t1; rgb.b=t2; rgb.r=t1-t3;
+            } else if (h<180) {
+                rgb.g=t1; rgb.r=t2; rgb.b=t2+t3;
+            } else if (h<240) {
+                rgb.b=t1; rgb.r=t2; rgb.g=t1-t3;
+            } else if (h<300) {
+                rgb.b=t1; rgb.g=t2; rgb.r=t2+t3;
+            } else if (h<360) {
+                rgb.r=t1; rgb.g=t2; rgb.b=t1-t3;
+            } else {
+                rgb.r=0; rgb.g=0; rgb.b=0;
+            }
         }
         return {r:Math.round(rgb.r), g:Math.round(rgb.g), b:Math.round(rgb.b)};
     };
@@ -524,3 +544,4 @@ For usage and examples: colpick.com/plugin
         }
     });
 })(jQuery);
+

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -1,6 +1,7 @@
 /*
 colpick Color Picker
-Copyright 2013 Jose Vargas. Licensed under GPL license. Based on Stefan Petre's Color Picker www.eyecon.ro, dual licensed under the MIT and GPL licenses
+Copyright 2013 Jose Vargas. Licensed under GPL license. Based on Stefan Petre's Color Picker www.eyecon.ro, dual licensed 
+under the MIT and GPL licenses
 
 For usage and examples: colpick.com/plugin
  */
@@ -8,7 +9,31 @@ For usage and examples: colpick.com/plugin
 (function ($) {
     var colpick = function () {
         var
-            tpl = '<div class="colpick"><div class="colpick_color"><div class="colpick_color_overlay1"><div class="colpick_color_overlay2"><div class="colpick_selector_outer"><div class="colpick_selector_inner"></div></div></div></div></div><div class="colpick_hue"><div class="colpick_hue_arrs"><div class="colpick_hue_larr"></div><div class="colpick_hue_rarr"></div></div></div><div class="colpick_new_color"></div><div class="colpick_current_color"></div><div class="colpick_hex_field"><div class="colpick_field_letter">#</div><input type="text" maxlength="6" size="6" /></div><div class="colpick_rgb_r colpick_field"><div class="colpick_field_letter">R</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_rgb_g colpick_field"><div class="colpick_field_letter">G</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_rgb_b colpick_field"><div class="colpick_field_letter">B</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_hsb_h colpick_field"><div class="colpick_field_letter">H</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_hsb_s colpick_field"><div class="colpick_field_letter">S</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_hsb_b colpick_field"><div class="colpick_field_letter">B</div><input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div><div class="colpick_submit"></div></div>',
+            tpl = '<div class="colpick"><div class="colpick_color"><div class="colpick_color_overlay1">' +
+                '<div class="colpick_color_overlay2"><div class="colpick_selector_outer"><div class="colpick_selector_inner">' +
+                '</div></div></div></div></div><div class="colpick_hue"><div class="colpick_hue_arrs">' +
+                '<div class="colpick_hue_larr"></div><div class="colpick_hue_rarr"></div></div></div>' +
+                '<div class="colpick_new_color"></div><div class="colpick_current_color"></div>' +
+                '<div class="colpick_hex_field"><div class="colpick_field_letter">#</div>' +
+                '<input type="text" maxlength="6" size="6" /></div><div class="colpick_rgb_r colpick_field">' +
+                '<div class="colpick_field_letter">R</div><input type="text" maxlength="3" size="3" />' +
+                '<div class="colpick_field_arrs"><div class="colpick_field_uarr"></div>' +
+                '<div class="colpick_field_darr"></div></div></div><div class="colpick_rgb_g colpick_field">' +
+                '<div class="colpick_field_letter">G</div><input type="text" maxlength="3" size="3" />' +
+                '<div class="colpick_field_arrs"><div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div>' +
+                '</div></div><div class="colpick_rgb_b colpick_field"><div class="colpick_field_letter">B</div>' +
+                '<input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs">' +
+                '<div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div>' +
+                '<div class="colpick_hsb_h colpick_field"><div class="colpick_field_letter">H</div>' +
+                '<input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs">' +
+                '<div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div>' +
+                '<div class="colpick_hsb_s colpick_field"><div class="colpick_field_letter">S</div>' +
+                '<input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs">' +
+                '<div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div>' +
+                '<div class="colpick_hsb_b colpick_field"><div class="colpick_field_letter">B</div>' +
+                '<input type="text" maxlength="3" size="3" /><div class="colpick_field_arrs">' +
+                '<div class="colpick_field_uarr"></div><div class="colpick_field_darr"></div></div></div>' +
+                '<div class="colpick_submit"></div></div>',
             defaults = {
                 showEvent: 'click',
                 onShow: function () {},
@@ -52,7 +77,8 @@ For usage and examples: colpick.com/plugin
             },
             // Set the hue selector position
             setHue = function (hsb, cal) {
-                $(cal).data('colpick').hue.css('top', parseInt($(cal).data('colpick').height - $(cal).data('colpick').height * hsb.h/360, 10));
+                $(cal).data('colpick').hue.css('top',
+                    parseInt($(cal).data('colpick').height - $(cal).data('colpick').height * hsb.h / 360, 10));
             },
             // Set current and new colors
             setCurrentColor = function (hsb, cal) {
@@ -91,7 +117,8 @@ For usage and examples: colpick.com/plugin
                 setSelector(col, cal.get(0));
                 setHue(col, cal.get(0));
                 setNewColor(col, cal.get(0));
-                cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el, 0]);
+                cal.data('colpick').onChange.apply(cal.parent(),
+                    [col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el, 0]);
             },
             // Change style on blur and on focus of inputs
             blur = function (ev) {
@@ -107,7 +134,8 @@ For usage and examples: colpick.com/plugin
                 var field = $(this).parent().find('input').focus();
                 var current = {
                     el: $(this).parent().addClass('colpick_slider'),
-                    max: this.parentNode.className.indexOf('_hsb_h') > 0 ? 360 : (this.parentNode.className.indexOf('_hsb') > 0 ? 100 : 255),
+                    max: this.parentNode.className.indexOf('_hsb_h') > 0 ? 360 :
+                        (this.parentNode.className.indexOf('_hsb') > 0 ? 100 : 255),
                     y: ev.pageY,
                     field: field,
                     val: parseInt(field.val(), 10),
@@ -143,7 +171,8 @@ For usage and examples: colpick.com/plugin
                 var pageY = ((ev.type == 'touchstart') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
                     current.cal.data('colpick')
-                        .fields.eq(4).val(parseInt(360*(current.cal.data('colpick').height - (pageY - current.y))/current.cal.data('colpick').height, 10))
+                        .fields.eq(4).val(parseInt(360 * (current.cal.data('colpick').height -
+                            (pageY - current.y)) / current.cal.data('colpick').height, 10))
                         .get(0),
                     [current.cal.data('colpick').livePreview]
                 );
@@ -153,7 +182,9 @@ For usage and examples: colpick.com/plugin
                 var pageY = ((ev.type == 'touchmove') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
                     ev.data.cal.data('colpick')
-                        .fields.eq(4).val(parseInt(360*(ev.data.cal.data('colpick').height - Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageY - ev.data.y))))/ev.data.cal.data('colpick').height, 10))
+                        .fields.eq(4).val(parseInt(360 * (ev.data.cal.data('colpick').height -
+                            Math.max(0, Math.min(ev.data.cal.data('colpick').height, (pageY - ev.data.y)))) /
+                            ev.data.cal.data('colpick').height, 10))
                         .get(0),
                     [ev.data.preview]
                 );
@@ -189,7 +220,8 @@ For usage and examples: colpick.com/plugin
 
                 change.apply(
                     current.cal.data('colpick').fields
-                        .eq(6).val(parseInt(100*(current.cal.data('colpick').height - (pageY - current.pos.top))/current.cal.data('colpick').height, 10)).end()
+                        .eq(6).val(parseInt(100 * (current.cal.data('colpick').height - (pageY - current.pos.top)) /
+                            current.cal.data('colpick').height, 10)).end()
                         .eq(5).val(parseInt(100*(pageX - current.pos.left)/current.cal.data('colpick').height, 10))
                         .get(0),
                     [current.preview]
@@ -208,8 +240,11 @@ For usage and examples: colpick.com/plugin
 
                 change.apply(
                     ev.data.cal.data('colpick').fields
-                        .eq(6).val(parseInt(100*(ev.data.cal.data('colpick').height - Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageY - ev.data.pos.top))))/ev.data.cal.data('colpick').height, 10)).end()
-                        .eq(5).val(parseInt(100*(Math.max(0,Math.min(ev.data.cal.data('colpick').height,(pageX - ev.data.pos.left))))/ev.data.cal.data('colpick').height, 10))
+                        .eq(6).val(parseInt(100 * (ev.data.cal.data('colpick').height -
+                            Math.max(0, Math.min(ev.data.cal.data('colpick').height, (pageY - ev.data.pos.top)))) /
+                            ev.data.cal.data('colpick').height, 10)).end()
+                        .eq(5).val(parseInt(100 * (Math.max(0, Math.min(ev.data.cal.data('colpick').height,
+                            (pageX - ev.data.pos.left)))) / ev.data.cal.data('colpick').height, 10))
                         .get(0),
                     [ev.data.preview]
                 );
@@ -343,7 +378,8 @@ For usage and examples: colpick.com/plugin
                         cal.find('div.colpick_submit').html(options.submitText).click(clickSubmit);
                         // Setup input fields
                         options.fields = cal.find('input').change(change).blur(blur).focus(focus);
-                        cal.find('div.colpick_field_arrs').mousedown(downIncrement).end().find('div.colpick_current_color').click(restoreOriginal);
+                        cal.find('div.colpick_field_arrs').mousedown(downIncrement);
+                        cal.find('div.colpick_current_color').click(restoreOriginal);
                         // Setup hue selector
                         options.selector = cal.find('div.colpick_color').on('mousedown touchstart',downSelector);
                         options.selectorIndic = options.selector.find('div.colpick_selector_outer');
@@ -356,16 +392,27 @@ For usage and examples: colpick.com/plugin
                         var isIE = navigator.appName === 'Microsoft Internet Explorer';
                         var IEver = isIE ? parseFloat( UA.match( /msie ([0-9]{1,}[\.0-9]{0,})/ )[1] ) : 0;
                         var ngIE = ( isIE && IEver < 10 );
-                        var stops = ['#ff0000','#ff0080','#ff00ff','#8000ff','#0000ff','#0080ff','#00ffff','#00ff80','#00ff00','#80ff00','#ffff00','#ff8000','#ff0000'];
+                        var stops = ['#ff0000', '#ff0080', '#ff00ff', '#8000ff', '#0000ff', '#0080ff', '#00ffff', '#00ff80',
+                            '#00ff00', '#80ff00', '#ffff00', '#ff8000', '#ff0000'];
                         if (ngIE) {
                             var i, div;
                             for (i=0; i<=11; i++) {
-                                div = $('<div></div>').attr('style','height:8.333333%; filter:progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='+stops[i]+', endColorstr='+stops[i+1]+'); -ms-filter: "progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr='+stops[i]+', endColorstr='+stops[i+1]+')";');
+                                div = $('<div></div>').attr('style',
+                                    'height:8.333333%; filter:progid:' +
+                                    'DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr=' + stops[i] +
+                                    ', endColorstr=' + stops[i + 1] +
+                                    '); -ms-filter: "progid:DXImageTransform.Microsoft.gradient(GradientType=0,startColorstr=' +
+                                    stops[i] + ', endColorstr=' + stops[i + 1] + ')";');
                                 huebar.append(div);
                             }
                         } else {
                             stopList = stops.join(',');
-                            huebar.attr('style','background:-webkit-linear-gradient(top,'+stopList+'); background: -o-linear-gradient(top,'+stopList+'); background: -ms-linear-gradient(top,'+stopList+'); background:-moz-linear-gradient(top,'+stopList+'); -webkit-linear-gradient(top,'+stopList+'); background:linear-gradient(to bottom,'+stopList+'); ');
+                            huebar.attr('style', 'background:-webkit-linear-gradient(top,' + stopList +
+                                '); background: -o-linear-gradient(top,' + stopList +
+                                '); background: -ms-linear-gradient(top,' + stopList +
+                                '); background:-moz-linear-gradient(top,' + stopList +
+                                '); -webkit-linear-gradient(top,' + stopList +
+                                '); background:linear-gradient(to bottom,' + stopList + '); ');
                         }
                         cal.find('div.colpick_hue').on('mousedown touchstart',downHue);
                         options.newColor = cal.find('div.colpick_new_color');
@@ -436,7 +483,8 @@ For usage and examples: colpick.com/plugin
                         setSelector(col, cal.get(0));
                         
                         setNewColor(col, cal.get(0));
-                        cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el, 1]);
+                        cal.data('colpick').onChange.apply(cal.parent(),
+                            [col, hsbToHex(col), hsbToRgb(col), cal.data('colpick').el, 1]);
                         if (setCurrent) {
                             setCurrentColor(col, cal.get(0));
                         }

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -496,12 +496,22 @@ For usage and examples: colpick.com/plugin
         };
     }();
     // Color space convertions
-    var hexToRgb = function (hex) {
-        var hex = parseInt(((hex.indexOf('#') > -1) ? hex.substring(1) : hex), 16);
-        return {r: hex >> 16, g: (hex & 0x00FF00) >> 8, b: (hex & 0x0000FF)};
+    var hexToRgb = function (hexString) {
+        if (typeof hexString !== "string") {
+            print("Error - ColPick.js::hexToRgb expects string object.");
+            return;
+        }
+
+        var hexNumber = parseInt(((hexString.indexOf('#') > -1) ? hexString.substring(1) : hexString), 16);
+        return { r: hexNumber >> 16, g: (hexNumber & 0x00FF00) >> 8, b: (hexNumber & 0x0000FF)};
     };
-    var hexToHsb = function (hex) {
-        return rgbToHsb(hexToRgb(hex));
+    var hexToHsb = function (hexString) {
+        if (typeof hexString !== "string") {
+            print("Error - ColPick.js::hexToHsb expects string object.");
+            return;
+        }
+
+        return rgbToHsb(hexToRgb(hexString));
     };
     var rgbToHsb = function (rgb) {
         var hsb = {h: 0, s: 0, b: 0};

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -211,7 +211,7 @@ For usage and examples: colpick.com/plugin
                 $(document).on('mouseup touchend',current,upSelector);
                 $(document).on('mousemove touchmove',current,moveSelector);
 
-                var payeX,pageY;
+                var pageX,pageY;
                 if (ev.type == 'touchstart') {
                     pageX = ev.originalEvent.changedTouches[0].pageX,
                     pageY = ev.originalEvent.changedTouches[0].pageY;
@@ -231,7 +231,7 @@ For usage and examples: colpick.com/plugin
                 return false;
             },
             moveSelector = function (ev) {
-                var payeX,pageY;
+                var pageX,pageY;
                 if (ev.type == 'touchmove') {
                     pageX = ev.originalEvent.changedTouches[0].pageX,
                     pageY = ev.originalEvent.changedTouches[0].pageY;
@@ -388,7 +388,7 @@ For usage and examples: colpick.com/plugin
                         // Store parts of the plugin
                         options.el = this;
                         options.hue = cal.find('div.colpick_hue_arrs');
-                        huebar = options.hue.parent();
+                        var huebar = options.hue.parent();
                         // Paint the hue bar
                         var UA = navigator.userAgent.toLowerCase();
                         var isIE = navigator.appName === 'Microsoft Internet Explorer';
@@ -408,7 +408,7 @@ For usage and examples: colpick.com/plugin
                                 huebar.append(div);
                             }
                         } else {
-                            stopList = stops.join(',');
+                            var stopList = stops.join(',');
                             huebar.attr('style', 'background:-webkit-linear-gradient(top,' + stopList +
                                 '); background: -o-linear-gradient(top,' + stopList +
                                 '); background: -ms-linear-gradient(top,' + stopList +

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -302,6 +302,9 @@ For usage and examples: colpick.com/plugin
                 setSelector(col, cal.get(0));
                 setHue(col, cal.get(0));
                 setNewColor(col, cal.get(0));
+                // If the user triggered this behavior, then any prior color change should be negated.
+                cal.data('colpick').onChange.apply(cal.parent(), [col, hsbToHex(col), 
+                    hsbToRgb(col), cal.data('colpick').el, 0]);
             };
         return {
             init: function (opt) {

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -392,7 +392,7 @@ For usage and examples: colpick.com/plugin
                         // Paint the hue bar
                         var UA = navigator.userAgent.toLowerCase();
                         var isIE = navigator.appName === 'Microsoft Internet Explorer';
-                        var IEver = isIE ? parseFloat( UA.match( /msie ([0-9]{1,}[\.0-9]{0,})/ )[1] ) : 0;
+                        var IEver = isIE ? parseFloat( UA.match( /msie ([0-9]{1,}[.0-9]{0,})/ )[1] ) : 0;
                         var ngIE = ( isIE && IEver < 10 );
                         var stops = ['#ff0000', '#ff0080', '#ff00ff', '#8000ff', '#0000ff', '#0080ff', '#00ffff', '#00ff80',
                             '#00ff00', '#80ff00', '#ffff00', '#ff8000', '#ff0000'];

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -29,7 +29,7 @@ var ICON_FOR_TYPE = {
 
 var EDITOR_TIMEOUT_DURATION = 1500;
 var KEY_P = 80; // Key code for letter p used for Parenting hotkey.
-var colorPickers = [];
+var colorPickers = {};
 var lastEntityID = null;
 
 function debugPrint(message) {
@@ -69,8 +69,8 @@ function enableProperties() {
 function disableProperties() {
     disableChildren(document.getElementById("properties-list"), "input, textarea, checkbox, .dropdown dl, .color-picker");
     disableChildren(document, ".colpick");
-    for (var i = 0; i < colorPickers.length; i++) {
-        colorPickers[i].colpickHide();
+    for (var pickKey in colorPickers) {
+        colorPickers[pickKey].colpickHide();
     }
     var elLocked = document.getElementById("property-locked");
 
@@ -83,7 +83,6 @@ function disableProperties() {
 function showElements(els, show) {
     for (var i = 0; i < els.length; i++) {
         els[i].style.display = (show) ? 'table' : 'none';
-
     }
 }
 
@@ -1304,13 +1303,19 @@ function loaded() {
         elColorRed.addEventListener('change', colorChangeFunction);
         elColorGreen.addEventListener('change', colorChangeFunction);
         elColorBlue.addEventListener('change', colorChangeFunction);
-        colorPickers.push($('#property-color-control2').colpick({
+        colorPickers['#property-color-control2'] = $('#property-color-control2').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-color-control2').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-color-control2'].colpickSetColor({ 
+                    "r": elColorRed.value, 
+                    "g": elColorGreen.value, 
+                    "b": elColorBlue.value});
             },
             onHide: function(colpick) {
                 $('#property-color-control2').attr('active', 'false');
@@ -1319,7 +1324,7 @@ function loaded() {
                 $(el).css('background-color', '#' + hex);
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
             }
-        }));
+        });
 
         elLightSpotLight.addEventListener('change', createEmitCheckedPropertyUpdateFunction('isSpotlight'));
 
@@ -1328,13 +1333,20 @@ function loaded() {
         elLightColorRed.addEventListener('change', lightColorChangeFunction);
         elLightColorGreen.addEventListener('change', lightColorChangeFunction);
         elLightColorBlue.addEventListener('change', lightColorChangeFunction);
-        colorPickers.push($('#property-light-color').colpick({
+        colorPickers['#property-light-color'] = $('#property-light-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-light-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-light-color'].colpickSetColor({
+                    "r": elLightColorRed.value,
+                    "g": elLightColorGreen.value,
+                    "b": elLightColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-light-color').attr('active', 'false');
@@ -1343,7 +1355,7 @@ function loaded() {
                 $(el).css('background-color', '#' + hex);
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b);
             }
-        }));
+        });
 
         elLightIntensity.addEventListener('change', createEmitNumberPropertyUpdateFunction('intensity', 1));
         elLightFalloffRadius.addEventListener('change', createEmitNumberPropertyUpdateFunction('falloffRadius', 1));
@@ -1383,13 +1395,20 @@ function loaded() {
         elTextTextColorRed.addEventListener('change', textTextColorChangeFunction);
         elTextTextColorGreen.addEventListener('change', textTextColorChangeFunction);
         elTextTextColorBlue.addEventListener('change', textTextColorChangeFunction);
-        colorPickers.push($('#property-text-text-color').colpick({
+        colorPickers['#property-text-text-color'] = $('#property-text-text-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-text-text-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-text-text-color'].colpickSetColor({
+                    "r": elTextTextColorRed.value,
+                    "g": elTextTextColorGreen.value,
+                    "b": elTextTextColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-text-text-color').attr('active', 'false');
@@ -1399,7 +1418,7 @@ function loaded() {
                 $(el).attr('active', 'false');
                 emitColorPropertyUpdate('textColor', rgb.r, rgb.g, rgb.b);
             }
-        }));
+        });
 
         var textBackgroundColorChangeFunction = createEmitColorPropertyUpdateFunction(
             'backgroundColor', elTextBackgroundColorRed, elTextBackgroundColorGreen, elTextBackgroundColorBlue);
@@ -1407,13 +1426,20 @@ function loaded() {
         elTextBackgroundColorRed.addEventListener('change', textBackgroundColorChangeFunction);
         elTextBackgroundColorGreen.addEventListener('change', textBackgroundColorChangeFunction);
         elTextBackgroundColorBlue.addEventListener('change', textBackgroundColorChangeFunction);
-        colorPickers.push($('#property-text-background-color').colpick({
+        colorPickers['#property-text-background-color'] = $('#property-text-background-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-text-background-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-text-background-color'].colpickSetColor({
+                    "r": elTextBackgroundColorRed.value,
+                    "g": elTextBackgroundColorGreen.value,
+                    "b": elTextBackgroundColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-text-background-color').attr('active', 'false');
@@ -1422,7 +1448,7 @@ function loaded() {
                 $(el).css('background-color', '#' + hex);
                 emitColorPropertyUpdate('backgroundColor', rgb.r, rgb.g, rgb.b);
             }
-        }));
+        });
 
         // Key light
         var keyLightModeChanged = createZoneComponentModeChangedFunction('keyLightMode',
@@ -1432,13 +1458,20 @@ function loaded() {
         elZoneKeyLightModeDisabled.addEventListener('change', keyLightModeChanged);
         elZoneKeyLightModeEnabled.addEventListener('change', keyLightModeChanged);
 
-        colorPickers.push($('#property-zone-key-light-color').colpick({
+        colorPickers['#property-zone-key-light-color'] = $('#property-zone-key-light-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-zone-key-light-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-zone-key-light-color'].colpickSetColor({
+                    "r": elZoneKeyLightColorRed.value,
+                    "g": elZoneKeyLightColorGreen.value,
+                    "b": elZoneKeyLightColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-zone-key-light-color').attr('active', 'false');
@@ -1447,7 +1480,7 @@ function loaded() {
                 $(el).css('background-color', '#' + hex);
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b, 'keyLight');
             }
-        }));
+        });
         var zoneKeyLightColorChangeFunction = createEmitGroupColorPropertyUpdateFunction('keyLight', 'color', 
             elZoneKeyLightColorRed, elZoneKeyLightColorGreen, elZoneKeyLightColorBlue);
 
@@ -1501,13 +1534,20 @@ function loaded() {
 
         elZoneHazeRange.addEventListener('change', createEmitGroupNumberPropertyUpdateFunction('haze', 'hazeRange'));
 
-        colorPickers.push($('#property-zone-haze-color').colpick({
+        colorPickers['#property-zone-haze-color'] = $('#property-zone-haze-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-zone-haze-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-zone-haze-color'].colpickSetColor({
+                    "r": elZoneHazeColorRed.value,
+                    "g": elZoneHazeColorGreen.value,
+                    "b": elZoneHazeColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-zone-haze-color').attr('active', 'false');
@@ -1516,7 +1556,7 @@ function loaded() {
                 $(el).css('background-color', '#' + hex);
                 emitColorPropertyUpdate('hazeColor', rgb.r, rgb.g, rgb.b, 'haze');
             }
-        }));
+        });
         var zoneHazeColorChangeFunction = createEmitGroupColorPropertyUpdateFunction('haze', 'hazeColor', 
             elZoneHazeColorRed, 
             elZoneHazeColorGreen, 
@@ -1526,13 +1566,20 @@ function loaded() {
         elZoneHazeColorGreen.addEventListener('change', zoneHazeColorChangeFunction);
         elZoneHazeColorBlue.addEventListener('change', zoneHazeColorChangeFunction);
 
-        colorPickers.push($('#property-zone-haze-glare-color').colpick({
+        colorPickers['#property-zone-haze-glare-color'] = $('#property-zone-haze-glare-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-zone-haze-glare-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-zone-haze-glare-color'].colpickSetColor({
+                    "r": elZoneHazeGlareColorRed.value,
+                    "g": elZoneHazeGlareColorGreen.value,
+                    "b": elZoneHazeGlareColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-zone-haze-glare-color').attr('active', 'false');
@@ -1541,7 +1588,7 @@ function loaded() {
                 $(el).css('background-color', '#' + hex);
                 emitColorPropertyUpdate('hazeGlareColor', rgb.r, rgb.g, rgb.b, 'haze');
             }
-        }));
+        });
         var zoneHazeGlareColorChangeFunction = createEmitGroupColorPropertyUpdateFunction('haze', 'hazeGlareColor', 
             elZoneHazeGlareColorRed, 
             elZoneHazeGlareColorGreen, 
@@ -1568,13 +1615,20 @@ function loaded() {
         elZoneSkyboxColorRed.addEventListener('change', zoneSkyboxColorChangeFunction);
         elZoneSkyboxColorGreen.addEventListener('change', zoneSkyboxColorChangeFunction);
         elZoneSkyboxColorBlue.addEventListener('change', zoneSkyboxColorChangeFunction);
-        colorPickers.push($('#property-zone-skybox-color').colpick({
+        colorPickers['#property-zone-skybox-color'] = $('#property-zone-skybox-color').colpick({
             colorScheme: 'dark',
             layout: 'hex',
             color: '000000',
             submit: false, // We don't want to have a submission button
             onShow: function(colpick) {
                 $('#property-zone-skybox-color').attr('active', 'true');
+                // The original color preview within the picker needs to be updated on show because
+                // prior to the picker being shown we don't have access to the selections' starting color.
+                colorPickers['#property-zone-skybox-color'].colpickSetColor({
+                    "r": elZoneSkyboxColorRed.value,
+                    "g": elZoneSkyboxColorGreen.value,
+                    "b": elZoneSkyboxColorBlue.value
+                });
             },
             onHide: function(colpick) {
                 $('#property-zone-skybox-color').attr('active', 'false');
@@ -1583,7 +1637,7 @@ function loaded() {
                 $(el).css('background-color', '#' + hex);
                 emitColorPropertyUpdate('color', rgb.r, rgb.g, rgb.b, 'skybox');
             }
-        }));
+        });
 
         elZoneSkyboxURL.addEventListener('change', createEmitGroupTextPropertyUpdateFunction('skybox', 'url'));
 


### PR DESCRIPTION
* Fixes Color Picker original/initial color preview being black.
* Fixes Color Picker not showing the old vs new color preview as it should
* Fixes Color Picker original color restore not working.
* Addresses various ESLint Issues within <code>colpick.js</code>

NOTE:  This was originally proposed along with other changes as PR #12058; however, it was closed in favor of submitting changes in more atomic PRs.   This is the second atomic change set and follow up to PR #12241.

** Testing **

Testing should be done in both Desktop & HMD modes.

Create or select an instance of a light, text, shape, and zone entity within the world. Below is a listing of all known color fields:

Light Color
Text Color
Text Background Color
Shape Color
Haze Key Light Color
Haze Glaze Color
Haze Glare Color

Each color field should:
* When opened show the same color as the color picker thumbnail within the color preview section.
    * At this point both the New Color Preview (on the left) and the Old Color Preview (on the right) sections should have the same color appearing to be one solid piece.
* When manipulating the color via the picker color or hue area the New Color Preview (on the left side) should update accordingly.  The Old Color Preview Section (on the right) should remain the same color as it was originally.
* Clicking on the Old Color Preview section should reset the Entity's Color to it's original color and the New Color Preview section should update accordingly.

**_Before Example Color Preview Area:_**
![case4315_lightcolor_before](https://user-images.githubusercontent.com/28965411/34362103-8f8ed086-ea3e-11e7-9d0b-b424c13df5ed.jpg)
**_After Example Color Preview Area_**
![case4315_lightcolorpreview_after](https://user-images.githubusercontent.com/28965411/36165428-89f3430a-10bd-11e8-8e60-64973b0bd0aa.jpg)


