### PR TITLE
clear wallet when picking a new one

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -174,11 +174,12 @@ Rectangle {
     WalletChoice {
         id: walletChoice;
         proceedFunction: function (isReset) {
-            console.log(isReset ? "Reset wallet." : "Trying again with new wallet.");
+            console.log("WalletChoice", isReset ? "Reset wallet." : "Trying again with new wallet.");
             Commerce.setSoftReset();
             if (isReset) {
                 walletResetSetup();
             } else {
+                Commerce.clearWallet();
                 var msg = { referrer: walletChoice.referrer }
                 followReferrer(msg);
             }

--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -138,6 +138,11 @@ void QmlCommerce::setSoftReset() {
     wallet->setSoftReset();
 }
 
+void QmlCommerce::clearWallet() {
+    auto wallet = DependencyManager::get<Wallet>();
+    wallet->clear();
+}
+
 void QmlCommerce::setPassphrase(const QString& passphrase) {
     auto wallet = DependencyManager::get<Wallet>();
     wallet->setPassphrase(passphrase);

--- a/interface/src/commerce/QmlCommerce.h
+++ b/interface/src/commerce/QmlCommerce.h
@@ -67,6 +67,7 @@ protected:
     Q_INVOKABLE void setPassphrase(const QString& passphrase);
     Q_INVOKABLE void changePassphrase(const QString& oldPassphrase, const QString& newPassphrase);
     Q_INVOKABLE void setSoftReset();
+    Q_INVOKABLE void clearWallet();
 
     Q_INVOKABLE void buy(const QString& assetId, int cost, const bool controlledFailure = false);
     Q_INVOKABLE void balance();

--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -343,17 +343,21 @@ Wallet::Wallet() {
     auto accountManager = DependencyManager::get<AccountManager>();
     connect(accountManager.data(), &AccountManager::usernameChanged, this, [&]() {
         getWalletStatus();
-        _publicKeys.clear();
-
-        if (_securityImage) {
-            delete _securityImage;
-        }
-        _securityImage = nullptr;
-
-        // tell the provider we got nothing
-        updateImageProvider();
-        _passphrase->clear();
+        clear();
     });
+}
+
+void Wallet::clear() {
+    _publicKeys.clear();
+
+    if (_securityImage) {
+        delete _securityImage;
+    }
+    _securityImage = nullptr;
+
+    // tell the provider we got nothing
+    updateImageProvider();
+    _passphrase->clear();
 }
 
 Wallet::~Wallet() {

--- a/interface/src/commerce/Wallet.h
+++ b/interface/src/commerce/Wallet.h
@@ -49,8 +49,9 @@ public:
     bool getPassphraseIsCached() { return !(_passphrase->isEmpty()); }
     bool walletIsAuthenticatedWithPassphrase();
     bool changePassphrase(const QString& newPassphrase);
-    void setSoftReset() { _isOverridingServer = true;  }
+    void setSoftReset() { _isOverridingServer = true; }
     bool wasSoftReset() { bool was = _isOverridingServer; _isOverridingServer = false; return was; }
+    void clear();
 
     void getWalletStatus();
     enum WalletStatus {


### PR DESCRIPTION
fixes "Wrong wallet displays after "Locate Other Keys" button is selected"