### PR TITLE
Relax deadlock watchdog

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -392,7 +392,7 @@ const QHash<QString, Application::AcceptURLMethod> Application::_acceptedExtensi
 class DeadlockWatchdogThread : public QThread {
 public:
     static const unsigned long HEARTBEAT_UPDATE_INTERVAL_SECS = 1;
-    static const unsigned long MAX_HEARTBEAT_AGE_USECS = 30 * USECS_PER_SECOND;
+    static const unsigned long MAX_HEARTBEAT_AGE_USECS = 120 * USECS_PER_SECOND; // 2 mins with no checkin probably a deadlock
     static const int WARNING_ELAPSED_HEARTBEAT = 500 * USECS_PER_MSEC; // warn if elapsed heartbeat average is large
     static const int HEARTBEAT_SAMPLES = 100000; // ~5 seconds worth of samples
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1719,6 +1719,10 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         properties["has_async_reprojection"] = displayPlugin->hasAsyncReprojection();
         properties["hardware_stats"] = displayPlugin->getHardwareStats();
 
+        // deadlock watchdog related stats
+        properties["deadlock_watchdog_maxElapsed"] = (int)DeadlockWatchdogThread::_maxElapsed;
+        properties["deadlock_watchdog_maxElapsedAverage"] = (int)DeadlockWatchdogThread::_maxElapsedAverage;
+
         auto bandwidthRecorder = DependencyManager::get<BandwidthRecorder>();
         properties["packet_rate_in"] = bandwidthRecorder->getCachedTotalAverageInputPacketsPerSecond();
         properties["packet_rate_out"] = bandwidthRecorder->getCachedTotalAverageOutputPacketsPerSecond();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7542,6 +7542,18 @@ void Application::deadlockApplication() {
     }
 }
 
+// cause main thread to be unresponsive for 35 seconds
+void Application::unresponsiveApplication() {
+    // to avoid compiler warnings about a loop that will never exit
+    uint64_t start = usecTimestampNow();
+    uint64_t UNRESPONSIVE_FOR_SECONDS = 35;
+    uint64_t UNRESPONSIVE_FOR_USECS = UNRESPONSIVE_FOR_SECONDS * USECS_PER_SECOND;
+    qCDebug(interfaceapp) << "Intentionally cause Interface to be unresponsive for " << UNRESPONSIVE_FOR_SECONDS << " seconds";
+    while (usecTimestampNow() - start < UNRESPONSIVE_FOR_USECS) {
+        QThread::sleep(1);
+    }
+}
+
 void Application::setActiveDisplayPlugin(const QString& pluginName) {
     auto menu = Menu::getInstance();
     foreach(DisplayPluginPointer displayPlugin, PluginManager::getInstance()->getDisplayPlugins()) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -367,6 +367,7 @@ public slots:
     void updateHeartbeat() const;
 
     static void deadlockApplication();
+    static void unresponsiveApplication(); // cause main thread to be unresponsive for 35 seconds
 
     void rotationModeChanged() const;
 

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -713,6 +713,7 @@ Menu::Menu() {
     MenuWrapper* crashMenu = developerMenu->addMenu("Crash");
 
     addActionToQMenuAndActionHash(crashMenu, MenuOption::DeadlockInterface, 0, qApp, SLOT(deadlockApplication()));
+    addActionToQMenuAndActionHash(crashMenu, MenuOption::UnresponsiveInterface, 0, qApp, SLOT(unresponsiveApplication()));
 
     action = addActionToQMenuAndActionHash(crashMenu, MenuOption::CrashPureVirtualFunction);
     connect(action, &QAction::triggered, qApp, []() { crash::pureVirtualCall(); });

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -77,6 +77,7 @@ namespace MenuOption {
     const QString CrashNewFault = "New Fault";
     const QString CrashNewFaultThreaded = "New Fault (threaded)";
     const QString DeadlockInterface = "Deadlock Interface";
+    const QString UnresponsiveInterface = "Unresponsive Interface";
     const QString DecreaseAvatarSize = "Decrease Avatar Size";
     const QString DefaultSkybox = "Default Skybox";
     const QString DeleteAvatarBookmark = "Delete Avatar Bookmark...";


### PR DESCRIPTION
- Deadlock watchdog is relaxed to 2 minutes before a crash is forced
- The "meta verse stats" now included deadlock watchdog data in it's regular stats checkin so we can better see if people on low end machines are experiencing long sections of unresponsive behavior
- A new debug menu is added to "force" an unresponsive state of 35 seconds to help test this feature

# Test plan
- Run this build and do basic startup/smoke test to ensure that nothing obvious is broken
- Choose Debug > Unresponsive Interface -- see that the application pauses for 35 seconds, but does not crash
- Check the log file and see that after the 35 second pause a message is displayed as follows:
```
[02/22 17:47:43] [DEBUG] [hifi.interface] Intentionally cause Interface to be unresponsive for  35  seconds
```
and that several messages of the following format are displayed
```
[02/22 17:48:16] [DEBUG] [hifi.interface.deadlock] DEADLOCK WATCHDOG WARNING: lastHeartbeatAge: 33075317 elapsedMovingAverage: 822 PREVIOUS maxElapsed: 32074849 NEW maxElapsed: 33075317 ** NEW MAX ELAPSED ** maxElapsedAverage: 822 samples: 882
[02/22 17:48:17] [DEBUG] [hifi.interface.deadlock] DEADLOCK WATCHDOG WARNING: lastHeartbeatAge: 34075478 elapsedMovingAverage: 822 PREVIOUS maxElapsed: 33075317 NEW maxElapsed: 34075478 ** NEW MAX ELAPSED ** maxElapsedAverage: 822 samples: 882
```
- Choose Debug > Deadlock Interface -- see that the application will pause for 2 minutes and then crash
- After running these tests, please contact me and let me know so I can check our metabase database to verify that the deadlock watchdog stats were sent for your session.