### PR TITLE
if a node can't change locks, don't allow it to create an already-locked entity

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1508,6 +1508,11 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                 }
             }
 
+            if (isAdd && properties.getLocked() && !senderNode->isAllowedEditor()) {
+                // if a node can't change locks, don't allow them to create an already-locked entity
+                properties.setLocked(false);
+            }
+
             // If we got a valid edit packet, then it could be a new entity or it could be an update to
             // an existing entity... handle appropriately
             if (validEditPacket) {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1511,6 +1511,7 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
             if (isAdd && properties.getLocked() && !senderNode->isAllowedEditor()) {
                 // if a node can't change locks, don't allow them to create an already-locked entity
                 properties.setLocked(false);
+                bumpTimestamp(properties);
             }
 
             // If we got a valid edit packet, then it could be a new entity or it could be an update to


### PR DESCRIPTION
- if a node can't change locks and attempts to rez a locked entity, force it to be unlocked instead
