### PR TITLE
cleanup around how EntityItems are added/removed from the "simulation"

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5307,11 +5307,13 @@ void Application::update(float deltaTime) {
             {
                 PROFILE_RANGE(simulation_physics, "PreStep");
                 PerformanceTimer perfTimer("preStep)");
-                static VectorOfMotionStates motionStates;
-                _entitySimulation->getObjectsToRemoveFromPhysics(motionStates);
-                _physicsEngine->removeObjects(motionStates);
-                _entitySimulation->deleteObjectsRemovedFromPhysics();
+                {
+                    const VectorOfMotionStates& motionStates = _entitySimulation->getObjectsToRemoveFromPhysics();
+                    _physicsEngine->removeObjects(motionStates);
+                    _entitySimulation->deleteObjectsRemovedFromPhysics();
+                }
 
+                VectorOfMotionStates motionStates;
                 getEntities()->getTree()->withReadLock([&] {
                     _entitySimulation->getObjectsToAddToPhysics(motionStates);
                     _physicsEngine->addObjects(motionStates);
@@ -5325,7 +5327,7 @@ void Application::update(float deltaTime) {
 
                 _entitySimulation->applyDynamicChanges();
 
-                 avatarManager->getObjectsToRemoveFromPhysics(motionStates);
+                avatarManager->getObjectsToRemoveFromPhysics(motionStates);
                 _physicsEngine->removeObjects(motionStates);
                 avatarManager->getObjectsToAddToPhysics(motionStates);
                 _physicsEngine->addObjects(motionStates);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4715,7 +4715,7 @@ void Application::init() {
     auto entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();
 
     // connect the _entityCollisionSystem to our EntityTreeRenderer since that's what handles running entity scripts
-    connect(_entitySimulation.get(), &EntitySimulation::entityCollisionWithEntity,
+    connect(_entitySimulation.get(), &PhysicalEntitySimulation::entityCollisionWithEntity,
             getEntities().data(), &EntityTreeRenderer::entityCollisionWithEntity);
 
     // connect the _entities (EntityTreeRenderer) to our script engine's EntityScriptingInterface for firing

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -2962,13 +2962,6 @@ void EntityItem::retrieveMarketplacePublicKey() {
 }
 
 void EntityItem::preDelete() {
-    // clear out any left-over actions
-    EntityTreeElementPointer element = _element; // use local copy of _element for logic below
-    EntityTreePointer entityTree = element ? element->getTree() : nullptr;
-    EntitySimulationPointer simulation = entityTree ? entityTree->getSimulation() : nullptr;
-    if (simulation) {
-        clearActions(simulation);
-    }
 }
 
 void EntityItem::addMaterial(graphics::MaterialLayer material, const std::string& parentMaterialName) {

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -71,14 +71,6 @@ void EntitySimulation::prepareEntityForDelete(EntityItemPointer entity) {
     }
 }
 
-void EntitySimulation::addEntityInternal(EntityItemPointer entity) {
-    if (entity->isMovingRelativeToParent() && !entity->getPhysicsInfo()) {
-        QMutexLocker lock(&_mutex);
-        _simpleKinematicEntities.insert(entity);
-        entity->setLastSimulated(usecTimestampNow());
-    }
-}
-
 void EntitySimulation::changeEntityInternal(EntityItemPointer entity) {
     QMutexLocker lock(&_mutex);
     if (entity->isMovingRelativeToParent() && !entity->getPhysicsInfo()) {

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -40,12 +40,9 @@ void EntitySimulation::updateEntities() {
     sortEntitiesThatMoved();
 }
 
-void EntitySimulation::takeDeadEntities(VectorOfEntities& entitiesToDelete) {
+void EntitySimulation::takeDeadEntities(SetOfEntities& entitiesToDelete) {
     QMutexLocker lock(&_mutex);
-    for (auto entity : _deadEntities) {
-        // push this entity onto the external list
-        entitiesToDelete.push_back(entity);
-    }
+    entitiesToDelete.swap(_deadEntities);
     _deadEntities.clear();
 }
 

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -71,19 +71,6 @@ void EntitySimulation::prepareEntityForDelete(EntityItemPointer entity) {
     }
 }
 
-void EntitySimulation::changeEntityInternal(EntityItemPointer entity) {
-    QMutexLocker lock(&_mutex);
-    if (entity->isMovingRelativeToParent() && !entity->getPhysicsInfo()) {
-        int numKinematicEntities = _simpleKinematicEntities.size();
-        _simpleKinematicEntities.insert(entity);
-        if (numKinematicEntities != _simpleKinematicEntities.size()) {
-            entity->setLastSimulated(usecTimestampNow());
-        }
-    } else {
-        _simpleKinematicEntities.remove(entity);
-    }
-}
-
 // protected
 void EntitySimulation::expireMortalEntities(const quint64& now) {
     if (now > _nextExpiry) {

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -84,7 +84,7 @@ protected:
     // These pure virtual methods are protected because they are not to be called will-nilly. The base class
     // calls them in the right places.
     virtual void updateEntitiesInternal(const quint64& now) = 0;
-    virtual void addEntityInternal(EntityItemPointer entity);
+    virtual void addEntityInternal(EntityItemPointer entity) = 0;
     virtual void removeEntityInternal(EntityItemPointer entity) = 0;
     virtual void changeEntityInternal(EntityItemPointer entity);
     virtual void clearEntitiesInternal() = 0;

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -43,7 +43,6 @@ const int DIRTY_SIMULATION_FLAGS =
         Simulation::DIRTY_SIMULATOR_ID;
 
 class EntitySimulation : public QObject, public std::enable_shared_from_this<EntitySimulation> {
-Q_OBJECT
 public:
     EntitySimulation() : _mutex(QMutex::Recursive), _entityTree(NULL), _nextExpiry(quint64(-1)) { }
     virtual ~EntitySimulation() { setEntityTree(NULL); }
@@ -56,8 +55,6 @@ public:
     void setEntityTree(EntityTreePointer tree);
 
     void updateEntities();
-
-//    friend class EntityTree;
 
     virtual void addDynamic(EntityDynamicPointer dynamic);
     virtual void removeDynamic(const QUuid dynamicID);
@@ -82,9 +79,6 @@ public:
 
     /// \param entity pointer to EntityItem that needs to be put on the entitiesToDelete list and removed from others.
     virtual void prepareEntityForDelete(EntityItemPointer entity);
-
-signals:
-    void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 
 protected:
     // These pure virtual methods are protected because they are not to be called will-nilly. The base class
@@ -124,7 +118,6 @@ private:
 
 
     SetOfEntities _entitiesToUpdate; // entities that need to call EntityItem::update()
-
 };
 
 #endif // hifi_EntitySimulation_h

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -75,7 +75,7 @@ public:
 
     EntityTreePointer getEntityTree() { return _entityTree; }
 
-    virtual void takeDeadEntities(VectorOfEntities& entitiesToDelete);
+    virtual void takeDeadEntities(SetOfEntities& entitiesToDelete);
 
     /// \param entity pointer to EntityItem that needs to be put on the entitiesToDelete list and removed from others.
     virtual void prepareEntityForDelete(EntityItemPointer entity);

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -75,7 +75,7 @@ public:
 
     EntityTreePointer getEntityTree() { return _entityTree; }
 
-    virtual void takeEntitiesToDelete(VectorOfEntities& entitiesToDelete);
+    virtual void takeDeadEntities(VectorOfEntities& entitiesToDelete);
 
     /// \param entity pointer to EntityItem that needs to be put on the entitiesToDelete list and removed from others.
     virtual void prepareEntityForDelete(EntityItemPointer entity);
@@ -102,7 +102,7 @@ protected:
     QMutex _dynamicsMutex { QMutex::Recursive };
 
 protected:
-    SetOfEntities _entitiesToDelete; // entities simulation decided needed to be deleted (EntityTree will actually delete)
+    SetOfEntities _deadEntities;
 
 private:
     void moveSimpleKinematics();

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -85,7 +85,7 @@ protected:
     // calls them in the right places.
     virtual void updateEntitiesInternal(const quint64& now) = 0;
     virtual void addEntityInternal(EntityItemPointer entity) = 0;
-    virtual void removeEntityInternal(EntityItemPointer entity) = 0;
+    virtual void removeEntityInternal(EntityItemPointer entity);
     virtual void changeEntityInternal(EntityItemPointer entity) = 0;
     virtual void clearEntitiesInternal() = 0;
 

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -86,7 +86,7 @@ protected:
     virtual void updateEntitiesInternal(const quint64& now) = 0;
     virtual void addEntityInternal(EntityItemPointer entity) = 0;
     virtual void removeEntityInternal(EntityItemPointer entity) = 0;
-    virtual void changeEntityInternal(EntityItemPointer entity);
+    virtual void changeEntityInternal(EntityItemPointer entity) = 0;
     virtual void clearEntitiesInternal() = 0;
 
     void expireMortalEntities(const quint64& now);

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -94,7 +94,6 @@ OctreeElementPointer EntityTree::createNewElement(unsigned char* octalCode) {
 void EntityTree::eraseAllOctreeElements(bool createNewRoot) {
     emit clearingEntities();
 
-    // this would be a good place to clean up our entities...
     if (_simulation) {
         _simulation->clearEntities();
     }
@@ -552,8 +551,6 @@ void EntityTree::setSimulation(EntitySimulationPointer simulation) {
             assert(simulation->getEntityTree().get() == this);
         }
         if (_simulation && _simulation != simulation) {
-            // It's important to clearEntities() on the simulation since taht will update each
-            // EntityItem::_simulationState correctly so as to not confuse the next _simulation.
             _simulation->clearEntities();
         }
         _simulation = simulation;
@@ -1803,13 +1800,13 @@ void EntityTree::update(bool simulate) {
             _simulation->updateEntities();
             {
                 PROFILE_RANGE(simulation_physics, "Deletes");
-                VectorOfEntities pendingDeletes;
-                _simulation->takeEntitiesToDelete(pendingDeletes);
-                if (pendingDeletes.size() > 0) {
+                VectorOfEntities deadEntities;
+                _simulation->takeDeadEntities(deadEntities);
+                if (deadEntities.size() > 0) {
                     // translate into list of ID's
                     QSet<EntityItemID> idsToDelete;
 
-                    for (auto entity : pendingDeletes) {
+                    for (auto entity : deadEntities) {
                         idsToDelete.insert(entity->getEntityItemID());
                     }
 

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -453,12 +453,13 @@ bool EntityTree::updateEntity(EntityItemPointer entity, const EntityItemProperti
 
         uint32_t newFlags = entity->getDirtyFlags() & ~preFlags;
         if (newFlags) {
-            if (_simulation) {
+            if (entity->isSimulated()) {
+                assert((bool)_simulation);
                 if (newFlags & DIRTY_SIMULATION_FLAGS) {
                     _simulation->changeEntity(entity);
                 }
             } else {
-                // normally the _simulation clears ALL updateFlags, but since there is none we do it explicitly
+                // normally the _simulation clears ALL dirtyFlags, but when not possible we do it explicitly
                 entity->clearDirtyFlags();
             }
         }
@@ -469,7 +470,7 @@ bool EntityTree::updateEntity(EntityItemPointer entity, const EntityItemProperti
         if (entityScriptBefore != entityScriptAfter || reload) {
             emitEntityScriptChanging(entity->getEntityItemID(), reload); // the entity script has changed
         }
-     }
+    }
 
     // TODO: this final containingElement check should eventually be removed (or wrapped in an #ifdef DEBUG).
     if (!entity->getElement()) {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -260,7 +260,7 @@ void EntityTree::postAddEntity(EntityItemPointer entity) {
             return;
         }
     }
-    
+
     // check to see if we need to simulate this entity..
     if (_simulation) {
         _simulation->addEntity(entity);
@@ -693,7 +693,7 @@ void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator)
             trackDeletedEntity(theEntity->getEntityItemID());
         }
 
-        if (_simulation) {
+        if (theEntity->isSimulated()) {
             _simulation->prepareEntityForDelete(theEntity);
         }
     }
@@ -1689,7 +1689,7 @@ void EntityTree::releaseSceneEncodeData(OctreeElementExtraEncodeData* extraEncod
 }
 
 void EntityTree::entityChanged(EntityItemPointer entity) {
-    if (_simulation) {
+    if (entity->isSimulated()) {
         _simulation->changeEntity(entity);
     }
 }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1800,7 +1800,7 @@ void EntityTree::update(bool simulate) {
             _simulation->updateEntities();
             {
                 PROFILE_RANGE(simulation_physics, "Deletes");
-                VectorOfEntities deadEntities;
+                SetOfEntities deadEntities;
                 _simulation->takeDeadEntities(deadEntities);
                 if (deadEntities.size() > 0) {
                     // translate into list of ID's

--- a/libraries/entities/src/MaterialEntityItem.cpp
+++ b/libraries/entities/src/MaterialEntityItem.cpp
@@ -267,8 +267,11 @@ void MaterialEntityItem::setOwningAvatarID(const QUuid& owningAvatarID) {
 
 void MaterialEntityItem::removeMaterial() {
     graphics::MaterialPointer material = getMaterial();
+    if (!material) {
+        return;
+    }
     QUuid parentID = getClientOnly() ? getOwningAvatarID() : getParentID();
-    if (!material || parentID.isNull()) {
+    if (parentID.isNull()) {
         return;
     }
 

--- a/libraries/entities/src/SimpleEntitySimulation.cpp
+++ b/libraries/entities/src/SimpleEntitySimulation.cpp
@@ -111,7 +111,18 @@ void SimpleEntitySimulation::removeEntityInternal(EntityItemPointer entity) {
 }
 
 void SimpleEntitySimulation::changeEntityInternal(EntityItemPointer entity) {
-    EntitySimulation::changeEntityInternal(entity);
+    {
+        QMutexLocker lock(&_mutex);
+        if (entity->isMovingRelativeToParent() && !entity->getPhysicsInfo()) {
+            int numKinematicEntities = _simpleKinematicEntities.size();
+            _simpleKinematicEntities.insert(entity);
+            if (numKinematicEntities != _simpleKinematicEntities.size()) {
+                entity->setLastSimulated(usecTimestampNow());
+            }
+        } else {
+            _simpleKinematicEntities.remove(entity);
+        }
+    }
     if (entity->getSimulatorID().isNull()) {
         QMutexLocker lock(&_mutex);
         _entitiesWithSimulationOwner.remove(entity);

--- a/libraries/entities/src/SimpleEntitySimulation.cpp
+++ b/libraries/entities/src/SimpleEntitySimulation.cpp
@@ -105,7 +105,6 @@ void SimpleEntitySimulation::addEntityInternal(EntityItemPointer entity) {
 
 void SimpleEntitySimulation::removeEntityInternal(EntityItemPointer entity) {
     EntitySimulation::removeEntityInternal(entity);
-    QMutexLocker lock(&_mutex);
     _entitiesWithSimulationOwner.remove(entity);
     _entitiesThatNeedSimulationOwner.remove(entity);
 }

--- a/libraries/entities/src/SimpleEntitySimulation.cpp
+++ b/libraries/entities/src/SimpleEntitySimulation.cpp
@@ -85,7 +85,11 @@ void SimpleEntitySimulation::updateEntitiesInternal(const quint64& now) {
 }
 
 void SimpleEntitySimulation::addEntityInternal(EntityItemPointer entity) {
-    EntitySimulation::addEntityInternal(entity);
+    if (entity->isMovingRelativeToParent() && !entity->getPhysicsInfo()) {
+        QMutexLocker lock(&_mutex);
+        _simpleKinematicEntities.insert(entity);
+        entity->setLastSimulated(usecTimestampNow());
+    }
     if (!entity->getSimulatorID().isNull()) {
         QMutexLocker lock(&_mutex);
         _entitiesWithSimulationOwner.insert(entity);

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -67,6 +67,7 @@ EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItemPointer 
     _accelerationNearlyGravityCount(0),
     _numInactiveUpdates(1)
 {
+    // EntityMotionState keeps a SharedPointer to its EntityItem which is only set in the CTOR
     _type = MOTIONSTATE_TYPE_ENTITY;
     assert(_entity);
     assert(entityTreeIsLocked());
@@ -80,6 +81,7 @@ EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItemPointer 
 
 EntityMotionState::~EntityMotionState() {
     if (_entity) {
+        // EntityMotionState keeps a SharedPointer to its EntityItem which is only cleared in the DTOR
         assert(_entity->getPhysicsInfo() == this);
         _entity->setPhysicsInfo(nullptr);
         _entity.reset();
@@ -127,7 +129,7 @@ void EntityMotionState::handleEasyChanges(uint32_t& flags) {
 
     if (flags & Simulation::DIRTY_SIMULATOR_ID) {
         if (_entity->getSimulatorID().isNull()) {
-            // simulation ownership has been removed by an external simulator
+            // simulation ownership has been removed
             if (glm::length2(_entity->getWorldVelocity()) == 0.0f) {
                 // this object is coming to rest --> clear the ACTIVATION flag and _outgoingPriority
                 flags &= ~Simulation::DIRTY_PHYSICS_ACTIVATION;
@@ -630,7 +632,7 @@ void EntityMotionState::sendUpdate(OctreeEditPacketSender* packetSender, uint32_
         _entity->rememberHasSimulationOwnershipBid();
         // ...then reset _outgoingPriority
         _outgoingPriority = 0;
-        // _outgoingPrioriuty will be re-computed before next bid,
+        // _outgoingPriority will be re-computed before next bid,
         // or will be set to agree with ownership priority should we win the bid
     } else if (_outgoingPriority != _entity->getSimulationPriority()) {
         // we own the simulation but our desired priority has changed

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -67,7 +67,6 @@ EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItemPointer 
     _accelerationNearlyGravityCount(0),
     _numInactiveUpdates(1)
 {
-    // EntityMotionState keeps a SharedPointer to its EntityItem which is only set in the CTOR
     _type = MOTIONSTATE_TYPE_ENTITY;
     assert(_entity);
     assert(entityTreeIsLocked());
@@ -81,7 +80,6 @@ EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItemPointer 
 
 EntityMotionState::~EntityMotionState() {
     if (_entity) {
-        // EntityMotionState keeps a SharedPointer to its EntityItem which is only cleared in the DTOR
         assert(_entity->getPhysicsInfo() == this);
         _entity->setPhysicsInfo(nullptr);
         _entity.reset();

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -49,8 +49,7 @@ bool entityTreeIsLocked() {
 
 EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItemPointer entity) :
     ObjectMotionState(nullptr),
-    _entityPtr(entity),
-    _entity(entity.get()),
+    _entity(entity),
     _serverPosition(0.0f),
     _serverRotation(),
     _serverVelocity(0.0f),
@@ -80,8 +79,11 @@ EntityMotionState::EntityMotionState(btCollisionShape* shape, EntityItemPointer 
 }
 
 EntityMotionState::~EntityMotionState() {
-    assert(_entity);
-    _entity = nullptr;
+    if (_entity) {
+        assert(_entity->getPhysicsInfo() == this);
+        _entity->setPhysicsInfo(nullptr);
+        _entity.reset();
+    }
 }
 
 void EntityMotionState::updateServerPhysicsVariables() {

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -25,6 +25,7 @@
 class EntityMotionState : public ObjectMotionState {
 public:
 
+    EntityMotionState() = delete;
     EntityMotionState(btCollisionShape* shape, EntityItemPointer item);
     virtual ~EntityMotionState();
 

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -99,12 +99,8 @@ protected:
     void setShape(const btCollisionShape* shape) override;
     void setMotionType(PhysicsMotionType motionType) override;
 
-    // In the glorious future (when entities lib depends on physics lib) the EntityMotionState will be
-    // properly "owned" by the EntityItem and will be deleted by it in the dtor.  In pursuit of that
-    // state of affairs we can't keep a real EntityItemPointer as data member (it would produce a
-    // recursive dependency).  Instead we keep a EntityItemWeakPointer to break that dependency while
-    // still granting us the capability to generate EntityItemPointers as necessary (for external data
-    // structures that use the MotionState to get to the EntityItem).
+    // EntityMotionState keeps a SharedPointer to its EntityItem which is only set in the CTOR
+    // and is only cleared in the DTOR
     EntityItemPointer _entity;
 
     bool _serverVariablesSet { false };

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -70,7 +70,7 @@ public:
     virtual QUuid getSimulatorID() const override;
     virtual void bump(uint8_t priority) override;
 
-    EntityItemPointer getEntity() const { return _entityPtr.lock(); }
+    const EntityItemPointer& getEntity() const { return _entity; }
 
     void resetMeasuredBodyAcceleration();
     void measureBodyAcceleration();
@@ -104,9 +104,7 @@ protected:
     // recursive dependency).  Instead we keep a EntityItemWeakPointer to break that dependency while
     // still granting us the capability to generate EntityItemPointers as necessary (for external data
     // structures that use the MotionState to get to the EntityItem).
-    EntityItemWeakPointer _entityPtr;
-    // Meanwhile we also keep a raw EntityItem* for internal stuff where the pointer is guaranteed valid.
-    EntityItem* _entity;
+    EntityItemPointer _entity;
 
     bool _serverVariablesSet { false };
     glm::vec3 _serverPosition;    // in simulation-frame (not world-frame)

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -73,17 +73,15 @@ void PhysicalEntitySimulation::removeEntityInternal(EntityItemPointer entity) {
     }
 }
 
-void PhysicalEntitySimulation::takeDeadEntities(VectorOfEntities& deadEntities) {
+void PhysicalEntitySimulation::takeDeadEntities(SetOfEntities& deadEntities) {
     QMutexLocker lock(&_mutex);
     for (auto entity : _deadEntities) {
-        // this entity is still in its tree, so we insert into the external list
-        deadEntities.push_back(entity);
-
         EntityMotionState* motionState = static_cast<EntityMotionState*>(entity->getPhysicsInfo());
         if (motionState) {
             _entitiesToRemoveFromPhysics.insert(entity);
         }
     }
+    _deadEntities.swap(deadEntities);
     _deadEntities.clear();
 }
 

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -80,8 +80,6 @@ void PhysicalEntitySimulation::takeEntitiesToDelete(VectorOfEntities& entitiesTo
         // this entity is still in its tree, so we insert into the external list
         entitiesToDelete.push_back(entity);
 
-        // Someday when we invert the entities/physics lib dependencies we can let EntityItem delete its own PhysicsInfo
-        // rather than do it here
         EntityMotionState* motionState = static_cast<EntityMotionState*>(entity->getPhysicsInfo());
         if (motionState) {
             _entitiesToRemoveFromPhysics.insert(entity);
@@ -141,6 +139,8 @@ void PhysicalEntitySimulation::clearEntitiesInternal() {
         EntityMotionState* motionState = static_cast<EntityMotionState*>(entity->getPhysicsInfo());
         if (motionState) {
             entity->setPhysicsInfo(nullptr);
+            // someday when we invert the entities/physics lib dependencies we can let EntityItem delete its own PhysicsInfo
+            // until then we must do it here
             delete motionState;
         }
     }
@@ -192,6 +192,8 @@ void PhysicalEntitySimulation::deleteObjectsRemovedFromPhysics() {
         EntityMotionState* motionState = static_cast<EntityMotionState*>(entity->getPhysicsInfo());
         assert(motionState);
         entity->setPhysicsInfo(nullptr);
+        // someday when we invert the entities/physics lib dependencies we can let EntityItem delete its own PhysicsInfo
+        // until then we must do it here
         delete motionState;
 
         if (entity->isDead()) {

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -38,7 +38,7 @@ public:
     virtual void addDynamic(EntityDynamicPointer dynamic) override;
     virtual void applyDynamicChanges() override;
 
-    virtual void takeDeadEntities(VectorOfEntities& deadEntities) override;
+    virtual void takeDeadEntities(SetOfEntities& deadEntities) override;
 
 signals:
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -54,8 +54,9 @@ protected: // only called by EntitySimulation
 public:
     virtual void prepareEntityForDelete(EntityItemPointer entity) override;
 
-    void getObjectsToRemoveFromPhysics(VectorOfMotionStates& result);
+    const VectorOfMotionStates& getObjectsToRemoveFromPhysics();
     void deleteObjectsRemovedFromPhysics();
+
     void getObjectsToAddToPhysics(VectorOfMotionStates& result);
     void setObjectsToChange(const VectorOfMotionStates& objectsToChange);
     void getObjectsToChange(VectorOfMotionStates& result);
@@ -67,9 +68,10 @@ public:
     EntityEditPacketSender* getPacketSender() { return _entityPacketSender; }
 
 private:
-    SetOfEntities _entitiesToRemoveFromPhysics;
-    SetOfEntities _entitiesToForget;
     SetOfEntities _entitiesToAddToPhysics;
+    SetOfEntities _entitiesToRemoveFromPhysics;
+
+    VectorOfMotionStates _objectsToDelete;
 
     SetOfEntityMotionStates _pendingChanges; // EntityMotionStates already in PhysicsEngine that need their physics changed
     SetOfEntityMotionStates _outgoingChanges; // EntityMotionStates for which we may need to send updates to entity-server

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -28,6 +28,7 @@ using PhysicalEntitySimulationPointer = std::shared_ptr<PhysicalEntitySimulation
 using SetOfEntityMotionStates = QSet<EntityMotionState*>;
 
 class PhysicalEntitySimulation : public EntitySimulation {
+    Q_OBJECT
 public:
     PhysicalEntitySimulation();
     ~PhysicalEntitySimulation();
@@ -38,6 +39,9 @@ public:
     virtual void applyDynamicChanges() override;
 
     virtual void takeEntitiesToDelete(VectorOfEntities& entitiesToDelete) override;
+
+signals:
+    void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 
 protected: // only called by EntitySimulation
     // overrides for EntitySimulation

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -38,7 +38,7 @@ public:
     virtual void addDynamic(EntityDynamicPointer dynamic) override;
     virtual void applyDynamicChanges() override;
 
-    virtual void takeEntitiesToDelete(VectorOfEntities& entitiesToDelete) override;
+    virtual void takeDeadEntities(VectorOfEntities& deadEntities) override;
 
 signals:
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
@@ -68,7 +68,7 @@ public:
 
 private:
     SetOfEntities _entitiesToRemoveFromPhysics;
-    SetOfEntities _entitiesToRelease;
+    SetOfEntities _entitiesToForget;
     SetOfEntities _entitiesToAddToPhysics;
 
     SetOfEntityMotionStates _pendingChanges; // EntityMotionStates already in PhysicsEngine that need their physics changed


### PR DESCRIPTION
- only bother removing entities from simulation that have actually been added
- more correct variable names for more readable code
- less spaghetti: methods moved to classes that use them