### PR TITLE
Fixed log spam undefined error

### DIFF
--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1322,8 +1322,9 @@ SelectionDisplay = (function() {
                                        isActiveTool(handleScaleRTFCube) || isActiveTool(handleStretchXSphere) || 
                                        isActiveTool(handleStretchYSphere) || isActiveTool(handleStretchZSphere));
 
-        var showOutlineForZone = (SelectionManager.selections.length === 1 &&
-                                  SelectionManager.savedProperties[SelectionManager.selections[0]].type === "Zone");
+        var showOutlineForZone = (SelectionManager.selections.length === 1 && 
+                                    typeof SelectionManager.savedProperties[SelectionManager.selections[0]] !== "undefined" &&
+                                    SelectionManager.savedProperties[SelectionManager.selections[0]].type === "Zone");
         that.setHandleScaleEdgeVisible(showOutlineForZone || (!isActiveTool(handleRotatePitchRing) &&
                                                               !isActiveTool(handleRotateYawRing) &&
                                                               !isActiveTool(handleRotateRollRing)));


### PR DESCRIPTION
## Test Plan
1. Open up the log (Ctrl + Shift + L)
2. Open up the create menu
3. Click on any object
4. You should **NOT** see this error:
`[CRITICAL] [hifi.scriptengine] [defaultScripts.js] [UncaughtException signalHandlerException] Error: Result of expression 'SelectionManager.savedProperties[SelectionManager.selections[0]]' [undefined] is not an object. in file:///C:/Program Files/High Fidelity-Dev/scripts/system/libraries/entitySelectionTool.js:1326`
5. Create a zone, check to see that the gray outline still appears when you rotate it