### PR TITLE
Commerce workaround for broken qt5.10

### DIFF
--- a/scripts/system/help.js
+++ b/scripts/system/help.js
@@ -40,7 +40,7 @@
     }
 
     function onScreenChanged(type, url) {
-        onHelpScreen = type === "Web" && url.startsWith(HELP_URL);
+        onHelpScreen = type === "Web" && (url.indexOf(HELP_URL) === 0);
         button.editProperties({ isActive: onHelpScreen });
     }
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/13738/Loading-graphic-displays-infinitely-on-Marketplace