### PR TITLE
Fix Local lights not showing anymore

### DIFF
--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -142,12 +142,11 @@ void RenderDeferredTask::build(JobModel& task, const render::Varying& input, ren
     const auto ambientOcclusionFramebuffer = ambientOcclusionOutputs.getN<AmbientOcclusionEffect::Outputs>(0);
     const auto ambientOcclusionUniforms = ambientOcclusionOutputs.getN<AmbientOcclusionEffect::Outputs>(1);
 
-    
+    // Clear Light, Haze and Skybox Stages and render zones from the general metas bucket
+    const auto zones = task.addJob<ZoneRendererTask>("ZoneRenderer", metas);
+
     // Draw Lights just add the lights to the current list of lights to deal with. NOt really gpu job for now.
     task.addJob<DrawLight>("DrawLight", lights);
-
-    // Filter zones from the general metas bucket
-    const auto zones = task.addJob<ZoneRendererTask>("ZoneRenderer", metas);
 
     // Light Clustering
     // Create the cluster grid of lights, cpu job for now


### PR DESCRIPTION
Local lights were not rendered anymore since the build 7918 when we merge back changes from the android branch to master.
In that former branch we added a "LightStage.clear()" in  the ZoneRendererJob 
It s ok in Forrward renderer right now, but not in the Deferred Renderer because it s happening AFTER the local lights are added to the current list of lights for this frame and just erase that information.

I simply swapped the order of the ZoneRendererJob with DrawLocalLights in the DeferredRenderTask and the local lights are back.

## TEST PLAN #
Go to any domain with Light entities (dev-welcome, dev-avatarisland or rust)
In this PR the local lights are displaying correctly
they don't show in current master since version 7918
