### PR TITLE
Bug fix for Scrambled Avatars 

### DIFF
--- a/libraries/fbx/src/FBXReader.cpp
+++ b/libraries/fbx/src/FBXReader.cpp
@@ -1481,6 +1481,11 @@ FBXGeometry* FBXReader::extractFBXGeometry(const QVariantHash& mapping, const QS
     }
     while (!remainingModels.isEmpty()) {
         QString first = *remainingModels.constBegin();
+        foreach (const QString& id, remainingModels) {
+            if (id < first) {
+                first = id;
+            }
+        }
         QString topID = getTopModelID(_connectionParentMap, models, first, url);
         appendModelIDs(_connectionParentMap.value(topID), _connectionChildMap, models, remainingModels, modelIDs, true);
     }


### PR DESCRIPTION
This reverts commit a7ec4501e65396d4c7bf2316dd73188cea7a3c7d.

Because remainingModels is a QSet, the order is not guaranteed, therefore the same code iterating over the same items will sometimes have a different ordering. See docs for [QSet](http://doc.qt.io/qt-5/qset.html).

This was bug was occasionally causing scrambled avatars, because both the transmitter and receiver of the AvatarData packets make the strong assumption that the joint orders are identical.  When they are not the avatars bones will not match up.