### PR TITLE
Wrap text in query dialogs. Add right margins for input field and but…

### DIFF
--- a/interface/resources/qml/controls-uit/TextField.qml
+++ b/interface/resources/qml/controls-uit/TextField.qml
@@ -165,8 +165,10 @@ TextField {
         text: textField.label
         colorScheme: textField.colorScheme
         anchors.left: parent.left
+        anchors.right: parent.right
         anchors.bottom: parent.top
         anchors.bottomMargin: 3
+        wrapMode: Text.WordWrap
         visible: label != ""
     }
 }

--- a/interface/resources/qml/dialogs/TabletQueryDialog.qml
+++ b/interface/resources/qml/dialogs/TabletQueryDialog.qml
@@ -65,10 +65,7 @@ TabletModalWindow {
         id: modalWindowItem
         width: parent.width - 12
         height: 240
-        anchors {
-            verticalCenter: parent.verticalCenter
-            horizontalCenter: parent.horizontalCenter
-        }
+        anchors.horizontalCenter: parent.horizontalCenter
         
        QtObject {
             id: d
@@ -81,18 +78,20 @@ TabletModalWindow {
                 var targetWidth = Math.max(titleWidth, modalWindowItem.width)
                 var targetHeight = (items ? comboBox.controlHeight : textResult.controlHeight) + 5 * hifi.dimensions.contentSpacing.y + buttons.height
                 modalWindowItem.width = (targetWidth < d.minWidth) ? d.minWidth : ((targetWidth > d.maxWdith) ? d.maxWidth : targetWidth);
-                modalWindowItem.height = ((targetHeight < d.minHeight) ? d.minHeight : ((targetHeight > d.maxHeight) ? d.maxHeight : targetHeight)) + ((keyboardEnabled && keyboardRaised) ? (keyboard.raisedHeight + 2 * hifi.dimensions.contentSpacing.y) : 0) + modalWindowItem.frameMarginTop
+                modalWindowItem.height = ((targetHeight < d.minHeight) ? d.minHeight : ((targetHeight > d.maxHeight) ? d.maxHeight : targetHeight)) + modalWindowItem.frameMarginTop
+                modalWindowItem.y = (root.height - (modalWindowItem.height + ((keyboardEnabled && keyboardRaised) ? (keyboard.raisedHeight + 2 * hifi.dimensions.contentSpacing.y) : 0))) / 2
             }
         }
         
         Item {
             anchors {
                 top: parent.top
-                bottom: keyboard.top;
+                bottom: buttons.top;
                 left: parent.left;
                 right: parent.right;
                 margins: 0
                 bottomMargin: 2 * hifi.dimensions.contentSpacing.y
+                topMargin: modalWindowItem.frameMarginTop
             }
 
             // FIXME make a text field type that can be bound to a history for autocompletion
@@ -125,22 +124,6 @@ TabletModalWindow {
             }
         }
         
-        property alias keyboardOverride: root.keyboardOverride
-        property alias keyboardRaised: root.keyboardRaised
-        property alias punctuationMode: root.punctuationMode
-        
-        Keyboard {
-            id: keyboard
-            raised: keyboardEnabled && keyboardRaised
-            numeric: punctuationMode
-            anchors {
-                left: parent.left
-                right: parent.right
-                bottom: buttons.top
-                bottomMargin: raised ? 2 * hifi.dimensions.contentSpacing.y : 0
-            }
-        }
-       
         Flow {
             id: buttons
             focus: true
@@ -179,7 +162,17 @@ TabletModalWindow {
         }
     }
 
-   Keys.onPressed: {
+    Keyboard {
+        id: keyboard
+        raised: keyboardEnabled && keyboardRaised
+        numeric: punctuationMode
+        anchors {
+            left: parent.left
+            right: parent.right
+            top: modalWindowItem.bottom
+        }
+    }
+    Keys.onPressed: {
         if (!visible) {
             return
         }

--- a/interface/resources/qml/dialogs/TabletQueryDialog.qml
+++ b/interface/resources/qml/dialogs/TabletQueryDialog.qml
@@ -72,13 +72,13 @@ TabletModalWindow {
         
        QtObject {
             id: d
-            readonly property int minWidth: 470
-            readonly property int maxWidth: 470
+            readonly property int minWidth: modalWindowItem.width
+            readonly property int maxWidth: modalWindowItem.width
             readonly property int minHeight: 120
             readonly property int maxHeight: 720
 
             function resize() {
-                var targetWidth = Math.max(titleWidth, 470)
+                var targetWidth = Math.max(titleWidth, modalWindowItem.width)
                 var targetHeight = (items ? comboBox.controlHeight : textResult.controlHeight) + 5 * hifi.dimensions.contentSpacing.y + buttons.height
                 modalWindowItem.width = (targetWidth < d.minWidth) ? d.minWidth : ((targetWidth > d.maxWdith) ? d.maxWidth : targetWidth);
                 modalWindowItem.height = ((targetHeight < d.minHeight) ? d.minHeight : ((targetHeight > d.maxHeight) ? d.maxHeight : targetHeight)) + ((keyboardEnabled && keyboardRaised) ? (keyboard.raisedHeight + 2 * hifi.dimensions.contentSpacing.y) : 0) + modalWindowItem.frameMarginTop
@@ -106,6 +106,7 @@ TabletModalWindow {
                     right: parent.right;
                     bottom: parent.bottom
                     leftMargin: 5
+                    rightMargin: 5
                 }
             }
 
@@ -150,6 +151,7 @@ TabletModalWindow {
                 bottom: parent.bottom
                 right: parent.right
                 margins: 0
+                rightMargin: hifi.dimensions.borderRadius
                 bottomMargin: hifi.dimensions.contentSpacing.y
             }
             Button { action: cancelAction }

--- a/interface/src/scripting/AssetMappingsScriptingInterface.cpp
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.cpp
@@ -69,11 +69,11 @@ void AssetMappingsScriptingInterface::getMapping(QString path, QJSValue callback
 
 void AssetMappingsScriptingInterface::uploadFile(QString path, QString mapping, QJSValue startedCallback, QJSValue completedCallback, bool dropEvent) {
     static const QString helpText =
-        "Upload your asset to a specific folder by entering the full path. Specifying\n"
+        "Upload your asset to a specific folder by entering the full path. Specifying"
         "a new folder name will automatically create that folder for you.";
     static const QString dropHelpText =
         "This file will be added to your Asset Server.\n"
-        "Use the field below to place your file in a specific folder or to rename it.\n"
+        "Use the field below to place your file in a specific folder or to rename it. "
         "Specifying a new folder name will automatically create that folder for you.";
 
     auto offscreenUi = DependencyManager::get<OffscreenUi>();

--- a/interface/src/scripting/AssetMappingsScriptingInterface.cpp
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.cpp
@@ -69,7 +69,7 @@ void AssetMappingsScriptingInterface::getMapping(QString path, QJSValue callback
 
 void AssetMappingsScriptingInterface::uploadFile(QString path, QString mapping, QJSValue startedCallback, QJSValue completedCallback, bool dropEvent) {
     static const QString helpText =
-        "Upload your asset to a specific folder by entering the full path. Specifying"
+        "Upload your asset to a specific folder by entering the full path. Specifying "
         "a new folder name will automatically create that folder for you.";
     static const QString dropHelpText =
         "This file will be added to your Asset Server.\n"


### PR DESCRIPTION
…tons

https://highfidelity.manuscript.com/f/cases/12818/Asset-import-dialog-has-cosmetic-issues

Test plan:
- Open the Tablet
- Navigate to MENU->EDIT->ASSET BROWSER
- Click the CHOOSE FILE button
- Navigate to a directory with importable assets
- Select a file and click OPEN
- Make sure all elements located in bounds of gray dialog's area and no striked out text