### PR TITLE
Make sure Flickable for GridView for TabletHome will not flick

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletHome.qml
+++ b/interface/resources/qml/hifi/tablet/TabletHome.qml
@@ -130,6 +130,7 @@ Item {
                         flickableDirection: Flickable.AutoFlickIfNeeded
                         keyNavigationEnabled: false
                         highlightFollowsCurrentItem: false
+                        interactive: false
 
                         property int previousGridIndex: -1
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/edit/12332/Home-page-of-the-tablet-allows-vertical-scroll

Test steps:
- Open Tablet
- Make sure its not flickable vertically
- Make sure its not flickable horizontally when apps <= 12