### PR TITLE
Corrected edge case of creating a snapshot with "" as the filename.

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -266,9 +266,8 @@ public:
 
     float getGameLoopRate() const { return _gameLoopCounter.rate(); }
 
-    // Note that takeSnapshot has a default value, as this method is used internally.
     void takeSnapshot(bool notify, bool includeAnimated = false, float aspectRatio = 0.0f, const QString& filename = QString());
-    void takeSecondaryCameraSnapshot(const QString& filename);
+    void takeSecondaryCameraSnapshot(const QString& filename = QString());
 
     void shareSnapshot(const QString& filename, const QUrl& href = QUrl(""));
 

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -334,8 +334,8 @@ public slots:
      * @param {number} aspectRatio=0 - The width/height ratio of the snapshot required. If the value is <code>0</code> the
      *     full resolution is used (window dimensions in desktop mode; HMD display dimensions in HMD mode), otherwise one of the
      *     dimensions is adjusted in order to match the aspect ratio.
-     * @param {string} filename=QString() - If this value is not null then the image will be saved to this filename, with an appended ",jpg".
-	 *      otherwise, the image will be saved as 'hifi-snap-by-<user name>-YYYY-MM-DD_HH-MM-SS'
+     * @param {string} filename="" - If this value is not given, or is <code>""</code> then the image will be saved to this filename, with an appended ",jpg".
+	 *      otherwise, the image will be saved as 'hifi-snap-by-<user name>-YYYY-MM-DD_HH-MM-SS'.
      * @example <caption>Using the snapshot function and signals.</caption>
      * function onStillSnapshotTaken(path, notify) {
      *     print("Still snapshot taken: " + path);
@@ -357,7 +357,7 @@ public slots:
      * var notify = true;
      * var animated = true;
      * var aspect = 1920 / 1080;
-     * var filename = QString();
+     * var filename = "";
      * Window.takeSnapshot(notify, animated, aspect, filename);
      */
     void takeSnapshot(bool notify = true, bool includeAnimated = false, float aspectRatio = 0.0f, const QString& filename = QString());
@@ -365,7 +365,7 @@ public slots:
     /**jsdoc
      * Takes a still snapshot of the current view from the secondary camera that can be set up through the {@link Render} API.
      * @function Window.takeSecondaryCameraSnapshot
-     * @param {string} filename=QString() - If this value is not null then the image will be saved to this filename, with an appended ".jpg"
+     * @param {string} filename="" - If this value is not given, or is <code>""</code> then the image will be saved to this filename, with an appended ".jpg".
      *
      * var filename = QString();
      */

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -325,6 +325,7 @@ public slots:
      * {@link Window.stillSnapshotTaken|stillSnapshotTaken} is emitted; when a still image plus moving images are captured, 
      * {@link Window.processingGifStarted|processingGifStarted} and {@link Window.processingGifCompleted|processingGifCompleted}
      * are emitted. The path to store the snapshots and the length of the animated GIF to capture are specified in Settings >
+     * NOTE:  to provide a non-default value - all previous parameters must be provided.
      * General > Snapshots.
      * @function Window.takeSnapshot
      * @param {boolean} notify=true - This value is passed on through the {@link Window.stillSnapshotTaken|stillSnapshotTaken}
@@ -334,8 +335,10 @@ public slots:
      * @param {number} aspectRatio=0 - The width/height ratio of the snapshot required. If the value is <code>0</code> the
      *     full resolution is used (window dimensions in desktop mode; HMD display dimensions in HMD mode), otherwise one of the
      *     dimensions is adjusted in order to match the aspect ratio.
-     * @param {string} filename="" - If this value is not given, or is <code>""</code> then the image will be saved to this filename, with an appended ",jpg".
-	 *      otherwise, the image will be saved as 'hifi-snap-by-<user name>-YYYY-MM-DD_HH-MM-SS'.
+     * @param {string} filename="" - If this parameter is not given, the image will be saved as 'hifi-snap-by-<user name>-YYYY-MM-DD_HH-MM-SS'.
+     *     If this parameter is <code>""</code> then the image will be saved as ".jpg".
+     *     Otherwise, the image will be saved to this filename, with an appended ".jpg".
+     *
      * @example <caption>Using the snapshot function and signals.</caption>
      * function onStillSnapshotTaken(path, notify) {
      *     print("Still snapshot taken: " + path);
@@ -364,8 +367,11 @@ public slots:
 
     /**jsdoc
      * Takes a still snapshot of the current view from the secondary camera that can be set up through the {@link Render} API.
+     * NOTE:  to provide a non-default value - all previous parameters must be provided.
      * @function Window.takeSecondaryCameraSnapshot
-     * @param {string} filename="" - If this value is not given, or is <code>""</code> then the image will be saved to this filename, with an appended ".jpg".
+     * @param {string} filename="" - If this parameter is not given, the image will be saved as 'hifi-snap-by-<user name>-YYYY-MM-DD_HH-MM-SS'.
+     *     If this parameter is <code>""</code> then the image will be saved as ".jpg".
+     *     Otherwise, the image will be saved to this filename, with an appended ".jpg".
      *
      * var filename = QString();
      */


### PR DESCRIPTION
# Description
`takeSnapshot` and `takeSecondaryCameraSnapshot` had different behaviour if the user provided and empty string as a file name.
Now - this will create a file named `.jpg`.
This change does not effect existing scripts. 
1.  Take two snapshots in desktop mode and verify that they are created correctly.
2.  Repeat in HMD
3.  Select new location for snapshots (Menu->Settings->General)
4.  Repeat steps 1 & 2
5. Run the following script commands and verify that 4 snapshots are created,
a, Window.takeSnapshot(true);
b. Window.takeSnapshot(true, false);
c. Window.takeSnapshot(true, false, 1.6);
d. Window.takeSecondaryCameraSnapshot();
## New functionality tests
1.  Run the following script command and verify that snapshot named `.jpg` is created
a.  Window.takeSnapshot(true, false, 1.6, "");
2.  Delete the file just created.
3.  Run the following script command and verify that snapshot named `.jpg` is created
a.  Window.takeSecondaryCameraSnapshot("");
3.  Change the snapshot location using the script command ` Snapshot.setSnapshotsLocation(path);`;
4.  Repeat steps 1 - 3