### PR TITLE
Update content backup downloads to be asynchronous

### DIFF
--- a/domain-server/resources/web/content/js/content.js
+++ b/domain-server/resources/web/content/js/content.js
@@ -134,7 +134,7 @@ $(document).ready(function(){
 
   $('body').on('click',  '.' + BACKUP_DOWNLOAD_LINK_CLASS, function(ev) {
     ev.preventDefault();
-    var backupID = $(this).data('backup-id')
+    var backupID = $(this).data('backup-id');
 
     showSpinnerAlert("Preparing backup...");
     function checkBackupStatus() {

--- a/domain-server/resources/web/content/js/content.js
+++ b/domain-server/resources/web/content/js/content.js
@@ -132,6 +132,41 @@ $(document).ready(function(){
   var ACTIVE_BACKUP_ROW_CLASS = 'active-backup';
   var CORRUPTED_ROW_CLASS = 'danger';
 
+  $('body').on('click',  '.' + BACKUP_DOWNLOAD_LINK_CLASS, function(ev) {
+    ev.preventDefault();
+    var backupID = $(this).data('backup-id')
+
+    showSpinnerAlert("Preparing backup...");
+    function checkBackupStatus() {
+      $.ajax({
+        url: "/api/backups/" + backupID,
+        dataType: 'json',
+        success: function(data) {
+          if (data.complete) {
+            if (data.error == '') {
+              location.href = "/api/backups/download/" + backupID;
+              swal.close();
+            } else {
+              showErrorMessage(
+                "Error",
+                "There was an error preparing your backup. Please refresh the page and try again."
+              );
+            }
+          } else {
+            setTimeout(checkBackupStatus, 500);
+          }
+        },
+        error: function() {
+          showErrorMessage(
+            "Error",
+            "There was an error preparing your backup."
+          );
+        },
+      });
+    }
+    checkBackupStatus();
+  });
+
   function reloadBackupInformation() {
     // make a GET request to get backup information to populate the table
     $.ajax({
@@ -164,7 +199,7 @@ $(document).ready(function(){
           + "<div class='dropdown'><div class='dropdown-toggle' data-toggle='dropdown' aria-expanded='false'><span class='glyphicon glyphicon-option-vertical'></span></div>"
           + "<ul class='dropdown-menu dropdown-menu-right'>"
           + "<li><a class='" + BACKUP_RESTORE_LINK_CLASS + "' href='#'>Restore from here</a></li><li class='divider'></li>"
-          + "<li><a class='" + BACKUP_DOWNLOAD_LINK_CLASS + "' href='/api/backups/" + backup.id + "'>Download</a></li><li class='divider'></li>"
+          + "<li><a class='" + BACKUP_DOWNLOAD_LINK_CLASS + "' data-backup-id='" + backup.id + "' href='#'>Download</a></li><li class='divider'></li>"
           + "<li><a class='" + BACKUP_DELETE_LINK_CLASS + "' href='#' target='_blank'>Delete</a></li></ul></div></td>";
       }
 

--- a/domain-server/src/DomainContentBackupManager.h
+++ b/domain-server/src/DomainContentBackupManager.h
@@ -20,6 +20,7 @@
 #include <QString>
 #include <QVector>
 #include <QDateTime>
+#include <QTimer>
 
 #include <mutex>
 #include <unordered_map>
@@ -52,6 +53,7 @@ struct ConsolidatedBackupInfo {
     State state;
     QString error;
     QString absoluteFilePath;
+    std::chrono::system_clock::time_point createdAt;
 };
 
 class DomainContentBackupManager : public GenericThread {
@@ -108,9 +110,12 @@ protected:
     bool recoverFromBackupZip(const QString& backupName, QuaZip& backupZip);
 
 private slots:
+    void removeOldConsolidatedBackups();
     void consolidateBackupInternal(QString fileName);
 
 private:
+    QTimer _consolidatedBackupCleanupTimer;
+
     const QString _consolidatedBackupDirectory;
     const QString _backupDirectory;
     std::vector<BackupHandlerPointer> _backupHandlers;

--- a/domain-server/src/DomainContentBackupManager.h
+++ b/domain-server/src/DomainContentBackupManager.h
@@ -15,9 +15,14 @@
 #ifndef hifi_DomainContentBackupManager_h
 #define hifi_DomainContentBackupManager_h
 
+#include <RegisteredMetaTypes.h>
+
 #include <QString>
 #include <QVector>
 #include <QDateTime>
+
+#include <mutex>
+#include <unordered_map>
 
 #include <GenericThread.h>
 
@@ -36,6 +41,17 @@ struct BackupItemInfo {
     QString absolutePath;
     QDateTime createdAt;
     bool isManualBackup;
+};
+
+struct ConsolidatedBackupInfo {
+    enum State {
+        CONSOLIDATING,
+        COMPLETE_WITH_ERROR,
+        COMPLETE_WITH_SUCCESS
+    };
+    State state;
+    QString error;
+    QString absoluteFilePath;
 };
 
 class DomainContentBackupManager : public GenericThread {
@@ -61,6 +77,7 @@ public:
     void addBackupHandler(BackupHandlerPointer handler);
     void aboutToFinish();  /// call this to inform the persist thread that the owner is about to finish to support final persist
     void replaceData(QByteArray data);
+    ConsolidatedBackupInfo consolidateBackup(QString fileName);
 
 public slots:
     void getAllBackupsAndStatus(MiniPromise::Promise promise);
@@ -68,7 +85,6 @@ public slots:
     void recoverFromBackup(MiniPromise::Promise promise, const QString& backupName);
     void recoverFromUploadedBackup(MiniPromise::Promise promise, QByteArray uploadedBackup);
     void deleteBackup(MiniPromise::Promise promise, const QString& backupName);
-    void consolidateBackup(MiniPromise::Promise promise, QString fileName);
 
 signals:
     void loadCompleted();
@@ -91,10 +107,17 @@ protected:
 
     bool recoverFromBackupZip(const QString& backupName, QuaZip& backupZip);
 
+private slots:
+    void consolidateBackupInternal(QString fileName);
+
 private:
+    const QString _consolidatedBackupDirectory;
     const QString _backupDirectory;
     std::vector<BackupHandlerPointer> _backupHandlers;
     std::chrono::milliseconds _persistInterval { 0 };
+
+    std::mutex _consolidatedBackupsMutex;
+    std::unordered_map<QString, ConsolidatedBackupInfo> _consolidatedBackups;
 
     std::atomic<bool> _isRecovering { false };
     QString _recoveryFilename { };


### PR DESCRIPTION
Previously backups would be consolidated into a full .zip when the
backup was requested. Because of the potential for a large number of
assets, this could take awhile, causing a browser to fail due to timeout
before the backup was available. This change splits the download
endpoint into 2 parts - one to request information about a backup and
possibly kick off a consolidation, and another to request the actual
file once the consolidate backup is available.