### PR TITLE
Fix spectator camera crash

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2338,6 +2338,7 @@ void Application::initializeGL() {
         qFatal("Unable to make offscreen context current");
     }
     _offscreenContext->doneCurrent();
+    _offscreenContext->setThreadContext();
     _renderEventHandler = new RenderEventHandler(_glWidget->qglContext());
 
     // The UI can't be created until the primary OpenGL

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -119,7 +119,7 @@ protected:
     void renderFromTexture(gpu::Batch& batch, const gpu::TexturePointer texture, glm::ivec4 viewport, const glm::ivec4 scissor);
     virtual void updateFrameData();
 
-    void withMainThreadContext(std::function<void()> f) const;
+    void withOtherThreadContext(std::function<void()> f) const;
 
     void present();
     virtual void swapBuffers();

--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -16,6 +16,7 @@
 
 #include <QtCore/QProcessEnvironment>
 #include <QtCore/QDebug>
+#include <QtCore/QThread>
 #include <QtGui/QOffscreenSurface>
 #include <QtGui/QOpenGLContext>
 #include <QtGui/QOpenGLDebugLogger>
@@ -118,4 +119,30 @@ QObject* OffscreenGLCanvas::getContextObject() {
 void OffscreenGLCanvas::moveToThreadWithContext(QThread* thread) {
     moveToThread(thread);
     _context->moveToThread(thread);
+}
+
+static const char* THREAD_CONTEXT_PROPERTY = "offscreenGlCanvas";
+
+void OffscreenGLCanvas::setThreadContext() {
+    QThread::currentThread()->setProperty(THREAD_CONTEXT_PROPERTY, QVariant::fromValue<QObject*>(this));
+}
+
+bool OffscreenGLCanvas::restoreThreadContext() {
+    // Restore the rendering context for this thread
+    auto threadCanvasVariant = QThread::currentThread()->property(THREAD_CONTEXT_PROPERTY);
+    if (!threadCanvasVariant.isValid()) {
+        return false;
+    }
+
+    auto threadCanvasObject = qvariant_cast<QObject*>(threadCanvasVariant);
+    auto threadCanvas = static_cast<OffscreenGLCanvas*>(threadCanvasObject);
+    if (!threadCanvas) {
+        return false;
+    }
+
+    if (!threadCanvas->makeCurrent()) {
+        qFatal("Unable to restore Offscreen rendering context");
+    }
+
+    return true;
 }

--- a/libraries/gl/src/gl/OffscreenGLCanvas.h
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.h
@@ -32,6 +32,9 @@ public:
     }
     QObject* getContextObject();
     
+    void setThreadContext();
+    static bool restoreThreadContext();
+
 private slots:
     void onMessageLogged(const QOpenGLDebugMessage &debugMessage);
 

--- a/libraries/qml/src/qml/impl/RenderEventHandler.cpp
+++ b/libraries/qml/src/qml/impl/RenderEventHandler.cpp
@@ -58,6 +58,7 @@ void RenderEventHandler::onInitalize() {
         return;
     }
 
+    _canvas.setThreadContext();
     if (!_canvas.makeCurrent()) {
         qFatal("Unable to make QML rendering context current on render thread");
     }

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -485,7 +485,7 @@ bool OpenVrDisplayPlugin::internalActivate() {
     if (_threadedSubmit) {
         _submitThread = std::make_shared<OpenVrSubmitThread>(*this);
         if (!_submitCanvas) {
-            withMainThreadContext([&] {
+            withOtherThreadContext([&] {
                 _submitCanvas = std::make_shared<gl::OffscreenContext>();
                 _submitCanvas->create();
                 _submitCanvas->doneCurrent();


### PR DESCRIPTION
Fix for [FB12338](https://highfidelity.manuscript.com/f/cases/12338/Turning-on-Spectator-Camera-crashes-Interface)

The problem was the code to capture textures rendered by the present thread relied on a function in the display plugin `withMainThreadContext`, which as the name suggests, expect to be run from the main thread.  Now that QML rendering is happening off the main thread, the assumptions caused the code to crash as it was attempting to manipulate the main thread context from another thread while the main thread context was active.

The PR renames `withMainThreadContext` to `withOtherThreadContext` and removes the assumption.  It adds a new mechanism for offscreen GL surfaces to attach themselves to a target thread so that they can be re-bound after the present thread context is finished with its work.  This is encapsulated inside the new `OffscreenGlCanvas` functions `setThreadContext`  and `restoreThreadContext`.


## Testing

Run the spectator camera script, and in the tablet while in HMD mode, enable the camera.  In master, this will crash, but in this build it should behave as expected.  

Suggest also testing snapshot functionality as that uses a similar code path.  