### PR TITLE
Add a Q_DECLARE_METATYPE in TextureCache.

### DIFF
--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -133,6 +133,8 @@ private:
 
 using NetworkTexturePointer = QSharedPointer<NetworkTexture>;
 
+Q_DECLARE_METATYPE(QWeakPointer<NetworkTexture>)
+
 /// Stores cached textures, including render-to-texture targets.
 class TextureCache : public ResourceCache, public Dependency {
     Q_OBJECT


### PR DESCRIPTION
There was a missing declaration that was causing an assert in the
Qt meta-object system on startup in debug builds:

Q_DECLARE_METATYPE(QWeakPointer<NetworkTexture>)

Bug fixed by Clement.