### PR TITLE
Fix inability to 'bake' models on Windows

### DIFF
--- a/tools/oven/src/BakerCLI.cpp
+++ b/tools/oven/src/BakerCLI.cpp
@@ -28,7 +28,7 @@ void BakerCLI::bakeFile(QUrl inputUrl, const QString& outputPath, const QString&
 
     // if the URL doesn't have a scheme, assume it is a local file
     if (inputUrl.scheme() != "http" && inputUrl.scheme() != "https" && inputUrl.scheme() != "ftp") {
-        inputUrl.setScheme("file");
+        inputUrl = QUrl::fromLocalFile(inputUrl.toString());
     }
 
     qDebug() << "Baking file type: " << type;

--- a/tools/oven/src/BakerCLI.cpp
+++ b/tools/oven/src/BakerCLI.cpp
@@ -27,7 +27,7 @@ BakerCLI::BakerCLI(OvenCLIApplication* parent) : QObject(parent) {
 void BakerCLI::bakeFile(QUrl inputUrl, const QString& outputPath, const QString& type) {
 
     // if the URL doesn't have a scheme, assume it is a local file
-    if (inputUrl.scheme() != "http" && inputUrl.scheme() != "https" && inputUrl.scheme() != "ftp") {
+    if (inputUrl.scheme() != "http" && inputUrl.scheme() != "https" && inputUrl.scheme() != "ftp" && inputUrl.scheme() != "file") {
         inputUrl = QUrl::fromLocalFile(inputUrl.toString());
     }
 


### PR DESCRIPTION
The issue happened because drive letter on Windows is treated by QUrl as 'scheme', so replacing it with 'file' resulted in broken url, like 'file:///Users/ai/AppData'. Fix is based on re-creating url using 'fromLocalFile' which results in more safe specifying 'file:///' url prefix. 