### PR TITLE
Commerce: Fix Certificate Info error

### DIFF
--- a/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
+++ b/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
@@ -52,6 +52,23 @@ Rectangle {
         onCertificateInfoResult: {
             if (result.status !== 'success') {
                 console.log("Failed to get certificate info", result.message);
+                // We should still tell the user that static cert verification failed
+                if (root.certificateStatus !== 3) { // CERTIFICATE_STATUS_STATIC_VERIFICATION_FAILED
+                    root.useGoldCert = false;
+                    root.certTitleTextColor = hifi.colors.redHighlight;
+                    root.certTextColor = hifi.colors.redHighlight;
+                    root.infoTextColor = hifi.colors.redHighlight;
+                    titleBarText.text = "Certificate Unavailable";
+                    popText.text = "";
+                    showInMarketplaceButton.visible = false;
+                    root.certInfoReplaceMode = 0;
+                    root.itemName = "";
+                    root.itemEdition = "";
+                    root.itemOwner = "";
+                    root.dateOfPurchase = "";
+                    root.itemCost = "";
+                    errorText.text = "Information about this certificate is currently unavailable. Please try again later.";
+                }
             } else {
                 root.marketplaceUrl = result.data.marketplace_item_url;
                 root.isMyCert = result.isMyCert ? result.isMyCert : false;

--- a/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
+++ b/interface/resources/qml/hifi/commerce/inspectionCertificate/InspectionCertificate.qml
@@ -51,7 +51,7 @@ Rectangle {
 
         onCertificateInfoResult: {
             if (result.status !== 'success') {
-                console.log("Failed to get certificate info", result.message);
+                console.log("Failed to get certificate info", result.data.message);
                 // We should still tell the user that static cert verification failed
                 if (root.certificateStatus !== 3) { // CERTIFICATE_STATUS_STATIC_VERIFICATION_FAILED
                     root.useGoldCert = false;

--- a/interface/src/commerce/Ledger.cpp
+++ b/interface/src/commerce/Ledger.cpp
@@ -35,12 +35,19 @@ QJsonObject Ledger::apiResponse(const QString& label, QNetworkReply& reply) {
 QJsonObject Ledger::failResponse(const QString& label, QNetworkReply& reply) {
     QString response = reply.readAll();
     qWarning(commerce) << "FAILED" << label << response;
-    QJsonObject result
-    {
-        { "status", "fail" },
-        { "message", response }
-    };
-    return result;
+
+    // tempResult will be NULL if the response isn't valid JSON.
+    QJsonDocument tempResult = QJsonDocument::fromJson(response.toLocal8Bit());
+    if (tempResult.isNull()) {
+        QJsonObject result
+        {
+            { "status", "fail" },
+            { "message", response }
+        };
+        return result;
+    } else {
+        return tempResult.object();
+    }
 }
 #define ApiHandler(NAME) void Ledger::NAME##Success(QNetworkReply& reply) { emit NAME##Result(apiResponse(#NAME, reply)); }
 #define FailHandler(NAME) void Ledger::NAME##Failure(QNetworkReply& reply) { emit NAME##Result(failResponse(#NAME, reply)); }
@@ -338,11 +345,7 @@ void Ledger::certificateInfoSuccess(QNetworkReply& reply) {
     emit certificateInfoResult(replyObject);
 }
 void Ledger::certificateInfoFailure(QNetworkReply& reply) {
-    QByteArray response = reply.readAll();
-    QJsonObject replyObject = QJsonDocument::fromJson(response).object();
-
-    failResponse("certificateInfo", reply);
-    emit certificateInfoResult(replyObject);
+    emit certificateInfoResult(failResponse("certificateInfo", reply));
 }
 void Ledger::certificateInfo(const QString& certificateId) {
     QString endpoint = "proof_of_purchase_status/transfer";

--- a/interface/src/commerce/Ledger.cpp
+++ b/interface/src/commerce/Ledger.cpp
@@ -334,7 +334,13 @@ void Ledger::certificateInfoSuccess(QNetworkReply& reply) {
     qInfo(commerce) << "certificateInfo" << "response" << QJsonDocument(replyObject).toJson(QJsonDocument::Compact);
     emit certificateInfoResult(replyObject);
 }
-void Ledger::certificateInfoFailure(QNetworkReply& reply) { failResponse("certificateInfo", reply); }
+void Ledger::certificateInfoFailure(QNetworkReply& reply) {
+    QByteArray response = reply.readAll();
+    QJsonObject replyObject = QJsonDocument::fromJson(response).object();
+
+    failResponse("certificateInfo", reply);
+    emit certificateInfoResult(replyObject);
+}
 void Ledger::certificateInfo(const QString& certificateId) {
     QString endpoint = "proof_of_purchase_status/transfer";
     QJsonObject request;


### PR DESCRIPTION
Fixes [MS13742](https://highfidelity.manuscript.com/f/cases/13742/).

When a client is attempting to get information about a certificate, sometimes the call to the backend `certificate_info` endpoint fails (for various reasons). Before this PR, that failure would cause the certificate display to show a loading GIF forever. Now, the certificate display tells the user that certificate info can't be displayed.