### PR TITLE
Don't leave trash web processes when changing web entity urls

### DIFF
--- a/libraries/entities-renderer/src/RenderableWebEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.h
@@ -47,15 +47,19 @@ private:
     bool buildWebSurface(const TypedEntityPointer& entity);
     void destroyWebSurface();
     bool hasWebSurface();
-    void loadSourceURL();
     glm::vec2 getWindowSize(const TypedEntityPointer& entity) const;
 
+
     int _geometryId{ 0 };
-    enum contentType {
-        htmlContent,
-        qmlContent
+    enum class ContentType {
+        NoContent,
+        HtmlContent,
+        QmlContent
     };
-    contentType _contentType;
+
+    static ContentType getContentType(const QString& urlString);
+
+    ContentType _contentType{ ContentType::NoContent };
     QSharedPointer<OffscreenQmlSurface> _webSurface;
     glm::vec3 _contextPosition;
     gpu::TexturePointer _texture;


### PR DESCRIPTION
Fix for [Bug 13150](https://highfidelity.manuscript.com/f/cases/13150/Web-Entities-do-not-clean-up-their-processes-when-changing-web-URLs)

## Details

The existing code repeatedly uses the `OffscreenQmlSurface::load` function to load QML or to load a URL for the web QML renderer.  However, this function isn't designed to _replace_ existing content in a surface, but rather to allow the loading of a root surface and then to allow loading of children.  The upshot is that every time a new URL was entered, an new web QML renderer was loaded and made a child of the existing one, covering it up essentially.  

The modified code will instead destroy any existing surface unless both the old and new surface are web content, in which case it will simply update the URL target for the existing QML object.  All other cases will destroy the existing QML surface and create a new one.  

## Testing

Open Process Explorer or Process Manager, and launch interface.  Go to a domain with a web entity, or create one.  Note the number of QtWebEngineProcess child processes under the Interface process.  Change the URL on the web entity several times.  

In the current master build, each change will result in a new child process.  In this build, a new process will spawn, but the old one should disappear, so changing the URL multiple times should leave the nuber of child processes constant.