### PR TITLE
Commerce: Wallet/Send Money UI fixes

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
@@ -75,8 +75,6 @@ Item {
     // TODO: Fix this unlikely bug
     onVisibleChanged: {
         if (visible) {
-            passphraseField.error = false;
-            passphraseField.focus = true;
             sendSignalToParent({method: 'disableHmdPreview'});
         } else {
             sendSignalToParent({method: 'maybeEnableHmdPreview'});
@@ -206,6 +204,14 @@ Item {
             placeholderText: "passphrase";
             activeFocusOnPress: true;
             activeFocusOnTab: true;
+            
+            onVisibleChanged: {
+                if (visible) {
+                    error = false;
+                    focus = true;
+                    forceActiveFocus();
+                }
+            }
 
             onFocusChanged: {
                 root.keyboardRaised = focus;

--- a/interface/resources/qml/hifi/commerce/wallet/sendMoney/SendMoney.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/sendMoney/SendMoney.qml
@@ -923,7 +923,7 @@ Item {
             anchors.leftMargin: 20;
             anchors.right: parent.right;
             anchors.rightMargin: 20;
-            height: 140;
+            height: 95;
                 
             FontLoader { id: firaSansSemiBold; source: "../../../../../fonts/FiraSans-SemiBold.ttf"; }
             TextArea {

--- a/interface/resources/qml/hifi/commerce/wallet/sendMoney/SendMoney.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/sendMoney/SendMoney.qml
@@ -947,8 +947,14 @@ Item {
                 wrapMode: TextEdit.Wrap;
                 activeFocusOnPress: true;
                 activeFocusOnTab: true;
-                // Workaround for no max length on TextAreas
                 onTextChanged: {
+                    // Don't allow tabs or newlines
+                    if ((/[\n\r\t]/g).test(text)) {
+                        var cursor = cursorPosition;
+                        text = text.replace(/[\n\r\t]/g, '');
+                        cursorPosition = cursor-1;
+                    }
+                    // Workaround for no max length on TextAreas
                     if (text.length > maximumLength) {
                         var cursor = cursorPosition;
                         text = previousText;


### PR DESCRIPTION
- Shrink height of Optional Message in Send Money to prevent OSK from appearing on top of "Send Publicly" checkbox
- Prevent input of tabs and newlines in Optional Message in Send Money
- Force focus on passphrase field when it opens

Fixes both issues in [MS12424](https://highfidelity.fogbugz.com/f/cases/12424/UI-Bugs-in-Send-Money). Also fixes [MS11379](https://highfidelity.manuscript.com/f/cases/11379).