### PR TITLE
Use correct platform-specific gpu library

### DIFF
--- a/plugins/oculus/CMakeLists.txt
+++ b/plugins/oculus/CMakeLists.txt
@@ -19,7 +19,7 @@ if (WIN32 AND (NOT USE_GLES))
   set(TARGET_NAME oculus)
   setup_hifi_plugin(Multimedia)
   link_hifi_libraries(
-    shared task gl gpu gpu-gl controllers ui qml
+    shared task gl gpu ${PLATFORM_GL_BACKEND} controllers ui qml
     plugins ui-plugins display-plugins input-plugins
     audio-client networking render-utils
     ${PLATFORM_GL_BACKEND}

--- a/tests/render-perf/CMakeLists.txt
+++ b/tests/render-perf/CMakeLists.txt
@@ -14,7 +14,7 @@ set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Tests/manual-tests/")
 # link in the shared libraries
 link_hifi_libraries(
     shared task networking animation 
-    ktx image octree gl gpu gpu-gl  
+    ktx image octree gl gpu ${PLATFORM_GL_BACKEND}
     render render-utils 
     graphics fbx model-networking graphics-scripting
     entities entities-renderer audio avatars script-engine 


### PR DESCRIPTION
Building with GLES on desktop wasn't working.  (Although it still crashes immediately on startup).

Test plan:
- No real change, just make sure everything builds and you can run Interface on Windows and Mac.