### PR TITLE
Logspam fix for editing in HMD mode

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -814,13 +814,16 @@ function findClickedEntity(event) {
 // Handles selections on overlays while in edit mode by querying entities from
 // entityIconOverlayManager.
 function handleOverlaySelectionToolUpdates(channel, message, sender) {
+    var wantDebug = false;
     if (sender !== MyAvatar.sessionUUID || channel !== 'entityToolUpdates')
         return;
 
     var data = JSON.parse(message);
 
     if (data.method === "selectOverlay") {
-        print("setting selection to overlay " + data.overlayID);
+        if (wantDebug) {
+            print("setting selection to overlay " + data.overlayID);
+        }
         var entity = entityIconOverlayManager.findEntity(data.overlayID);
 
         if (entity !== null) {


### PR DESCRIPTION
Wrap selection print in wantDebug to avoid spamming logs in HMD mode
Fixes Manuscript Case 12157

Test Plan:
Follow the repro steps in 12157 and confirm that the following log messages (Developer Tools > Log) do not appear when moving items in HMD Create mode.

[1/8 9:4:47] [defaultScripts.js] setting selection to overlay {cbcb59f6-2ef7-4ea5-b48f-387cf4f1aef2}
