### PR TITLE
Correct can cast shadow flag being visible on entities that can't cast shadows

### DIFF
--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -313,7 +313,7 @@
                 <label>ID:</label>
                 <input type="text" id="property-id" readonly>
             </div>
-            <div class="property checkbox">
+            <div class="can-cast-shadow-section property checkbox">
                 <input type="checkbox" id="property-can-cast-shadow">
                 <label for="property-can-cast-shadow">Can cast shadow</label>
             </div>


### PR DESCRIPTION
# Description
The cast shadow was appearing on entity types that do not cast shadows, such as zones and particles.
Note that this flag is in the BEHAVIOUR section.
# Test
1.  Verify that zones don't have the `can cast shadow` flag, but do have the `cast shadows` flag in the keylight section.  Check this flag to enable shadows.
2.  Enter domain on local host
3.  Verify that models do have the `can cast shadow` flag and unchecking the flag turns shadow off for that model.
4.  Verify that shapes (cube/sphere) do have the `can cast shadow` flag and unchecking the flag turns shadow off for that model.
5.  Verify that particle effects do not have the `can cast shadow` flag.
