### PR TITLE
RC65: Fix undefined request from JS

### DIFF
--- a/scripts/modules/request.js
+++ b/scripts/modules/request.js
@@ -71,7 +71,7 @@ module.exports = {
             }
         }
         httpRequest.open(options.method, options.uri, true);
-        httpRequest.send(options.body);
+        httpRequest.send(options.body || null);
         }
 };
 


### PR DESCRIPTION
When HTTP requests are made from JavaScript, and those requests don't have a body, the HTTP request would be sent with an `undefined` body, rather than an empty one. This caused problems when making HTTP requests to the Staging metaverse via `request.js`.

One thing this fixes is the "Connections" tab in the PAL when using the Staging metaverse.