### PR TITLE
Materials on primitives

### DIFF
--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -123,5 +123,5 @@ void MaterialEntityRenderer::doRender(RenderArgs* args) {
     // Draw!
     DependencyManager::get<GeometryCache>()->renderSphere(batch);
 
-    args->_details._trianglesRendered += DependencyManager::get<GeometryCache>()->getSphereTriangleCount();
+    args->_details._trianglesRendered += (int)DependencyManager::get<GeometryCache>()->getSphereTriangleCount();
 }

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -9,6 +9,7 @@
 #include "RenderableMaterialEntityItem.h"
 
 #include "RenderPipelines.h"
+#include "GeometryCache.h"
 
 using namespace render;
 using namespace render::entities;
@@ -90,138 +91,6 @@ ShapeKey MaterialEntityRenderer::getShapeKey() {
     return builder.build();
 }
 
-glm::vec3 MaterialEntityRenderer::getVertexPos(float phi, float theta) {
-    return glm::vec3(glm::sin(theta) * glm::cos(phi), glm::cos(theta), glm::sin(theta) * glm::sin(phi));
-}
-
-glm::vec3 MaterialEntityRenderer::getTangent(float phi, float theta) {
-    return glm::vec3(-glm::cos(theta) * glm::cos(phi), glm::sin(theta), -glm::cos(theta) * glm::sin(phi));
-}
-
-void MaterialEntityRenderer::addVertex(std::vector<float>& buffer, const glm::vec3& pos, const glm::vec3& tan, const glm::vec2 uv) {
-    buffer.push_back(pos.x); buffer.push_back(pos.y); buffer.push_back(pos.z);
-    buffer.push_back(tan.x); buffer.push_back(tan.y); buffer.push_back(tan.z);
-    buffer.push_back(uv.x); buffer.push_back(uv.y);
-}
-
-void MaterialEntityRenderer::addTriangleFan(std::vector<float>& buffer, int stack, int step) {
-    float v1 = ((float)stack) / STACKS;
-    float theta1 = v1 * (float)M_PI;
-    glm::vec3 tip = getVertexPos(0, theta1);
-    float v2 = ((float)(stack + step)) / STACKS;
-    float theta2 = v2 * (float)M_PI;
-    for (int i = 0; i < SLICES; i++) {
-        float u1 = ((float)i) / SLICES;
-        float u2 = ((float)(i + step)) / SLICES;
-        float phi1 = u1 * M_PI_TIMES_2;
-        float phi2 = u2 * M_PI_TIMES_2;
-        /* (flipped for negative step)
-             p1
-            /  \
-           /    \
-          /      \
-        p3 ------ p2
-        */
-
-        glm::vec3 pos2 = getVertexPos(phi2, theta2);
-        glm::vec3 pos3 = getVertexPos(phi1, theta2);
-
-        glm::vec3 tan1 = getTangent(0, theta1);
-        glm::vec3 tan2 = getTangent(phi2, theta2);
-        glm::vec3 tan3 = getTangent(phi1, theta2);
-
-        glm::vec2 uv1 = glm::vec2((u1 + u2) / 2.0f, v1);
-        glm::vec2 uv2 = glm::vec2(u2, v2);
-        glm::vec2 uv3 = glm::vec2(u1, v2);
-
-        addVertex(buffer, tip, tan1, uv1);
-        addVertex(buffer, pos2, tan2, uv2);
-        addVertex(buffer, pos3, tan3, uv3);
-
-        _numVertices += 3;
-    }
-}
-
-int MaterialEntityRenderer::_numVertices = 0;
-std::shared_ptr<gpu::Stream::Format> MaterialEntityRenderer::_streamFormat = nullptr;
-std::shared_ptr<gpu::BufferStream> MaterialEntityRenderer::_stream = nullptr;
-std::shared_ptr<gpu::Buffer> MaterialEntityRenderer::_verticesBuffer = nullptr;
-
-void MaterialEntityRenderer::generateMesh() {
-    _streamFormat = std::make_shared<gpu::Stream::Format>();
-    _stream = std::make_shared<gpu::BufferStream>();
-    _verticesBuffer = std::make_shared<gpu::Buffer>();
-
-    const int NUM_POS_COORDS = 3;
-    const int NUM_TANGENT_COORDS = 3;
-    const int VERTEX_TANGENT_OFFSET = NUM_POS_COORDS * sizeof(float);
-    const int VERTEX_TEXCOORD_OFFSET = VERTEX_TANGENT_OFFSET + NUM_TANGENT_COORDS * sizeof(float);
-
-    _streamFormat->setAttribute(gpu::Stream::POSITION, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0);
-    _streamFormat->setAttribute(gpu::Stream::NORMAL, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0);
-    _streamFormat->setAttribute(gpu::Stream::TANGENT, 0, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), VERTEX_TANGENT_OFFSET);
-    _streamFormat->setAttribute(gpu::Stream::TEXCOORD, 0, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::UV), VERTEX_TEXCOORD_OFFSET);
-
-    _stream->addBuffer(_verticesBuffer, 0, _streamFormat->getChannels().at(0)._stride);
-
-    std::vector<float> vertexBuffer;
-
-    // Top
-    addTriangleFan(vertexBuffer, 0, 1);
-
-    // Middle section
-    for (int j = 1; j < STACKS - 1; j++) {
-        float v1 = ((float)j) / STACKS;
-        float v2 = ((float)(j + 1)) / STACKS;
-        float theta1 = v1 * (float)M_PI;
-        float theta2 = v2 * (float)M_PI;
-        for (int i = 0; i < SLICES; i++) {
-            float u1 = ((float)i) / SLICES;
-            float u2 = ((float)(i + 1)) / SLICES;
-            float phi1 = u1 * M_PI_TIMES_2;
-            float phi2 = u2 * M_PI_TIMES_2;
-
-            /*
-            p2 ---- p3
-             |    /  |
-             |   /   |
-             |  /    |
-            p1 ---- p4
-            */
-
-            glm::vec3 pos1 = getVertexPos(phi1, theta2);
-            glm::vec3 pos2 = getVertexPos(phi1, theta1);
-            glm::vec3 pos3 = getVertexPos(phi2, theta1);
-            glm::vec3 pos4 = getVertexPos(phi2, theta2);
-
-            glm::vec3 tan1 = getTangent(phi1, theta2);
-            glm::vec3 tan2 = getTangent(phi1, theta1);
-            glm::vec3 tan3 = getTangent(phi2, theta1);
-            glm::vec3 tan4 = getTangent(phi2, theta2);
-
-            glm::vec2 uv1 = glm::vec2(u1, v2);
-            glm::vec2 uv2 = glm::vec2(u1, v1);
-            glm::vec2 uv3 = glm::vec2(u2, v1);
-            glm::vec2 uv4 = glm::vec2(u2, v2);
-
-            addVertex(vertexBuffer, pos1, tan1, uv1);
-            addVertex(vertexBuffer, pos2, tan2, uv2);
-            addVertex(vertexBuffer, pos3, tan3, uv3);
-
-            addVertex(vertexBuffer, pos3, tan3, uv3);
-            addVertex(vertexBuffer, pos4, tan4, uv4);
-            addVertex(vertexBuffer, pos1, tan1, uv1);
-
-            _numVertices += 6;
-        }
-    }
-
-    // Bottom
-    addTriangleFan(vertexBuffer, STACKS, -1);
-
-    _verticesBuffer->append(vertexBuffer.size() * sizeof(float), (gpu::Byte*) vertexBuffer.data());
-}
-
 void MaterialEntityRenderer::doRender(RenderArgs* args) {
     PerformanceTimer perfTimer("RenderableMaterialEntityItem::render");
     Q_ASSERT(args->_batch);
@@ -252,14 +121,7 @@ void MaterialEntityRenderer::doRender(RenderArgs* args) {
     args->_details._materialSwitches++;
 
     // Draw!
-    if (_numVertices == 0) {
-        generateMesh();
-    }
+    DependencyManager::get<GeometryCache>()->renderSphere(batch);
 
-    batch.setInputFormat(_streamFormat);
-    batch.setInputStream(0, *_stream);
-    batch.draw(gpu::TRIANGLES, _numVertices, 0);
-
-    const int NUM_VERTICES_PER_TRIANGLE = 3;
-    args->_details._trianglesRendered += _numVertices / NUM_VERTICES_PER_TRIANGLE;
+    args->_details._trianglesRendered += DependencyManager::get<GeometryCache>()->getSphereTriangleCount();
 }

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.h
@@ -40,20 +40,6 @@ private:
     Transform _renderTransform;
 
     std::shared_ptr<NetworkMaterial> _drawMaterial;
-
-    static int _numVertices;
-    static std::shared_ptr<gpu::Stream::Format> _streamFormat;
-    static std::shared_ptr<gpu::BufferStream> _stream;
-    static std::shared_ptr<gpu::Buffer> _verticesBuffer;
-
-    void generateMesh();
-    void addTriangleFan(std::vector<float>& buffer, int stack, int step);
-    static glm::vec3 getVertexPos(float phi, float theta);
-    static glm::vec3 getTangent(float phi, float theta);
-    static void addVertex(std::vector<float>& buffer, const glm::vec3& pos, const glm::vec3& tan, const glm::vec2 uv);
-    const int SLICES = 15;
-    const int STACKS = 9;
-    const float M_PI_TIMES_2 = 2.0f * (float)M_PI;
 };
 
 } } 

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -138,11 +138,12 @@ ItemKey ShapeEntityRenderer::getKey() {
 }
 
 bool ShapeEntityRenderer::useMaterialPipeline() const {
-    withReadLock([&] {
-        if (_procedural.isReady()) {
-            return false;
-        }
+    bool proceduralReady = resultWithReadLock<bool>([&] {
+        return _procedural.isReady();
     });
+    if (proceduralReady) {
+        return false;
+    }
 
     graphics::MaterialKey drawMaterialKey;
     auto mat = _materials.find("0");

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -19,6 +19,8 @@
 #include "render-utils/simple_vert.h"
 #include "render-utils/simple_frag.h"
 
+#include "RenderPipelines.h"
+
 //#define SHAPE_ENTITY_USE_FADE_EFFECT
 #ifdef SHAPE_ENTITY_USE_FADE_EFFECT
 #include <FadeEffect.h>
@@ -108,9 +110,91 @@ bool ShapeEntityRenderer::isTransparent() const {
     if (_procedural.isEnabled() && _procedural.isFading()) {
         return Interpolate::calculateFadeRatio(_procedural.getFadeStartTime()) < 1.0f;
     }
-    
-    //        return _entity->getLocalRenderAlpha() < 1.0f || Parent::isTransparent();
+
+    auto mat = _materials.find("0");
+    if (mat != _materials.end()) {
+        if (mat->second.top().material) {
+            auto matKey = mat->second.top().material->getKey();
+            if (matKey.isTranslucent()) {
+                return true;
+            }
+        }
+    }
+
     return Parent::isTransparent();
+}
+
+ItemKey ShapeEntityRenderer::getKey() {
+    ItemKey::Builder builder;
+    builder.withTypeShape().withTypeMeta().withTagBits(render::ItemKey::TAG_BITS_0 | render::ItemKey::TAG_BITS_1);
+
+    withReadLock([&] {
+        if (isTransparent()) {
+            builder.withTransparent();
+        }
+    });
+
+    return builder.build();
+}
+
+bool ShapeEntityRenderer::useMaterialPipeline() const {
+    withReadLock([&] {
+        if (_procedural.isReady()) {
+            return false;
+        }
+    });
+
+    graphics::MaterialKey drawMaterialKey;
+    auto mat = _materials.find("0");
+    if (mat != _materials.end() && mat->second.top().material) {
+        drawMaterialKey = mat->second.top().material->getKey();
+    }
+
+    if (drawMaterialKey.isEmissive() || drawMaterialKey.isUnlit() || drawMaterialKey.isMetallic() || drawMaterialKey.isScattering()) {
+        return true;
+    }
+
+    // If the material is using any map, we need to use a material ShapeKey
+    for (int i = 0; i < graphics::Material::MapChannel::NUM_MAP_CHANNELS; i++) {
+        if (drawMaterialKey.isMapChannel(graphics::Material::MapChannel(i))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+ShapeKey ShapeEntityRenderer::getShapeKey() {
+    if (useMaterialPipeline()) {
+        graphics::MaterialKey drawMaterialKey;
+        if (_materials["0"].top().material) {
+            drawMaterialKey = _materials["0"].top().material->getKey();
+        }
+
+        bool isTranslucent = drawMaterialKey.isTranslucent();
+        bool hasTangents = drawMaterialKey.isNormalMap();
+        bool hasLightmap = drawMaterialKey.isLightmapMap();
+        bool isUnlit = drawMaterialKey.isUnlit();
+
+        ShapeKey::Builder builder;
+        builder.withMaterial();
+
+        if (isTranslucent) {
+            builder.withTranslucent();
+        }
+        if (hasTangents) {
+            builder.withTangents();
+        }
+        if (hasLightmap) {
+            builder.withLightmap();
+        }
+        if (isUnlit) {
+            builder.withUnlit();
+        }
+
+        return builder.build();
+    } else {
+        return Parent::getShapeKey();
+    }
 }
 
 void ShapeEntityRenderer::doRender(RenderArgs* args) {
@@ -149,7 +233,7 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
         } else {
             geometryCache->renderShape(batch, geometryShape, outColor);
         }
-    } else {
+    } else if (!useMaterialPipeline()) {
         // FIXME, support instanced multi-shape rendering using multidraw indirect
         outColor.a *= _isFading ? Interpolate::calculateFadeRatio(_fadeStartTime) : 1.0f;
         auto pipeline = outColor.a < 1.0f ? geometryCache->getTransparentShapePipeline() : geometryCache->getOpaqueShapePipeline();
@@ -158,6 +242,11 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
         } else {
             geometryCache->renderSolidShapeInstance(args, batch, geometryShape, outColor, pipeline);
         }
+    } else {
+        RenderPipelines::bindMaterial(mat, batch, args->_enableTexturing);
+        args->_details._materialSwitches++;
+
+        geometryCache->renderShape(batch, geometryShape);
     }
 
     const auto triCount = geometryCache->getShapeTriangleCount(geometryShape);

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.h
@@ -24,6 +24,10 @@ public:
 
     virtual scriptable::ScriptableModelBase getScriptableModel() override;
 
+protected:
+    ItemKey getKey() override;
+    ShapeKey getShapeKey() override;
+
 private:
     virtual bool needsRenderUpdate() const override;
     virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
@@ -31,6 +35,8 @@ private:
     virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) override;
     virtual void doRender(RenderArgs* args) override;
     virtual bool isTransparent() const override;
+
+    bool useMaterialPipeline() const;
 
     Procedural _procedural;
     QString _lastUserData;

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -401,7 +401,7 @@ vec2 calculateSphereTexCoord(const vec3& vertex) {
 }
 
 vec3 calculateSphereTangent(float u) {
-    float phi = u * M_PI * 2.0f;
+    float phi = u * (float)M_PI * 2.0f;
     return -glm::normalize(glm::vec3(glm::sin(phi), 0.0f, glm::cos(phi)));
 }
 
@@ -414,7 +414,6 @@ void setupSmoothShape(GeometryCache::ShapeData& shapeData, const geometry::Solid
     for (const auto& vertex : shape.vertices) {
         addVec3ToVector(vertices, vertex);
         addVec3ToVector(vertices, vertex);
-        vec2 uv = calculateSphereTexCoord(vertex);
         addVec2ToVector(vertices, calculateSphereTexCoord(vertex));
         // We'll fill in the correct tangents later, once we correct the UVs
         addVec3ToVector(vertices, vec3(0.0f));

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -354,6 +354,15 @@ public:
     /// Set a batch to the simple pipeline, returning the previous pipeline
     void useSimpleDrawPipeline(gpu::Batch& batch, bool noBlend = false);
 
+    struct ShapeVertex {
+        ShapeVertex(const vec3& pos, const vec3& normal, const vec2& uv, const vec3& tangent) : pos(pos), normal(normal), uv(uv), tangent(tangent) {}
+
+        vec3 pos;
+        vec3 normal;
+        vec2 uv;
+        vec3 tangent;
+    };
+
     struct ShapeData {
         gpu::BufferView _positionView;
         gpu::BufferView _normalView;
@@ -362,7 +371,7 @@ public:
         gpu::BufferView _indicesView;
         gpu::BufferView _wireIndicesView;
 
-        void setupVertices(gpu::BufferPointer& vertexBuffer, const std::vector<float>& vertices);
+        void setupVertices(gpu::BufferPointer& vertexBuffer, const std::vector<ShapeVertex>& vertices);
         void setupIndices(gpu::BufferPointer& indexBuffer, const geometry::IndexVector& indices, const geometry::IndexVector& wireIndices);
         void setupBatch(gpu::Batch& batch) const;
         void draw(gpu::Batch& batch) const;

--- a/libraries/render-utils/src/GeometryCache.h
+++ b/libraries/render-utils/src/GeometryCache.h
@@ -357,10 +357,12 @@ public:
     struct ShapeData {
         gpu::BufferView _positionView;
         gpu::BufferView _normalView;
+        gpu::BufferView _texCoordView;
+        gpu::BufferView _tangentView;
         gpu::BufferView _indicesView;
         gpu::BufferView _wireIndicesView;
 
-        void setupVertices(gpu::BufferPointer& vertexBuffer, const geometry::VertexVector& vertices);
+        void setupVertices(gpu::BufferPointer& vertexBuffer, const std::vector<float>& vertices);
         void setupIndices(gpu::BufferPointer& indexBuffer, const geometry::IndexVector& indices, const geometry::IndexVector& wireIndices);
         void setupBatch(gpu::Batch& batch) const;
         void draw(gpu::Batch& batch) const;

--- a/libraries/render-utils/src/MaterialTextures.slh
+++ b/libraries/render-utils/src/MaterialTextures.slh
@@ -148,25 +148,25 @@ vec3 fetchLightmapMap(vec2 uv) {
 }
 <@endfunc@>
 
-<@func tangentToViewSpace(fetchedNormal, interpolatedNormal, interpolatedTangent, normal)@>
+<@func evalMaterialNormal(fetchedNormal, interpolatedNormal, interpolatedTangent, normal)@>
 {
     vec3 normalizedNormal = normalize(<$interpolatedNormal$>.xyz);
     vec3 normalizedTangent = normalize(<$interpolatedTangent$>.xyz);
-    vec3 normalizedBitangent = normalize(cross(normalizedNormal, normalizedTangent));
+    vec3 normalizedBitangent = cross(normalizedNormal, normalizedTangent);
     vec3 localNormal = <$fetchedNormal$>;
-    <$normal$> = vec3(normalizedTangent * localNormal.x + normalizedNormal * localNormal.y + normalizedBitangent * localNormal.z);
+    <$normal$> = vec3(normalizedBitangent * localNormal.x + normalizedNormal * localNormal.y + normalizedTangent * localNormal.z);
 }
 <@endfunc@>
 
-<@func tangentToViewSpaceLOD(fragPos, fetchedNormal, interpolatedNormal, interpolatedTangent, normal)@>
+<@func evalMaterialNormalLOD(fragPos, fetchedNormal, interpolatedNormal, interpolatedTangent, normal)@>
 {
     vec3 normalizedNormal = normalize(<$interpolatedNormal$>.xyz);
     vec3 normalizedTangent = normalize(<$interpolatedTangent$>.xyz);
-    vec3 normalizedBitangent = normalize(cross(normalizedNormal, normalizedTangent));
+    vec3 normalizedBitangent = cross(normalizedNormal, normalizedTangent);
     // attenuate the normal map divergence from the mesh normal based on distance
-    // THe attenuation range [20,100] meters from the eye is arbitrary for now
+    // The attenuation range [20,100] meters from the eye is arbitrary for now
     vec3 localNormal = mix(<$fetchedNormal$>, vec3(0.0, 1.0, 0.0), smoothstep(20.0, 100.0, (-<$fragPos$>).z));
-    <$normal$> = vec3(normalizedTangent * localNormal.x + normalizedNormal * localNormal.y + normalizedBitangent * localNormal.z);
+    <$normal$> = vec3(normalizedBitangent * localNormal.x + normalizedNormal * localNormal.y + normalizedTangent * localNormal.z);
 }
 <@endfunc@>
 

--- a/libraries/render-utils/src/forward_model_normal_map.slf
+++ b/libraries/render-utils/src/forward_model_normal_map.slf
@@ -58,7 +58,7 @@ void main(void) {
 
     vec3 fragPosition = _position.xyz;
     vec3 fragNormal;
-    <$tangentToViewSpace(normalTex, _normal, _tangent, fragNormal)$>
+    <$evalMaterialNormal(normalTex, _normal, _tangent, fragNormal)$>
 
     TransformCamera cam = getTransformCamera();
 

--- a/libraries/render-utils/src/model_lightmap_normal_map.slf
+++ b/libraries/render-utils/src/model_lightmap_normal_map.slf
@@ -33,11 +33,11 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedo, roughness, normalTexel, metallicTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmapVal)$>
     
-    vec3 viewNormal;
-    <$tangentToViewSpaceLOD(_position, normalTexel, _normal, _tangent, viewNormal)$>
+    vec3 fragNormal;
+    <$evalMaterialNormalLOD(_position, normalTexel, _normal, _tangent, fragNormal)$>
 
     packDeferredFragmentLightmap(
-        normalize(viewNormal.xyz), 
+        normalize(fragNormal.xyz),
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), albedo.a),
         getMaterialAlbedo(mat) * albedo.rgb * _color,
         getMaterialRoughness(mat) * roughness,

--- a/libraries/render-utils/src/model_lightmap_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_lightmap_normal_map_fade.slf
@@ -43,11 +43,11 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedo, roughness, normalTexel, metallicTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmapVal)$>
     
-    vec3 viewNormal;
-    <$tangentToViewSpaceLOD(_position, normalTexel, _normal, _tangent, viewNormal)$>
+    vec3 fragNormal;
+    <$evalMaterialNormalLOD(_position, normalTexel, _normal, _tangent, fragNormal)$>
 
     packDeferredFragmentLightmap(
-        normalize(viewNormal.xyz), 
+        normalize(fragNormal.xyz),
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), albedo.a),
         getMaterialAlbedo(mat) * albedo.rgb * _color,
         getMaterialRoughness(mat) * roughness,

--- a/libraries/render-utils/src/model_normal_map.slf
+++ b/libraries/render-utils/src/model_normal_map.slf
@@ -46,8 +46,8 @@ void main(void) {
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
-    vec3 viewNormal;
-    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, viewNormal)$>
+    vec3 fragNormal;
+    <$evalMaterialNormalLOD(_position, normalTex, _normal, _tangent, fragNormal)$>
 
     float metallic = getMaterialMetallic(mat);
     <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;
@@ -56,7 +56,7 @@ void main(void) {
     <$evalMaterialScattering(scatteringTex, scattering, matKey, scattering)$>;
 
     packDeferredFragment(
-        normalize(viewNormal.xyz), 
+        normalize(fragNormal.xyz),
         opacity,
         albedo,
         roughness,

--- a/libraries/render-utils/src/model_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_normal_map_fade.slf
@@ -56,8 +56,8 @@ void main(void) {
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
-    vec3 viewNormal;
-    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, viewNormal)$>
+    vec3 fragNormal;
+    <$evalMaterialNormalLOD(_position, normalTex, _normal, _tangent, fragNormal)$>
 
     float metallic = getMaterialMetallic(mat);
     <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;
@@ -65,7 +65,7 @@ void main(void) {
     float scattering = getMaterialScattering(mat);
 
     packDeferredFragment(
-        normalize(viewNormal.xyz), 
+        normalize(fragNormal.xyz),
         opacity,
         albedo,
         roughness,

--- a/libraries/render-utils/src/model_translucent_normal_map.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map.slf
@@ -61,7 +61,7 @@ void main(void) {
 
     vec3 fragPosition = _position.xyz;
     vec3 fragNormal;
-    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, fragNormal)$>
+    <$evalMaterialNormalLOD(_position, normalTex, _normal, _tangent, fragNormal)$>
 
     TransformCamera cam = getTransformCamera();
     vec3 fragEyeVector = vec3(cam._viewInverse * vec4(-fragPosition, 0.0));

--- a/libraries/render-utils/src/model_translucent_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map_fade.slf
@@ -71,7 +71,7 @@ void main(void) {
     vec3 fragPosition = _position.xyz;
     // Lighting is done in world space
     vec3 fragNormal;
-    <$tangentToViewSpaceLOD(_position, normalTex, _normal, _tangent, fragNormal)$>
+    <$evalMaterialNormalLOD(_position, normalTex, _normal, _tangent, fragNormal)$>
 
     TransformCamera cam = getTransformCamera();
     vec3 fragEyeVector = vec3(cam._viewInverse * vec4(-fragPosition, 0.0));

--- a/libraries/shared/src/shared/Shapes.cpp
+++ b/libraries/shared/src/shared/Shapes.cpp
@@ -8,8 +8,11 @@
 
 #include "Shapes.h"
 
+#include "qmath.h"
+
 namespace geometry {
 
+using glm::vec2;
 using glm::vec3;
 
 // The golden ratio
@@ -20,7 +23,7 @@ Solid<3> tesselate(const Solid<3>& solid_, int count) {
     float length = glm::length(solid.vertices[0]);
     for (int i = 0; i < count; ++i) {
         Solid<3> result { solid.vertices, {} };
-        result.vertices.reserve(solid.vertices.size() + solid.faces.size() * 3);
+        result.vertices.reserve(solid.vertices.size() + solid.faces.size() * 6);
         for (size_t f = 0; f < solid.faces.size(); ++f) {
             Index baseVertex = (Index)result.vertices.size();
             const Face<3>& oldFace = solid.faces[f];
@@ -30,13 +33,26 @@ Solid<3> tesselate(const Solid<3>& solid_, int count) {
             vec3 ab = glm::normalize(a + b) * length;
             vec3 bc = glm::normalize(b + c) * length;
             vec3 ca = glm::normalize(c + a) * length;
+
+            result.vertices.push_back(a);
+            result.vertices.push_back(ab);
+            result.vertices.push_back(ca);
+            result.faces.push_back(Face<3>{ { baseVertex, baseVertex + 1, baseVertex + 2 } });
+
+            result.vertices.push_back(ab);
+            result.vertices.push_back(b);
+            result.vertices.push_back(bc);
+            result.faces.push_back(Face<3>{ { baseVertex + 3, baseVertex + 4, baseVertex + 5 } });
+
+            result.vertices.push_back(bc);
+            result.vertices.push_back(c);
+            result.vertices.push_back(ca);
+            result.faces.push_back(Face<3>{ { baseVertex + 6, baseVertex + 7, baseVertex + 8 } });
+
             result.vertices.push_back(ab);
             result.vertices.push_back(bc);
             result.vertices.push_back(ca);
-            result.faces.push_back(Face<3>{ { oldFace[0], baseVertex, baseVertex + 2 } });
-            result.faces.push_back(Face<3>{ { baseVertex, oldFace[1], baseVertex + 1 } });
-            result.faces.push_back(Face<3>{ { baseVertex + 1, oldFace[2], baseVertex + 2 } });
-            result.faces.push_back(Face<3>{ { baseVertex, baseVertex + 1, baseVertex + 2 } });
+            result.faces.push_back(Face<3>{ { baseVertex + 9, baseVertex + 10, baseVertex + 11 } });
         }
         solid = result;
     }
@@ -50,6 +66,10 @@ const Solid<3>& tetrahedron() {
     static const auto D = vec3(-1, -1, 1);
     static const Solid<3> TETRAHEDRON = Solid<3>{
         { A, B, C, D },
+        { vec2(0.75f, 0.5f), vec2(0.5f, 0.0f), vec2(0.25f, 0.5f),
+          vec2(0.5f, 1.0f), vec2(1.0f, 1.0f), vec2(0.75f, 0.5f),
+          vec2(0.25f, 0.5f), vec2(0.5f, 1.0f), vec2(0.75f, 0.5f),
+          vec2(0.25f, 0.5f), vec2(0.0f, 1.0f), vec2(0.5f, 1.0f) },
         FaceVector<3>{
             Face<3> { { 0, 1, 2 } },
                 Face<3> { { 3, 1, 0 } },
@@ -65,8 +85,15 @@ const Solid<4>& cube() {
     static const auto B = vec3(-1, 1, 1);
     static const auto C = vec3(-1, 1, -1);
     static const auto D = vec3(1, 1, -1);
+    static const float THIRD = 1.0f / 3.0f;
     static const Solid<4> CUBE = Solid<4>{
         { A, B, C, D, -A, -B, -C, -D },
+        { vec2(0.5f, 0.0f), vec2(0.25f, 0.0f), vec2(0.25f, THIRD), vec2(0.5f, THIRD),
+          vec2(0.5f, THIRD), vec2(0.25f, THIRD), vec2(0.25f, 2.0f * THIRD), vec2(0.5f, 2.0f * THIRD),
+          vec2(0.25f, THIRD), vec2(0.0f, THIRD), vec2(0.0f, 2.0f * THIRD), vec2(0.25f, 2.0f * THIRD),
+          vec2(1.0f, THIRD), vec2(0.75f, THIRD), vec2(0.75f, 2.0f * THIRD), vec2(1.0f, 2.0f * THIRD),
+          vec2(0.75f, THIRD), vec2(0.5f, THIRD), vec2(0.5f, 2.0f * THIRD), vec2(0.75f, 2.0f * THIRD),
+          vec2(0.25f, 1.0f), vec2(0.5f, 1.0f), vec2(0.5f, 2.0f * THIRD), vec2(0.25f, 2.0f * THIRD) },
         FaceVector<4>{
             Face<4> { { 3, 2, 1, 0 } },
                 Face<4> { { 0, 1, 7, 6 } },
@@ -86,8 +113,18 @@ const Solid<3>& octahedron() {
     static const auto D = vec3(0, 0, -1);
     static const auto E = vec3(1, 0, 0);
     static const auto F = vec3(-1, 0, 0);
+    static const float THIRD = 1.0f / 3.0f;
+    static const float SEVENTH = 1.0f / 7.0f;
     static const Solid<3> OCTAHEDRON = Solid<3>{
         { A, B, C, D, E, F},
+        { vec2(2.0f * SEVENTH, THIRD), vec2(SEVENTH, 2.0f * THIRD), vec2(3.0f * SEVENTH, 2.0f * THIRD),
+          vec2(2.0f * SEVENTH, THIRD), vec2(3.0f * SEVENTH, 2.0f * THIRD), vec2(4.0f * SEVENTH, THIRD),
+          vec2(5.0f * SEVENTH, 0.0f), vec2(4.0f * SEVENTH, THIRD), vec2(6.0f * SEVENTH, THIRD),
+          vec2(2.0f * SEVENTH, THIRD), vec2(0.0f, THIRD), vec2(1.0f * SEVENTH, 2.0f * THIRD),
+          vec2(2.0f * SEVENTH, 1.0f), vec2(3.0f * SEVENTH, 2.0f * THIRD), vec2(1.0f * SEVENTH, 2.0f * THIRD),
+          vec2(5.0f * SEVENTH, 2.0f * THIRD), vec2(4.0f * SEVENTH, THIRD), vec2(3.0f * SEVENTH, 2.0f * THIRD),
+          vec2(5.0f * SEVENTH, 2.0f * THIRD), vec2(6.0f * SEVENTH, THIRD), vec2(4.0f * SEVENTH, THIRD),
+          vec2(5.0f * SEVENTH, 2.0f * THIRD), vec2(1.0f, 2.0f * THIRD), vec2(6.0f * SEVENTH, THIRD) },
         FaceVector<3> {
             Face<3> { { 0, 2, 4, } },
             Face<3> { { 0, 4, 3, } },
@@ -116,11 +153,52 @@ const Solid<5>& dodecahedron() {
     static const vec3 I = vec3(0, -IP, P);
     static const vec3 J = vec3(P, 0, IP);
 
+
+    /*                                   _
+                          / \            |
+                        /     \          y2
+                      /         \        |
+                    /             \      _
+                   \               /     |
+                    \             /      y1
+                     \           /       |
+                      ___________        _
+                  |x3|- - x1 - -||x3|
+                  |- - - - x2- - - -|
+    */
+
+    // x1, x2, and x3 are the solutions to the following system of equations:
+    // 1 = 3 * x1 + 3 * x2 + x3
+    // x1 + 2 * x3 = (golden ratio) * x1
+    // x2 = x1 + 2 * x3
+    static const float x1 = 4.0f / (17.0f + 7.0f * sqrt(5.0f));
+    static const float x2 = (1.0f / 11.0f) * (5.0f * sqrt(5.0f) - 9.0f);
+    static const float x2_2 = x2 / 2.0f;
+    static const float x3 = (1.0f / 11.0f) * (6.0f * sqrt(5.0f) - 13.0f);
+    // y1 and y2 are the solutions to the following system of equations (x is the sidelength, but is different than x1 because the scale in the y direction is different):
+    // 1 = 3 * y1 + 2 * y2
+    // y1 = sin(108 deg) * x
+    // y1 + y2 = x * sqrt(5 + 2 * sqrt(5)) / 2
+    static const float y1 = sqrt(2.0f * (5.0f + sqrt(5.0f))) / (sqrt(2.0f * (5.0f + sqrt(5.0f))) + 4.0f * sqrt(5.0f + 2.0f * sqrt(5.0f)));
+    static const float y2 = -(sqrt(2.0f * (5.0f + sqrt(5.0f))) - 2.0f * sqrt(5.0f + 2.0f * sqrt(5.0f))) / (sqrt(2.0f * (5.0f + sqrt(5.0f))) + 4.0f * sqrt(5.0f + 2.0f * sqrt(5.0f)));
+
     static const Solid<5> DODECAHEDRON = Solid<5>{
         {
             A,  B,  C,  D,  E,  F,  G,  H,  I,  J,
             -A, -B, -C, -D, -E, -F, -G, -H, -I, -J,
         },
+        { vec2(x1 + x2_2, 0.0f), vec2(x2_2, 0.0f), vec2(x2_2 - x3, y1), vec2(x3 + x1, y1 + y2), vec2(x3 + x1 + x2_2, y1),
+          vec2(1.0f - (x2 - x3 + x2_2), 0.0f), vec2(1.0f - (x2 + x1 + x3), y2), vec2(1.0f - (x2 + x1), y1 + y2), vec2(1.0f - x2, y1 + y2), vec2(1.0f - (x2 - x3), y2),
+          vec2(1.0f - x2_2, y1), vec2(1.0f - x2, y1 + y2), vec2(1.0f - (x3 + x1), y1 + y2 + y1), vec2(1.0f - x3, y1 + y2 + y1), vec2(1.0f, y1 + y2),
+          vec2(x3, y1 + y2), vec2(0.0f, y1 + y2 + y1), vec2(x2_2, y1 + y2 + y1 + y2), vec2(x2, y1 + y2 + y1), vec2(x1 + x3, y1 + y2),
+          vec2(x3 + x1, y1 + y2), vec2(x2, y1 + y2 + y1), vec2(x2 + x1, y1 + y2 + y1), vec2(x3 + x1 + x2, y1 + y2), vec2(x3 + x1 + x2_2, y1),
+          vec2(x3 + x1 + x2_2, y1), vec2(x3 + x1 + x2, y1 + y2), vec2(x3 + x1 + x2 + x2_2, y1), vec2(x1 + x2 + x2_2, 0.0f), vec2(x3 + x1 + x2_2 + x3, 0.0f),
+          vec2(1.0f - (x3 + x1 + x2_2), 1.0f - y1), vec2(1.0f - (x3 + x1 + x2), 1.0f - (y1 + y2)), vec2(1.0f - (x3 + x1 + x2 + x2_2), 1.0f - y1), vec2(1.0f - (x1 + x2 + x2_2), 1.0f), vec2(1.0f - (x3 + x1 + x2_2 + x3), 1.0f),
+          vec2(x2 + x1 + x3, 1.0f - y2), vec2(x2 + x1, 1.0f - (y1 + y2)), vec2(x2, 1.0f - (y1 + y2)), vec2(x2 - x3, 1.0f - y2), vec2(x2 - x3 + x2_2, 1.0f),
+          vec2(x2 + x1 + x2, y1 + y2 + y1), vec2(x3 + x1 + x2 + x1, y1 + y2), vec2(x3 + x1 + x2, y1 + y2), vec2(x2 + x1, y1 + y2 + y1), vec2(x2 + x1 + x2_2, y1 + y2 + y1 + y2),
+          vec2(1.0f - (x3 + x1 + x2), y1 + y2 + y1), vec2(1.0f - (x2 + x1), y1 + y2), vec2(1.0f - (x2 + x1 + x2_2), y1), vec2(1.0f - (x2 + x1 + x2), y1 + y2), vec2(1.0f - (x3 + x1 + x2 + x1), y1 + y2 + y1),
+          vec2(1.0f - (x3 + x1 + x2_2), y1 + y2 + y1 + y2), vec2(1.0f - (x3 + x1), y1 + y2 + y1), vec2(1.0f - x2, y1 + y2), vec2(1.0f - (x2 + x1), y2 + y1), vec2(1.0f - (x3 + x1 + x2), y1 + y2 + y1),
+          vec2(1.0f - (x1 + x2_2), 1.0f), vec2(1.0f - x2_2, 1.0f), vec2(1.0f - (x2_2 - x3), 1.0f - y1), vec2(1.0f - (x1 + x3), 1.0f - (y1 + y2)), vec2(1.0f - (x3 + x1 + x2_2), 1.0f - y1) },
         FaceVector<5> {
             Face<5> { { 0, 1, 2, 3, 4 } },
             Face<5> { { 0, 5, 18, 6, 1 } },
@@ -148,12 +226,33 @@ const Solid<3>& icosahedron() {
     static const auto D = vec3(P, 0, N);
     static const auto E = vec3(P, 0, -N);
     static const auto F = vec3(0, N, -P);
-
+    static const float THIRD = 1.0f / 3.0f;
+    static const float ELEVENTH = 1.0f / 11.0f;
     static const Solid<3> ICOSAHEDRON = Solid<3> {
         {
             A, B, C, D, E, F,
             -A, -B, -C, -D, -E, -F,
         },
+        { vec2(3.0f * ELEVENTH, 0.0f), vec2(2.0f * ELEVENTH, THIRD), vec2(4.0f * ELEVENTH, THIRD),
+          vec2(2.0f * ELEVENTH, THIRD), vec2(3.0f * ELEVENTH, 2.0f * THIRD), vec2(4.0f * ELEVENTH, THIRD),
+          vec2(3.0f * ELEVENTH, 2.0f * THIRD), vec2(5.0f * ELEVENTH, 2.0f * THIRD), vec2(4.0f * ELEVENTH, THIRD),
+          vec2(5.0f * ELEVENTH, 2.0f * THIRD), vec2(6.0f * ELEVENTH, THIRD), vec2(4.0f * ELEVENTH, THIRD),
+          vec2(6.0f * ELEVENTH, THIRD), vec2(5.0f * ELEVENTH, 0.0f), vec2(4.0f * ELEVENTH, THIRD),
+          vec2(1.0f * ELEVENTH, 0.0f), vec2(0.0f, THIRD), vec2(2.0f * ELEVENTH, THIRD),
+          vec2(1.0f * ELEVENTH, 2.0f * THIRD), vec2(2.0f * ELEVENTH, THIRD), vec2(0.0f, THIRD),
+          vec2(2.0f * ELEVENTH, THIRD), vec2(1.0f * ELEVENTH, 2.0f * THIRD), vec2(3.0f * ELEVENTH, 2.0f * THIRD),
+          vec2(2.0f * ELEVENTH, 1.0f), vec2(3.0f * ELEVENTH, 2.0f * THIRD), vec2(1.0f * ELEVENTH, 2.0f * THIRD),
+          vec2(3.0f * ELEVENTH, 2.0f * THIRD), vec2(4.0f * ELEVENTH, 1.0f), vec2(5.0f * ELEVENTH, 2.0f * THIRD),
+          vec2(7.0f * ELEVENTH, 2.0f * THIRD), vec2(5.0f * ELEVENTH, 2.0f * THIRD), vec2(6.0f * ELEVENTH, 1.0f),
+          vec2(5.0f * ELEVENTH, 2.0f * THIRD), vec2(7.0f * ELEVENTH, 2.0f * THIRD), vec2(6.0f * ELEVENTH, THIRD),
+          vec2(8.0f * ELEVENTH, THIRD), vec2(6.0f * ELEVENTH, THIRD), vec2(7.0f * ELEVENTH, 2.0f * THIRD),
+          vec2(6.0f * ELEVENTH, THIRD), vec2(8.0f * ELEVENTH, THIRD), vec2(7.0f * ELEVENTH, 0.0f),
+          vec2(10.0f * ELEVENTH, THIRD), vec2(9.0f * ELEVENTH, 0.0f), vec2(8.0f * ELEVENTH, THIRD),
+          vec2(7.0f * ELEVENTH, 2.0f * THIRD), vec2(8.0f * ELEVENTH, 1.0f), vec2(9.0f * ELEVENTH, 2.0f * THIRD),
+          vec2(8.0f * ELEVENTH, THIRD), vec2(7.0f * ELEVENTH, 2.0f * THIRD), vec2(9.0f * ELEVENTH, 2.0f * THIRD),
+          vec2(10.0f * ELEVENTH, THIRD), vec2(8.0f * ELEVENTH, THIRD), vec2(9.0f * ELEVENTH, 2.0f * THIRD),
+          vec2(1.0f, 2.0f * THIRD), vec2(10.0f * ELEVENTH, THIRD), vec2(9.0f * ELEVENTH, 2.0f * THIRD),
+          vec2(10.0f * ELEVENTH, 1.0f), vec2(1.0f, 2.0f * THIRD), vec2(9.0f * ELEVENTH, 2.0f * THIRD) },
         FaceVector<3> {
             Face<3> { { 1, 2, 0 } },
             Face<3> { { 2, 3, 0 } },

--- a/libraries/shared/src/shared/Shapes.cpp
+++ b/libraries/shared/src/shared/Shapes.cpp
@@ -22,7 +22,7 @@ Solid<3> tesselate(const Solid<3>& solid_, int count) {
     Solid<3> solid = solid_;
     float length = glm::length(solid.vertices[0]);
     for (int i = 0; i < count; ++i) {
-        Solid<3> result { solid.vertices, {} };
+        Solid<3> result { solid.vertices, {}, {} };
         result.vertices.reserve(solid.vertices.size() + solid.faces.size() * 6);
         for (size_t f = 0; f < solid.faces.size(); ++f) {
             Index baseVertex = (Index)result.vertices.size();
@@ -171,16 +171,16 @@ const Solid<5>& dodecahedron() {
     // 1 = 3 * x1 + 3 * x2 + x3
     // x1 + 2 * x3 = (golden ratio) * x1
     // x2 = x1 + 2 * x3
-    static const float x1 = 4.0f / (17.0f + 7.0f * sqrt(5.0f));
-    static const float x2 = (1.0f / 11.0f) * (5.0f * sqrt(5.0f) - 9.0f);
+    static const float x1 = 4.0f / (17.0f + 7.0f * sqrtf(5.0f));
+    static const float x2 = (1.0f / 11.0f) * (5.0f * sqrtf(5.0f) - 9.0f);
     static const float x2_2 = x2 / 2.0f;
-    static const float x3 = (1.0f / 11.0f) * (6.0f * sqrt(5.0f) - 13.0f);
+    static const float x3 = (1.0f / 11.0f) * (6.0f * sqrtf(5.0f) - 13.0f);
     // y1 and y2 are the solutions to the following system of equations (x is the sidelength, but is different than x1 because the scale in the y direction is different):
     // 1 = 3 * y1 + 2 * y2
     // y1 = sin(108 deg) * x
-    // y1 + y2 = x * sqrt(5 + 2 * sqrt(5)) / 2
-    static const float y1 = sqrt(2.0f * (5.0f + sqrt(5.0f))) / (sqrt(2.0f * (5.0f + sqrt(5.0f))) + 4.0f * sqrt(5.0f + 2.0f * sqrt(5.0f)));
-    static const float y2 = -(sqrt(2.0f * (5.0f + sqrt(5.0f))) - 2.0f * sqrt(5.0f + 2.0f * sqrt(5.0f))) / (sqrt(2.0f * (5.0f + sqrt(5.0f))) + 4.0f * sqrt(5.0f + 2.0f * sqrt(5.0f)));
+    // y1 + y2 = x * sqrtf(5 + 2 * sqrtf(5)) / 2
+    static const float y1 = sqrtf(2.0f * (5.0f + sqrtf(5.0f))) / (sqrtf(2.0f * (5.0f + sqrtf(5.0f))) + 4.0f * sqrtf(5.0f + 2.0f * sqrtf(5.0f)));
+    static const float y2 = -(sqrtf(2.0f * (5.0f + sqrtf(5.0f))) - 2.0f * sqrtf(5.0f + 2.0f * sqrtf(5.0f))) / (sqrtf(2.0f * (5.0f + sqrtf(5.0f))) + 4.0f * sqrtf(5.0f + 2.0f * sqrtf(5.0f)));
 
     static const Solid<5> DODECAHEDRON = Solid<5>{
         {

--- a/libraries/shared/src/shared/Shapes.h
+++ b/libraries/shared/src/shared/Shapes.h
@@ -22,6 +22,7 @@ namespace geometry {
     using Index = uint32_t;
     using Vec = glm::vec3;
     using VertexVector = std::vector<Vec>;
+    using TexCoordVector = std::vector<glm::vec2>;
     using IndexVector = std::vector<Index>;
 
     template <size_t N>
@@ -33,6 +34,7 @@ namespace geometry {
     template <size_t N>
     struct Solid {
         VertexVector vertices;
+        TexCoordVector texCoords;
         FaceVector<N> faces;
 
         Solid<N>& fitDimension(float newMaxDimension) {


### PR DESCRIPTION
- adds UVs and tangents to ShapeEntities so they fully support materials
- fixes a normal mapping bug
- fixes https://highfidelity.fogbugz.com/f/cases/12745/Setting-Shape-entity-item-s-alpha-property-to-non-1-makes-entity-render-black

Test plan:
- run [this](https://gist.githubusercontent.com/SamGondelman/3f2db7655b51ae2ffe3741778faef7e2/raw/1cd047ff7cd871a03dc5910c4b35a71622dadb7e/PrimitiveMaterials.js).  You should see a row of 13 shapes and two more on a higher row.
- The bottom row of shapes should all be textured and have a normal map.
- For the first 5 shapes, the black edges in the textures should perfectly line up with their edges.  The numbers around each point should all be the same on the different faces that share that point.
- For the next 6 shapes (up to the flat shapes), you should see the texture wrapped around them once horizontally.  The top and bottom (of the shapes that have them) should look like cut-outs of the texture.
- The cube on the top row should be red and transparent.
- The sphere on the top row should be identical to the sphere below it (it's actually a material entity).
- Go to a domain with procedural shape entities (eschatology is good).  Verify that they still appear correctly.

For future reference, this is how our shapes are UV-mapped (top left is (0, 0), bottom right is (1, 1)):
![texturetetrahedron](https://user-images.githubusercontent.com/7650116/37120321-e9d16d94-220e-11e8-8f0b-b2ecb77a4374.png)
![texturecube](https://user-images.githubusercontent.com/7650116/37120317-e96b63dc-220e-11e8-93e8-64f7425e9932.png)
![textureoctahedron](https://user-images.githubusercontent.com/7650116/37120320-e9b81790-220e-11e8-9f4d-ed73e6617044.png)
![textureicosahedron](https://user-images.githubusercontent.com/7650116/37120319-e9a31020-220e-11e8-95e6-d94b6fcbddc5.png)
![texturedodecahedron](https://user-images.githubusercontent.com/7650116/37120318-e985b020-220e-11e8-93cb-bbee0f01af1e.png)