### PR TITLE
Fix Window API position and size reporting

### DIFF
--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -51,7 +51,7 @@ WindowScriptingInterface::WindowScriptingInterface() {
         }
     });
 
-    connect(qApp->getWindow(), &MainWindow::windowGeometryChanged, this, &WindowScriptingInterface::geometryChanged);
+    connect(qApp->getWindow(), &MainWindow::windowGeometryChanged, this, &WindowScriptingInterface::onWindowGeometryChanged);
 }
 
 WindowScriptingInterface::~WindowScriptingInterface() {
@@ -395,6 +395,15 @@ int WindowScriptingInterface::getX() {
 
 int WindowScriptingInterface::getY() {
     return qApp->getWindow()->y();
+}
+
+void WindowScriptingInterface::onWindowGeometryChanged(const QRect& windowGeometry) {
+    auto geometry = windowGeometry;
+    auto menu = qApp->getPrimaryMenu();
+    if (menu) {
+        geometry.setHeight(geometry.height() - menu->geometry().height());
+    }
+    emit geometryChanged(geometry);
 }
 
 void WindowScriptingInterface::copyToClipboard(const QString& text) {

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -390,11 +390,13 @@ glm::vec2 WindowScriptingInterface::getDeviceSize() const {
 }
 
 int WindowScriptingInterface::getX() {
-    return qApp->getWindow()->x();
+    return qApp->getWindow()->geometry().x();
 }
 
 int WindowScriptingInterface::getY() {
-    return qApp->getWindow()->y();
+    auto menu = qApp->getPrimaryMenu();
+    int menuHeight = menu ? menu->geometry().height() : 0;
+    return qApp->getWindow()->geometry().y() + menuHeight;
 }
 
 void WindowScriptingInterface::onWindowGeometryChanged(const QRect& windowGeometry) {

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -401,7 +401,7 @@ void WindowScriptingInterface::onWindowGeometryChanged(const QRect& windowGeomet
     auto geometry = windowGeometry;
     auto menu = qApp->getPrimaryMenu();
     if (menu) {
-        geometry.setHeight(geometry.height() - menu->geometry().height());
+        geometry.setY(geometry.y() + menu->geometry().height());
     }
     emit geometryChanged(geometry);
 }

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -33,8 +33,10 @@
  * @property {number} innerHeight - The height of the drawable area of the Interface window (i.e., without borders or other
  *     chrome), in pixels. <em>Read-only.</em>
  * @property {object} location - Provides facilities for working with your current metaverse location. See {@link location}.
- * @property {number} x - The x coordinate of the top left corner of the Interface window on the display. <em>Read-only.</em>
- * @property {number} y - The y coordinate of the top left corner of the Interface window on the display. <em>Read-only.</em>
+ * @property {number} x - The x display coordinate of the top left corner of the drawable area of the Interface window. 
+ *     <em>Read-only.</em>
+ * @property {number} y - The y display coordinate of the top left corner of the drawable area of the Interface window. 
+ *     <em>Read-only.</em>
  */
 
 class WindowScriptingInterface : public QObject, public Dependency {

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -522,6 +522,7 @@ public slots:
     void closeMessageBox(int id);
 
 private slots:
+    void onWindowGeometryChanged(const QRect& geometry);
     void onMessageBoxSelected(int button);
     void disconnectedFromDomain();
 

--- a/libraries/ui/src/MainWindow.cpp
+++ b/libraries/ui/src/MainWindow.cpp
@@ -79,12 +79,12 @@ void MainWindow::closeEvent(QCloseEvent* event) {
 }
 
 void MainWindow::moveEvent(QMoveEvent* event) {
-    emit windowGeometryChanged(QRect(event->pos(), size()));
+    emit windowGeometryChanged(QRect(QPoint(geometry().x(), geometry().y()), size()));  // Geometry excluding the window frame.
     QMainWindow::moveEvent(event);
 }
 
 void MainWindow::resizeEvent(QResizeEvent* event) {
-    emit windowGeometryChanged(QRect(QPoint(x(), y()), event->size()));
+    emit windowGeometryChanged(QRect(QPoint(geometry().x(), geometry().y()), size()));  // Geometry excluding the window frame.
     QMainWindow::resizeEvent(event);
 }
 


### PR DESCRIPTION
Fixes and makes consistent:
- Window.x, .y, innerWidth, innerHeight
- Window.geometryChanged()
- Window.getDeviceSize()