### PR TITLE
Fix "text" overlay not clipping to right and bottom margins

### DIFF
--- a/interface/resources/qml/hifi/overlays/TextOverlay.qml
+++ b/interface/resources/qml/hifi/overlays/TextOverlay.qml
@@ -20,6 +20,7 @@ Overlay {
             font.family: "Helvetica"
             font.pixelSize: 18
             lineHeight: 18
+            clip: true
         }
     }
 

--- a/interface/src/ui/overlays/TextOverlay.cpp
+++ b/interface/src/ui/overlays/TextOverlay.cpp
@@ -40,8 +40,10 @@ QUrl const TextOverlay::URL(QString("hifi/overlays/TextOverlay.qml"));
  *
  * @property {number} margin=0 - Sets the <code>leftMargin</code> and <code>topMargin</code> values, in pixels.
  *     <em>Write-only.</em>
- * @property {number} leftMargin=0 - The left margin's size, in pixels. <em>Write-only.</em>
- * @property {number} topMargin=0 - The top margin's size, in pixels. <em>Write-only.</em>
+ * @property {number} leftMargin=0 - The left margin's size, in pixels. This value is also used for the right margin. 
+ *     <em>Write-only.</em>
+ * @property {number} topMargin=0 - The top margin's size, in pixels. This value is also used for the bottom margin. 
+ *     <em>Write-only.</em>
  * @property {string} text="" - The text to display. Text does not automatically wrap; use <code>\n</code> for a line break. Text
  *     is clipped to the <code>bounds</code>. <em>Write-only.</em>
  * @property {number} font.size=18 - The size of the text, in pixels. <em>Write-only.</em>


### PR DESCRIPTION
The "leftMargin" and "topMargin" property values are also used as the right and bottom margin values.