### PR TITLE
Fix 'Private' HMD preview texture enable/disable...again

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseChange.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseChange.qml
@@ -24,6 +24,18 @@ Item {
     HifiConstants { id: hifi; }
 
     id: root;
+    
+    // This will cause a bug -- if you bring up passphrase selection in HUD mode while
+    // in HMD while having HMD preview enabled, then move, then finish passphrase selection,
+    // HMD preview will stay off.
+    // TODO: Fix this unlikely bug
+    onVisibleChanged: {
+        if (visible) {
+            sendSignalToWallet({method: 'disableHmdPreview'});
+        } else {
+            sendSignalToWallet({method: 'maybeEnableHmdPreview'});
+        }
+    }
 
     // Username Text
     RalewayRegular {

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
@@ -68,10 +68,6 @@ Item {
         propagateComposedEvents: false;
         hoverEnabled: true;
     }
-    
-    Component.onDestruction: {
-        sendSignalToParent({method: 'maybeEnableHmdPreview'});
-    }
 
     // This will cause a bug -- if you bring up passphrase selection in HUD mode while
     // in HMD while having HMD preview enabled, then move, then finish passphrase selection,

--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseSelection.qml
@@ -61,9 +61,6 @@ Item {
             if (root.shouldImmediatelyFocus) {
                 focusFirstTextField();
             }
-            sendMessageToLightbox({method: 'disableHmdPreview'});
-        } else {
-            sendMessageToLightbox({method: 'maybeEnableHmdPreview'});
         }
     }
     

--- a/interface/resources/qml/hifi/commerce/wallet/SecurityImageChange.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/SecurityImageChange.qml
@@ -44,6 +44,17 @@ Item {
         }
     }
     
+    // This will cause a bug -- if you bring up security image selection in HUD mode while
+    // in HMD while having HMD preview enabled, then move, then finish passphrase selection,
+    // HMD preview will stay off.
+    // TODO: Fix this unlikely bug
+    onVisibleChanged: {
+        if (visible) {
+            sendSignalToWallet({method: 'disableHmdPreview'});
+        } else {
+            sendSignalToWallet({method: 'maybeEnableHmdPreview'});
+        }
+    }    
 
     // Security Image
     Item {

--- a/interface/resources/qml/hifi/commerce/wallet/SecurityImageSelection.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/SecurityImageSelection.qml
@@ -25,18 +25,6 @@ Item {
 
     id: root;
     property alias currentIndex: securityImageGrid.currentIndex;
-    
-    // This will cause a bug -- if you bring up security image selection in HUD mode while
-    // in HMD while having HMD preview enabled, then move, then finish passphrase selection,
-    // HMD preview will stay off.
-    // TODO: Fix this unlikely bug
-    onVisibleChanged: {
-        if (visible) {
-            sendSignalToWallet({method: 'disableHmdPreview'});
-        } else {
-            sendSignalToWallet({method: 'maybeEnableHmdPreview'});
-        }
-    }
 
     SecurityImageModel {
         id: gridModel;

--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -237,7 +237,7 @@ Rectangle {
                     } else {
                         sendToScript(msg);
                     }
-                } else if (msg.method === 'maybeEnableHmdPreview') {
+                } else {
                     sendToScript(msg);
                 }
             }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -76,6 +76,12 @@ Item {
         var currentStepNumber = root.activeView.substring(5);
         UserActivityLogger.commerceWalletSetupProgress(timestamp, root.setupAttemptID,
             Math.round((timestamp - root.startingTimestamp)/1000), currentStepNumber, root.setupStepNames[currentStepNumber - 1]);
+
+        if (root.activeView === "step_2" || root.activeView === "step_3") {
+            sendSignalToWallet({method: 'disableHmdPreview'});
+        } else {
+            sendSignalToWallet({method: 'maybeEnableHmdPreview'});
+        }
     }
 
     //
@@ -441,7 +447,7 @@ Item {
     }
     Item {
         id: choosePassphraseContainer;
-        visible: root.hasShownSecurityImageTip && root.activeView === "step_3";
+        visible: root.activeView === "step_3";
         // Anchors
         anchors.top: titleBarContainer.bottom;
         anchors.topMargin: 30;
@@ -451,10 +457,7 @@ Item {
 
         onVisibleChanged: {
             if (visible) {
-                sendSignalToWallet({method: 'disableHmdPreview'});
                 Commerce.getWalletAuthenticatedStatus();
-            } else {
-                sendSignalToWallet({method: 'maybeEnableHmdPreview'});
             }
         }
 


### PR DESCRIPTION
The UX of when to enable and disable the HMD preview on sensitive, private screens (such as commerce passphrase entry) is complicated. This PR introduces a change in logic in an attempt to correct that behavior AND fix [MS12470](https://highfidelity.manuscript.com/f/cases/12470/Security-picture-does-not-display-on-Tip-page).