### PR TITLE
Don't default unknown Marketplace item types to 'Entity'

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -147,8 +147,7 @@ Rectangle {
         } else if (root.itemHref.indexOf('.json') > -1) {
             root.itemType = "entity"; // "wearable" type handled later
         } else {
-            console.log("WARNING - Item type is UNKNOWN!");
-            root.itemType = "entity";
+            root.itemType = "unknown";
         }
     }
 


### PR DESCRIPTION
Fixes [MS13037](https://highfidelity.manuscript.com/f/cases/13037). Without this fix, uncertified items listed on the Marketplace wouldn't be usable.