### PR TITLE
RC65: Fix font loading for MacOS via completely different font loading method

### DIFF
--- a/interface/resources/qml/CurrentAPI.qml
+++ b/interface/resources/qml/CurrentAPI.qml
@@ -33,8 +33,6 @@ Item {
         width: parent.width
         height: parent.height
     }
-    
-    FontLoader { id: ralewayRegular; source: pathToFonts + "fonts/Raleway-Regular.ttf"; }
 
     Timer {
         id: updateList

--- a/interface/resources/qml/controls-uit/CheckBoxQQC2.qml
+++ b/interface/resources/qml/controls-uit/CheckBoxQQC2.qml
@@ -109,9 +109,9 @@ CheckBox {
 
     contentItem: Text {
         id: root
-        FontLoader { id: ralewaySemiBold; source: pathToFonts + "fonts/Raleway-SemiBold.ttf"; }
         font.pixelSize: hifi.fontSizes.inputLabel
-        font.family: ralewaySemiBold.name
+        font.family: "Raleway"
+        font.weight: Font.DemiBold
         text: checkBox.text
         color: checkBox.color
         x: 2

--- a/interface/resources/qml/controls-uit/Keyboard.qml
+++ b/interface/resources/qml/controls-uit/Keyboard.qml
@@ -125,8 +125,7 @@ Rectangle {
         TextInput {
             id: mirrorText
             visible: showMirrorText
-            FontLoader { id: font; source: "../../fonts/FiraSans-Regular.ttf"; }
-            font.family: font.name
+            font.family: "Fira Sans"
             font.pixelSize: 20
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
@@ -164,8 +163,6 @@ Rectangle {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 0
-
-        FontLoader { id: hiFiGlyphs; source: pathToFonts + "fonts/hifi-glyphs.ttf"; }
 
         Column {
             id: columnAlpha
@@ -250,7 +247,7 @@ Rectangle {
                 Key { width: 43; glyph: ","; }
                 Key { width: 43; glyph: "."; }
                 Key {
-                    fontFamily: hiFiGlyphs.name;
+                    fontFamily: "hifi-glyphs";
                     fontPixelSize: 48;
                     letterAnchors.topMargin: -4;
                     verticalAlignment: Text.AlignVCenter;
@@ -343,7 +340,7 @@ Rectangle {
                 Key { width: 43; glyph: ","; }
                 Key { width: 43; glyph: "."; }
                 Key {
-                    fontFamily: hiFiGlyphs.name;
+                    fontFamily: "hifi-glyphs";
                     fontPixelSize: 48;
                     letterAnchors.topMargin: -4;
                     verticalAlignment: Text.AlignVCenter;

--- a/interface/resources/qml/controls-uit/SpinBox.qml
+++ b/interface/resources/qml/controls-uit/SpinBox.qml
@@ -25,8 +25,7 @@ SpinBox {
     property color colorLabelInside: hifi.colors.white
     property real controlHeight: height + (spinBoxLabel.visible ? spinBoxLabel.height + spinBoxLabel.anchors.bottomMargin : 0)
 
-    FontLoader { id: firaSansSemiBold; source: "../../fonts/FiraSans-SemiBold.ttf"; }
-    font.family: firaSansSemiBold.name
+    font.family: "Fira Sans SemiBold"
     font.pixelSize: hifi.fontSizes.textFieldInput
     height: hifi.fontSizes.textFieldInput + 13  // Match height of TextField control.
 

--- a/interface/resources/qml/controls-uit/TextEdit.qml
+++ b/interface/resources/qml/controls-uit/TextEdit.qml
@@ -16,9 +16,9 @@ import "../styles-uit"
 TextEdit {
 
     property real size: 32
-
-    FontLoader { id: ralewaySemiBold; source: "../../fonts/Raleway-SemiBold.ttf"; }
-    font.family: ralewaySemiBold.name
+    
+    font.family: "Raleway"
+    font.weight: Font.DemiBold
     font.pointSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft

--- a/interface/resources/qml/controls-uit/TextField.qml
+++ b/interface/resources/qml/controls-uit/TextField.qml
@@ -34,9 +34,7 @@ TextField {
 
     placeholderText: textField.placeholderText
 
-    FontLoader { id: firaSansRegular; source: "../../fonts/FiraSans-Regular.ttf"; }
-    FontLoader { id: hifiGlyphs; source: "../../fonts/hifi-glyphs.ttf"; }
-    font.family: firaSansRegular.name
+    font.family: "Fira Sans"
     font.pixelSize: hifi.fontSizes.textFieldInput
     height: implicitHeight + 3  // Make surrounding box higher so that highlight is vertically centered.
     property alias textFieldLabel: textFieldLabel

--- a/interface/resources/qml/controls/FontAwesome.qml
+++ b/interface/resources/qml/controls/FontAwesome.qml
@@ -4,13 +4,12 @@ import QtQuick.Controls.Styles 1.3
 
 Text {
     id: root
-    FontLoader { id: iconFont; source: "../../fonts/fontawesome-webfont.ttf"; }
     property int size: 32
     width: size
     height: size
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: iconFont.name
+    font.family: "FontAwesome"
 }
 

--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -532,9 +532,6 @@ ModalWindow {
             itemDelegate: Item {
                 clip: true
 
-                FontLoader { id: firaSansSemiBold; source: "../../fonts/FiraSans-SemiBold.ttf"; }
-                FontLoader { id: firaSansRegular; source: "../../fonts/FiraSans-Regular.ttf"; }
-
                 FiraSansSemiBold {
                     text: getText();
                     elide: styleData.elideMode
@@ -548,7 +545,7 @@ ModalWindow {
                     size: hifi.fontSizes.tableText
                     color: hifi.colors.baseGrayHighlight
                     font.family: (styleData.row !== -1 && fileTableView.model.get(styleData.row).fileIsDir)
-                        ? firaSansSemiBold.name : firaSansRegular.name
+                        ? "Fira Sans SemiBold" : "Fira Sans"
 
                     function getText() {
                         if (styleData.row === -1) {

--- a/interface/resources/qml/dialogs/TabletFileDialog.qml
+++ b/interface/resources/qml/dialogs/TabletFileDialog.qml
@@ -496,9 +496,6 @@ TabletModalWindow {
             itemDelegate: Item {
                 clip: true
 
-                //FontLoader { id: firaSansSemiBold; source: "../../fonts/FiraSans-SemiBold.ttf"; }
-                //FontLoader { id: firaSansRegular; source: "../../fonts/FiraSans-Regular.ttf"; }
-
                 FiraSansSemiBold {
                     text: getText();
                     elide: styleData.elideMode
@@ -512,7 +509,7 @@ TabletModalWindow {
                     size: hifi.fontSizes.tableText
                     color: hifi.colors.baseGrayHighlight
                     //font.family: (styleData.row !== -1 && fileTableView.model.get(styleData.row).fileIsDir)
-                        //? firaSansSemiBold.name : firaSansRegular.name
+                        //? "Fira Sans SemiBold" : "Fira Sans"
 
                     function getText() {
                         if (styleData.row === -1) {

--- a/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
+++ b/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
@@ -345,9 +345,6 @@ Item {
             itemDelegate: Item {
                 clip: true
 
-                FontLoader { id: firaSansSemiBold; source: "../../../fonts/FiraSans-SemiBold.ttf"; }
-                FontLoader { id: firaSansRegular; source: "../../../fonts/FiraSans-Regular.ttf"; }
-
                 FiraSansSemiBold {
                     text: styleData.value
                     elide: styleData.elideMode
@@ -361,7 +358,7 @@ Item {
                     size: hifi.fontSizes.tableText
                     color: hifi.colors.baseGrayHighlight
                     font.family: (styleData.row !== -1 && assetTableView.model.get(styleData.row).fileIsDir)
-                        ? firaSansSemiBold.name : firaSansRegular.name
+                        ? "Fira Sans SemiBold" : "Fira Sans"
                 }
             }
 

--- a/interface/resources/qml/hifi/AssetServer.qml
+++ b/interface/resources/qml/hifi/AssetServer.qml
@@ -187,9 +187,10 @@ Windows.ScrollingWindow {
             var textures = JSON.stringify({ "tex.picture": defaultURL});
             var shapeType = "box";
             var dynamic = false;
+            var collisionless = true;
             var position = Vec3.sum(MyAvatar.position, Vec3.multiply(2, Quat.getForward(MyAvatar.orientation)));
             var gravity = Vec3.multiply(Vec3.fromPolar(Math.PI / 2, 0), 0);
-            Entities.addModelEntity(name, modelURL, textures, shapeType, dynamic, position, gravity);
+            Entities.addModelEntity(name, modelURL, textures, shapeType, dynamic, collisionless, position, gravity);
         } else {
             var SHAPE_TYPE_NONE = 0;
             var SHAPE_TYPE_SIMPLE_HULL = 1;
@@ -234,6 +235,7 @@ Windows.ScrollingWindow {
                     var result = JSON.parse(jsonResult);
                     var url = result.textInput.trim();
                     var shapeType;
+                    var collisionless = false;
                     switch (result.comboBox) {
                         case SHAPE_TYPE_SIMPLE_HULL:
                             shapeType = "simple-hull";
@@ -252,6 +254,7 @@ Windows.ScrollingWindow {
                             break;
                         default:
                             shapeType = "none";
+                            collisionless = true;
                     }
 
                     var dynamic = result.checkBox !== null ? result.checkBox : DYNAMIC_DEFAULT;
@@ -273,7 +276,7 @@ Windows.ScrollingWindow {
                         print("Asset browser - adding asset " + url + " (" + name + ") to world.");
 
                         // Entities.addEntity doesn't work from QML, so we use this.
-                        Entities.addModelEntity(name, url, "", shapeType, dynamic, addPosition, gravity);
+                        Entities.addModelEntity(name, url, "", shapeType, dynamic, collisionless, addPosition, gravity);
                     }
                 }
             });
@@ -657,8 +660,7 @@ Windows.ScrollingWindow {
 
                         text: styleData.value
 
-                        FontLoader { id: firaSansSemiBold; source: "../../fonts/FiraSans-SemiBold.ttf"; }
-                        font.family: firaSansSemiBold.name
+                        font.family: "Fira Sans SemiBold"
                         font.pixelSize: hifi.fontSizes.textFieldInput
                         height: hifi.dimensions.tableRowHeight
 

--- a/interface/resources/qml/hifi/AssetServer.qml
+++ b/interface/resources/qml/hifi/AssetServer.qml
@@ -187,10 +187,9 @@ Windows.ScrollingWindow {
             var textures = JSON.stringify({ "tex.picture": defaultURL});
             var shapeType = "box";
             var dynamic = false;
-            var collisionless = true;
             var position = Vec3.sum(MyAvatar.position, Vec3.multiply(2, Quat.getForward(MyAvatar.orientation)));
             var gravity = Vec3.multiply(Vec3.fromPolar(Math.PI / 2, 0), 0);
-            Entities.addModelEntity(name, modelURL, textures, shapeType, dynamic, collisionless, position, gravity);
+            Entities.addModelEntity(name, modelURL, textures, shapeType, dynamic, position, gravity);
         } else {
             var SHAPE_TYPE_NONE = 0;
             var SHAPE_TYPE_SIMPLE_HULL = 1;
@@ -235,7 +234,6 @@ Windows.ScrollingWindow {
                     var result = JSON.parse(jsonResult);
                     var url = result.textInput.trim();
                     var shapeType;
-                    var collisionless = false;
                     switch (result.comboBox) {
                         case SHAPE_TYPE_SIMPLE_HULL:
                             shapeType = "simple-hull";
@@ -254,7 +252,6 @@ Windows.ScrollingWindow {
                             break;
                         default:
                             shapeType = "none";
-                            collisionless = true;
                     }
 
                     var dynamic = result.checkBox !== null ? result.checkBox : DYNAMIC_DEFAULT;
@@ -276,7 +273,7 @@ Windows.ScrollingWindow {
                         print("Asset browser - adding asset " + url + " (" + name + ") to world.");
 
                         // Entities.addEntity doesn't work from QML, so we use this.
-                        Entities.addModelEntity(name, url, "", shapeType, dynamic, collisionless, addPosition, gravity);
+                        Entities.addModelEntity(name, url, "", shapeType, dynamic, addPosition, gravity);
                     }
                 }
             });

--- a/interface/resources/qml/hifi/ComboDialog.qml
+++ b/interface/resources/qml/hifi/ComboDialog.qml
@@ -25,8 +25,6 @@ Item {
     property int dialogHeight;
     property int comboOptionTextSize: 16;
     property int comboBodyTextSize: 16;
-    FontLoader { id: ralewayRegular; source: "../../fonts/Raleway-Regular.ttf"; }
-    FontLoader { id: ralewaySemiBold; source: "../../fonts/Raleway-SemiBold.ttf"; }
     visible: false;
     id: combo;
     anchors.fill: parent;

--- a/interface/resources/qml/hifi/DesktopLetterboxMessage.qml
+++ b/interface/resources/qml/hifi/DesktopLetterboxMessage.qml
@@ -24,8 +24,6 @@ Item {
     property real headerTextMargin: -5
     property real headerGlyphMargin: -15
     property bool isDesktop: false
-    FontLoader { id: ralewayRegular; source: "../../fonts/Raleway-Regular.ttf"; }
-    FontLoader { id: ralewaySemiBold; source: "../../fonts/Raleway-SemiBold.ttf"; }
     visible: false
     id: letterbox
     anchors.fill: parent
@@ -78,7 +76,8 @@ Item {
                     // Text Size
                     font.pixelSize: headerTextPixelSize
                     // Style
-                    font.family: ralewaySemiBold.name
+                    font.family: "Raleway"
+                    font.weight: Font.DemiBold
                     color: hifi.colors.darkGray
                     horizontalAlignment: Text.AlignHLeft
                     verticalAlignment: Text.AlignVCenter
@@ -101,7 +100,7 @@ Item {
                 horizontalAlignment: Text.AlignHLeft
                 // Style
                 font.pixelSize: popupTextPixelSize
-                font.family: ralewayRegular.name
+                font.family: "Raleway"
                 color: hifi.colors.darkGray
                 wrapMode: Text.WordWrap
                 textFormat: Text.StyledText

--- a/interface/resources/qml/hifi/LetterboxMessage.qml
+++ b/interface/resources/qml/hifi/LetterboxMessage.qml
@@ -23,8 +23,6 @@ Item {
     property real popupTextPixelSize: 16
     property real headerTextMargin: -5
     property real headerGlyphMargin: -15
-    FontLoader { id: ralewayRegular; source: "../../fonts/Raleway-Regular.ttf"; }
-    FontLoader { id: ralewaySemiBold; source: "../../fonts/Raleway-SemiBold.ttf"; }
     visible: false
     id: letterbox
     anchors.fill: parent
@@ -82,7 +80,8 @@ Item {
                     // Text Size
                     font.pixelSize: headerTextPixelSize
                     // Style
-                    font.family: ralewaySemiBold.name
+                    font.family: "Raleway"
+                    font.weight: Font.DemiBold
                     color: hifi.colors.darkGray
                     horizontalAlignment: Text.AlignHLeft
                     verticalAlignment: Text.AlignVCenter
@@ -127,7 +126,7 @@ Item {
                 horizontalAlignment: Text.AlignHLeft
                 // Style
                 font.pixelSize: popupTextPixelSize
-                font.family: ralewayRegular.name
+                font.family: "Raleway"
                 color: hifi.colors.darkGray
                 wrapMode: Text.WordWrap
                 textFormat: Text.StyledText

--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -177,8 +177,7 @@ Item {
             anchors.right: parent.right
             anchors.rightMargin: editGlyph.width + editGlyph.anchors.rightMargin
             // Style
-            FontLoader { id: firaSansSemiBold; source: "../../fonts/FiraSans-SemiBold.ttf"; }
-            font.family: firaSansSemiBold.name
+            font.family: "Fira Sans SemiBold"
             font.pixelSize: displayNameTextPixelSize
             selectionColor: hifi.colors.blueAccent
             selectedTextColor: "black"

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -908,7 +908,6 @@ Rectangle {
                 anchors.horizontalCenter: parent.horizontalCenter;
             }
 
-            FontLoader { id: ralewayRegular; source: "../../fonts/Raleway-Regular.ttf"; }
             Text {
                 id: connectionHelpText;
                 // Anchors
@@ -923,7 +922,7 @@ Rectangle {
                 horizontalAlignment: Text.AlignHLeft
                 // Style
                 font.pixelSize: 18;
-                font.family: ralewayRegular.name
+                font.family: "Raleway"
                 color: hifi.colors.darkGray
                 wrapMode: Text.WordWrap
                 textFormat: Text.StyledText;

--- a/interface/resources/qml/hifi/commerce/common/EmulatedMarketplaceHeader.qml
+++ b/interface/resources/qml/hifi/commerce/common/EmulatedMarketplaceHeader.qml
@@ -141,10 +141,9 @@ Item {
                 }
             }
 
-            FontLoader { id: ralewayRegular; source: "../../../../fonts/Raleway-Regular.ttf"; }
             TextMetrics {
                 id: textMetrics;
-                font.family: ralewayRegular.name
+                font.family: "Raleway"
                 text: usernameText.text;
             }
 

--- a/interface/resources/qml/hifi/commerce/wallet/sendMoney/SendMoney.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/sendMoney/SendMoney.qml
@@ -924,14 +924,13 @@ Item {
             anchors.right: parent.right;
             anchors.rightMargin: 20;
             height: 95;
-                
-            FontLoader { id: firaSansSemiBold; source: "../../../../../fonts/FiraSans-SemiBold.ttf"; }
+
             TextArea {
                 id: optionalMessage;
                 property int maximumLength: 72;
                 property string previousText: text;
                 placeholderText: "<i>Optional Public Message (" + maximumLength + " character limit)</i>";
-                font.family: firaSansSemiBold.name;
+                font.family: "Fira Sans SemiBold";
                 font.pixelSize: 20;
                 // Anchors
                 anchors.fill: parent;

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -144,7 +144,7 @@ Rectangle {
     }
 
     function canAddToWorld(path) {
-        var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i];
+        var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i, /\.jpg\b/i, /\.png\b/i];
         
         if (selectedItemCount > 1) {
             return false;
@@ -188,9 +188,10 @@ Rectangle {
             var textures = JSON.stringify({ "tex.picture": defaultURL});
             var shapeType = "box";
             var dynamic = false;
+            var collisionless = true;
             var position = Vec3.sum(MyAvatar.position, Vec3.multiply(2, Quat.getForward(MyAvatar.orientation)));
             var gravity = Vec3.multiply(Vec3.fromPolar(Math.PI / 2, 0), 0);
-            Entities.addModelEntity(name, modelURL, textures, shapeType, dynamic, position, gravity);
+            Entities.addModelEntity(name, modelURL, textures, shapeType, dynamic, collisionless, position, gravity);
         } else {
             var SHAPE_TYPE_NONE = 0;
             var SHAPE_TYPE_SIMPLE_HULL = 1;
@@ -235,6 +236,7 @@ Rectangle {
                     var result = JSON.parse(jsonResult);
                     var url = result.textInput.trim();
                     var shapeType;
+                    var collisionless = false;
                     switch (result.comboBox) {
                         case SHAPE_TYPE_SIMPLE_HULL:
                             shapeType = "simple-hull";
@@ -253,6 +255,7 @@ Rectangle {
                             break;
                         default:
                             shapeType = "none";
+                            collisionless = true;
                     }
 
                     var dynamic = result.checkBox !== null ? result.checkBox : DYNAMIC_DEFAULT;
@@ -274,7 +277,7 @@ Rectangle {
                         print("Asset browser - adding asset " + url + " (" + name + ") to world.");
 
                         // Entities.addEntity doesn't work from QML, so we use this.
-                        Entities.addModelEntity(name, url, "", shapeType, dynamic, addPosition, gravity);
+                        Entities.addModelEntity(name, url, "", shapeType, dynamic, collisionless, addPosition, gravity);
                     }
                 }
             });
@@ -656,8 +659,7 @@ Rectangle {
 
                         text: styleData.value
 
-                        FontLoader { id: firaSansSemiBold; source: "../../fonts/FiraSans-SemiBold.ttf"; }
-                        font.family: firaSansSemiBold.name
+                        font.family: "Fira Sans SemiBold"
                         font.pixelSize: hifi.fontSizes.textFieldInput
                         height: hifi.dimensions.tableRowHeight
 

--- a/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletAssetServer.qml
@@ -144,7 +144,7 @@ Rectangle {
     }
 
     function canAddToWorld(path) {
-        var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i, /\.jpg\b/i, /\.png\b/i];
+        var supportedExtensions = [/\.fbx\b/i, /\.obj\b/i];
         
         if (selectedItemCount > 1) {
             return false;
@@ -188,10 +188,9 @@ Rectangle {
             var textures = JSON.stringify({ "tex.picture": defaultURL});
             var shapeType = "box";
             var dynamic = false;
-            var collisionless = true;
             var position = Vec3.sum(MyAvatar.position, Vec3.multiply(2, Quat.getForward(MyAvatar.orientation)));
             var gravity = Vec3.multiply(Vec3.fromPolar(Math.PI / 2, 0), 0);
-            Entities.addModelEntity(name, modelURL, textures, shapeType, dynamic, collisionless, position, gravity);
+            Entities.addModelEntity(name, modelURL, textures, shapeType, dynamic, position, gravity);
         } else {
             var SHAPE_TYPE_NONE = 0;
             var SHAPE_TYPE_SIMPLE_HULL = 1;
@@ -236,7 +235,6 @@ Rectangle {
                     var result = JSON.parse(jsonResult);
                     var url = result.textInput.trim();
                     var shapeType;
-                    var collisionless = false;
                     switch (result.comboBox) {
                         case SHAPE_TYPE_SIMPLE_HULL:
                             shapeType = "simple-hull";
@@ -255,7 +253,6 @@ Rectangle {
                             break;
                         default:
                             shapeType = "none";
-                            collisionless = true;
                     }
 
                     var dynamic = result.checkBox !== null ? result.checkBox : DYNAMIC_DEFAULT;
@@ -277,7 +274,7 @@ Rectangle {
                         print("Asset browser - adding asset " + url + " (" + name + ") to world.");
 
                         // Entities.addEntity doesn't work from QML, so we use this.
-                        Entities.addModelEntity(name, url, "", shapeType, dynamic, collisionless, addPosition, gravity);
+                        Entities.addModelEntity(name, url, "", shapeType, dynamic, addPosition, gravity);
                     }
                 }
             });

--- a/interface/resources/qml/hifi/tablet/tabletWindows/TabletFileDialog.qml
+++ b/interface/resources/qml/hifi/tablet/tabletWindows/TabletFileDialog.qml
@@ -478,9 +478,6 @@ Rectangle {
             itemDelegate: Item {
                 clip: true
 
-                //FontLoader { id: firaSansSemiBold; source: "../../fonts/FiraSans-SemiBold.ttf"; }
-                //FontLoader { id: firaSansRegular; source: "../../fonts/FiraSans-Regular.ttf"; }
-
                 FiraSansSemiBold {
                     text: getText();
                     elide: styleData.elideMode
@@ -494,7 +491,7 @@ Rectangle {
                     size: hifi.fontSizes.tableText
                     color: hifi.colors.baseGrayHighlight
                     //font.family: (styleData.row !== -1 && fileTableView.model.get(styleData.row).fileIsDir)
-                        //? firaSansSemiBold.name : firaSansRegular.name
+                        //? "Fira Sans SemiBold" : "Fira Sans"
 
                     function getText() {
                         if (styleData.row === -1) {

--- a/interface/resources/qml/styles-uit/AnonymousProRegular.qml
+++ b/interface/resources/qml/styles-uit/AnonymousProRegular.qml
@@ -14,10 +14,9 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: anonymousProRegular; source: "../../fonts/AnonymousPro-Regular.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: anonymousProRegular.name
+    font.family: "Anonymous Pro"
 }

--- a/interface/resources/qml/styles-uit/FiraSansRegular.qml
+++ b/interface/resources/qml/styles-uit/FiraSansRegular.qml
@@ -14,10 +14,9 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: firaSansRegular; source: "../../fonts/FiraSans-Regular.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: firaSansRegular.name
+    font.family: "Fira Sans"
 }

--- a/interface/resources/qml/styles-uit/FiraSansSemiBold.qml
+++ b/interface/resources/qml/styles-uit/FiraSansSemiBold.qml
@@ -14,10 +14,9 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: firaSansSemiBold; source: pathToFonts + "fonts/FiraSans-SemiBold.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: firaSansSemiBold.name
+    font.family: "Fira Sans SemiBold"
 }

--- a/interface/resources/qml/styles-uit/HiFiGlyphs.qml
+++ b/interface/resources/qml/styles-uit/HiFiGlyphs.qml
@@ -12,12 +12,11 @@ import QtQuick 2.5
 
 Text {
     id: root
-    FontLoader { id: hiFiGlyphs; source: pathToFonts + "fonts/hifi-glyphs.ttf"; }
     property int size: 32
     font.pixelSize: size
     width: size
     height: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: hiFiGlyphs.name
+    font.family: "hifi-glyphs"
 }

--- a/interface/resources/qml/styles-uit/RalewayBold.qml
+++ b/interface/resources/qml/styles-uit/RalewayBold.qml
@@ -14,11 +14,10 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: ralewayBold; source: pathToFonts + "fonts/Raleway-Bold.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: ralewayBold.name
-    font.bold: true  // Font seems to need this in order to display bold.
+    font.family: "Raleway"
+    font.bold: true
 }

--- a/interface/resources/qml/styles-uit/RalewayLight.qml
+++ b/interface/resources/qml/styles-uit/RalewayLight.qml
@@ -14,10 +14,9 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: ralewayLight; source: "../../fonts/Raleway-Light.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: ralewayLight.name
+    font.family: "Raleway Light"
 }

--- a/interface/resources/qml/styles-uit/RalewayRegular.qml
+++ b/interface/resources/qml/styles-uit/RalewayRegular.qml
@@ -14,10 +14,9 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: ralewayRegular; source: pathToFonts + "fonts/Raleway-Regular.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: ralewayRegular.name
+    font.family: "Raleway"
 }

--- a/interface/resources/qml/styles-uit/RalewaySemiBold.qml
+++ b/interface/resources/qml/styles-uit/RalewaySemiBold.qml
@@ -14,10 +14,10 @@ import QtQuick.Controls.Styles 1.4
 
 Text {
     id: root
-    FontLoader { id: ralewaySemiBold; source: pathToFonts + "fonts/Raleway-SemiBold.ttf"; }
     property real size: 32
     font.pixelSize: size
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
-    font.family: ralewaySemiBold.name
+    font.family: "Raleway"
+    font.weight: Font.DemiBold
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -978,15 +978,15 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     qInstallMessageHandler(messageHandler);
 
     QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "styles/Inconsolata.otf");
-    QFontDatabase::addApplicationFont(":/fonts/fontawesome-webfont.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/hifi-glyphs.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/AnonymousPro-Regular.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/FiraSans-Regular.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/FiraSans-SemiBold.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/Raleway-Light.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/Raleway-Regular.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/Raleway-Bold.ttf");
-    QFontDatabase::addApplicationFont(":/fonts/Raleway-SemiBold.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/fontawesome-webfont.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/hifi-glyphs.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/AnonymousPro-Regular.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/FiraSans-Regular.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/FiraSans-SemiBold.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/Raleway-Light.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/Raleway-Regular.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/Raleway-Bold.ttf");
+    QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/Raleway-SemiBold.ttf");
     _window->setWindowTitle("High Fidelity Interface");
 
     Model::setAbstractViewStateInterface(this); // The model class will sometimes need to know view state details from us

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -978,6 +978,15 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     qInstallMessageHandler(messageHandler);
 
     QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "styles/Inconsolata.otf");
+    QFontDatabase::addApplicationFont(":/fonts/fontawesome-webfont.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/hifi-glyphs.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/AnonymousPro-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/FiraSans-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/FiraSans-SemiBold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/Raleway-Light.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/Raleway-Regular.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/Raleway-Bold.ttf");
+    QFontDatabase::addApplicationFont(":/fonts/Raleway-SemiBold.ttf");
     _window->setWindowTitle("High Fidelity Interface");
 
     Model::setAbstractViewStateInterface(this); // The model class will sometimes need to know view state details from us


### PR DESCRIPTION
For some reason, loading `.ttf` fonts via `qrc:/` on MacOS doesn't work, even though it works on Windows and is supposedly supported. This PR fixes glyph loading on MacOS, with no behavioral change to font loading on other platforms.