### PR TITLE
Hificonstants as object

### DIFF
--- a/interface/resources/qml/styles-uit/HifiConstants.qml
+++ b/interface/resources/qml/styles-uit/HifiConstants.qml
@@ -17,23 +17,23 @@ QtObject {
         // Translates icon enum to glyph char.
         var glyph;
         switch (icon) {
-            case hifi.icons.information:
-                glyph = hifi.glyphs.info;
+            case icons.information:
+                glyph = glyphs.info;
                 break;
-            case hifi.icons.question:
-                glyph = hifi.glyphs.question;
+            case icons.question:
+                glyph = glyphs.question;
                 break;
-            case hifi.icons.warning:
-                glyph = hifi.glyphs.alert;
+            case icons.warning:
+                glyph = glyphs.alert;
                 break;
-            case hifi.icons.critical:
-                glyph = hifi.glyphs.error;
+            case icons.critical:
+                glyph = glyphs.error;
                 break;
-            case hifi.icons.placemark:
-                glyph = hifi.glyphs.placemark;
+            case icons.placemark:
+                glyph = glyphs.placemark;
                 break;
             default:
-                glyph = hifi.glyphs.noIcon;
+                glyph = glyphs.noIcon;
         }
         return glyph;
     }

--- a/interface/resources/qml/styles-uit/HifiConstants.qml
+++ b/interface/resources/qml/styles-uit/HifiConstants.qml
@@ -11,7 +11,7 @@
 import QtQuick 2.5
 import QtQuick.Window 2.2
 
-Item {
+QtObject {
     readonly property alias colors: colors
     readonly property alias colorSchemes: colorSchemes
     readonly property alias dimensions: dimensions
@@ -46,7 +46,7 @@ Item {
         return glyph;
     }
 
-    Item {
+    QtObject {
         id: colors
 
         // Base colors
@@ -134,14 +134,14 @@ Item {
         readonly property color tabBackgroundLight: "#d4d4d4"
     }
 
-    Item {
+    QtObject {
         id: colorSchemes
         readonly property int light: 0
         readonly property int dark: 1
         readonly property int faintGray: 2
     }
 
-    Item {
+    QtObject {
         id: dimensions
         readonly property bool largeScreen: Screen.width >= 1920 && Screen.height >= 1080
         readonly property real borderRadius: largeScreen ? 7.5 : 5.0
@@ -168,7 +168,7 @@ Item {
         readonly property real buttonWidth: 120
     }
 
-    Item {
+    QtObject {
         id: fontSizes  // In pixels
         readonly property real overlayTitle: dimensions.largeScreen ? 18 : 14
         readonly property real tabName: dimensions.largeScreen ? 12 : 10
@@ -194,7 +194,7 @@ Item {
         readonly property real disclosureButton: dimensions.largeScreen ? 30 : 22
     }
 
-    Item {
+    QtObject {
         id: icons
         // Values per OffscreenUi::Icon
         readonly property int none: 0
@@ -205,7 +205,7 @@ Item {
         readonly property int placemark: 5
     }
 
-    Item {
+    QtObject {
         id: buttons
         readonly property int white: 0
         readonly property int blue: 1
@@ -231,7 +231,7 @@ Item {
         id: effects
         readonly property int fadeInDuration: 300
     }
-    Item {
+    QtObject {
         id: glyphs
         readonly property string noIcon: ""
         readonly property string hmd: "b"

--- a/interface/resources/qml/styles-uit/HifiConstants.qml
+++ b/interface/resources/qml/styles-uit/HifiConstants.qml
@@ -12,14 +12,6 @@ import QtQuick 2.5
 import QtQuick.Window 2.2
 
 QtObject {
-    readonly property alias colors: colors
-    readonly property alias colorSchemes: colorSchemes
-    readonly property alias dimensions: dimensions
-    readonly property alias fontSizes: fontSizes
-    readonly property alias glyphs: glyphs
-    readonly property alias icons: icons
-    readonly property alias buttons: buttons
-    readonly property alias effects: effects
 
     function glyphForIcon(icon) {
         // Translates icon enum to glyph char.
@@ -46,9 +38,7 @@ QtObject {
         return glyph;
     }
 
-    QtObject {
-        id: colors
-
+    readonly property QtObject colors: QtObject {
         // Base colors
         readonly property color baseGray: "#393939"
         readonly property color darkGray: "#121212"
@@ -134,15 +124,13 @@ QtObject {
         readonly property color tabBackgroundLight: "#d4d4d4"
     }
 
-    QtObject {
-        id: colorSchemes
+    readonly property QtObject colorSchemes: QtObject {
         readonly property int light: 0
         readonly property int dark: 1
         readonly property int faintGray: 2
     }
 
-    QtObject {
-        id: dimensions
+    readonly property QtObject dimensions: QtObject {
         readonly property bool largeScreen: Screen.width >= 1920 && Screen.height >= 1080
         readonly property real borderRadius: largeScreen ? 7.5 : 5.0
         readonly property real borderWidth: largeScreen ? 2 : 1
@@ -168,8 +156,8 @@ QtObject {
         readonly property real buttonWidth: 120
     }
 
-    QtObject {
-        id: fontSizes  // In pixels
+    readonly property QtObject fontSizes: QtObject {
+        // In pixels
         readonly property real overlayTitle: dimensions.largeScreen ? 18 : 14
         readonly property real tabName: dimensions.largeScreen ? 12 : 10
         readonly property real sectionName: dimensions.largeScreen ? 12 : 10
@@ -194,8 +182,7 @@ QtObject {
         readonly property real disclosureButton: dimensions.largeScreen ? 30 : 22
     }
 
-    QtObject {
-        id: icons
+    readonly property QtObject icons: QtObject {
         // Values per OffscreenUi::Icon
         readonly property int none: 0
         readonly property int question: 1
@@ -205,8 +192,7 @@ QtObject {
         readonly property int placemark: 5
     }
 
-    QtObject {
-        id: buttons
+    readonly property QtObject buttons: QtObject {
         readonly property int white: 0
         readonly property int blue: 1
         readonly property int red: 2
@@ -227,12 +213,11 @@ QtObject {
         readonly property int radius: 5
     }
 
-    QtObject {
-        id: effects
+    readonly property QtObject effects: QtObject {
         readonly property int fadeInDuration: 300
     }
-    QtObject {
-        id: glyphs
+
+    readonly property QtObject glyphs: QtObject {
         readonly property string noIcon: ""
         readonly property string hmd: "b"
         readonly property string screen: "c"


### PR DESCRIPTION
The idea of the fix is to remove an visual Item from QML scenes, while the HifiConstants is just a constants placeholder. This might reduce resources footprint and also will not treat HifiConstants as an default visual item, which sometimes might fool some QML components in terms of focus change etc

Test plan: since the fix touches almost all QML code, the test should be finding regressions between this and master in terms of UI