### PR TITLE
fix controllerDispatcher error in logs

### DIFF
--- a/scripts/system/controllers/controllerDispatcher.js
+++ b/scripts/system/controllers/controllerDispatcher.js
@@ -43,6 +43,7 @@ Script.include("/~/system/libraries/controllerDispatcherUtils.js");
         this.totalVariance = 0;
         this.highVarianceCount = 0;
         this.veryhighVarianceCount = 0;
+        this.orderedPluginNames = [];
         this.tabletID = null;
         this.blacklist = [];
         this.pointerManager = new PointerManager();


### PR DESCRIPTION
It seems that the controllerDispacther update function will run before any modules have been add. The result is the `controllerDispactherPluginsNeedSort` will never be set to `true` and `orderedPluginNames` will never be define causing an error in the update function. As a solution I explicitly give the `orderedPluginNames` a default value