### PR TITLE
Export boolean entity properties properly

### DIFF
--- a/libraries/entities/src/EntityItemPropertiesMacros.h
+++ b/libraries/entities/src/EntityItemPropertiesMacros.h
@@ -105,6 +105,7 @@ inline QScriptValue convertScriptValue(QScriptEngine* e, const glm::vec2& v) { r
 inline QScriptValue convertScriptValue(QScriptEngine* e, const glm::vec3& v) { return vec3toScriptValue(e, v); }
 inline QScriptValue convertScriptValue(QScriptEngine* e, float v) { return QScriptValue(v); }
 inline QScriptValue convertScriptValue(QScriptEngine* e, int v) { return QScriptValue(v); }
+inline QScriptValue convertScriptValue(QScriptEngine* e, bool v) { return QScriptValue(v); }
 inline QScriptValue convertScriptValue(QScriptEngine* e, quint16 v) { return QScriptValue(v); }
 inline QScriptValue convertScriptValue(QScriptEngine* e, quint32 v) { return QScriptValue(v); }
 inline QScriptValue convertScriptValue(QScriptEngine* e, quint64 v) { return QScriptValue((qsreal)v); }


### PR DESCRIPTION
This one liner seems to make boolean properties better discoverable in entity exports. ~Lets check backwards compatibility.~  backward compatible with stable build ✔️ 

Instead of writing `0` or `1`, it will write `true` or `false` for boolean properties to the entities JSON file.

## test plan

Use https://highfidelity.testrail.net/index.php?/cases/view/7049 with a few additional steps.

Note: Please comment results of those steps under the same number.

5a. Enable the dynamic checkbox.      (The entity is now dynamic)
14a. Open the just created `PURPLE BOX.json` in a text editor. (It should contain the line `"dynamic": true,`)
23a. (Both entities should be dynamic, try pushing them around, they should move)




