### PR TITLE
Attempt to resolve potential overlay crashes at shutdown

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7488,7 +7488,7 @@ DisplayPluginPointer Application::getActiveDisplayPlugin() const {
         return _displayPlugin;
     }
 
-    if (!_displayPlugin) {
+    if (!_aboutToQuit && !_displayPlugin) {
         const_cast<Application*>(this)->updateDisplayMode();
         Q_ASSERT(_displayPlugin);
     }

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -54,6 +54,7 @@ Overlays::Overlays() {
 }
 
 void Overlays::cleanupAllOverlays() {
+    _shuttingDown = true;
     QMap<OverlayID, Overlay::Pointer> overlaysHUD;
     QMap<OverlayID, Overlay::Pointer> overlaysWorld;
     {
@@ -147,6 +148,10 @@ void Overlays::enable() {
 // Note, can't be invoked by scripts, but can be called by the InterfaceParentFinder
 // class on packet processing threads
 Overlay::Pointer Overlays::getOverlay(OverlayID id) const {
+    if (_shuttingDown) {
+        return nullptr;
+    }
+
     QMutexLocker locker(&_mutex);
     if (_overlaysHUD.contains(id)) {
         return _overlaysHUD[id];
@@ -157,6 +162,10 @@ Overlay::Pointer Overlays::getOverlay(OverlayID id) const {
 }
 
 OverlayID Overlays::addOverlay(const QString& type, const QVariant& properties) {
+    if (_shuttingDown) {
+        return UNKNOWN_OVERLAY_ID;
+    }
+
     if (QThread::currentThread() != thread()) {
         OverlayID result;
         PROFILE_RANGE(script, __FUNCTION__);
@@ -261,6 +270,10 @@ OverlayID Overlays::addOverlay(const QString& type, const QVariant& properties) 
 }
 
 OverlayID Overlays::addOverlay(const Overlay::Pointer& overlay) {
+    if (_shuttingDown) {
+        return UNKNOWN_OVERLAY_ID;
+    }
+
     OverlayID thisID = OverlayID(QUuid::createUuid());
     overlay->setOverlayID(thisID);
     overlay->setStackOrder(_stackOrder++);
@@ -283,6 +296,10 @@ OverlayID Overlays::addOverlay(const Overlay::Pointer& overlay) {
 }
 
 OverlayID Overlays::cloneOverlay(OverlayID id) {
+    if (_shuttingDown) {
+        return UNKNOWN_OVERLAY_ID;
+    }
+
     if (QThread::currentThread() != thread()) {
         OverlayID result;
         PROFILE_RANGE(script, __FUNCTION__);
@@ -301,6 +318,10 @@ OverlayID Overlays::cloneOverlay(OverlayID id) {
 }
 
 bool Overlays::editOverlay(OverlayID id, const QVariant& properties) {
+    if (_shuttingDown) {
+        return false;
+    }
+
     auto thisOverlay = getOverlay(id);
     if (!thisOverlay) {
         return false;
@@ -320,6 +341,10 @@ bool Overlays::editOverlay(OverlayID id, const QVariant& properties) {
 }
 
 bool Overlays::editOverlays(const QVariant& propertiesById) {
+    if (_shuttingDown) {
+        return false;
+    }
+
     bool defer2DOverlays = QThread::currentThread() != thread();
 
     QVariantMap deferrred;
@@ -351,6 +376,10 @@ bool Overlays::editOverlays(const QVariant& propertiesById) {
 }
 
 void Overlays::deleteOverlay(OverlayID id) {
+    if (_shuttingDown) {
+        return;
+    }
+
     if (QThread::currentThread() != thread()) {
         QMetaObject::invokeMethod(this, "deleteOverlay", Q_ARG(OverlayID, id));
         return;
@@ -374,6 +403,9 @@ void Overlays::deleteOverlay(OverlayID id) {
 }
 
 QString Overlays::getOverlayType(OverlayID overlayId) {
+    if (_shuttingDown) {
+        return "";
+    }
     if (QThread::currentThread() != thread()) {
         QString result;
         PROFILE_RANGE(script, __FUNCTION__);
@@ -389,7 +421,7 @@ QString Overlays::getOverlayType(OverlayID overlayId) {
 }
 
 OverlayID Overlays::getOverlayAtPoint(const glm::vec2& point) {
-    if (!_enabled) {
+    if (_shuttingDown || !_enabled) {
         return UNKNOWN_OVERLAY_ID;
     }
 

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -680,6 +680,7 @@ private:
     unsigned int _stackOrder { 1 };
 
     bool _enabled = true;
+    std::atomic<bool> _shuttingDown{ false };
 
     PointerEvent calculateOverlayPointerEvent(OverlayID overlayID, PickRay ray, RayToOverlayIntersectionResult rayPickResult,
         QMouseEvent* event, PointerEvent::EventType eventType);

--- a/interface/src/ui/overlays/QmlOverlay.h
+++ b/interface/src/ui/overlays/QmlOverlay.h
@@ -32,10 +32,11 @@ public:
     void render(RenderArgs* args) override;
 
 private:
+    Q_INVOKABLE void qmlElementDestroyed();
     Q_INVOKABLE void buildQmlElement(const QUrl& url);
 
 protected:
-    std::shared_ptr<QQuickItem> _qmlElement;
+    QQuickItem* _qmlElement{ nullptr };
 };
 
 #endif // hifi_QmlOverlay_h


### PR DESCRIPTION
## Testing

Enter a domain with streaming video or audio in a web entity.  Shutdown the application.  Should not crash.