### PR TITLE
Android: Fix octal code signed char issue

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -425,8 +425,8 @@ bool EntityTree::updateEntity(EntityItemPointer entity, const EntityItemProperti
             if (!childEntity) {
                 continue;
             }
-            EntityTreeElementPointer containingElement = childEntity->getElement();
-            if (!containingElement) {
+            EntityTreeElementPointer childContainingElement = childEntity->getElement();
+            if (!childContainingElement) {
                 continue;
             }
 
@@ -440,7 +440,7 @@ bool EntityTree::updateEntity(EntityItemPointer entity, const EntityItemProperti
                 addToNeedsParentFixupList(childEntity);
             }
 
-            UpdateEntityOperator theChildOperator(getThisPointer(), containingElement, childEntity, queryCube);
+            UpdateEntityOperator theChildOperator(getThisPointer(), childContainingElement, childEntity, queryCube);
             recurseTreeWithOperator(&theChildOperator);
             foreach (SpatiallyNestablePointer childChild, childEntity->getChildren()) {
                 if (childChild && childChild->getNestableType() == NestableType::Entity) {

--- a/libraries/entities/src/UpdateEntityOperator.cpp
+++ b/libraries/entities/src/UpdateEntityOperator.cpp
@@ -288,7 +288,7 @@ OctreeElementPointer UpdateEntityOperator::possiblyCreateChildAt(const OctreeEle
             int indexOfChildContainingNewEntity = element->getMyChildContaining(_newEntityBox);
 
             if (childIndex == indexOfChildContainingNewEntity) {
-                return element->addChildAtIndex(childIndex);;
+                return element->addChildAtIndex(childIndex);
             }
         }
     }

--- a/libraries/shared/src/OctalCode.cpp
+++ b/libraries/shared/src/OctalCode.cpp
@@ -46,7 +46,7 @@ void printOctalCode(const unsigned char* octalCode) {
 }
 
 char sectionValue(const unsigned char* startByte, char startIndexInByte) {
-    char rightShift = 8 - startIndexInByte - 3;
+    int8_t rightShift = 8 - startIndexInByte - 3;
 
     if (rightShift < 0) {
         return ((startByte[0] << -rightShift) & 7) + (startByte[1] >> (8 + rightShift));
@@ -73,7 +73,7 @@ int branchIndexWithDescendant(const unsigned char* ancestorOctalCode, const unsi
     return sectionValue(descendantOctalCode + 1 + (branchStartBit / 8), branchStartBit % 8);
 }
 
-unsigned char* childOctalCode(const unsigned char* parentOctalCode, char childNumber) {
+unsigned char* childOctalCode(const unsigned char* parentOctalCode, int childNumber) {
 
     // find the length (in number of three bit code sequences)
     // in the parent
@@ -111,7 +111,7 @@ unsigned char* childOctalCode(const unsigned char* parentOctalCode, char childNu
 
     // calculate the amount of left shift required
     // this will be -1 or -2 if there's wrap
-    char leftShift = 8 - (startBit % 8) - 3;
+    int8_t leftShift = 8 - (startBit % 8) - 3;
 
     if (leftShift < 0) {
         // we have a wrap-around to accomodate

--- a/libraries/shared/src/OctalCode.h
+++ b/libraries/shared/src/OctalCode.h
@@ -30,7 +30,7 @@ using OctalCodePtrList = std::vector<OctalCodePtr>;
 void printOctalCode(const unsigned char* octalCode);
 size_t bytesRequiredForCodeLength(unsigned char threeBitCodes);
 int branchIndexWithDescendant(const unsigned char* ancestorOctalCode, const unsigned char* descendantOctalCode);
-unsigned char* childOctalCode(const unsigned char* parentOctalCode, char childNumber);
+unsigned char* childOctalCode(const unsigned char* parentOctalCode, int childNumber);
 
 const int OVERFLOWED_OCTCODE_BUFFER = -1;
 const int UNKNOWN_OCTCODE_LENGTH = -2;


### PR DESCRIPTION
Android Studio uses clang by default which treats `char` as `unsigned char`, instead of `signed char`.  Some EXTREMELY OLD octal code was breaking as a result.

Test plan:
- (Desktop and mobile) Go to dev-mobile.  The carts and hats, etc. in the middle area around the fountain should appear properly.