### PR TITLE
Fix for hand IK jitter

### DIFF
--- a/libraries/animation/src/ElbowConstraint.cpp
+++ b/libraries/animation/src/ElbowConstraint.cpp
@@ -66,16 +66,12 @@ bool ElbowConstraint::apply(glm::quat& rotation) const {
     bool twistWasClamped = (twistAngle != clampedTwistAngle);
 
     // update rotation
-    const float MIN_SWING_REAL_PART = 0.99999f;
-    if (twistWasClamped || fabsf(swingRotation.w) < MIN_SWING_REAL_PART) {
-        if (twistWasClamped) {
-            twistRotation = glm::angleAxis(clampedTwistAngle, _axis);
-        }
-        // we discard all swing and only keep twist
-        rotation = twistRotation * _referenceRotation;
-        return true;
+    if (twistWasClamped) {
+        twistRotation = glm::angleAxis(clampedTwistAngle, _axis);
     }
-    return false;
+    // we discard all swing and only keep twist
+    rotation = twistRotation * _referenceRotation;
+    return true;
 }
 
 glm::quat ElbowConstraint::computeCenterRotation() const {


### PR DESCRIPTION
When in HMD mode, holding your hand controller in front of your face, would often result in a 1-2 mm pop in wrist position. This was due to a problem in the IK elbow constraint. When the swing rotation out of the elbow's reference plane was close to but not exactly identity the joint would not be properly constrained, i.e. the swing rotation was not removed.  But when the magnitude of that swing became large enough the constraint would engage and the swing would then be removed. This small change in swing rotation was noticeable as a 1-2 mm jitter in the hand that would occur once or twice a second.