### PR TITLE
Fixed extra " in backup_instructions.html

### DIFF
--- a/interface/resources/html/commerce/backup_instructions.html
+++ b/interface/resources/html/commerce/backup_instructions.html
@@ -342,7 +342,7 @@
           <p>In High Fidelity, your private keys are used to securely access the contents of your Wallet and Purchases.</p>
 
         <hr>
-        <h3>Where are my private keys stored?"</h3>
+        <h3>Where are my private keys stored?</h3>
           <p>By default, your private keys are only stored on your hard drive in High Fidelity Interface's <code>AppData</code> directory.</p>
           <p>Here is the file path of your hifikey - you can browse to it using your file explorer.</p>
           <div class="alert"> <code>HIFIKEY_PATH_REPLACEME</code> </div>


### PR DESCRIPTION
When you generate your wallet, your browser will launch up the backup_instructions.html page. It's been there for some time now, however one of the sub-headings had an additional " after. 

This PR fixes it - no QA should be necessary for this.