### PR TITLE
fixing AddressManager keyboard when switching domains

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
@@ -113,7 +113,6 @@ StackView {
         id: addressBarDialog
 
         property bool keyboardEnabled: false
-        property bool keyboardRaised: false
         property bool punctuationMode: false
 
         width: parent.width
@@ -401,11 +400,10 @@ StackView {
                 addressLine.text = "";
             }
         }
-           
 
         HifiControls.Keyboard {
             id: keyboard
-            raised: parent.keyboardEnabled && parent.keyboardRaised
+            raised: parent.keyboardEnabled
             numeric: parent.punctuationMode
             anchors {
                 bottom: parent.bottom
@@ -413,7 +411,7 @@ StackView {
                 right: parent.right
             }
         }
-        
+
     }
 
     function updateLocationText(enteringAddress) {


### PR DESCRIPTION
fixing AddressManager keyboard when switching domains

- ticket - https://highfidelity.manuscript.com/f/cases/12864/HMD-In-some-cases-virtual-keyboard-fails-to-appear-if-interface-does-not-have-focus