### PR TITLE
EntityScriptServer should wait for script engine to complete for deleting itself

### DIFF
--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -566,8 +566,15 @@ void EntityScriptServer::handleOctreePacket(QSharedPointer<ReceivedMessage> mess
 void EntityScriptServer::aboutToFinish() {
     shutdownScriptEngine();
 
+    auto entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();
     // our entity tree is going to go away so tell that to the EntityScriptingInterface
-    DependencyManager::get<EntityScriptingInterface>()->setEntityTree(nullptr);
+    entityScriptingInterface->setEntityTree(nullptr);
+
+    // Should always be true as they are singletons.
+    if (entityScriptingInterface->getPacketSender() == &_entityEditSender) {
+        // The packet sender is about to go away.
+        entityScriptingInterface->setPacketSender(nullptr);
+    }
 
     DependencyManager::get<ResourceManager>()->cleanup();
 

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -476,6 +476,7 @@ void EntityScriptServer::clear() {
         // do this here (instead of in deleter) to avoid marshalling unload signals back to this thread
         _entitiesScriptEngine->unloadAllEntityScripts();
         _entitiesScriptEngine->stop();
+        _entitiesScriptEngine->waitTillDoneRunning();
     }
 
     _entityViewer.clear();


### PR DESCRIPTION
Top-level AC class EntityScriptServer contains the EntityEditPacketSender (derived from OctreeEditPacketSender). A pointer to it is registered with the singleton EntityScriptingInterface. When the EntityScriptServer is shutting down it tells the script engine to stop but does not wait for it. By the time the script engine finishes the EntityScriptServer is deleted via a deferred delete and therefore the OctreeEditPacketSender is also deleted and crash occurs when it is used.

This change adds a wait for the script engine to complete when called from EntityScriptServer::shutdownScriptEngine(). It also clears the dangling pointer.

https://highfidelity.manuscript.com/f/cases/11071/
