### PR TITLE
Fix font loading for MacOS via completely different font loading method

### DIFF
--- a/interface/resources/qml/CurrentAPI.qml
+++ b/interface/resources/qml/CurrentAPI.qml
@@ -33,8 +33,6 @@ Item {
         width: parent.width
         height: parent.height
     }
-    
-    FontLoader { id: ralewayRegular; source: "qrc:/fonts/Raleway-Regular.ttf"; }
 
     Timer {
         id: updateList

--- a/interface/resources/qml/controls-uit/CheckBoxQQC2.qml
+++ b/interface/resources/qml/controls-uit/CheckBoxQQC2.qml
@@ -109,9 +109,9 @@ CheckBox {
 
     contentItem: Text {
         id: root
-        FontLoader { id: ralewaySemiBold; source: "qrc:/fonts/Raleway-SemiBold.ttf"; }
         font.pixelSize: hifi.fontSizes.inputLabel
-        font.family: ralewaySemiBold.name
+        font.family: "Raleway"
+        font.weight: Font.DemiBold
         text: checkBox.text
         color: checkBox.color
         x: 2

--- a/interface/resources/qml/controls-uit/Keyboard.qml
+++ b/interface/resources/qml/controls-uit/Keyboard.qml
@@ -125,8 +125,7 @@ Rectangle {
         TextInput {
             id: mirrorText
             visible: showMirrorText
-            FontLoader { id: font; source: "qrc:/fonts/FiraSans-Regular.ttf"; }
-            font.family: font.name
+            font.family: "Fira Sans"
             font.pixelSize: 20
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
@@ -164,8 +163,6 @@ Rectangle {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 0
-
-        FontLoader { id: hiFiGlyphs; source: "qrc:/fonts/hifi-glyphs.ttf"; }
 
         Column {
             id: columnAlpha
@@ -250,7 +247,7 @@ Rectangle {
                 Key { width: 43; glyph: ","; }
                 Key { width: 43; glyph: "."; }
                 Key {
-                    fontFamily: hiFiGlyphs.name;
+                    fontFamily: "hifi-glyphs";
                     fontPixelSize: 48;
                     letterAnchors.topMargin: -4;
                     verticalAlignment: Text.AlignVCenter;
@@ -343,7 +340,7 @@ Rectangle {
                 Key { width: 43; glyph: ","; }
                 Key { width: 43; glyph: "."; }
                 Key {
-                    fontFamily: hiFiGlyphs.name;
+                    fontFamily: "hifi-glyphs";
                     fontPixelSize: 48;
                     letterAnchors.topMargin: -4;
                     verticalAlignment: Text.AlignVCenter;

--- a/interface/resources/qml/controls-uit/SpinBox.qml
+++ b/interface/resources/qml/controls-uit/SpinBox.qml
@@ -25,8 +25,7 @@ SpinBox {
     property color colorLabelInside: hifi.colors.white
     property real controlHeight: height + (spinBoxLabel.visible ? spinBoxLabel.height + spinBoxLabel.anchors.bottomMargin : 0)
 
-    FontLoader { id: firaSansSemiBold; source: "qrc:/fonts/FiraSans-SemiBold.ttf"; }
-    font.family: firaSansSemiBold.name
+    font.family: "Fira Sans SemiBold"
     font.pixelSize: hifi.fontSizes.textFieldInput
     height: hifi.fontSizes.textFieldInput + 13  // Match height of TextField control.
 

--- a/interface/resources/qml/controls-uit/TextEdit.qml
+++ b/interface/resources/qml/controls-uit/TextEdit.qml
@@ -16,9 +16,9 @@ import "../styles-uit"
 TextEdit {
 
     property real size: 32
-
-    FontLoader { id: ralewaySemiBold; source: "qrc:/fonts/Raleway-SemiBold.ttf"; }
-    font.family: ralewaySemiBold.name
+    
+    font.family: "Raleway"
+    font.weight: Font.DemiBold
     font.pointSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft

--- a/interface/resources/qml/controls-uit/TextField.qml
+++ b/interface/resources/qml/controls-uit/TextField.qml
@@ -34,9 +34,7 @@ TextField {
 
     placeholderText: textField.placeholderText
 
-    FontLoader { id: firaSansRegular; source: "qrc:/fonts/FiraSans-Regular.ttf"; }
-    FontLoader { id: hifiGlyphs; source: "qrc:/fonts/hifi-glyphs.ttf"; }
-    font.family: firaSansRegular.name
+    font.family: "Fira Sans"
     font.pixelSize: hifi.fontSizes.textFieldInput
     height: implicitHeight + 3  // Make surrounding box higher so that highlight is vertically centered.
     property alias textFieldLabel: textFieldLabel

--- a/interface/resources/qml/controls/FontAwesome.qml
+++ b/interface/resources/qml/controls/FontAwesome.qml
@@ -4,13 +4,12 @@ import QtQuick.Controls.Styles 1.3
 
 Text {
     id: root
-    FontLoader { id: iconFont; source: "qrc:/fonts/fontawesome-webfont.ttf"; }
     property int size: 32
     width: size
     height: size
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: iconFont.name
+    font.family: "FontAwesome"
 }
 

--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -532,9 +532,6 @@ ModalWindow {
             itemDelegate: Item {
                 clip: true
 
-                FontLoader { id: firaSansSemiBold; source: "qrc:/fonts/FiraSans-SemiBold.ttf"; }
-                FontLoader { id: firaSansRegular; source: "qrc:/fonts/FiraSans-Regular.ttf"; }
-
                 FiraSansSemiBold {
                     text: getText();
                     elide: styleData.elideMode
@@ -548,7 +545,7 @@ ModalWindow {
                     size: hifi.fontSizes.tableText
                     color: hifi.colors.baseGrayHighlight
                     font.family: (styleData.row !== -1 && fileTableView.model.get(styleData.row).fileIsDir)
-                        ? firaSansSemiBold.name : firaSansRegular.name
+                        ? "Fira Sans SemiBold" : "Fira Sans"
 
                     function getText() {
                         if (styleData.row === -1) {

--- a/interface/resources/qml/dialogs/TabletFileDialog.qml
+++ b/interface/resources/qml/dialogs/TabletFileDialog.qml
@@ -496,9 +496,6 @@ TabletModalWindow {
             itemDelegate: Item {
                 clip: true
 
-                //FontLoader { id: firaSansSemiBold; source: "qrc:/fonts/FiraSans-SemiBold.ttf"; }
-                //FontLoader { id: firaSansRegular; source: "qrc:/fonts/FiraSans-Regular.ttf"; }
-
                 FiraSansSemiBold {
                     text: getText();
                     elide: styleData.elideMode
@@ -512,7 +509,7 @@ TabletModalWindow {
                     size: hifi.fontSizes.tableText
                     color: hifi.colors.baseGrayHighlight
                     //font.family: (styleData.row !== -1 && fileTableView.model.get(styleData.row).fileIsDir)
-                        //? firaSansSemiBold.name : firaSansRegular.name
+                        //? "Fira Sans SemiBold" : "Fira Sans"
 
                     function getText() {
                         if (styleData.row === -1) {

--- a/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
+++ b/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
@@ -345,9 +345,6 @@ Item {
             itemDelegate: Item {
                 clip: true
 
-                FontLoader { id: firaSansSemiBold; source: "qrc:/fonts/FiraSans-SemiBold.ttf"; }
-                FontLoader { id: firaSansRegular; source: "qrc:/fonts/FiraSans-Regular.ttf"; }
-
                 FiraSansSemiBold {
                     text: styleData.value
                     elide: styleData.elideMode
@@ -361,7 +358,7 @@ Item {
                     size: hifi.fontSizes.tableText
                     color: hifi.colors.baseGrayHighlight
                     font.family: (styleData.row !== -1 && assetTableView.model.get(styleData.row).fileIsDir)
-                        ? firaSansSemiBold.name : firaSansRegular.name
+                        ? "Fira Sans SemiBold" : "Fira Sans"
                 }
             }
 

--- a/interface/resources/qml/hifi/AssetServer.qml
+++ b/interface/resources/qml/hifi/AssetServer.qml
@@ -660,8 +660,7 @@ Windows.ScrollingWindow {
 
                         text: styleData.value
 
-                        FontLoader { id: firaSansSemiBold; source: "qrc:/fonts/FiraSans-SemiBold.ttf"; }
-                        font.family: firaSansSemiBold.name
+                        font.family: "Fira Sans SemiBold"
                         font.pixelSize: hifi.fontSizes.textFieldInput
                         height: hifi.dimensions.tableRowHeight
 

--- a/interface/resources/qml/hifi/ComboDialog.qml
+++ b/interface/resources/qml/hifi/ComboDialog.qml
@@ -25,8 +25,6 @@ Item {
     property int dialogHeight;
     property int comboOptionTextSize: 16;
     property int comboBodyTextSize: 16;
-    FontLoader { id: ralewayRegular; source: "qrc:/fonts/Raleway-Regular.ttf"; }
-    FontLoader { id: ralewaySemiBold; source: "qrc:/fonts/Raleway-SemiBold.ttf"; }
     visible: false;
     id: combo;
     anchors.fill: parent;

--- a/interface/resources/qml/hifi/DesktopLetterboxMessage.qml
+++ b/interface/resources/qml/hifi/DesktopLetterboxMessage.qml
@@ -24,8 +24,6 @@ Item {
     property real headerTextMargin: -5
     property real headerGlyphMargin: -15
     property bool isDesktop: false
-    FontLoader { id: ralewayRegular; source: "qrc:/fonts/Raleway-Regular.ttf"; }
-    FontLoader { id: ralewaySemiBold; source: "qrc:/fonts/Raleway-SemiBold.ttf"; }
     visible: false
     id: letterbox
     anchors.fill: parent
@@ -78,7 +76,8 @@ Item {
                     // Text Size
                     font.pixelSize: headerTextPixelSize
                     // Style
-                    font.family: ralewaySemiBold.name
+                    font.family: "Raleway"
+                    font.weight: Font.DemiBold
                     color: hifi.colors.darkGray
                     horizontalAlignment: Text.AlignHLeft
                     verticalAlignment: Text.AlignVCenter
@@ -101,7 +100,7 @@ Item {
                 horizontalAlignment: Text.AlignHLeft
                 // Style
                 font.pixelSize: popupTextPixelSize
-                font.family: ralewayRegular.name
+                font.family: "Raleway"
                 color: hifi.colors.darkGray
                 wrapMode: Text.WordWrap
                 textFormat: Text.StyledText

--- a/interface/resources/qml/hifi/LetterboxMessage.qml
+++ b/interface/resources/qml/hifi/LetterboxMessage.qml
@@ -23,8 +23,6 @@ Item {
     property real popupTextPixelSize: 16
     property real headerTextMargin: -5
     property real headerGlyphMargin: -15
-    FontLoader { id: ralewayRegular; source: "qrc:/fonts/Raleway-Regular.ttf"; }
-    FontLoader { id: ralewaySemiBold; source: "qrc:/fonts/Raleway-SemiBold.ttf"; }
     visible: false
     id: letterbox
     anchors.fill: parent
@@ -82,7 +80,8 @@ Item {
                     // Text Size
                     font.pixelSize: headerTextPixelSize
                     // Style
-                    font.family: ralewaySemiBold.name
+                    font.family: "Raleway"
+                    font.weight: Font.DemiBold
                     color: hifi.colors.darkGray
                     horizontalAlignment: Text.AlignHLeft
                     verticalAlignment: Text.AlignVCenter
@@ -127,7 +126,7 @@ Item {
                 horizontalAlignment: Text.AlignHLeft
                 // Style
                 font.pixelSize: popupTextPixelSize
-                font.family: ralewayRegular.name
+                font.family: "Raleway"
                 color: hifi.colors.darkGray
                 wrapMode: Text.WordWrap
                 textFormat: Text.StyledText

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -177,8 +177,7 @@ Item {
             anchors.right: parent.right
             anchors.rightMargin: editGlyph.width + editGlyph.anchors.rightMargin
             // Style
-            FontLoader { id: firaSansSemiBold; source: "qrc:/fonts/FiraSans-SemiBold.ttf"; }
-            font.family: firaSansSemiBold.name
+            font.family: "Fira Sans SemiBold"
             font.pixelSize: displayNameTextPixelSize
             selectionColor: hifi.colors.blueAccent
             selectedTextColor: "black"

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -908,7 +908,6 @@ Rectangle {
                 anchors.horizontalCenter: parent.horizontalCenter;
             }
 
-            FontLoader { id: ralewayRegular; source: "qrc:/fonts/Raleway-Regular.ttf"; }
             Text {
                 id: connectionHelpText;
                 // Anchors
@@ -923,7 +922,7 @@ Rectangle {
                 horizontalAlignment: Text.AlignHLeft
                 // Style
                 font.pixelSize: 18;
-                font.family: ralewayRegular.name
+                font.family: "Raleway"
                 color: hifi.colors.darkGray
                 wrapMode: Text.WordWrap
                 textFormat: Text.StyledText;

--- a/interface/resources/qml/hifi/commerce/common/EmulatedMarketplaceHeader.qml
+++ b/interface/resources/qml/hifi/commerce/common/EmulatedMarketplaceHeader.qml
@@ -141,10 +141,9 @@ Item {
                 }
             }
 
-            FontLoader { id: ralewayRegular; source: "qrc:/fonts/Raleway-Regular.ttf"; }
             TextMetrics {
                 id: textMetrics;
-                font.family: ralewayRegular.name
+                font.family: "Raleway"
                 text: usernameText.text;
             }
 

--- a/interface/resources/qml/hifi/commerce/wallet/sendMoney/SendMoney.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/sendMoney/SendMoney.qml
@@ -924,14 +924,13 @@ Item {
             anchors.right: parent.right;
             anchors.rightMargin: 20;
             height: 95;
-                
-            FontLoader { id: firaSansSemiBold; source: "qrc:/fonts/FiraSans-SemiBold.ttf"; }
+
             TextArea {
                 id: optionalMessage;
                 property int maximumLength: 72;
                 property string previousText: text;
                 placeholderText: "<i>Optional Public Message (" + maximumLength + " character limit)</i>";
-                font.family: firaSansSemiBold.name;
+                font.family: "Fira Sans SemiBold";
                 font.pixelSize: 20;
                 // Anchors
                 anchors.fill: parent;

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -659,8 +659,7 @@ Rectangle {
 
                         text: styleData.value
 
-                        FontLoader { id: firaSansSemiBold; source: "qrc:/fonts/FiraSans-SemiBold.ttf"; }
-                        font.family: firaSansSemiBold.name
+                        font.family: "Fira Sans SemiBold"
                         font.pixelSize: hifi.fontSizes.textFieldInput
                         height: hifi.dimensions.tableRowHeight
 

--- a/interface/resources/qml/hifi/tablet/tabletWindows/TabletFileDialog.qml
+++ b/interface/resources/qml/hifi/tablet/tabletWindows/TabletFileDialog.qml
@@ -478,9 +478,6 @@ Rectangle {
             itemDelegate: Item {
                 clip: true
 
-                //FontLoader { id: firaSansSemiBold; source: "qrc:/fonts/FiraSans-SemiBold.ttf"; }
-                //FontLoader { id: firaSansRegular; source: "qrc:/fonts/FiraSans-Regular.ttf"; }
-
                 FiraSansSemiBold {
                     text: getText();
                     elide: styleData.elideMode
@@ -494,7 +491,7 @@ Rectangle {
                     size: hifi.fontSizes.tableText
                     color: hifi.colors.baseGrayHighlight
                     //font.family: (styleData.row !== -1 && fileTableView.model.get(styleData.row).fileIsDir)
-                        //? firaSansSemiBold.name : firaSansRegular.name
+                        //? "Fira Sans SemiBold" : "Fira Sans"
 
                     function getText() {
                         if (styleData.row === -1) {

--- a/interface/resources/qml/styles-uit/AnonymousProRegular.qml
+++ b/interface/resources/qml/styles-uit/AnonymousProRegular.qml
@@ -14,10 +14,9 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: anonymousProRegular; source: "qrc:/fonts/AnonymousPro-Regular.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: anonymousProRegular.name
+    font.family: "Anonymous Pro"
 }

--- a/interface/resources/qml/styles-uit/FiraSansRegular.qml
+++ b/interface/resources/qml/styles-uit/FiraSansRegular.qml
@@ -14,10 +14,9 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: firaSansRegular; source: "qrc:/fonts/FiraSans-Regular.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: firaSansRegular.name
+    font.family: "Fira Sans"
 }

--- a/interface/resources/qml/styles-uit/FiraSansSemiBold.qml
+++ b/interface/resources/qml/styles-uit/FiraSansSemiBold.qml
@@ -14,10 +14,9 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: firaSansSemiBold; source: "qrc:/fonts/FiraSans-SemiBold.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: firaSansSemiBold.name
+    font.family: "Fira Sans SemiBold"
 }

--- a/interface/resources/qml/styles-uit/HiFiGlyphs.qml
+++ b/interface/resources/qml/styles-uit/HiFiGlyphs.qml
@@ -12,12 +12,11 @@ import QtQuick 2.5
 
 Text {
     id: root
-    FontLoader { id: hiFiGlyphs; source: "qrc:/fonts/hifi-glyphs.ttf"; }
     property int size: 32
     font.pixelSize: size
     width: size
     height: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: hiFiGlyphs.name
+    font.family: "hifi-glyphs"
 }

--- a/interface/resources/qml/styles-uit/RalewayBold.qml
+++ b/interface/resources/qml/styles-uit/RalewayBold.qml
@@ -14,11 +14,10 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: ralewayBold; source: "qrc:/fonts/Raleway-Bold.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: ralewayBold.name
-    font.bold: true  // Font seems to need this in order to display bold.
+    font.family: "Raleway"
+    font.bold: true
 }

--- a/interface/resources/qml/styles-uit/RalewayLight.qml
+++ b/interface/resources/qml/styles-uit/RalewayLight.qml
@@ -14,10 +14,9 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: ralewayLight; source: "qrc:/fonts/Raleway-Light.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: ralewayLight.name
+    font.family: "Raleway Light"
 }

--- a/interface/resources/qml/styles-uit/RalewayRegular.qml
+++ b/interface/resources/qml/styles-uit/RalewayRegular.qml
@@ -14,10 +14,9 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: ralewayRegular; source: "qrc:/fonts/Raleway-Regular.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: ralewayRegular.name
+    font.family: "Raleway"
 }

--- a/interface/resources/qml/styles-uit/RalewaySemiBold.qml
+++ b/interface/resources/qml/styles-uit/RalewaySemiBold.qml
@@ -14,10 +14,10 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: ralewaySemiBold; source: "qrc:/fonts/Raleway-SemiBold.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: ralewaySemiBold.name
+    font.family: "Raleway"
+    font.weight: Font.DemiBold
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -981,6 +981,15 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     qInstallMessageHandler(messageHandler);
 
     QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "styles/Inconsolata.otf");
+    QFontDatabase::addApplicationFont(":/fonts/fontawesome-webfont.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/hifi-glyphs.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/AnonymousPro-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/FiraSans-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/FiraSans-SemiBold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/Raleway-Light.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/Raleway-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/Raleway-Bold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/Raleway-SemiBold.ttf");
     _window->setWindowTitle("High Fidelity Interface");
 
     Model::setAbstractViewStateInterface(this); // The model class will sometimes need to know view state details from us

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -981,15 +981,15 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     qInstallMessageHandler(messageHandler);
 
     QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "styles/Inconsolata.otf");
-    QFontDatabase::addApplicationFont(":/fonts/fontawesome-webfont.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/hifi-glyphs.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/AnonymousPro-Regular.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/FiraSans-Regular.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/FiraSans-SemiBold.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/Raleway-Light.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/Raleway-Regular.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/Raleway-Bold.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/Raleway-SemiBold.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/fontawesome-webfont.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/hifi-glyphs.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/AnonymousPro-Regular.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/FiraSans-Regular.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/FiraSans-SemiBold.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/Raleway-Light.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/Raleway-Regular.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/Raleway-Bold.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/Raleway-SemiBold.ttf");
     _window->setWindowTitle("High Fidelity Interface");
 
     Model::setAbstractViewStateInterface(this); // The model class will sometimes need to know view state details from us


### PR DESCRIPTION
For some reason, loading `.ttf` fonts via `qrc:/` on MacOS doesn't work, even though it works on Windows and is supposedly supported. This PR fixes glyph loading on MacOS, with no behavioral change to font loading on other platforms.