### PR TITLE
Search main window by checking object name

### DIFF
--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -625,8 +625,7 @@ private:
         auto windows = qApp->topLevelWindows();
         QWindow* result = nullptr;
         for (auto window : windows) {
-            QVariant isMainWindow = window->property("MainWindow");
-            if (!qobject_cast<QQuickWindow*>(window)) {
+            if (window->objectName().contains("MainWindow")) {
                 result = window;
                 break;
             }


### PR DESCRIPTION
At some systems interface gets crash on startup due to invalid window choose as MainWindow

Test plan:
- Start inteface
- no crash on startup inside KeyboardFocusHack() class