### PR TITLE
Fix for avatar recording only working once

### DIFF
--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -578,6 +578,7 @@ void Connection::processControl(ControlPacketPointer controlPacket) {
 #ifdef UDT_CONNECTION_DEBUG
                 qCDebug(networking) << "Got handshake request, stopping SendQueue";
 #endif
+                _hasReceivedHandshakeACK = false;
                 stopSendQueue();
             }
             break;


### PR DESCRIPTION
This is a minimal hotfix that fixes the Agent<->AvatarMixer connection not getting reset correctly.

https://highfidelity.manuscript.com/f/cases/12103/
