### PR TITLE
Fix name conflict with c++ class and qml file(master)

### DIFF
--- a/interface/resources/qml/AudioScopeUI.qml
+++ b/interface/resources/qml/AudioScopeUI.qml
@@ -12,6 +12,7 @@ import QtQuick 2.5
 import QtQuick.Controls 1.4
 import "styles-uit"
 import "controls-uit" as HifiControlsUit
+import "." as HifiRoot
 
 Item {
     id: root

--- a/interface/resources/qml/AudioScopeUI.qml
+++ b/interface/resources/qml/AudioScopeUI.qml
@@ -12,7 +12,6 @@ import QtQuick 2.5
 import QtQuick.Controls 1.4
 import "styles-uit"
 import "controls-uit" as HifiControlsUit
-import "." as HifiRoot
 
 Item {
     id: root

--- a/scripts/developer/utilities/audio/audioScope.js
+++ b/scripts/developer/utilities/audio/audioScope.js
@@ -1,4 +1,4 @@
-var qml = Script.resourcesPath() + '/qml/AudioScope.qml';
+var qml = Script.resourcesPath() + '/qml/AudioScopeUI.qml';
 var window = new OverlayWindow({
     title: 'Audio Scope',
     source: qml,


### PR DESCRIPTION
When using the AudioScope class in AudioScope.qml. The qml thought you where referencing the file, instead of the object.

ticket - https://highfidelity.manuscript.com/f/cases/13706/Audio-Scope-Broken