### PR TITLE
Fix several styling/alignment/overlapping issues in 'Add to world' and 'Rename' dialogs in Asset Browser

### DIFF
--- a/interface/resources/qml/controls-uit/Keyboard.qml
+++ b/interface/resources/qml/controls-uit/Keyboard.qml
@@ -26,15 +26,17 @@ Rectangle {
 
     readonly property int keyboardRowHeight: 50
     readonly property int keyboardWidth: 480
+    readonly property int keyboardHeight: 200
 
     readonly property int mirrorTextHeight: keyboardRowHeight
 
     property bool password: false
     property alias mirroredText: mirrorText.text
     property bool showMirrorText: true
-    readonly property int raisedHeight: 200
 
-    height: enabled && raised ? raisedHeight + (showMirrorText ? keyboardRowHeight : 0) : 0
+    readonly property int raisedHeight: keyboardHeight + (showMirrorText ? keyboardRowHeight : 0)
+
+    height: enabled && raised ? raisedHeight : 0
     visible: enabled && raised
 
     property bool shiftMode: false
@@ -158,7 +160,7 @@ Rectangle {
         id: keyboardRect
         y: showMirrorText ? mirrorTextHeight : 0
         width: keyboardWidth
-        height: raisedHeight
+        height: keyboardHeight
         color: "#252525"
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
@@ -167,7 +169,7 @@ Rectangle {
         Column {
             id: columnAlpha
             width: keyboardWidth
-            height: raisedHeight
+            height: keyboardHeight
             visible: !numeric
 
             Row {
@@ -259,7 +261,7 @@ Rectangle {
         Column {
             id: columnNumeric
             width: keyboardWidth
-            height: raisedHeight
+            height: keyboardHeight
             visible: numeric
 
             Row {

--- a/interface/resources/qml/controls-uit/TextField.qml
+++ b/interface/resources/qml/controls-uit/TextField.qml
@@ -34,6 +34,11 @@ TextField {
 
     placeholderText: textField.placeholderText
 
+    property bool rightAnchorSet: false;
+    anchors.onRightChanged: {
+        rightAnchorSet = true;
+    }
+
     font.family: "Fira Sans"
     font.pixelSize: hifi.fontSizes.textFieldInput
     height: implicitHeight + 3  // Make surrounding box higher so that highlight is vertically centered.
@@ -165,11 +170,11 @@ TextField {
         anchors.left: parent.left
 
         Binding on anchors.right {
-            when: parent.right
-            value: parent.right
+            when: rightAnchorSet
+            value: textField.right
         }
         Binding on wrapMode {
-            when: parent.right
+            when: rightAnchorSet
             value: Text.WordWrap
         }
 

--- a/interface/resources/qml/dialogs/CustomQueryDialog.qml
+++ b/interface/resources/qml/dialogs/CustomQueryDialog.qml
@@ -122,12 +122,6 @@ ModalWindow {
                 root.width = (targetWidth < d.minWidth) ? d.minWidth : ((targetWidth > d.maxWdith) ? d.maxWidth : targetWidth);
                 root.height = (targetHeight < d.minHeight) ? d.minHeight : ((targetHeight > d.maxHeight) ?
                                                                             d.maxHeight : targetHeight);
-                if (checkBoxField.visible && comboBoxField.visible) {
-                    checkBoxField.width = extraInputs.width / 2;
-                    comboBoxField.width = extraInputs.width / 2;
-                } else if (!checkBoxField.visible && comboBoxField.visible) {
-                    comboBoxField.width = extraInputs.width;
-                }
             }
         }
 
@@ -198,6 +192,15 @@ ModalWindow {
                 label: root.comboBox.label;
                 focus: Boolean(root.comboBox);
                 visible: Boolean(root.comboBox);
+                Binding on x {
+                    when: comboBoxField.visible
+                    value: !checkBoxField.visible ? buttons.x : acceptButton.x
+                }
+
+                Binding on width {
+                    when: comboBoxField.visible
+                    value: !checkBoxField.visible ? buttons.width : buttons.width - acceptButton.x
+                }
                 anchors {
                     right: parent.right;
                     bottom: parent.bottom;

--- a/interface/resources/qml/dialogs/TabletCustomQueryDialog.qml
+++ b/interface/resources/qml/dialogs/TabletCustomQueryDialog.qml
@@ -140,12 +140,6 @@ TabletModalWindow {
                 root.width = (targetWidth < d.minWidth) ? d.minWidth : ((targetWidth > d.maxWdith) ? d.maxWidth : targetWidth);
                 modalWindowItem.height = (targetHeight < d.minHeight) ? d.minHeight : ((targetHeight > d.maxHeight) ?
                                                                                            d.maxHeight : targetHeight);
-                if (checkBoxField.visible && comboBoxField.visible) {
-                    checkBoxField.width = extraInputs.width / 2;
-                    comboBoxField.width = extraInputs.width / 2;
-                } else if (!checkBoxField.visible && comboBoxField.visible) {
-                    comboBoxField.width = extraInputs.width;
-                }
             }
         }
 
@@ -223,6 +217,15 @@ TabletModalWindow {
                 label: root.comboBox.label;
                 focus: Boolean(root.comboBox);
                 visible: Boolean(root.comboBox);
+                Binding on x {
+                    when: comboBoxField.visible
+                    value: !checkBoxField.visible ? buttons.x : acceptButton.x
+                }
+
+                Binding on width {
+                    when: comboBoxField.visible
+                    value: !checkBoxField.visible ? buttons.width : buttons.width - acceptButton.x
+                }
                 anchors {
                     right: parent.right;
                     bottom: parent.bottom;

--- a/interface/resources/qml/dialogs/TabletQueryDialog.qml
+++ b/interface/resources/qml/dialogs/TabletQueryDialog.qml
@@ -89,9 +89,9 @@ TabletModalWindow {
                 bottom: buttons.top;
                 left: parent.left;
                 right: parent.right;
-                leftMargin: 12
-                rightMargin: 12
+                margins: 0
                 bottomMargin: 2 * hifi.dimensions.contentSpacing.y
+                topMargin: modalWindowItem.frameMarginTop
             }
 
             // FIXME make a text field type that can be bound to a history for autocompletion
@@ -104,6 +104,8 @@ TabletModalWindow {
                     left: parent.left;
                     right: parent.right;
                     bottom: parent.bottom
+                    leftMargin: 5
+                    rightMargin: 5
                 }
             }
 
@@ -131,8 +133,8 @@ TabletModalWindow {
             anchors {
                 bottom: parent.bottom
                 right: parent.right
-                leftMargin: 12
-                rightMargin: 12
+                margins: 0
+                rightMargin: hifi.dimensions.borderRadius
                 bottomMargin: hifi.dimensions.contentSpacing.y
             }
             Button { action: cancelAction }

--- a/interface/resources/qml/dialogs/TabletQueryDialog.qml
+++ b/interface/resources/qml/dialogs/TabletQueryDialog.qml
@@ -89,9 +89,9 @@ TabletModalWindow {
                 bottom: buttons.top;
                 left: parent.left;
                 right: parent.right;
-                margins: 0
+                leftMargin: 12
+                rightMargin: 12
                 bottomMargin: 2 * hifi.dimensions.contentSpacing.y
-                topMargin: modalWindowItem.frameMarginTop
             }
 
             // FIXME make a text field type that can be bound to a history for autocompletion
@@ -104,8 +104,6 @@ TabletModalWindow {
                     left: parent.left;
                     right: parent.right;
                     bottom: parent.bottom
-                    leftMargin: 5
-                    rightMargin: 5
                 }
             }
 
@@ -133,8 +131,8 @@ TabletModalWindow {
             anchors {
                 bottom: parent.bottom
                 right: parent.right
-                margins: 0
-                rightMargin: hifi.dimensions.borderRadius
+                leftMargin: 12
+                rightMargin: 12
                 bottomMargin: hifi.dimensions.contentSpacing.y
             }
             Button { action: cancelAction }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23638/37542293-bcbd87a4-296e-11e8-8e93-2bb492b5e5c4.png)
