### PR TITLE
fix -- make drag-and-drop of json mean import again

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6275,8 +6275,9 @@ bool Application::canAcceptURL(const QString& urlString) const {
 
 bool Application::acceptURL(const QString& urlString, bool defaultUpload) {
     QUrl url(urlString);
-    if (isDomainURL(url)) {
-        // this is a URL for a domain, either hifi:// or serverless - have the AddressManager handle it
+
+    if (url.scheme() == URL_SCHEME_HIFI) {
+        // this is a hifi URL - have the AddressManager handle it
         QMetaObject::invokeMethod(DependencyManager::get<AddressManager>().data(), "handleLookupString",
                                   Qt::AutoConnection, Q_ARG(const QString&, urlString));
         return true;


### PR DESCRIPTION
- make drag-and-drop of a json file into interface's window mean import again, rather than open as a serverless-domain
