### PR TITLE
Add Controller.Actions.Sprint as synonym of Controller.Actions.SPRINT

### DIFF
--- a/libraries/controllers/src/controllers/Actions.cpp
+++ b/libraries/controllers/src/controllers/Actions.cpp
@@ -128,6 +128,7 @@ namespace controller {
             makeButtonPair(Action::TOGGLE_MUTE, "ToggleMute"),
             makeButtonPair(Action::CYCLE_CAMERA, "CycleCamera"),
             makeButtonPair(Action::TOGGLE_OVERLAY, "ToggleOverlay"),
+            makeButtonPair(Action::SPRINT, "Sprint"),
 
             makeAxisPair(Action::RETICLE_CLICK, "ReticleClick"),
             makeAxisPair(Action::RETICLE_X, "ReticleX"),


### PR DESCRIPTION
This to make it consistent with other Actions property names. Controller.Actions.SPRINT is deprecated because it is all-caps.