### PR TITLE
don't update avatar entities if the avatars ID is AVATAR_SELF_ID

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -219,7 +219,7 @@ void Avatar::updateAvatarEntities() {
         return;
     }
 
-    if (getID() == QUuid()) {
+    if (getID() == QUuid() || getID() == AVATAR_SELF_ID) {
         return; // wait until MyAvatar gets an ID before doing this.
     }
 


### PR DESCRIPTION
When transitioning between domains we set the sessionUUID to be AVATAR_SELF_ID, instead of being the Null UUID. The avatar will update its avatar entities, but when the avatar receives the actual sessionUUID it will not update the avatar entities owningAvatarID. Thus resulting of you unable to edit your avatar entities.

Ticket - https://highfidelity.fogbugz.com/f/cases/12339/Avatar-entity-usually-cannot-be-edited-after-changing-domains