### PR TITLE
Fix HUD sphere rendering after TAA changes

### DIFF
--- a/libraries/render-utils/src/RenderCommonTask.cpp
+++ b/libraries/render-utils/src/RenderCommonTask.cpp
@@ -98,6 +98,12 @@ void CompositeHUD::run(const RenderContextPointer& renderContext) {
     // Grab the HUD texture
 #if !defined(DISABLE_QML)
     gpu::doInBatch("CompositeHUD", renderContext->args->_context, [&](gpu::Batch& batch) {
+        glm::mat4 projMat;
+        Transform viewMat;
+        renderContext->args->getViewFrustum().evalProjectionMatrix(projMat);
+        renderContext->args->getViewFrustum().evalViewTransform(viewMat);
+        batch.setProjectionTransform(projMat);
+        batch.setViewTransform(viewMat, true);
         if (renderContext->args->_hudOperator) {
             renderContext->args->_hudOperator(batch, renderContext->args->_hudTexture, renderContext->args->_renderMode == RenderArgs::RenderMode::MIRROR_RENDER_MODE);
         }


### PR DESCRIPTION
Evidently the HUD sphere depended on some state being set by antialiasing, and that state wasn't being set anymore (unless any overlays or debug things were rendering).  Now the CompositeHUD pass sets that state itself.

https://highfidelity.manuscript.com/f/cases/13189/HUD-UI-Elements-do-not-appear-in-HMD-unless-you-press-the-trigger

Test plan:
- Enable both options under Developer -> UI
- In desktop mode, you should see the toolbar.
- In HMD, you should see the HUD sphere and it should render as it did before.  (In master right now, it will only render if there is an overlay present in the scene).