### PR TITLE
Fix far grabbing a grabbable child when the parent is not grabbable.

### DIFF
--- a/scripts/system/controllers/controllerModules/farActionGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farActionGrabEntity.js
@@ -475,7 +475,7 @@ Script.include("/~/system/libraries/Xform.js");
                         entityID = targetEntity.id;
                         targetProps = targetEntity.props;
 
-                        if (entityIsGrabbable(targetProps)) {
+                        if (entityIsGrabbable(targetProps) || entityIsGrabbable(this.targetObject.entityProps)) {
                             if (!entityIsDistanceGrabbable(targetProps)) {
                                 this.targetObject.makeDynamic();
                             }


### PR DESCRIPTION
If you have a parent-child tree hierarchy, when you far-grab a child. If the child or parent is grabbable to will move the whole tree hierarchy. This PR fixes the case of not being able to move the tree is the child is grabbable but the parent is not.

https://highfidelity.manuscript.com/f/cases/13399/Grabbable-children-of-non-grabbable-parents-cannot-be-far-grabbed