### PR TITLE
fix for toolbar slowly drifting on switching between HMD/Desktop modes

### DIFF
--- a/interface/resources/qml/windows/Window.qml
+++ b/interface/resources/qml/windows/Window.qml
@@ -89,6 +89,15 @@ Fadable {
         window.shown = value;
     }
 
+    // used to snap window content to pixel by translating content by negative fractional part of the x/y
+    // thus if x was 5.41, snapper's x will be -0.41
+    // avoiding fractional window position is to avoid artifacts in text rendering when the fractional positions are present.
+    transform: Translate {
+        id: snapper
+        x: 0;
+        y: 0;
+    }
+
     property var rectifier: Timer {
         property bool executing: false;
         interval: 100
@@ -97,8 +106,8 @@ Fadable {
 
         onTriggered: {
             executing = true;
-            x = Math.floor(x);
-            y = Math.floor(y);
+            snapper.x = Math.floor(x) - x;
+            snapper.y = Math.floor(y) - y;
             executing = false;
         }
 


### PR DESCRIPTION
To avoid possible font rendering artifacts there was a adjusting x/y position on any window to pixel. As the result, depending on the pixel size of the desktop window and the pixel size of the HMD UI repeatedly switching between modes could easily cause drift in one direction or another. 