### PR TITLE
Fix new material UI indentation

### DIFF
--- a/interface/resources/qml/hifi/tablet/NewMaterialDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewMaterialDialog.qml
@@ -131,7 +131,7 @@ Rectangle {
                     spacing: 5
 
                     anchors.horizontalCenter: column3.horizontalCenter
-                    anchors.horizontalCenterOffset: -20
+                    anchors.horizontalCenterOffset: 0
 
                     Button {
                         id: button1


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/12490/Creating-Material-Entity-page-does-not-align-properly

This UI will likely be redesigned soon but this is a temporary fix for a small issue.

Test plan:
- Open Create.
- Click the Material button.
- The left side of the "Add" button should align with the left side of the text box above it.