### PR TITLE
Loghandler

### DIFF
--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -22,7 +22,6 @@
 #include <QtCore/QDateTime>
 #include <QtCore/QDebug>
 #include <QtCore/QMutexLocker>
-#include <QtCore/QRegExp>
 #include <QtCore/QThread>
 #include <QtCore/QTimer>
 
@@ -92,12 +91,13 @@ void LogHandler::setShouldDisplayMilliseconds(bool shouldDisplayMilliseconds) {
 
 void LogHandler::flushRepeatedMessages() {
     QMutexLocker lock(&_mutex);
-    QHash<QString, int>::iterator message = _repeatMessageCountHash.begin();
-    while (message != _repeatMessageCountHash.end()) {
+    for(auto& message: _repeatedMessages) {
 
-        if (message.value() > 0) {
+        if (message->messageCount > 1) {
             QString repeatMessage = QString("%1 repeated log entries matching \"%2\" - Last entry: \"%3\"")
-            .arg(message.value()).arg(message.key()).arg(_lastRepeatedMessage.value(message.key()));
+                .arg(message->messageCount - 1)
+                .arg(message->regexp.pattern())
+                .arg(message->lastMessage);
 
             QMessageLogContext emptyContext;
             lock.unlock();
@@ -105,8 +105,7 @@ void LogHandler::flushRepeatedMessages() {
             lock.relock();
         }
 
-        _lastRepeatedMessage.remove(message.key());
-        message = _repeatMessageCountHash.erase(message);
+        message->messageCount = 0;
     }
 }
 
@@ -118,44 +117,25 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
 
     if (type == LogDebug) {
         // for debug messages, check if this matches any of our regexes for repeated log messages
-        foreach(const QString& regexString, getInstance()._repeatedMessageRegexes) {
-            QRegExp repeatRegex(regexString);
-            if (repeatRegex.indexIn(message) != -1) {
-
-                if (!_repeatMessageCountHash.contains(regexString)) {
-                    // we have a match but didn't have this yet - output the first one
-                    _repeatMessageCountHash[regexString] = 0;
-
-                    // break the foreach so we output the first match
-                    break;
-                } else {
-                    // we have a match - add 1 to the count of repeats for this message and set this as the last repeated message
-                    _repeatMessageCountHash[regexString] += 1;
-                    _lastRepeatedMessage[regexString] = message;
-
-                    // return out, we're not printing this one
-                    return QString();
-                }
+        for(auto& repeatRegex: _repeatedMessages) {
+            if (repeatRegex->regexp.indexIn(message) != -1) {
+                // If we've printed the first one then return out.
+                if (repeatRegex->messageCount++ == 0) break;
+                repeatRegex->lastMessage = message;
+                return QString();
             }
         }
     }
+
     if (type == LogDebug) {
         // see if this message is one we should only print once
-        foreach(const QString& regexString, getInstance()._onlyOnceMessageRegexes) {
-            QRegExp onlyOnceRegex(regexString);
-            if (onlyOnceRegex.indexIn(message) != -1) {
-                if (!_onlyOnceMessageCountHash.contains(message)) {
-                    // we have a match and haven't yet printed this message.
-                    _onlyOnceMessageCountHash[message] = 1;
-                    // break the foreach so we output the first match
-                    break;
-                } else {
-                    // We've already printed this message, don't print it again.
-                    return QString();
+        for(auto& onceOnly : _onetimeMessages) {
+            if (onceOnly->regexp.indexIn(message) != -1) {
+                if (onceOnly->messageCount++ == 0) break;   // we have a match and haven't yet printed this message.
+                else return QString();  // We've already printed this message, don't print it again.
                 }
             }
         }
-    }
 
     // log prefix is in the following format
     // [TIMESTAMP] [DEBUG] [PID] [TID] [TARGET] logged string
@@ -217,10 +197,16 @@ const QString& LogHandler::addRepeatedMessageRegex(const QString& regexString) {
     QMetaObject::invokeMethod(this, "setupRepeatedMessageFlusher");
 
     QMutexLocker lock(&_mutex);
-    return *_repeatedMessageRegexes.insert(regexString);
+    std::unique_ptr<_RepeatedMessage> repeatRecord(new _RepeatedMessage());
+    repeatRecord->regexp = QRegExp(regexString);
+    _repeatedMessages.insert(std::move(repeatRecord));
+    return regexString;
 }
 
 const QString& LogHandler::addOnlyOnceMessageRegex(const QString& regexString) {
     QMutexLocker lock(&_mutex);
-    return *_onlyOnceMessageRegexes.insert(regexString);
+    std::unique_ptr<_OnceOnlyMessage> onetimeMessage(new _OnceOnlyMessage());
+    onetimeMessage->regexp = QRegExp(regexString);
+    _onetimeMessages.insert(std::move(onetimeMessage));
+    return regexString;
 }

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -117,10 +117,12 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
 
     if (type == LogDebug) {
         // for debug messages, check if this matches any of our regexes for repeated log messages
-        for(auto& repeatRegex: _repeatedMessages) {
+        for(auto& repeatRegex : _repeatedMessages) {
             if (repeatRegex->regexp.indexIn(message) != -1) {
                 // If we've printed the first one then return out.
-                if (repeatRegex->messageCount++ == 0) break;
+                if (repeatRegex->messageCount++ == 0) {
+                    break;
+                }
                 repeatRegex->lastMessage = message;
                 return QString();
             }
@@ -131,11 +133,17 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
         // see if this message is one we should only print once
         for(auto& onceOnly : _onetimeMessages) {
             if (onceOnly->regexp.indexIn(message) != -1) {
-                if (onceOnly->messageCount++ == 0) break;   // we have a match and haven't yet printed this message.
-                else return QString();  // We've already printed this message, don't print it again.
+                if (onceOnly->messageCount++ == 0) {
+                    // we have a match and haven't yet printed this message.
+                    break;
+                }
+                else {
+                    // We've already printed this message, don't print it again.
+                    return QString();
                 }
             }
         }
+    }
 
     // log prefix is in the following format
     // [TIMESTAMP] [DEBUG] [PID] [TID] [TARGET] logged string
@@ -197,7 +205,7 @@ const QString& LogHandler::addRepeatedMessageRegex(const QString& regexString) {
     QMetaObject::invokeMethod(this, "setupRepeatedMessageFlusher");
 
     QMutexLocker lock(&_mutex);
-    std::unique_ptr<_RepeatedMessage> repeatRecord(new _RepeatedMessage());
+    std::unique_ptr<RepeatedMessage> repeatRecord(new RepeatedMessage());
     repeatRecord->regexp = QRegExp(regexString);
     _repeatedMessages.insert(std::move(repeatRecord));
     return regexString;
@@ -205,7 +213,7 @@ const QString& LogHandler::addRepeatedMessageRegex(const QString& regexString) {
 
 const QString& LogHandler::addOnlyOnceMessageRegex(const QString& regexString) {
     QMutexLocker lock(&_mutex);
-    std::unique_ptr<_OnceOnlyMessage> onetimeMessage(new _OnceOnlyMessage());
+    std::unique_ptr<OnceOnlyMessage> onetimeMessage(new OnceOnlyMessage());
     onetimeMessage->regexp = QRegExp(regexString);
     _onetimeMessages.insert(std::move(onetimeMessage));
     return regexString;

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -13,11 +13,12 @@
 #ifndef hifi_LogHandler_h
 #define hifi_LogHandler_h
 
-#include <QHash>
 #include <QObject>
-#include <QSet>
 #include <QString>
+#include <QRegExp>
 #include <QMutex>
+#include <set>
+#include <memory>
 
 const int VERBOSE_LOG_INTERVAL_SECONDS = 5;
 
@@ -66,12 +67,19 @@ private:
     bool _shouldOutputProcessID { false };
     bool _shouldOutputThreadID { false };
     bool _shouldDisplayMilliseconds { false };
-    QSet<QString> _repeatedMessageRegexes;
-    QHash<QString, int> _repeatMessageCountHash;
-    QHash<QString, QString> _lastRepeatedMessage;
 
-    QSet<QString> _onlyOnceMessageRegexes;
-    QHash<QString, int> _onlyOnceMessageCountHash;
+    struct _RepeatedMessage {
+        QRegExp     regexp;
+        int         messageCount { 0 };
+        QString     lastMessage;
+    };
+    std::set<std::unique_ptr<_RepeatedMessage>> _repeatedMessages;
+
+    struct _OnceOnlyMessage {
+        QRegExp     regexp;
+        int         messageCount { 0 };
+    };
+    std::set<std::unique_ptr<_OnceOnlyMessage>> _onetimeMessages;
 
     static QMutex _mutex;
 };

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -68,18 +68,18 @@ private:
     bool _shouldOutputThreadID { false };
     bool _shouldDisplayMilliseconds { false };
 
-    struct _RepeatedMessage {
-        QRegExp     regexp;
-        int         messageCount { 0 };
-        QString     lastMessage;
+    struct RepeatedMessage {
+        QRegExp regexp;
+        int messageCount { 0 };
+        QString lastMessage;
     };
-    std::set<std::unique_ptr<_RepeatedMessage>> _repeatedMessages;
+    std::set<std::unique_ptr<RepeatedMessage>> _repeatedMessages;
 
-    struct _OnceOnlyMessage {
-        QRegExp     regexp;
-        int         messageCount { 0 };
+    struct OnceOnlyMessage {
+        QRegExp regexp;
+        int messageCount { 0 };
     };
-    std::set<std::unique_ptr<_OnceOnlyMessage>> _onetimeMessages;
+    std::set<std::unique_ptr<OnceOnlyMessage>> _onetimeMessages;
 
     static QMutex _mutex;
 };

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -17,7 +17,7 @@
 #include <QString>
 #include <QRegExp>
 #include <QMutex>
-#include <set>
+#include <vector>
 #include <memory>
 
 const int VERBOSE_LOG_INTERVAL_SECONDS = 5;
@@ -73,13 +73,13 @@ private:
         int messageCount { 0 };
         QString lastMessage;
     };
-    std::set<std::unique_ptr<RepeatedMessage>> _repeatedMessages;
+    std::vector<RepeatedMessage> _repeatedMessages;
 
     struct OnceOnlyMessage {
         QRegExp regexp;
         int messageCount { 0 };
     };
-    std::set<std::unique_ptr<OnceOnlyMessage>> _onetimeMessages;
+    std::vector<OnceOnlyMessage> _onetimeMessages;
 
     static QMutex _mutex;
 };


### PR DESCRIPTION
Changed LogHandler to maintain QRegExps rather than rebuild them on each message. Also use stl containers instead of Qt ones.

On Ubuntu there is no longer a crash in a global destructor when a regexp is created, since that call doesn't exist. In two tests one exited normally and one crashed in another Qt destructor, probably because the main thread had ended before the network and SendQueue threads. Previously the crash was 100% if the audio agent had connected to the interface.

https://highfidelity.manuscript.com/f/cases/13035/

https://highfidelity.sp.backtrace.io/dashboard/highfidelity/project/LinuxDomainServer/debugger/238244?frameID=17693&threadID=4920&variableID=