### PR TITLE
Fix for broken 'toggle audio meter' button

### DIFF
--- a/interface/resources/qml/AvatarInputsBar.qml
+++ b/interface/resources/qml/AvatarInputsBar.qml
@@ -14,9 +14,9 @@ import Qt.labs.settings 1.0
 
 import "./hifi/audio" as HifiAudio
 
-Hifi.AvatarInputs {
+Item {
     id: root;
-    objectName: "AvatarInputs"
+    objectName: "AvatarInputsBar"
     property int modality: Qt.NonModal
     width: audio.width;
     height: audio.height;
@@ -26,7 +26,7 @@ Hifi.AvatarInputs {
 
     HifiAudio.MicBar {
         id: audio;
-        visible: root.showAudioTools;
+        visible: AvatarInputs.showAudioTools;
         standalone: true;
 	    dragTarget: parent;
     }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2716,7 +2716,12 @@ void Application::onDesktopRootContextCreated(QQmlContext* surfaceContext) {
 
 void Application::onDesktopRootItemCreated(QQuickItem* rootItem) {
     Stats::show();
-    AvatarInputs::show();
+    auto surfaceContext = DependencyManager::get<OffscreenUi>()->getSurfaceContext();
+    surfaceContext->setContextProperty("Stats", Stats::getInstance());
+
+    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    auto qml = PathUtils::qmlUrl("AvatarInputsBar.qml");
+    offscreenUi->show(qml, "AvatarInputsBar");
 }
 
 void Application::updateCamera(RenderArgs& renderArgs, float deltaTime) {

--- a/interface/src/ui/AvatarInputs.cpp
+++ b/interface/src/ui/AvatarInputs.cpp
@@ -16,22 +16,19 @@
 #include "Application.h"
 #include "Menu.h"
 
-HIFI_QML_DEF(AvatarInputs)
-
 static AvatarInputs* INSTANCE{ nullptr };
 
 Setting::Handle<bool> showAudioToolsSetting { QStringList { "AvatarInputs", "showAudioTools" }, false };
 
 AvatarInputs* AvatarInputs::getInstance() {
     if (!INSTANCE) {
-        AvatarInputs::registerType();
+        INSTANCE = new AvatarInputs();
         Q_ASSERT(INSTANCE);
     }
     return INSTANCE;
 }
 
-AvatarInputs::AvatarInputs(QQuickItem* parent) :  QQuickItem(parent) {
-    INSTANCE = this;
+AvatarInputs::AvatarInputs(QObject* parent) : QObject(parent) {
     _showAudioTools = showAudioToolsSetting.get();
 }
 

--- a/interface/src/ui/AvatarInputs.h
+++ b/interface/src/ui/AvatarInputs.h
@@ -19,7 +19,7 @@ public: \
 private: \
     type _##name{ initialValue };
 
-class AvatarInputs : public QQuickItem {
+class AvatarInputs : public QObject {
     Q_OBJECT
     HIFI_QML_DECL
 
@@ -32,7 +32,7 @@ class AvatarInputs : public QQuickItem {
 public:
     static AvatarInputs* getInstance();
     Q_INVOKABLE float loudnessToAudioLevel(float loudness);
-    AvatarInputs(QQuickItem* parent = nullptr);
+    AvatarInputs(QObject* parent = nullptr);
     void update();
     bool showAudioTools() const   { return _showAudioTools; }
 


### PR DESCRIPTION
PR fixes the issue with inability to toggle 'audio meter' from desktop/HMD toolbar. The issue happened because 'AvatarInputs' singleton was exposed to QML before instantiating it (which happens on loading AvatarInputs.qml). The fix consists in splitting AvatarInputs into real singleton, created on 'getInstance()' and 'AvatarInputsBar.qml'.

Note: this is the same as https://github.com/highfidelity/hifi/pull/12597 but for RC65