### PR TITLE
FIX: make the grabbable checkbox function again when dynamic disabled

### DIFF
--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1281,7 +1281,7 @@ function loaded() {
             if (elCloneable.checked) {
                 elGrabbable.checked = false;
             }
-            userDataChanger("grabbableKey", "grabbable", elGrabbable, elUserData, properties.dynamic);
+            userDataChanger("grabbableKey", "grabbable", elGrabbable, elUserData, true);
         });
         elCloneableDynamic.addEventListener('change', function(event) {
             userDataChanger("grabbableKey", "cloneDynamic", event.target, elUserData, -1);


### PR DESCRIPTION
This PR will also respect the grabbable default true setting. Unlike the stable implementation which had 0 or 1 as default based on the value of properties.dynamic, which made the default value check completely useless.