### PR TITLE
[EntityPropertiesJS] Fix for 801 Uncaught TypeError (details below).

### DIFF
--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -798,10 +798,13 @@ function loaded() {
 
                         // HTML workaround since image is not yet a separate entity type
                         var IMAGE_MODEL_NAME = 'default-image-model.fbx';
-                        var urlParts = properties.modelURL.split('/')
-                        var propsFilename = urlParts[urlParts.length - 1];
-                        if (properties.type === "Model" && propsFilename === IMAGE_MODEL_NAME) {
-                            properties.type = "Image";
+                        if (properties.type === "Model") {
+                            var urlParts = properties.modelURL.split('/');
+                            var propsFilename = urlParts[urlParts.length - 1];
+
+                            if (propsFilename === IMAGE_MODEL_NAME) {
+                                properties.type = "Image";
+                            }
                         }
 
                         // Create class name for css ruleset filtering


### PR DESCRIPTION
entityProperties.js was throwing out: 801 Uncaught TypeError: Cannot read property 'split' of undefined

This moves properties.modelURL related checks behind the property.type validation check to avoid
calling the function on an undefined member if the object doesn't have that key defined.

This issue was observed on a build based on hifi/master with HEAD@6187731fdce7.

** Testing **

The functionality should remain as it was previously.  Use PR #12272's test plan; any issues should be verified (tested against) master as there should be no functional difference between this branch and master.