### PR TITLE
fix ContextOverlayInferface highlighing unspecified entities. 

### DIFF
--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -120,7 +120,7 @@ PickResultPointer LaserPointer::getVisualPickResult(const PickResultPointer& pic
             rayPickResult->distance = distance;
             rayPickResult->surfaceNormal = -normalizedDirection;
             rayPickResult->pickVariant["direction"] = vec3toVariant(normalizedDirection);
-        } else if (_lockEnd) {
+        } else if (type != IntersectionType::NONE && _lockEnd) {
             if (type == IntersectionType::ENTITY) {
                 endVec = DependencyManager::get<EntityScriptingInterface>()->getEntityTransform(rayPickResult->objectID)[3];
             } else if (type == IntersectionType::OVERLAY) {

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -103,7 +103,7 @@ private:
     LockEndObject _lockEndObject;
 
     void updateRenderStateOverlay(const OverlayID& id, const QVariant& props);
-    void updateRenderState(const RenderState& renderState, const IntersectionType type, float distance, const QUuid& objectID, const PickRay& pickRay, bool defaultState);
+    void updateRenderState(const RenderState& renderState, const IntersectionType type, float distance, const QUuid& objectID, const PickRay& pickRay);
     void disableRenderState(const RenderState& renderState);
 
     struct TriggerState {

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -82,6 +82,7 @@ public:
 protected:
     PointerEvent buildPointerEvent(const PickedObject& target, const PickResultPointer& pickResult, const std::string& button = "", bool hover = true) override;
 
+    PickResultPointer getVisualPickResult(const PickResultPointer& pickResult) override;
     PickedObject getHoveredObject(const PickResultPointer& pickResult) override;
     Pointer::Buttons getPressedButtons(const PickResultPointer& pickResult) override;
 

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -254,8 +254,7 @@ void ContextOverlayInterface::contextOverlays_hoverLeaveOverlay(const OverlayID&
 
 void ContextOverlayInterface::contextOverlays_hoverEnterEntity(const EntityItemID& entityID, const PointerEvent& event) {
     bool isMouse = event.getID() == PointerManager::MOUSE_POINTER_ID || DependencyManager::get<PointerManager>()->isMouse(event.getID());
-    if (_currentEntityWithContextOverlay == entityID && contextOverlayFilterPassed(entityID)
-        && _enabled && !isMouse) {
+    if (contextOverlayFilterPassed(entityID) && _enabled && !isMouse) {
         enableEntityHighlight(entityID);
     }
 }

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -254,7 +254,8 @@ void ContextOverlayInterface::contextOverlays_hoverLeaveOverlay(const OverlayID&
 
 void ContextOverlayInterface::contextOverlays_hoverEnterEntity(const EntityItemID& entityID, const PointerEvent& event) {
     bool isMouse = event.getID() == PointerManager::MOUSE_POINTER_ID || DependencyManager::get<PointerManager>()->isMouse(event.getID());
-    if (contextOverlayFilterPassed(entityID) && _enabled && !isMouse) {
+    if (_currentEntityWithContextOverlay == entityID && contextOverlayFilterPassed(entityID)
+        && _enabled && !isMouse) {
         enableEntityHighlight(entityID);
     }
 }

--- a/libraries/pointers/src/Pointer.cpp
+++ b/libraries/pointers/src/Pointer.cpp
@@ -68,8 +68,9 @@ void Pointer::update(unsigned int pointerID) {
     // This only needs to be a read lock because update won't change any of the properties that can be modified from scripts
     withReadLock([&] {
         auto pickResult = getPrevPickResult();
-        updateVisuals(pickResult);
-        generatePointerEvents(pointerID, pickResult);
+        auto visualPickResult = getVisualPickResult(pickResult);
+        updateVisuals(visualPickResult);
+        generatePointerEvents(pointerID, visualPickResult);
     });
 }
 

--- a/libraries/pointers/src/Pointer.h
+++ b/libraries/pointers/src/Pointer.h
@@ -89,6 +89,7 @@ protected:
 
     virtual bool shouldHover(const PickResultPointer& pickResult) { return true; }
     virtual bool shouldTrigger(const PickResultPointer& pickResult) { return true; }
+    virtual PickResultPointer getVisualPickResult(const PickResultPointer& pickResult) { return pickResult; };
 
     static const float POINTER_MOVE_DELAY;
     static const float TOUCH_PRESS_TO_MOVE_DEADSPOT_SQUARED;

--- a/scripts/system/controllers/controllerModules/farActionGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farActionGrabEntity.js
@@ -14,7 +14,7 @@
    PICK_MAX_DISTANCE, COLORS_GRAB_SEARCHING_HALF_SQUEEZE, COLORS_GRAB_SEARCHING_FULL_SQUEEZE, COLORS_GRAB_DISTANCE_HOLD,
    DEFAULT_SEARCH_SPHERE_DISTANCE, TRIGGER_OFF_VALUE, TRIGGER_ON_VALUE, ZERO_VEC, ensureDynamic,
    getControllerWorldLocation, projectOntoEntityXYPlane, ContextOverlay, HMD, Reticle, Overlays, isPointingAtUI
-   Picks, makeLaserLockInfo Xform, makeLaserParams, AddressManager, getEntityParents
+   Picks, makeLaserLockInfo Xform, makeLaserParams, AddressManager, getEntityParents, Selection
 */
 
 Script.include("/~/system/libraries/controllerDispatcherUtils.js");
@@ -467,8 +467,10 @@ Script.include("/~/system/libraries/Xform.js");
                             Script.clearTimeout(this.contextOverlayTimer);
                         }
                         this.contextOverlayTimer = false;
-                        if (entityID !== this.entityWithContextOverlay) {
+                        if (entityID === this.entityWithContextOverlay) {
                             this.destroyContextOverlay();
+                        } else {
+                            Selection.removeFromSelectedItemsList("contextOverlayHighlightList", "entity", entityID);
                         }
 
                         var targetEntity = this.targetObject.getTargetEntity();


### PR DESCRIPTION
ContextOverlayInterface would highlight an entity with a marketplace certification when a onHoverEnter event is received, regardless if the entity does not match the entityWithContextOverlay.

This PR fixes that issue.

ticket https://highfidelity.manuscript.com/f/cases/13177/Far-grabbing-certified-entities-does-not-remove-orange-outline