### PR TITLE
fix for not re-enabling preview on leaving security-sensitive pages in marketplace

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
@@ -69,6 +69,10 @@ Item {
         hoverEnabled: true;
     }
     
+    Component.onDestruction: {
+        sendSignalToParent({method: 'maybeEnableHmdPreview'});
+    }
+
     // This will cause a bug -- if you bring up passphrase selection in HUD mode while
     // in HMD while having HMD preview enabled, then move, then finish passphrase selection,
     // HMD preview will stay off.

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -222,6 +222,8 @@ Rectangle {
                     } else {
                         sendToScript(msg);
                     }
+                } else if (msg.method === 'maybeEnableHmdPreview') {
+                    sendToScript(msg);
                 }
             }
         }

--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -115,13 +115,15 @@ var selectionDisplay = null; // for gridTool.js to ignore
     var filterText; // Used for updating Purchases QML
 
     var onWalletScreen = false;
+    var onCommerceScreen = false;
+
     function onScreenChanged(type, url) {
         onMarketplaceScreen = type === "Web" && url.indexOf(MARKETPLACE_URL) !== -1;
         var onWalletScreenNow = url.indexOf(MARKETPLACE_WALLET_QML_PATH) !== -1;
-        onCommerceScreen = type === "QML" && (url.indexOf(MARKETPLACE_CHECKOUT_QML_PATH) !== -1 || url === MARKETPLACE_PURCHASES_QML_PATH
+        var onCommerceScreenNow = type === "QML" && (url.indexOf(MARKETPLACE_CHECKOUT_QML_PATH) !== -1 || url === MARKETPLACE_PURCHASES_QML_PATH
             || url.indexOf(MARKETPLACE_INSPECTIONCERTIFICATE_QML_PATH) !== -1);
 
-        if (!onWalletScreenNow && onWalletScreen) { // exiting wallet screen
+        if ((!onWalletScreenNow && onWalletScreen) || (!onCommerceScreenNow && onCommerceScreen)) { // exiting wallet or commerce screen
             if (isHmdPreviewDisabledBySecurity) {
                 DesktopPreviewProvider.setPreviewDisabledReason("USER");
                 Menu.setIsOptionChecked("Disable Preview", false);
@@ -129,6 +131,7 @@ var selectionDisplay = null; // for gridTool.js to ignore
             }
         }
 
+        onCommerceScreen = onCommerceScreenNow;
         onWalletScreen = onWalletScreenNow;
         wireEventBridge(onMarketplaceScreen || onCommerceScreen || onWalletScreen);
 


### PR DESCRIPTION
All pages that trigger the commerce specific disabled preview screen in the marketplace (places where user enters their wallet pin) do not dismiss the disabled preview screen when credentials are not entered, but rather the user selects the "Cancel" button or the tablet "x" button.