### PR TITLE
Android - Prevent crash when setting the url property to _webSurface.

### DIFF
--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -174,9 +174,7 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
         }
         
         if (urlChanged) {
-            if (_webSurface->getRootItem()) {
-                _webSurface->getRootItem()->setProperty("url", _lastSourceUrl);
-            }
+            _webSurface->getRootItem()->setProperty("url", _lastSourceUrl);
         }
 
         if (_contextPosition != entity->getWorldPosition()) {
@@ -241,7 +239,7 @@ void WebEntityRenderer::doRender(RenderArgs* args) {
 }
 
 bool WebEntityRenderer::hasWebSurface() {
-    return (bool)_webSurface;
+    return (bool)_webSurface && _webSurface->getRootItem();
 }
 
 bool WebEntityRenderer::buildWebSurface(const TypedEntityPointer& entity) {
@@ -305,7 +303,7 @@ bool WebEntityRenderer::buildWebSurface(const TypedEntityPointer& entity) {
     _fadeStartTime = usecTimestampNow();
     _webSurface->resume();
 
-    return true;
+    return _webSurface->getRootItem();
 }
 
 void WebEntityRenderer::destroyWebSurface() {

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -174,7 +174,9 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
         }
         
         if (urlChanged) {
-            _webSurface->getRootItem()->setProperty("url", _lastSourceUrl);
+            if (_webSurface->getRootItem()) {
+                _webSurface->getRootItem()->setProperty("url", _lastSourceUrl);
+            }
         }
 
         if (_contextPosition != entity->getWorldPosition()) {


### PR DESCRIPTION
Temporary solution for crashes on android when accessing domains with web objects (occurring now with dev-welcome).

Complete solution would be providing a way for Web Objects working on android (we don't have Qt WebEngineView for Android yet afaik).

Test plan:
- Create a web entity
- Bring up the tablet
- You should not crash and the web surfaces should render correctly.