### PR TITLE
Fix local KTX files never being removed from pending downloads

### DIFF
--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -472,7 +472,6 @@ void NetworkTexture::makeLocalRequest() {
         path = ":" + _url.path();
     }
 
-    auto self = _self;
     connect(this, &Resource::finished, this, &NetworkTexture::handleLocalRequestCompleted);
 
     path = FileUtils::selectFile(path);

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -459,6 +459,10 @@ void NetworkTexture::makeRequest() {
 
 }
 
+void NetworkTexture::handleLocalRequestCompleted() {
+    TextureCache::requestCompleted(_self);
+}
+
 void NetworkTexture::makeLocalRequest() {
     const QString scheme = _url.scheme();
     QString path;
@@ -467,6 +471,9 @@ void NetworkTexture::makeLocalRequest() {
     } else {
         path = ":" + _url.path();
     }
+
+    auto self = _self;
+    connect(this, &Resource::finished, this, &NetworkTexture::handleLocalRequestCompleted);
 
     path = FileUtils::selectFile(path);
 

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -71,6 +71,7 @@ public slots:
 protected:
     void makeRequest() override;
     void makeLocalRequest();
+    Q_INVOKABLE void handleLocalRequestCompleted();
 
     virtual bool isCacheable() const override { return _loaded; }
 


### PR DESCRIPTION
Fix for https://highfidelity.manuscript.com/f/cases/13056

## Testing

In current master builds, the textures for the default avatar will never be removed from the extended stats display and the 'content downloading' bar will never disappear.  With this PR build, this should no longer be the case.  