### PR TITLE
Inspection: Tweak mouse-right-click-to-inspect behavior

### DIFF
--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -64,6 +64,10 @@ signals:
     void contextOverlayClicked(const QUuid& currentEntityWithContextOverlay);
 
 public slots:
+    void clickDownOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
+    void holdingClickOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
+    void mouseReleaseOnEntity(const EntityItemID& entityItemID, const PointerEvent& event);
+
     bool createOrDestroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
     bool destroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
     bool destroyContextOverlay(const EntityItemID& entityItemID);
@@ -84,6 +88,8 @@ private:
     };
     bool _verboseLogging{ true };
     bool _enabled { true };
+    EntityItemID _mouseDownEntity{};
+    quint64 _mouseDownEntityTimestamp;
     EntityItemID _currentEntityWithContextOverlay{};
     EntityItemID _lastInspectedEntity{};
     QString _entityMarketplaceID;


### PR DESCRIPTION
Before this change, a user holding right click to mouselook would often invoke the (i) Context Overlay over certified entities without that being the user's intention.

As this change does not add any new code for hand controllers, it shouldn't affect the behavior of inspecting entities using hand controllers.