### PR TITLE
Fix two bugs with Create Menu

### DIFF
--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -199,7 +199,7 @@ Rectangle {
             var SHAPE_TYPE_BOX = 4;
             var SHAPE_TYPE_SPHERE = 5;
         
-            var SHAPE_TYPES = [];ww
+            var SHAPE_TYPES = [];
             SHAPE_TYPES[SHAPE_TYPE_NONE] = "No Collision";
             SHAPE_TYPES[SHAPE_TYPE_SIMPLE_HULL] = "Basic - Whole model";
             SHAPE_TYPES[SHAPE_TYPE_SIMPLE_COMPOUND] = "Good - Sub-meshes";

--- a/interface/resources/qml/hifi/tablet/EditTabView.qml
+++ b/interface/resources/qml/hifi/tablet/EditTabView.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.5
 import QtQuick.Controls 1.4
+import QtQuick.Controls 2.2 // Need both for short-term fix
 import QtWebEngine 1.1
 import QtWebChannel 1.0
 import QtQuick.Controls.Styles 1.4
@@ -8,6 +9,7 @@ import "../toolbars"
 import QtGraphicalEffects 1.0
 import "../../controls-uit" as HifiControls
 import "../../styles-uit"
+
 
 
 TabView {
@@ -23,8 +25,25 @@ TabView {
 
         Rectangle {
             color: "#404040"
+            id: container
+
+            Flickable {
+            height: parent.height
+            width: parent.width
+
+            contentHeight: createEntitiesFlow.height +  importButton.height + assetServerButton.height + 153
+            contentWidth: width
+
+            ScrollBar.vertical : ScrollBar {
+                visible: parent.contentHeight > parent.height
+                width: 20
+                background: Rectangle {
+                    color: hifi.colors.tableScrollBackgroundDark
+                }
+            }
 
             Text {
+                id: header
                 color: "#ffffff"
                 text: "Choose an Entity Type to Create:"
                 font.pixelSize: 14
@@ -176,6 +195,7 @@ TabView {
             }
 
             HifiControls.Button {
+                id: importButton
                 text: "Import Entities (.json)"
                 color: hifi.buttons.black
                 colorScheme: hifi.colorSchemes.dark
@@ -192,6 +212,7 @@ TabView {
                 }
             }
         }
+      } // Flickable
     }
 
     Tab {

--- a/interface/resources/qml/hifi/tablet/EditTabView.qml
+++ b/interface/resources/qml/hifi/tablet/EditTabView.qml
@@ -31,7 +31,9 @@ TabView {
             height: parent.height
             width: parent.width
 
-            contentHeight: createEntitiesFlow.height +  importButton.height + assetServerButton.height + 153
+            contentHeight: createEntitiesFlow.height +  importButton.height + assetServerButton.height +
+                           header.anchors.topMargin + createEntitiesFlow.anchors.topMargin +
+                           assetServerButton.anchors.topMargin + importButton.anchors.topMargin
             contentWidth: width
 
             ScrollBar.vertical : ScrollBar {


### PR DESCRIPTION
Fixes Manuscript Cases 12510 and 12511
Unblocks PR 12449 for testing once merged

Test Plan: 
- In HMD mode, run Test Rail case 1938 and confirm that you can now scroll the main page of the tablet and view the bottom two buttons
- In HMD mode, select the Asset Browser button from the Create Menu and confirm you can add a model to world from HMD mode 
- In Desktop Mode, run Test Rail case 1938 and confirm that you can resize and scroll the main page of the tablet
- In Desktop Mode, confirm you can still add a model to world from the Asset Browser