### PR TITLE
Fix for privacy screen not displayed during wallet creation on step 3, while user entering password for the wallet

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -441,7 +441,7 @@ Item {
     }
     Item {
         id: choosePassphraseContainer;
-        visible: root.activeView === "step_3";
+        visible: root.hasShownSecurityImageTip && root.activeView === "step_3";
         // Anchors
         anchors.top: titleBarContainer.bottom;
         anchors.topMargin: 30;
@@ -451,7 +451,10 @@ Item {
 
         onVisibleChanged: {
             if (visible) {
+                sendSignalToWallet({method: 'disableHmdPreview'});
                 Commerce.getWalletAuthenticatedStatus();
+            } else {
+                sendSignalToWallet({method: 'maybeEnableHmdPreview'});
             }
         }
 


### PR DESCRIPTION
Defect description: Commerce specific privacy "Disabled Preview" screen only displays during step 2 of the wallet setup wizard. Commerce specific privacy screen only occurs in HMD mode leaving this defect to only be apparent in HMD.