### PR TITLE
Fix NVTT for mac

### DIFF
--- a/cmake/externals/nvtt/CMakeLists.txt
+++ b/cmake/externals/nvtt/CMakeLists.txt
@@ -29,8 +29,8 @@ else ()
   
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL http://hifi-public.s3.amazonaws.com/dependencies/nvidia-texture-tools-2.1.0.hifi.zip
-    URL_MD5 5794b950f8b265a9a41b2839b3bf7ebb
+    URL http://hifi-public.s3.amazonaws.com/dependencies/nvidia-texture-tools-2.1.0.hifi-83462e4.zip
+    URL_MD5 602776e08515b54bfa1b8dc455003f0f
     CONFIGURE_COMMAND CMAKE_ARGS  ${ANDROID_CMAKE_ARGS} -DNVTT_SHARED=1 -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     LOG_DOWNLOAD 1
     LOG_CONFIGURE 1


### PR DESCRIPTION
I fixed up the archive we have on S3 so mac builds don't have that annoying NVTT issue anymore.