### PR TITLE
Add #include of Forward.h to AudioMixer.h

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "AudioMixer.h"
+
 #include <thread>
 
 #include <QtCore/QJsonArray>
@@ -35,8 +37,6 @@
 #include "AudioMixerClientData.h"
 #include "AvatarAudioStream.h"
 #include "InjectedAudioStream.h"
-
-#include "AudioMixer.h"
 
 static const float DEFAULT_ATTENUATION_PER_DOUBLING_IN_DISTANCE = 0.5f;    // attenuation = -6dB * log2(distance)
 static const int DISABLE_STATIC_JITTER_FRAMES = -1;

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -18,7 +18,7 @@
 #include <ThreadedAssignment.h>
 #include <UUIDHasher.h>
 
-#include "Plugins/Forward.h"
+#include <plugins/Forward.h>
 
 #include "AudioMixerStats.h"
 #include "AudioMixerSlavePool.h"

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -18,6 +18,8 @@
 #include <ThreadedAssignment.h>
 #include <UUIDHasher.h>
 
+#include "Plugins/Forward.h"
+
 #include "AudioMixerStats.h"
 #include "AudioMixerSlavePool.h"
 

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "AudioMixerClientData.h"
+
 #include <random>
 
 #include <QtCore/QDebug>
@@ -22,8 +24,6 @@
 #include "AudioLogging.h"
 #include "AudioHelpers.h"
 #include "AudioMixer.h"
-#include "AudioMixerClientData.h"
-
 
 AudioMixerClientData::AudioMixerClientData(const QUuid& nodeID) :
     NodeData(nodeID),

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -21,6 +21,7 @@
 #include <AudioLimiter.h>
 #include <UUIDHasher.h>
 
+#include <plugins/Forward.h>
 #include <plugins/CodecPlugin.h>
 
 #include "PositionalAudioStream.h"

--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include "AudioMixerSlave.h"
+
 #include <algorithm>
 
 #include <glm/glm.hpp>
@@ -33,8 +35,6 @@
 #include "AvatarAudioStream.h"
 #include "InjectedAudioStream.h"
 #include "AudioHelpers.h"
-
-#include "AudioMixerSlave.h"
 
 using AudioStreamMap = AudioMixerClientData::AudioStreamMap;
 


### PR DESCRIPTION
This makes the compile by Qt MOC less dependent on order of processing.
See Manuscript case 12527.