### PR TITLE
Android - Resize bottombar after window size changes (to always fill …

### DIFF
--- a/interface/resources/qml/hifi/+android/bottombar.qml
+++ b/interface/resources/qml/hifi/+android/bottombar.qml
@@ -45,10 +45,10 @@ Item {
         anchors.fill: parent
     }
 
-	Rectangle {
+    Rectangle {
         id: background
         anchors.fill : parent
- 		color: "#FF000000"
+        color: "#FF000000"
         border.color: "#FFFFFF"
         anchors.bottomMargin: -1
         anchors.leftMargin: -1
@@ -104,13 +104,26 @@ Item {
                 }
             }
         }
-	}
+    }
+
+    function relocateAndResize(newWindowWidth, newWindowHeight) {
+        width = newWindowWidth;
+        y = newWindowHeight - height;
+    }
+
+    function onWindowGeometryChanged(rect) {
+        relocateAndResize(rect.width, rect.height);
+    }
 
     Component.onCompleted: {
         // put on bottom
-        width = Window.innerWidth;
         height = 255;
-        y = Window.innerHeight - height;
+        relocateAndResize(Window.innerWidth, Window.innerHeight);
+        Window.geometryChanged.connect(onWindowGeometryChanged); // In devices with bars appearing at startup we should listen for this
+    }
+
+    Component.onDestruction: {
+        Window.geometryChanged.disconnect(onWindowGeometryChanged);
     }
     
     function addButton(properties) {

--- a/interface/resources/qml/hifi/+android/bottombar.qml
+++ b/interface/resources/qml/hifi/+android/bottombar.qml
@@ -25,7 +25,7 @@ import "."
 Item {
     id: bar
     x:0
-    height: 255;
+    height: 255
 
     property bool shown: true
 

--- a/interface/resources/qml/hifi/+android/bottombar.qml
+++ b/interface/resources/qml/hifi/+android/bottombar.qml
@@ -25,6 +25,7 @@ import "."
 Item {
     id: bar
     x:0
+    height: 255;
 
     property bool shown: true
 
@@ -117,7 +118,6 @@ Item {
 
     Component.onCompleted: {
         // put on bottom
-        height = 255;
         relocateAndResize(Window.innerWidth, Window.innerHeight);
         Window.geometryChanged.connect(onWindowGeometryChanged); // In devices with bars appearing at startup we should listen for this
     }


### PR DESCRIPTION
…the screen horizontally)

Solves problem in devices with navigation bar (no physical home/back buttons) where an screen resize happens when starting up and may make the bottom bar not fill the screen and position itself incorrectly.