### PR TITLE
Register AvatarInput when AvatarInput really created

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2726,6 +2726,8 @@ void Application::onDesktopRootContextCreated(QQmlContext* surfaceContext) {
 void Application::onDesktopRootItemCreated(QQuickItem* rootItem) {
     Stats::show();
     AvatarInputs::show();
+    DependencyManager::get<OffscreenUi>()->getSurfaceContext()->
+            setContextProperty("AvatarInputs", AvatarInputs::getInstance());
 }
 
 void Application::updateCamera(RenderArgs& renderArgs, float deltaTime) {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/12815/Show-Audio-Level-Meter-radio-button-in-Audio-menu-is-not-functional

Test plan:
- Open Interface in Toolbar mode
- open Audio app
- Check Audio meter is on