### PR TITLE
change default add to world shape for asset browser

### DIFF
--- a/interface/resources/qml/hifi/AssetServer.qml
+++ b/interface/resources/qml/hifi/AssetServer.qml
@@ -206,7 +206,7 @@ Windows.ScrollingWindow {
             SHAPE_TYPES[SHAPE_TYPE_BOX] = "Box";
             SHAPE_TYPES[SHAPE_TYPE_SPHERE] = "Sphere";
         
-            var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_STATIC_MESH;
+            var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_SIMPLE_COMPOUND;
             var DYNAMIC_DEFAULT = false;
             var prompt = desktop.customInputDialog({
                 textInput: {

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -207,7 +207,7 @@ Rectangle {
             SHAPE_TYPES[SHAPE_TYPE_BOX] = "Box";
             SHAPE_TYPES[SHAPE_TYPE_SPHERE] = "Sphere";
         
-            var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_STATIC_MESH;
+            var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_SIMPLE_COMPOUND;
             var DYNAMIC_DEFAULT = false;
             var prompt = tabletRoot.customInputDialog({
                 textInput: {


### PR DESCRIPTION
Default should not be to have exact collisions - can cause performance issues for high-poly models by accident. 