### PR TITLE
fix 4x 'fromQml' slots execution

### DIFF
--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -331,9 +331,9 @@ void OffscreenSurface::finishQmlLoad(QQmlComponent* qmlComponent,
     qmlComponent->deleteLater();
 
     onItemCreated(qmlContext, newItem);
-    connect(newItem, SIGNAL(sendToScript(QVariant)), this, SIGNAL(fromQml(QVariant)));
 
     if (!rootCreated) {
+        connect(newItem, SIGNAL(sendToScript(QVariant)), this, SIGNAL(fromQml(QVariant)));
         onRootCreated();
         emit rootItemCreated(newItem);
         // Call this callback after rootitem is set, otherwise VrMenu wont work

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -305,7 +305,6 @@ void OffscreenQmlSurface::onItemCreated(QQmlContext* qmlContext, QQuickItem* new
         qmlContext->setContextProperty("eventBridgeWrapper", new EventBridgeWrapper(eventBridge, qmlContext));
     }
 
-    connect(newItem, SIGNAL(sendToScript(QVariant)), this, SIGNAL(fromQml(QVariant)));
 }
 
 void OffscreenQmlSurface::onRootCreated() {


### PR DESCRIPTION
This PR is not based on any FogBugz issues, this is just an attempt to fix recent regression with multiplication of 'fromQml' slots execution due to: 

1. double connection of sendToScript to fromQml
2. connection of all the qml components instead of only TabletRoot. 