### PR TITLE
[Case 4315] Resolves Particle Tab Color Picker visual inconstency

### DIFF
--- a/scripts/system/particle_explorer/hifi-entity-ui.js
+++ b/scripts/system/particle_explorer/hifi-entity-ui.js
@@ -439,8 +439,9 @@ HifiEntityUI.prototype = {
 
 
         $colPickContainer.colpick({
-            colorScheme: 'dark',
-            layout: 'hex',
+            colorScheme: (group.layoutColorScheme === undefined ? 'dark' : group.layoutColorScheme),
+            layout: (group.layoutType === undefined ? 'hex' : group.layoutType),
+            submit: (group.useSubmitButton === undefined ? true : group.useSubmitButton),
             color: {
                 r: domArray[0].value,
                 g: domArray[1].value,

--- a/scripts/system/particle_explorer/particleExplorer.html
+++ b/scripts/system/particle_explorer/particleExplorer.html
@@ -27,6 +27,7 @@
 
     <link rel="stylesheet" type="text/css" href="../html/css/hifi-style.css">
     <link rel="stylesheet" type="text/css" href="../html/css/edit-style.css">
+    <link rel="stylesheet" type="text/css" href="../html/css/colpick.css">
     <link rel="stylesheet" type="text/css" href="particle-style.css">
 </head>
 <body>

--- a/scripts/system/particle_explorer/particleExplorer.js
+++ b/scripts/system/particle_explorer/particleExplorer.js
@@ -236,7 +236,10 @@
                         red: 255,
                         green: 255,
                         blue: 255
-                    }
+                    },
+                    layoutType: "hex",
+                    layoutColorScheme: "dark",
+                    useSubmitButton: false
                 },
                 {
                     type: "Row"
@@ -249,7 +252,10 @@
                         red: 0,
                         green: 0,
                         blue: 0
-                    }
+                    },
+                    layoutType: "hex",
+                    layoutColorScheme: "dark",
+                    useSubmitButton: false
                 },
                 {
                     type: "Row"
@@ -262,7 +268,10 @@
                         red: 255,
                         green: 255,
                         blue: 255
-                    }
+                    },
+                    layoutType: "hex",
+                    layoutColorScheme: "dark",
+                    useSubmitButton: false
                 },
                 {
                     type: "Row"
@@ -275,7 +284,10 @@
                         red: 255,
                         green: 255,
                         blue: 255
-                    }
+                    },
+                    layoutType: "hex",
+                    layoutColorScheme: "dark",
+                    useSubmitButton: false
                 },
                 {
                     type: "Row"


### PR DESCRIPTION
* Brings Particle Tab color pickers inline with Properties Tab color pickers which don't have the ok/submit button.
* Fixes the overall visual styling of color pickers within the Particle Tab which didn't obey the expected Color Picker layout.
* Fixes an exception within entitySelectionTool encountered during testing which interfered with entity selection.

**_NOTE:_**  This is a follow up to PR #12391 where the testing revealed the Particle Tab color pickers weren't visually consistent with the other pickers (see: https://github.com/highfidelity/hifi/pull/12391#issuecomment-365688774)


**Particle Tab Color Picker Before:**
![case4315_vfxtabbefore](https://user-images.githubusercontent.com/28965411/36561502-dc14b148-17e1-11e8-891e-1c7c0986289d.jpg)

**Particle Tab Color Picker After:**
![case4315_vfxtabafter](https://user-images.githubusercontent.com/28965411/36561515-e82912e4-17e1-11e8-95b6-9e831b63bdec.jpg)
