### PR TITLE
Fix for broken 'toggle audio meter' button

### DIFF
--- a/interface/resources/qml/AvatarInputsBar.qml
+++ b/interface/resources/qml/AvatarInputsBar.qml
@@ -14,9 +14,9 @@ import Qt.labs.settings 1.0
 
 import "./hifi/audio" as HifiAudio
 
-Hifi.AvatarInputs {
+Item {
     id: root;
-    objectName: "AvatarInputs"
+    objectName: "AvatarInputsBar"
     property int modality: Qt.NonModal
     width: audio.width;
     height: audio.height;
@@ -26,7 +26,7 @@ Hifi.AvatarInputs {
 
     HifiAudio.MicBar {
         id: audio;
-        visible: root.showAudioTools;
+        visible: AvatarInputs.showAudioTools;
         standalone: true;
 	    dragTarget: parent;
     }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2710,6 +2710,7 @@ void Application::onDesktopRootContextCreated(QQmlContext* surfaceContext) {
 
     surfaceContext->setContextProperty("ApplicationCompositor", &getApplicationCompositor());
 
+    surfaceContext->setContextProperty("AvatarInputs", AvatarInputs::getInstance());
     surfaceContext->setContextProperty("Selection", DependencyManager::get<SelectionScriptingInterface>().data());
     surfaceContext->setContextProperty("ContextOverlay", DependencyManager::get<ContextOverlayInterface>().data());
     surfaceContext->setContextProperty("Wallet", DependencyManager::get<WalletScriptingInterface>().data());
@@ -2723,10 +2724,12 @@ void Application::onDesktopRootContextCreated(QQmlContext* surfaceContext) {
 
 void Application::onDesktopRootItemCreated(QQuickItem* rootItem) {
     Stats::show();
-    AvatarInputs::show();
     auto surfaceContext = DependencyManager::get<OffscreenUi>()->getSurfaceContext();
     surfaceContext->setContextProperty("Stats", Stats::getInstance());
-    surfaceContext->setContextProperty("AvatarInputs", AvatarInputs::getInstance());
+
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    auto qml = PathUtils::qmlUrl("AvatarInputsBar.qml");
+    offscreenUi->show(qml, "AvatarInputsBar");
 }
 
 void Application::updateCamera(RenderArgs& renderArgs, float deltaTime) {

--- a/interface/src/ui/AvatarInputs.cpp
+++ b/interface/src/ui/AvatarInputs.cpp
@@ -16,19 +16,19 @@
 #include "Application.h"
 #include "Menu.h"
 
-HIFI_QML_DEF(AvatarInputs)
-
 static AvatarInputs* INSTANCE{ nullptr };
 
 Setting::Handle<bool> showAudioToolsSetting { QStringList { "AvatarInputs", "showAudioTools" }, false };
 
 AvatarInputs* AvatarInputs::getInstance() {
-    Q_ASSERT(INSTANCE);
+    if (!INSTANCE) {
+        INSTANCE = new AvatarInputs();
+        Q_ASSERT(INSTANCE);
+    }
     return INSTANCE;
 }
 
-AvatarInputs::AvatarInputs(QQuickItem* parent) :  QQuickItem(parent) {
-    INSTANCE = this;
+AvatarInputs::AvatarInputs(QObject* parent) : QObject(parent) {
     _showAudioTools = showAudioToolsSetting.get();
 }
 

--- a/interface/src/ui/AvatarInputs.h
+++ b/interface/src/ui/AvatarInputs.h
@@ -19,7 +19,7 @@ public: \
 private: \
     type _##name{ initialValue };
 
-class AvatarInputs : public QQuickItem {
+class AvatarInputs : public QObject {
     Q_OBJECT
     HIFI_QML_DECL
 
@@ -32,7 +32,7 @@ class AvatarInputs : public QQuickItem {
 public:
     static AvatarInputs* getInstance();
     Q_INVOKABLE float loudnessToAudioLevel(float loudness);
-    AvatarInputs(QQuickItem* parent = nullptr);
+    AvatarInputs(QObject* parent = nullptr);
     void update();
     bool showAudioTools() const   { return _showAudioTools; }
 


### PR DESCRIPTION
PR fixes the issue with inability to toggle 'audio meter' from desktop/HMD toolbar. The issue happened because 'AvatarInputs' singleton was exposed to QML before instantiating it (which happens on loading AvatarInputs.qml). The fix consists in splitting AvatarInputs into real singleton, created on 'getInstance()' and 'AvatarInputsBar.qml'.

Notes: after re-basing I noticed that it conflicts with '6cc36136bdb3fa3954f05ef960cd7c08dd2cef10'. While that changeset could also resolve FB12956, I think this PR still might be useful as it provides some separation between logic/singleton and QML which should be easier to maintain in future IMHO. 