### PR TITLE
Fix invalid message if cancel adding asset to AssetServer

### DIFF
--- a/interface/src/scripting/AssetMappingsScriptingInterface.cpp
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.cpp
@@ -80,7 +80,7 @@ void AssetMappingsScriptingInterface::uploadFile(QString path, QString mapping, 
     auto result = offscreenUi->inputDialog(OffscreenUi::ICON_INFORMATION, "Specify Asset Path",
                                            dropEvent ? dropHelpText : helpText, mapping);
 
-    if (!result.isValid()) {
+    if (!result.isValid() || result.toString() == "") {
         completedCallback.call({ -1 });
         return;
     }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/12868/Asset-Browser-Invalid-Path-error-displayed-incorrectly

Test plan:
- Navigate to Menu->Edit->Asset Browser->Choose File
- Select a valid fbx file to import
- Instead of importing the file, click Cancel
- No dialogs should appear
