### PR TITLE
RC66: Add an extra sanity check when calling fetchMetaSubItemBounds

### DIFF
--- a/libraries/render/src/render/Item.cpp
+++ b/libraries/render/src/render/Item.cpp
@@ -118,9 +118,15 @@ uint32_t Item::fetchMetaSubItemBounds(ItemBounds& subItemBounds, Scene& scene) c
     auto numSubs = fetchMetaSubItems(subItems);
 
     for (auto id : subItems) {
-        auto& item = scene.getItem(id);
-        if (item.exist()) {
-            subItemBounds.emplace_back(id, item.getBound());
+        // TODO: Adding an extra check here even thought we shouldn't have too.
+        // We have cases when the id returned by fetchMetaSubItems is not allocated
+        if (scene.isAllocatedID(id)) {
+            auto& item = scene.getItem(id);
+            if (item.exist()) {
+                subItemBounds.emplace_back(id, item.getBound());
+            } else {
+                numSubs--;
+            }
         } else {
             numSubs--;
         }


### PR DESCRIPTION
This pr address bug [13745](https://highfidelity.manuscript.com/f/cases/13745/Crash-in-fetchMetaItem-getBound)

The call to fetchMetaSubItems on a meta item sometimes return items id not allocated yet.
this shouldn't happen but it does and we see this in recent crash dumps.

I added a sanity check to avoid trying to access the item if it doesn't exist.

## TEST PLAN 
There is no real repro that i know of for that bug.
we will check that that crash stop happening when this pr is  in the wild.

