### PR TITLE
Near-field HRTF

### DIFF
--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -489,9 +489,6 @@ float approximateGain(const AvatarAudioStream& listeningNodeStream, const Positi
     // avatar: skip attenuation - it is too costly to approximate
 
     // distance attenuation: approximate, ignore zone-specific attenuations
-    // this is a good approximation for streams further than ATTENUATION_START_DISTANCE
-    // those streams closer will be amplified; amplifying close streams is acceptable
-    // when throttling, as close streams are expected to be heard by a user
     float distance = glm::length(relativePosition);
     return gain / distance;
 
@@ -536,23 +533,15 @@ float computeGain(const AudioMixerClientData& listenerNodeData, const AvatarAudi
             break;
         }
     }
+    // translate the zone setting to gain per log2(distance)
+    float g = glm::clamp(1.0f - attenuationPerDoublingInDistance, EPSILON, 1.0f);
 
-    // distance attenuation
-    const float ATTENUATION_START_DISTANCE = 1.0f;
     float distance = glm::length(relativePosition);
-    assert(ATTENUATION_START_DISTANCE > EPSILON);
-    if (distance >= ATTENUATION_START_DISTANCE) {
 
-        // translate the zone setting to gain per log2(distance)
-        float g = 1.0f - attenuationPerDoublingInDistance;
-        g = glm::clamp(g, EPSILON, 1.0f);
-
-        // calculate the distance coefficient using the distance to this node
-        float distanceCoefficient = fastExp2f(fastLog2f(g) * fastLog2f(distance/ATTENUATION_START_DISTANCE));
-
-        // multiply the current attenuation coefficient by the distance coefficient
-        gain *= distanceCoefficient;
-    }
+    // calculate the attenuation using the distance to this node
+    // reference attenuation of 0dB at distance = 1.0m
+    gain *= exp2f(log2f(g) * log2f(std::max(distance, HRTF_DISTANCE_MIN)));
+    gain = std::min(gain, 1.0f / HRTF_DISTANCE_MIN);
 
     return gain;
 }

--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -540,8 +540,8 @@ float computeGain(const AudioMixerClientData& listenerNodeData, const AvatarAudi
 
     // calculate the attenuation using the distance to this node
     // reference attenuation of 0dB at distance = 1.0m
-    gain *= exp2f(log2f(g) * log2f(std::max(distance, HRTF_DISTANCE_MIN)));
-    gain = std::min(gain, 1.0f / HRTF_DISTANCE_MIN);
+    gain *= exp2f(log2f(g) * log2f(std::max(distance, HRTF_NEARFIELD_MIN)));
+    gain = std::min(gain, 1.0f / HRTF_NEARFIELD_MIN);
 
     return gain;
 }

--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -49,7 +49,7 @@ void sendEnvironmentPacket(const SharedNodePointer& node, AudioMixerClientData& 
 inline float approximateGain(const AvatarAudioStream& listeningNodeStream, const PositionalAudioStream& streamToAdd,
         const glm::vec3& relativePosition);
 inline float computeGain(const AudioMixerClientData& listenerNodeData, const AvatarAudioStream& listeningNodeStream,
-        const PositionalAudioStream& streamToAdd, const glm::vec3& relativePosition, bool isEcho);
+        const PositionalAudioStream& streamToAdd, const glm::vec3& relativePosition, float distance, bool isEcho);
 inline float computeAzimuth(const AvatarAudioStream& listeningNodeStream, const PositionalAudioStream& streamToAdd,
         const glm::vec3& relativePosition);
 
@@ -276,7 +276,7 @@ void AudioMixerSlave::addStream(AudioMixerClientData& listenerNodeData, const QU
     glm::vec3 relativePosition = streamToAdd.getPosition() - listeningNodeStream.getPosition();
 
     float distance = glm::max(glm::length(relativePosition), EPSILON);
-    float gain = computeGain(listenerNodeData, listeningNodeStream, streamToAdd, relativePosition, isEcho);
+    float gain = computeGain(listenerNodeData, listeningNodeStream, streamToAdd, relativePosition, distance, isEcho);
     float azimuth = isEcho ? 0.0f : computeAzimuth(listeningNodeStream, listeningNodeStream, relativePosition);
     const int HRTF_DATASET_INDEX = 1;
 
@@ -496,7 +496,7 @@ float approximateGain(const AvatarAudioStream& listeningNodeStream, const Positi
 }
 
 float computeGain(const AudioMixerClientData& listenerNodeData, const AvatarAudioStream& listeningNodeStream,
-        const PositionalAudioStream& streamToAdd, const glm::vec3& relativePosition, bool isEcho) {
+        const PositionalAudioStream& streamToAdd, const glm::vec3& relativePosition, float distance, bool isEcho) {
     float gain = 1.0f;
 
     // injector: apply attenuation
@@ -536,11 +536,9 @@ float computeGain(const AudioMixerClientData& listenerNodeData, const AvatarAudi
     // translate the zone setting to gain per log2(distance)
     float g = glm::clamp(1.0f - attenuationPerDoublingInDistance, EPSILON, 1.0f);
 
-    float distance = glm::length(relativePosition);
-
     // calculate the attenuation using the distance to this node
     // reference attenuation of 0dB at distance = 1.0m
-    gain *= exp2f(log2f(g) * log2f(std::max(distance, HRTF_NEARFIELD_MIN)));
+    gain *= fastExp2f(fastLog2f(g) * fastLog2f(std::max(distance, HRTF_NEARFIELD_MIN)));
     gain = std::min(gain, 1.0f / HRTF_NEARFIELD_MIN);
 
     return gain;

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1826,7 +1826,7 @@ float AudioClient::gainForSource(float distance, float volume) {
 
     // attenuation = -6dB * log2(distance)
     // reference attenuation of 0dB at distance = 1.0m
-    float gain = volume / std::max(distance, HRTF_DISTANCE_MIN);
+    float gain = volume / std::max(distance, HRTF_NEARFIELD_MIN);
 
     return gain;
 }

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1824,16 +1824,9 @@ float AudioClient::azimuthForSource(const glm::vec3& relativePosition) {
 
 float AudioClient::gainForSource(float distance, float volume) {
 
-    const float ATTENUATION_BEGINS_AT_DISTANCE = 1.0f;
-
-    // I'm assuming that the AudioMixer's getting of the stream's attenuation
-    // factor is basically same as getting volume
-    float gain = volume;
-
-    // attenuate based on distance
-    if (distance >= ATTENUATION_BEGINS_AT_DISTANCE) {
-        gain /= (distance/ATTENUATION_BEGINS_AT_DISTANCE);  // attenuation = -6dB * log2(distance)
-    }
+    // attenuation = -6dB * log2(distance)
+    // reference attenuation of 0dB at distance = 1.0m
+    float gain = volume / std::max(distance, HRTF_DISTANCE_MIN);
 
     return gain;
 }

--- a/libraries/audio/src/AudioHRTF.cpp
+++ b/libraries/audio/src/AudioHRTF.cpp
@@ -790,10 +790,10 @@ static void nearFieldAzimuth(float azimuth, float distance, float& azimuthL, flo
 //
 static void nearFieldGain(float azimuth, float distance, float& gainL, float& gainR) {
 
-    // normalized distance factor = [0,1] as distance = [1,HRTF_HEAD_RADIUS]
-    assert(distance < 1.0f);
+    // normalized distance factor = [0,1] as distance = [HRTF_NEARFIELD_MAX,HRTF_HEAD_RADIUS]
+    assert(distance < HRTF_NEARFIELD_MAX);
     assert(distance > HRTF_HEAD_RADIUS);
-	float d = (1.0f - distance) * ( 1.0f / (1.0f - HRTF_HEAD_RADIUS));
+	float d = (HRTF_NEARFIELD_MAX - distance) * ( 1.0f / (HRTF_NEARFIELD_MAX - HRTF_HEAD_RADIUS));
 
     // angle of incidence at each ear
     float angleL = azimuth + HALFPI;
@@ -816,7 +816,7 @@ static void nearFieldGain(float azimuth, float distance, float& gainL, float& ga
     float cR = ((-0.000452339132f * angleR - 0.00173192444f) * angleR + 0.162476536f) * angleR;
 
     // approximate the gain correction
-    // NOTE: this must converge to 1.0 when distance = 1.0m at all azimuth
+    // NOTE: this must converge to 1.0 when distance = HRTF_NEARFIELD_MAX at all azimuth
     gainL = 1.0f - d * cL;
     gainR = 1.0f - d * cR;
 }
@@ -891,7 +891,7 @@ static void setFilters(float firCoef[4][HRTF_TAPS], float bqCoef[5][8], int dela
     assert(azimuth >= -PI);
     assert(azimuth <= +PI);
 
-    distance = MAX(distance, HRTF_DISTANCE_MIN);
+    distance = MAX(distance, HRTF_NEARFIELD_MIN);
 
     // compute the azimuth correction at each ear
     float azimuthL, azimuthR;
@@ -900,7 +900,7 @@ static void setFilters(float firCoef[4][HRTF_TAPS], float bqCoef[5][8], int dela
     // compute the DC gain correction at each ear
     float gainL = 1.0f;
     float gainR = 1.0f;
-    if (distance < 1.0f) {
+    if (distance < HRTF_NEARFIELD_MAX) {
         nearFieldGain(azimuth, distance, gainL, gainR);
     }
 

--- a/libraries/audio/src/AudioHRTF.h
+++ b/libraries/audio/src/AudioHRTF.h
@@ -23,6 +23,10 @@ static const int HRTF_BLOCK = 240;      // block processing size
 
 static const float HRTF_GAIN = 1.0f;    // HRTF global gain adjustment
 
+// Near-field HRTF
+static const float HRTF_DISTANCE_MIN = 0.125f;
+static const float HRTF_HEAD_RADIUS = 0.0875f;  // average human head
+
 class AudioHRTF {
 
 public:

--- a/libraries/audio/src/AudioHRTF.h
+++ b/libraries/audio/src/AudioHRTF.h
@@ -24,8 +24,9 @@ static const int HRTF_BLOCK = 240;      // block processing size
 static const float HRTF_GAIN = 1.0f;    // HRTF global gain adjustment
 
 // Near-field HRTF
-static const float HRTF_DISTANCE_MIN = 0.125f;
-static const float HRTF_HEAD_RADIUS = 0.0875f;  // average human head
+static const float HRTF_NEARFIELD_MAX = 1.0f;   // distance in meters
+static const float HRTF_NEARFIELD_MIN = 0.125f; // distance in meters
+static const float HRTF_HEAD_RADIUS = 0.0875f;  // average human head in meters
 
 class AudioHRTF {
 

--- a/libraries/audio/src/AudioHRTF.h
+++ b/libraries/audio/src/AudioHRTF.h
@@ -24,6 +24,7 @@ static const int HRTF_BLOCK = 240;      // block processing size
 static const float HRTF_GAIN = 1.0f;    // HRTF global gain adjustment
 
 // Near-field HRTF
+static const float HRTF_AZIMUTH_REF = 2.0f;     // IRCAM Listen HRTF was recorded at 2 meters
 static const float HRTF_NEARFIELD_MAX = 1.0f;   // distance in meters
 static const float HRTF_NEARFIELD_MIN = 0.125f; // distance in meters
 static const float HRTF_HEAD_RADIUS = 0.0875f;  // average human head in meters


### PR DESCRIPTION
HRTF improvements that render near-field effects, occurring when an audio source is closer than 1m from your head. Distance cues that are modelled:

- distance attenuation down to 0.125m, with large amplification possible (overload triggers compression)
- geometric correction of the levels at each ear [see first graph]
- geometric correction of the azimuth at each ear
- spectral correction (proximity effect and head shadowing/occlusion) [see second graph]

All parameter changes are continuously interpolated and should be artifact free. An audio source (440Hz tone) under rapid modulation of distance and azimuth, including 12dB of limiting, is shown in the third graph.

![nearfield_dcgain](https://user-images.githubusercontent.com/13965157/36572231-5d7ad372-17ef-11e8-9d1c-01f26de6195e.png)
![nearfield_dvf](https://user-images.githubusercontent.com/13965157/36572241-6b7e5700-17ef-11e8-9a08-733ee76b11b0.png)
<img width="750" alt="nearfield_tone_test" src="https://user-images.githubusercontent.com/13965157/36572263-90eb3940-17ef-11e8-943a-e85b5b177da1.png">
