### PR TITLE
Mitigation of Manuscript issue 12435

### DIFF
--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -756,6 +756,9 @@ void CharacterController::updateState() {
                     SET_STATE(State::Hover, "double jump button");
                 } else if ((jumpButtonHeld || vertTargetSpeedIsNonZero) && (now - _jumpButtonDownStartTime) > JUMP_TO_HOVER_PERIOD) {
                     SET_STATE(State::Hover, "jump button held");
+                } else if (_floorDistance > _scaleFactor * DEFAULT_AVATAR_FALL_HEIGHT) {
+                    // Transition to hover if we are above the fall threshold
+                    SET_STATE(State::Hover, "above fall threshold");
                 }
             }
             break;


### PR DESCRIPTION
# Background
This bug occurs rarely, when changing domains.  The effect is that the avatar initializes in the falling state, below the ground.  The current code does not deal with this case:  there is no simple way to stop the falling.
# Description
Transition to hover if falling and height above ground is greater than the threshold.
# Test
Follow https://highfidelity.testrail.net/index.php?/suites/view/866&group_by=cases:title&group_order=asc

# Regression test
In addition, also run the following tests:
Test going to a user in both the the "nearby" and "connections" tab of the PEOPLE app. It should work reliably, regardless of whether the person you are going to is on the ground or in the air.

Run the navigation test suite S256 (e.g., including "Can't get stuck in surfaces or floors", "Flying should work", etc.) Of course, the results of this PR should match that of master - no promises of doing better than master!