### PR TITLE
RC66: Fix shadows on primitives

### DIFF
--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -131,6 +131,8 @@ ItemKey ShapeEntityRenderer::getKey() {
     withReadLock([&] {
         if (isTransparent()) {
             builder.withTransparent();
+        } else if (_canCastShadow) {
+            builder.withShadowCaster();
         }
     });
 


### PR DESCRIPTION
Test plan:
- Go to a zone with shadows enabled and make sure your global shadow setting is on.
- Create a primitive (box or sphere, etc.).  It should cast a shadow.
- Set it to be transparent (in the console: `Entities.editEntity(<the entity id>, { alpha: 0.5 })`.  It shouldn't cast a shadow.
- Set it back to opaque (`Entities.editEntity(<the entity id>, { alpha: 1.0 })`).  It should cast a shadow again.