### PR TITLE
Commerce: Fix wrap mode for very long P2P memos

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
@@ -391,7 +391,7 @@ Item {
                             anchors.topMargin: 15;
                             width: 118;
                             height: paintedHeight;
-                            wrapMode: Text.WordWrap;
+                            wrapMode: Text.Wrap;
                             // Alignment
                             horizontalAlignment: Text.AlignRight;
                         }
@@ -408,7 +408,7 @@ Item {
                             height: paintedHeight;
                             color: model.status === "invalidated" ? hifi.colors.redAccent : hifi.colors.baseGrayHighlight;
                             linkColor: hifi.colors.blueAccent;
-                            wrapMode: Text.WordWrap;
+                            wrapMode: Text.Wrap;
                             font.strikeout: model.status === "invalidated";
 
                             onLinkActivated: {


### PR DESCRIPTION
Ensures that very long, single-word memos are wrapped correctly for viewing in Recent Activity.