### PR TITLE
Fix EntityItems not getting destroyed

### DIFF
--- a/interface/src/octree/OctreePacketProcessor.cpp
+++ b/interface/src/octree/OctreePacketProcessor.cpp
@@ -17,6 +17,8 @@
 #include "SceneScriptingInterface.h"
 
 OctreePacketProcessor::OctreePacketProcessor() {
+    setObjectName("Octree Packet Processor");
+
     auto& packetReceiver = DependencyManager::get<NodeList>()->getPacketReceiver();
     
     packetReceiver.registerDirectListenerForTypes({ PacketType::OctreeStats, PacketType::EntityData, PacketType::EntityErase },

--- a/libraries/entities/src/EntityTypes.cpp
+++ b/libraries/entities/src/EntityTypes.cpp
@@ -97,6 +97,7 @@ EntityItemPointer EntityTypes::constructEntityItem(EntityType entityType, const 
         auto mutableProperties = properties;
         mutableProperties.markAllChanged();
         newEntityItem = factory(entityID, mutableProperties);
+        newEntityItem->moveToThread(qApp->thread());
     }
     return newEntityItem;
 }


### PR DESCRIPTION
EntityItems are created on multiple threads.  Some of these threads do not have event loops, so when EntityItems are deleted with deleteLater, they are never actually destroyed.  Now, all EntityItems live on the main thread.

Also names the Octree Packet Processor thread because it was the one causing issues.

Test plan:
- No real functional change.  I've confirmed myself that now the destructors are called at the right time.
- Just to be safe, go to a domain with some entities.  Delete some and make sure they disappear.  Create some new entities and delete them and make sure they disappear.  Switch domains.  All of the entities in the old domain should disappear.