### PR TITLE
Fix/current context

### DIFF
--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -69,8 +69,7 @@ bool OffscreenGLCanvas::create(QOpenGLContext* sharedContext) {
         qFatal("Offscreen surface is invalid");
     }
 #endif
-
-#if !defined(USE_GLES)
+    
     if (gl::Context::enableDebugLogger()) {
         _context->makeCurrent(_offscreenSurface);
         QOpenGLDebugLogger *logger = new QOpenGLDebugLogger(this);
@@ -80,7 +79,6 @@ bool OffscreenGLCanvas::create(QOpenGLContext* sharedContext) {
         logger->startLogging(QOpenGLDebugLogger::SynchronousLogging);
         _context->doneCurrent();
     }
-#endif
 
     return true;
 }

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendShader.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendShader.cpp
@@ -17,8 +17,7 @@ std::string GLBackend::getBackendShaderHeader() const {
 
 #if defined(USE_GLES)
     static const std::string header(
-R"SHADER(
-#version 310 es
+R"SHADER(#version 310 es
 #extension GL_EXT_texture_buffer : enable
 precision lowp float; // check precision 2
 precision lowp samplerBuffer;
@@ -26,8 +25,7 @@ precision lowp sampler2DShadow;
 )SHADER");
 #else
     static const std::string header(
-R"SHADER(
-#version 410 core
+R"SHADER(#version 410 core
 )SHADER");
 #endif
 


### PR DESCRIPTION
Hotfix for [FATAL] Cannot make QOpenGLContext current in a different thread