### PR TITLE
Disable Add Button in Model Modal until user has entered text in the model URL

### DIFF
--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -122,6 +122,13 @@ Rectangle {
                     height: 400
                     spacing: 20
 
+                     Image {	
+                        id: image1	
+                        width: 30	
+                        height: 30	
+                        source: "qrc:/qtquickplugin/images/template_image.png"	
+                    }
+
                     Text {
                         id: text2
                         width: 160

--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -122,11 +122,11 @@ Rectangle {
                     height: 400
                     spacing: 20
 
-                     Image {	
-                        id: image1	
-                        width: 30	
-                        height: 30	
-                        source: "qrc:/qtquickplugin/images/template_image.png"	
+                    Image {
+                        id: image1
+                        width: 30
+                        height: 30
+                        source: "qrc:/qtquickplugin/images/template_image.png"
                     }
 
                     Text {

--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -71,6 +71,10 @@ Rectangle {
             onAccepted: {
                 newModelDialog.keyboardEnabled = false;
             }
+
+            onTextChanged : {
+                 button1.enabled = true;
+            }
             
             MouseArea {
                 anchors.fill: parent
@@ -117,13 +121,6 @@ Rectangle {
                     width: 200
                     height: 400
                     spacing: 20
-
-                    Image {
-                        id: image1
-                        width: 30
-                        height: 30
-                        source: "qrc:/qtquickplugin/images/template_image.png"
-                    }
 
                     Text {
                         id: text2
@@ -200,6 +197,7 @@ Rectangle {
                         id: button1
                         text: qsTr("Add")
                         z: -1
+                        enabled: false
                         onClicked: {
                             newModelDialog.sendToScript({
                                 method: "newModelDialogAdd",


### PR DESCRIPTION
Prevents users from being able to click 'add' to create a model entity without specifying a URL. This feature does not include validation checking for whether or not it is a _valid_ URL, but rather just that one exists.