### PR TITLE
Remove notifications and print outs when degrading LOD

### DIFF
--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -86,11 +86,6 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
                 if (_octreeSizeScale < ADJUST_LOD_MIN_SIZE_SCALE) {
                     _octreeSizeScale = ADJUST_LOD_MIN_SIZE_SCALE;
                 }
-                // DEBUG: Less is more, avoid logging all the time
-                /* qCDebug(interfaceapp) << "adjusting LOD DOWN"
-                    << "fps =" << currentFPS
-                    << "targetFPS =" << getLODDecreaseFPS()
-                    << "octreeSizeScale =" << _octreeSizeScale; */
                 emit LODDecreased();
                 // Assuming the LOD adjustment will work: we optimistically reset _avgRenderTime
                 // to provide an FPS just above the decrease threshold.  It will drift close to its
@@ -112,11 +107,6 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
                 if (_octreeSizeScale > ADJUST_LOD_MAX_SIZE_SCALE) {
                     _octreeSizeScale = ADJUST_LOD_MAX_SIZE_SCALE;
                 }
-                // DEBUG: Less is more, avoid logging all the time
-                /*    qCDebug(interfaceapp) << "adjusting LOD UP"
-                    << "fps =" << currentFPS
-                    << "targetFPS =" << getLODDecreaseFPS()
-                    << "octreeSizeScale =" << _octreeSizeScale; */
                 emit LODIncreased();
                 // Assuming the LOD adjustment will work: we optimistically reset _avgRenderTime
                 // to provide an FPS just below the increase threshold.  It will drift close to its

--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -86,10 +86,11 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
                 if (_octreeSizeScale < ADJUST_LOD_MIN_SIZE_SCALE) {
                     _octreeSizeScale = ADJUST_LOD_MIN_SIZE_SCALE;
                 }
-                qCDebug(interfaceapp) << "adjusting LOD DOWN"
+                // DEBUG: Less is more, avoid logging all the time
+                /* qCDebug(interfaceapp) << "adjusting LOD DOWN"
                     << "fps =" << currentFPS
                     << "targetFPS =" << getLODDecreaseFPS()
-                    << "octreeSizeScale =" << _octreeSizeScale;
+                    << "octreeSizeScale =" << _octreeSizeScale; */
                 emit LODDecreased();
                 // Assuming the LOD adjustment will work: we optimistically reset _avgRenderTime
                 // to provide an FPS just above the decrease threshold.  It will drift close to its
@@ -111,10 +112,11 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
                 if (_octreeSizeScale > ADJUST_LOD_MAX_SIZE_SCALE) {
                     _octreeSizeScale = ADJUST_LOD_MAX_SIZE_SCALE;
                 }
-                qCDebug(interfaceapp) << "adjusting LOD UP"
+                // DEBUG: Less is more, avoid logging all the time
+                /*    qCDebug(interfaceapp) << "adjusting LOD UP"
                     << "fps =" << currentFPS
                     << "targetFPS =" << getLODDecreaseFPS()
-                    << "octreeSizeScale =" << _octreeSizeScale;
+                    << "octreeSizeScale =" << _octreeSizeScale; */
                 emit LODIncreased();
                 // Assuming the LOD adjustment will work: we optimistically reset _avgRenderTime
                 // to provide an FPS just below the increase threshold.  It will drift close to its

--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -1,6 +1,6 @@
 "use strict";
 /*jslint vars:true, plusplus:true, forin:true*/
-/*global Script, Settings, Window, Controller, Overlays, SoundArray, LODManager, MyAvatar, Tablet, Camera, HMD, Menu, Quat, Vec3*/
+/*global Script, Settings, Window, Controller, Overlays, SoundArray, MyAvatar, Tablet, Camera, HMD, Menu, Quat, Vec3*/
 //
 //  notifications.js
 //  Version 0.801
@@ -84,21 +84,18 @@
     var NOTIFICATION_MENU_ITEM_POST = " Notifications";
     var PLAY_NOTIFICATION_SOUNDS_SETTING = "play_notification_sounds";
     var PLAY_NOTIFICATION_SOUNDS_TYPE_SETTING_PRE = "play_notification_sounds_type_";
-    var lodTextID = false;
-    var NOTIFICATIONS_MESSAGE_CHANNEL = "Hifi-Notifications"
+     var NOTIFICATIONS_MESSAGE_CHANNEL = "Hifi-Notifications"
 
     var NotificationType = {
         UNKNOWN: 0,
         SNAPSHOT: 1,
-        LOD_WARNING: 2,
-        CONNECTION_REFUSED: 3,
-        EDIT_ERROR: 4,
-        TABLET: 5,
-        CONNECTION: 6,
-        WALLET: 7,
+        CONNECTION_REFUSED: 2,
+        EDIT_ERROR: 3,
+        TABLET: 4,
+        CONNECTION: 5,
+        WALLET: 6,
         properties: [
             { text: "Snapshot" },
-            { text: "Level of Detail" },
             { text: "Connection Refused" },
             { text: "Edit error" },
             { text: "Tablet" },
@@ -153,10 +150,6 @@
 
     //  This handles the final dismissal of a notification after fading
     function dismiss(firstNoteOut, firstButOut, firstOut) {
-        if (firstNoteOut === lodTextID) {
-            lodTextID = false;
-        }
-
         Overlays.deleteOverlay(firstNoteOut);
         Overlays.deleteOverlay(firstButOut);
         notifications.splice(firstOut, 1);
@@ -418,9 +411,6 @@
 
     function deleteNotification(index) {
         var notificationTextID = notifications[index];
-        if (notificationTextID === lodTextID) {
-            lodTextID = false;
-        }
         Overlays.deleteOverlay(notificationTextID);
         Overlays.deleteOverlay(buttons[index]);
         notifications.splice(index, 1);
@@ -673,20 +663,6 @@
             Settings.setValue(PLAY_NOTIFICATION_SOUNDS_TYPE_SETTING_PRE + notificationType, Menu.isOptionChecked(menuItem));
         }
     }
-
-    LODManager.LODDecreased.connect(function () {
-        var warningText = "\n" +
-            "Due to the complexity of the content, the \n" +
-            "level of detail has been decreased. " +
-            "You can now see: \n" +
-            LODManager.getLODFeedbackText();
-
-        if (lodTextID === false) {
-            lodTextID = createNotification(warningText, NotificationType.LOD_WARNING);
-        } else {
-            Overlays.editOverlay(lodTextID, { text: warningText });
-        }
-    });
 
     Controller.keyPressEvent.connect(keyPressEvent);
     Controller.mousePressEvent.connect(mousePressEvent);

--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -84,7 +84,7 @@
     var NOTIFICATION_MENU_ITEM_POST = " Notifications";
     var PLAY_NOTIFICATION_SOUNDS_SETTING = "play_notification_sounds";
     var PLAY_NOTIFICATION_SOUNDS_TYPE_SETTING_PRE = "play_notification_sounds_type_";
-     var NOTIFICATIONS_MESSAGE_CHANNEL = "Hifi-Notifications";
+    var NOTIFICATIONS_MESSAGE_CHANNEL = "Hifi-Notifications";
 
     var NotificationType = {
         UNKNOWN: 0,

--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -84,7 +84,7 @@
     var NOTIFICATION_MENU_ITEM_POST = " Notifications";
     var PLAY_NOTIFICATION_SOUNDS_SETTING = "play_notification_sounds";
     var PLAY_NOTIFICATION_SOUNDS_TYPE_SETTING_PRE = "play_notification_sounds_type_";
-     var NOTIFICATIONS_MESSAGE_CHANNEL = "Hifi-Notifications"
+     var NOTIFICATIONS_MESSAGE_CHANNEL = "Hifi-Notifications";
 
     var NotificationType = {
         UNKNOWN: 0,


### PR DESCRIPTION
This is just too much noise so we decided to remove the  logging and the notifications whenever the LOD drops.
Bug [13743](https://highfidelity.fogbugz.com/f/cases/13743/REmove-notification-and-logging-of-LOD-change)

## TEST PLAN
In an heavy domain (such as dev-welcome for example) with stats expanded enabled ('/' key and clicked once in that ui)
You can observe the current LOD on the 4th column, bottom row.

In this PR, as the LOD varies and degreade (thus hidding smaller objects) no more notifications appears.
in the log file (ctrl + shipt + l) you don;t see anymore messages about the LOD dropping or improving.

IN master you see all the above

IN HMD, the LOD warning notifications are not visisble anymore either.
