### PR TITLE
RC65.1: Fix ray cast checks on tablet ID lists in edit.js

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -776,9 +776,12 @@ function findClickedEntity(event) {
     }
 
     var pickRay = Camera.computePickRay(event.x, event.y);
-    var overlayResult = Overlays.findRayIntersection(pickRay, true, getMainTabletIDs());
-    if (overlayResult.intersects) {
-        return null;
+    var tabletIDs = getMainTabletIDs();
+    if (tabletIDs.length > 0) {
+        var overlayResult = Overlays.findRayIntersection(pickRay, true, tabletIDs);
+        if (overlayResult.intersects) {
+            return null;
+        }
     }
 
     var entityResult = Entities.findRayIntersection(pickRay, true); // want precision picking
@@ -967,8 +970,13 @@ function mouseReleaseEvent(event) {
 
 function wasTabletClicked(event) {
     var rayPick = Camera.computePickRay(event.x, event.y);
-    var result = Overlays.findRayIntersection(rayPick, true, getMainTabletIDs());
-    return result.intersects;
+    var tabletIDs = getMainTabletIDs();
+    if (tabletIDs.length === 0) {
+        return false;
+    } else {
+        var result = Overlays.findRayIntersection(rayPick, true, getMainTabletIDs());
+        return result.intersects;
+    }
 }
 
 function mouseClickEvent(event) {


### PR DESCRIPTION
Return false if getMainTabletIDs list is empty in wasTabletClicked and skip the ray cast on tabletIDs list in findClickedEntity if the list is empty.

Fixes bug - https://highfidelity.manuscript.com/f/cases/13148

Test Plan:
https://highfidelity.testrail.net/index.php?/cases/view/1938 run in both desktop and HMD