### PR TITLE
correctly use default values and don't delete userData in entitiesProperties.js

### DIFF
--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -321,22 +321,19 @@ function multiDataUpdater(groupName, updateKeyPair, userDataElement, defaults) {
     }
     var keys = Object.keys(updateKeyPair);
     keys.forEach(function (key) {
-        delete parsedData[groupName][key];
         if (updateKeyPair[key] !== null && updateKeyPair[key] !== "null") {
             if (updateKeyPair[key] instanceof Element) {
                 if (updateKeyPair[key].type === "checkbox") {
-                    if (updateKeyPair[key].checked !== defaults[key]) {
-                        parsedData[groupName][key] = updateKeyPair[key].checked;
-                    }
+                    parsedData[groupName][key] = updateKeyPair[key].checked;
                 } else {
                     var val = isNaN(updateKeyPair[key].value) ? updateKeyPair[key].value : parseInt(updateKeyPair[key].value);
-                    if (val !== defaults[key]) {
-                        parsedData[groupName][key] = val;
-                    }
+                    parsedData[groupName][key] = val;
                 }
             } else {
                 parsedData[groupName][key] = updateKeyPair[key];
             }
+        } else if (defaults[key] !== null && defaults[key] !== "null") {
+            parsedData[groupName][key] = defaults[key];
         }
     });
     if (Object.keys(parsedData[groupName]).length === 0) {


### PR DESCRIPTION
In `entitiesProperties` function `multiDataupdater` we do not correctly use the default values. Instead of checking if the new data is equal to the default, we should only use the default data if the new data is `null`
This fixes issue in the create app like unable to toggle the grabbable checkbox if dynamic is not checked.

ticket - https://highfidelity.fogbugz.com/f/cases/12626/Setting-unsetting-grabbable-shouldn-t-wipe-out-other-UserData