### PR TITLE
Improve audio devices selection logic

### DIFF
--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -182,7 +182,6 @@ void AudioDeviceList::resetDevice(bool contextIsHMD) {
 }
 
 void AudioDeviceList::onDeviceChanged(const QAudioDeviceInfo& device, bool isHMD) {
-    auto oldDevice = isHMD ? _selectedHMDDevice : _selectedDesktopDevice;
     QAudioDeviceInfo& selectedDevice = isHMD ? _selectedHMDDevice : _selectedDesktopDevice;
     selectedDevice = device;
 

--- a/interface/src/scripting/AudioDevices.h
+++ b/interface/src/scripting/AudioDevices.h
@@ -65,6 +65,8 @@ protected:
     const QAudio::Mode _mode;
     QAudioDeviceInfo _selectedDesktopDevice;
     QAudioDeviceInfo _selectedHMDDevice;
+    QString _backupSelectedDesktopDeviceName;
+    QString _backupSelectedHMDDeviceName;
     QList<std::shared_ptr<AudioDevice>> _devices;
     QString _hmdSavedDeviceName;
     QString _desktopSavedDeviceName;

--- a/interface/src/scripting/AudioDevices.h
+++ b/interface/src/scripting/AudioDevices.h
@@ -54,7 +54,7 @@ signals:
 
 protected slots:
     void onDeviceChanged(const QAudioDeviceInfo& device, bool isHMD);
-    void onDevicesChanged(const QList<QAudioDeviceInfo>& devices, bool isHMD);
+    void onDevicesChanged(const QList<QAudioDeviceInfo>& devices);
 
 protected:
     friend class AudioDevices;

--- a/interface/src/scripting/AudioDevices.h
+++ b/interface/src/scripting/AudioDevices.h
@@ -51,6 +51,7 @@ public:
 
 signals:
     void deviceChanged(const QAudioDeviceInfo& device);
+    void selectedDevicePlugged(const QAudioDeviceInfo& device, bool isHMD);
 
 protected slots:
     void onDeviceChanged(const QAudioDeviceInfo& device, bool isHMD);
@@ -117,13 +118,13 @@ public:
     AudioDevices(bool& contextIsHMD);
     virtual ~AudioDevices();
 
-    void chooseInputDevice(const QAudioDeviceInfo& device, bool isHMD);
-    void chooseOutputDevice(const QAudioDeviceInfo& device, bool isHMD);
-
 signals:
     void nop();
 
 private slots:
+    void chooseInputDevice(const QAudioDeviceInfo& device, bool isHMD);
+    void chooseOutputDevice(const QAudioDeviceInfo& device, bool isHMD);
+
     void onContextChanged(const QString& context);
     void onDeviceSelected(QAudio::Mode mode, const QAudioDeviceInfo& device,
                           const QAudioDeviceInfo& previousDevice, bool isHMD);


### PR DESCRIPTION
This PR contains several changes: 

1. Fix for bug with incorrect selection in UI of HMD device after re-plugging Desktop device and vice versa.
1. Add logic for re-selecting audio device if it was plugged off/plugged on
2. Add logic to temporarily select 'similar-by-title' audio device if originally selected one was plugged off. 