### PR TITLE
Disable virtual trackpad rendering on non-Android builds

### DIFF
--- a/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.cpp
@@ -23,6 +23,7 @@ const QString Basic2DWindowOpenGLDisplayPlugin::NAME("Desktop");
 static const QString FULLSCREEN = "Fullscreen";
 
 void Basic2DWindowOpenGLDisplayPlugin::customizeContext() {
+#if defined(Q_OS_ANDROID)
     auto iconPath = PathUtils::resourcesPath() + "images/analog_stick.png";
     auto image = QImage(iconPath);
     if (image.format() != QImage::Format_ARGB32) {
@@ -61,8 +62,7 @@ void Basic2DWindowOpenGLDisplayPlugin::customizeContext() {
         _virtualPadStickBaseTexture->assignStoredMip(0, image.byteCount(), image.constBits());
         _virtualPadStickBaseTexture->setAutoGenerateMips(true);
     }
-
-
+#endif
     Parent::customizeContext();
 }
 
@@ -88,6 +88,7 @@ bool Basic2DWindowOpenGLDisplayPlugin::internalActivate() {
 }
 
 void Basic2DWindowOpenGLDisplayPlugin::compositeExtra() {
+#if defined(Q_OS_ANDROID)
     auto& virtualPadManager = VirtualPad::Manager::instance();
     if(virtualPadManager.getLeftVirtualPad()->isBeingTouched()) {
         // render stick base
@@ -115,6 +116,7 @@ void Basic2DWindowOpenGLDisplayPlugin::compositeExtra() {
             batch.draw(gpu::TRIANGLE_STRIP, 4);
         });
     }
+#endif
     Parent::compositeExtra();
 }
 

--- a/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.h
@@ -42,6 +42,8 @@ private:
     uint32_t _framerateTarget { 0 };
     int _fullscreenTarget{ -1 };
 
+#if defined(Q_OS_ANDROID)
     gpu::TexturePointer _virtualPadStickTexture;
     gpu::TexturePointer _virtualPadStickBaseTexture;
+#endif
 };


### PR DESCRIPTION
The virtual joystick should not be rendered on desktop.

## Testing

Master builds may show a rectangle and circle rendered on the desktop view.  This build should not show those rendering artifacts.  