### PR TITLE
Replace LogHandler repeated regex scheme with assigned ID tracking scheme

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -611,13 +611,13 @@ bool DomainServer::isPacketVerified(const udt::Packet& packet) {
                 // let the NodeList do its checks now (but pass it the sourceNode so it doesn't need to look it up again)
                 return nodeList->isPacketVerifiedWithSource(packet, sourceNode.data());
             } else {
-                HIFI_FDEBUG((*QLoggingCategory::defaultCategory()), "Packet of type" << headerType
+                HIFI_FDEBUG("Packet of type" << headerType
                     << "received from unmatched IP for UUID" << uuidStringWithoutCurlyBraces(sourceID));
 
                 return false;
             }
         } else {
-            HIFI_FDEBUG((*QLoggingCategory::defaultCategory()), "Packet of type" << headerType
+            HIFI_FDEBUG("Packet of type" << headerType
                 << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID));
 
             return false;
@@ -1268,7 +1268,7 @@ void DomainServer::processRequestAssignmentPacket(QSharedPointer<ReceivedMessage
 
     auto it = find_if(_acSubnetWhitelist.begin(), _acSubnetWhitelist.end(), isHostAddressInSubnet);
     if (it == _acSubnetWhitelist.end()) {
-        HIFI_FDEBUG((*QLoggingCategory::defaultCategory()),  "Received an assignment connect request from a disallowed ip address:"
+        HIFI_FDEBUG("Received an assignment connect request from a disallowed ip address:"
             << senderAddr.toString());
         return;
     }

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1284,10 +1284,10 @@ void DomainServer::processRequestAssignmentPacket(QSharedPointer<ReceivedMessage
 
     const qint64 NOISY_MESSAGE_INTERVAL_MSECS = 5 * 1000;
 
-    if (requestAssignment.getType() != Assignment::AgentType
-        || noisyMessageTimer.elapsed() > NOISY_MESSAGE_INTERVAL_MSECS) {
-        static QString repeatedMessage = LogHandler::getInstance().addOnlyOnceMessageRegex
-            ("Received a request for assignment type [^ ]+ from [^ ]+");
+    static bool printedAssignmentTypeMessage = false;
+    if (!printedAssignmentTypeMessage && (requestAssignment.getType() != Assignment::AgentType
+        || noisyMessageTimer.elapsed() > NOISY_MESSAGE_INTERVAL_MSECS)) {
+        printedAssignmentTypeMessage = true;
         qDebug() << "Received a request for assignment type" << requestAssignment.getType()
                  << "from" << message->getSenderSockAddr();
         noisyMessageTimer.restart();
@@ -1324,10 +1324,10 @@ void DomainServer::processRequestAssignmentPacket(QSharedPointer<ReceivedMessage
         _gatekeeper.addPendingAssignedNode(uniqueAssignment.getUUID(), assignmentToDeploy->getUUID(),
                                            requestAssignment.getWalletUUID(), requestAssignment.getNodeVersion());
     } else {
-        if (requestAssignment.getType() != Assignment::AgentType
-            || noisyMessageTimer.elapsed() > NOISY_MESSAGE_INTERVAL_MSECS) {
-            static QString repeatedMessage = LogHandler::getInstance().addOnlyOnceMessageRegex
-                ("Unable to fulfill assignment request of type [^ ]+ from [^ ]+");
+        static bool printedAssignmentRequestMessage = false;
+        if (!printedAssignmentRequestMessage && (requestAssignment.getType() != Assignment::AgentType
+            || noisyMessageTimer.elapsed() > NOISY_MESSAGE_INTERVAL_MSECS)) {
+            printedAssignmentRequestMessage = true;
             qDebug() << "Unable to fulfill assignment request of type" << requestAssignment.getType()
                 << "from" << message->getSenderSockAddr();
             noisyMessageTimer.restart();
@@ -1576,10 +1576,12 @@ void DomainServer::sendICEServerAddressToMetaverseAPI() {
     callbackParameters.jsonCallbackReceiver = this;
     callbackParameters.jsonCallbackMethod = "handleSuccessfulICEServerAddressUpdate";
 
-    static QString repeatedMessage = LogHandler::getInstance().addOnlyOnceMessageRegex
-        ("Updating ice-server address in High Fidelity Metaverse API to [^ \n]+");
-    qDebug() << "Updating ice-server address in High Fidelity Metaverse API to"
-             << (_iceServerSocket.isNull() ? "" : _iceServerSocket.getAddress().toString());
+    static bool printedIceServerMessage = false;
+    if (!printedIceServerMessage) {
+        printedIceServerMessage = true;
+        qDebug() << "Updating ice-server address in High Fidelity Metaverse API to"
+            << (_iceServerSocket.isNull() ? "" : _iceServerSocket.getAddress().toString());
+    }
 
     static const QString DOMAIN_ICE_ADDRESS_UPDATE = "/api/v1/domains/%1/ice_server_address";
 

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1273,24 +1273,11 @@ void DomainServer::processRequestAssignmentPacket(QSharedPointer<ReceivedMessage
         return;
     }
 
-    // Suppress these for Assignment::AgentType to once per 5 seconds
-    static QElapsedTimer noisyMessageTimer;
-    static bool wasNoisyTimerStarted = false;
-
-    if (!wasNoisyTimerStarted) {
-        noisyMessageTimer.start();
-        wasNoisyTimerStarted = true;
-    }
-
-    const qint64 NOISY_MESSAGE_INTERVAL_MSECS = 5 * 1000;
-
     static bool printedAssignmentTypeMessage = false;
-    if (!printedAssignmentTypeMessage && (requestAssignment.getType() != Assignment::AgentType
-        || noisyMessageTimer.elapsed() > NOISY_MESSAGE_INTERVAL_MSECS)) {
+    if (!printedAssignmentTypeMessage && requestAssignment.getType() != Assignment::AgentType) {
         printedAssignmentTypeMessage = true;
         qDebug() << "Received a request for assignment type" << requestAssignment.getType()
                  << "from" << message->getSenderSockAddr();
-        noisyMessageTimer.restart();
     }
 
     SharedAssignmentPointer assignmentToDeploy = deployableAssignmentForRequest(requestAssignment);
@@ -1325,12 +1312,10 @@ void DomainServer::processRequestAssignmentPacket(QSharedPointer<ReceivedMessage
                                            requestAssignment.getWalletUUID(), requestAssignment.getNodeVersion());
     } else {
         static bool printedAssignmentRequestMessage = false;
-        if (!printedAssignmentRequestMessage && (requestAssignment.getType() != Assignment::AgentType
-            || noisyMessageTimer.elapsed() > NOISY_MESSAGE_INTERVAL_MSECS)) {
+        if (!printedAssignmentRequestMessage && requestAssignment.getType() != Assignment::AgentType) {
             printedAssignmentRequestMessage = true;
             qDebug() << "Unable to fulfill assignment request of type" << requestAssignment.getType()
                 << "from" << message->getSenderSockAddr();
-            noisyMessageTimer.restart();
         }
     }
 }

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -611,22 +611,14 @@ bool DomainServer::isPacketVerified(const udt::Packet& packet) {
                 // let the NodeList do its checks now (but pass it the sourceNode so it doesn't need to look it up again)
                 return nodeList->isPacketVerifiedWithSource(packet, sourceNode.data());
             } else {
-                static const QString UNKNOWN_REGEX = "Packet of type \\d+ \\([\\sa-zA-Z:]+\\) received from unmatched IP for UUID";
-                static QString repeatedMessage
-                    = LogHandler::getInstance().addRepeatedMessageRegex(UNKNOWN_REGEX);
-
-                qDebug() << "Packet of type" << headerType
-                    << "received from unmatched IP for UUID" << uuidStringWithoutCurlyBraces(sourceID);
+                HIFI_FDEBUG((*QLoggingCategory::defaultCategory()), "Packet of type" << headerType
+                    << "received from unmatched IP for UUID" << uuidStringWithoutCurlyBraces(sourceID));
 
                 return false;
             }
         } else {
-            static const QString UNKNOWN_REGEX = "Packet of type \\d+ \\([\\sa-zA-Z:]+\\) received from unknown node with UUID";
-            static QString repeatedMessage
-                = LogHandler::getInstance().addRepeatedMessageRegex(UNKNOWN_REGEX);
-
-            qDebug() << "Packet of type" << headerType
-                << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID);
+            HIFI_FDEBUG((*QLoggingCategory::defaultCategory()), "Packet of type" << headerType
+                << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID));
 
             return false;
         }
@@ -1276,10 +1268,8 @@ void DomainServer::processRequestAssignmentPacket(QSharedPointer<ReceivedMessage
 
     auto it = find_if(_acSubnetWhitelist.begin(), _acSubnetWhitelist.end(), isHostAddressInSubnet);
     if (it == _acSubnetWhitelist.end()) {
-        static QString repeatedMessage = LogHandler::getInstance().addRepeatedMessageRegex(
-            "Received an assignment connect request from a disallowed ip address: [^ ]+");
-        qDebug() << "Received an assignment connect request from a disallowed ip address:"
-            << senderAddr.toString();
+        HIFI_FDEBUG((*QLoggingCategory::defaultCategory()),  "Received an assignment connect request from a disallowed ip address:"
+            << senderAddr.toString());
         return;
     }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6018,9 +6018,7 @@ bool Application::nearbyEntitiesAreReadyForPhysics() {
         bool result = true;
         foreach (EntityItemPointer entity, entities) {
             if (entity->shouldBePhysical() && !entity->isReadyToComputeShape()) {
-                static QString repeatedMessage =
-                    LogHandler::getInstance().addRepeatedMessageRegex("Physics disabled until entity loads: .*");
-                qCDebug(interfaceapp) << "Physics disabled until entity loads: " << entity->getID() << entity->getName();
+                HIFI_FDEBUG(interfaceapp(), "Physics disabled until entity loads: " << entity->getID() << entity->getName());
                 // don't break here because we want all the relevant entities to start their downloads
                 result = false;
             }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6018,7 +6018,7 @@ bool Application::nearbyEntitiesAreReadyForPhysics() {
         bool result = true;
         foreach (EntityItemPointer entity, entities) {
             if (entity->shouldBePhysical() && !entity->isReadyToComputeShape()) {
-                HIFI_FDEBUG(interfaceapp(), "Physics disabled until entity loads: " << entity->getID() << entity->getName());
+                HIFI_FCDEBUG(interfaceapp(), "Physics disabled until entity loads: " << entity->getID() << entity->getName());
                 // don't break here because we want all the relevant entities to start their downloads
                 result = false;
             }

--- a/interface/src/InterfaceDynamicFactory.cpp
+++ b/interface/src/InterfaceDynamicFactory.cpp
@@ -87,10 +87,8 @@ EntityDynamicPointer InterfaceDynamicFactory::factoryBA(EntityItemPointer ownerE
     if (dynamic) {
         dynamic->deserialize(data);
         if (dynamic->lifetimeIsOver()) {
-            static QString repeatedMessage =
-                LogHandler::getInstance().addRepeatedMessageRegex(".*factoryBA lifetimeIsOver during dynamic creation.*");
-            qDebug() << "InterfaceDynamicFactory::factoryBA lifetimeIsOver during dynamic creation --"
-                     << dynamic->getExpires() << "<" << usecTimestampNow();
+            HIFI_FDEBUG((*QLoggingCategory::defaultCategory()), "InterfaceDynamicFactory::factoryBA lifetimeIsOver during dynamic creation --"
+                     << dynamic->getExpires() << "<" << usecTimestampNow());
             return nullptr;
         }
     }

--- a/interface/src/InterfaceDynamicFactory.cpp
+++ b/interface/src/InterfaceDynamicFactory.cpp
@@ -87,7 +87,7 @@ EntityDynamicPointer InterfaceDynamicFactory::factoryBA(EntityItemPointer ownerE
     if (dynamic) {
         dynamic->deserialize(data);
         if (dynamic->lifetimeIsOver()) {
-            HIFI_FDEBUG((*QLoggingCategory::defaultCategory()), "InterfaceDynamicFactory::factoryBA lifetimeIsOver during dynamic creation --"
+            HIFI_FDEBUG("InterfaceDynamicFactory::factoryBA lifetimeIsOver during dynamic creation --"
                      << dynamic->getExpires() << "<" << usecTimestampNow());
             return nullptr;
         }

--- a/libraries/audio/src/AudioRingBuffer.cpp
+++ b/libraries/audio/src/AudioRingBuffer.cpp
@@ -164,7 +164,7 @@ int AudioRingBufferTemplate<T>::writeData(const char* data, int maxSize) {
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
 
-        HIFI_FDEBUG(audio(), RING_BUFFER_OVERFLOW_DEBUG);
+        HIFI_FCDEBUG(audio(), RING_BUFFER_OVERFLOW_DEBUG);
         qPrintable(RING_BUFFER_OVERFLOW_DEBUG);
     }
 
@@ -222,7 +222,7 @@ int AudioRingBufferTemplate<T>::addSilentSamples(int silentSamples) {
     if (numWriteSamples > samplesRoomFor) {
         numWriteSamples = samplesRoomFor;
 
-        HIFI_FDEBUG(audio(), DROPPED_SILENT_DEBUG);
+        HIFI_FCDEBUG(audio(), DROPPED_SILENT_DEBUG);
     }
 
     if (_endOfLastWrite + numWriteSamples > _buffer + _bufferLength) {
@@ -273,7 +273,7 @@ int AudioRingBufferTemplate<T>::writeSamples(ConstIterator source, int maxSample
         int samplesToDelete = samplesToCopy - samplesRoomFor;
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
-        HIFI_FDEBUG(audio(), RING_BUFFER_OVERFLOW_DEBUG);
+        HIFI_FCDEBUG(audio(), RING_BUFFER_OVERFLOW_DEBUG);
     }
 
     Sample* bufferLast = _buffer + _bufferLength - 1;
@@ -295,7 +295,7 @@ int AudioRingBufferTemplate<T>::writeSamplesWithFade(ConstIterator source, int m
         int samplesToDelete = samplesToCopy - samplesRoomFor;
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
-        HIFI_FDEBUG(audio(), RING_BUFFER_OVERFLOW_DEBUG);
+        HIFI_FCDEBUG(audio(), RING_BUFFER_OVERFLOW_DEBUG);
     }
 
     Sample* bufferLast = _buffer + _bufferLength - 1;

--- a/libraries/audio/src/AudioRingBuffer.cpp
+++ b/libraries/audio/src/AudioRingBuffer.cpp
@@ -169,8 +169,8 @@ int AudioRingBufferTemplate<T>::writeData(const char* data, int maxSize) {
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
 
-        std::call_once(messageIDFlag, [](int& id) { id = LogHandler::getInstance().newRepeatedMessageID(); },
-            repeatedOverflowMessageID);
+        std::call_once(messageIDFlag, [](int* id) { *id = LogHandler::getInstance().newRepeatedMessageID(); },
+            &repeatedOverflowMessageID);
         HIFI_FCDEBUG_ID(audio(), repeatedOverflowMessageID, RING_BUFFER_OVERFLOW_DEBUG);
     }
 
@@ -280,8 +280,8 @@ int AudioRingBufferTemplate<T>::writeSamples(ConstIterator source, int maxSample
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
 
-        std::call_once(messageIDFlag, [](int& id) { id = LogHandler::getInstance().newRepeatedMessageID(); },
-            repeatedOverflowMessageID);
+        std::call_once(messageIDFlag, [](int* id) { *id = LogHandler::getInstance().newRepeatedMessageID(); },
+            &repeatedOverflowMessageID);
         HIFI_FCDEBUG_ID(audio(), repeatedOverflowMessageID, RING_BUFFER_OVERFLOW_DEBUG);
     }
 
@@ -305,8 +305,8 @@ int AudioRingBufferTemplate<T>::writeSamplesWithFade(ConstIterator source, int m
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
 
-        std::call_once(messageIDFlag, [](int& id) { id = LogHandler::getInstance().newRepeatedMessageID(); },
-            repeatedOverflowMessageID);
+        std::call_once(messageIDFlag, [](int* id) { *id = LogHandler::getInstance().newRepeatedMessageID(); },
+            &repeatedOverflowMessageID);
         HIFI_FCDEBUG_ID(audio(), repeatedOverflowMessageID, RING_BUFFER_OVERFLOW_DEBUG);
     }
 

--- a/libraries/audio/src/AudioRingBuffer.cpp
+++ b/libraries/audio/src/AudioRingBuffer.cpp
@@ -39,9 +39,6 @@ AudioRingBufferTemplate<T>::AudioRingBufferTemplate(int numFrameSamples, int num
         _nextOutput = _buffer;
         _endOfLastWrite = _buffer;
     }
-
-    static QString repeatedOverflowMessage = LogHandler::getInstance().addRepeatedMessageRegex(RING_BUFFER_OVERFLOW_DEBUG);
-    static QString repeatedDroppedMessage = LogHandler::getInstance().addRepeatedMessageRegex(DROPPED_SILENT_DEBUG);
 }
 
 template <class T>
@@ -167,7 +164,8 @@ int AudioRingBufferTemplate<T>::writeData(const char* data, int maxSize) {
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
 
-        qCDebug(audio) << qPrintable(RING_BUFFER_OVERFLOW_DEBUG);
+        HIFI_FDEBUG(audio(), RING_BUFFER_OVERFLOW_DEBUG);
+        qPrintable(RING_BUFFER_OVERFLOW_DEBUG);
     }
 
     if (_endOfLastWrite + numWriteSamples > _buffer + _bufferLength) {
@@ -224,7 +222,7 @@ int AudioRingBufferTemplate<T>::addSilentSamples(int silentSamples) {
     if (numWriteSamples > samplesRoomFor) {
         numWriteSamples = samplesRoomFor;
 
-        qCDebug(audio) << qPrintable(DROPPED_SILENT_DEBUG);
+        HIFI_FDEBUG(audio(), DROPPED_SILENT_DEBUG);
     }
 
     if (_endOfLastWrite + numWriteSamples > _buffer + _bufferLength) {
@@ -275,7 +273,7 @@ int AudioRingBufferTemplate<T>::writeSamples(ConstIterator source, int maxSample
         int samplesToDelete = samplesToCopy - samplesRoomFor;
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
-        qCDebug(audio) << qPrintable(RING_BUFFER_OVERFLOW_DEBUG);
+        HIFI_FDEBUG(audio(), RING_BUFFER_OVERFLOW_DEBUG);
     }
 
     Sample* bufferLast = _buffer + _bufferLength - 1;
@@ -297,7 +295,7 @@ int AudioRingBufferTemplate<T>::writeSamplesWithFade(ConstIterator source, int m
         int samplesToDelete = samplesToCopy - samplesRoomFor;
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
-        qCDebug(audio) << qPrintable(RING_BUFFER_OVERFLOW_DEBUG);
+        HIFI_FDEBUG(audio(), RING_BUFFER_OVERFLOW_DEBUG);
     }
 
     Sample* bufferLast = _buffer + _bufferLength - 1;

--- a/libraries/audio/src/AudioRingBuffer.cpp
+++ b/libraries/audio/src/AudioRingBuffer.cpp
@@ -153,7 +153,7 @@ int AudioRingBufferTemplate<T>::appendData(char *data, int maxSize) {
 
 namespace {
     int repeatedOverflowMessageID = 0;
-    std::atomic<int> messageIDInit = 0;
+    std::once_flag messageIDFlag;
 }
 
 template <class T>
@@ -169,9 +169,8 @@ int AudioRingBufferTemplate<T>::writeData(const char* data, int maxSize) {
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
 
-        if (++messageIDInit == 1) {
-            repeatedOverflowMessageID = LogHandler::getInstance().newRepeatedMessageID();
-        }
+        std::call_once(messageIDFlag, [](int& id) { id = LogHandler::getInstance().newRepeatedMessageID(); },
+            repeatedOverflowMessageID);
         HIFI_FCDEBUG_ID(audio(), repeatedOverflowMessageID, RING_BUFFER_OVERFLOW_DEBUG);
     }
 
@@ -281,9 +280,8 @@ int AudioRingBufferTemplate<T>::writeSamples(ConstIterator source, int maxSample
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
 
-        if (++messageIDInit == 1) {
-            repeatedOverflowMessageID = LogHandler::getInstance().newRepeatedMessageID();
-        }
+        std::call_once(messageIDFlag, [](int& id) { id = LogHandler::getInstance().newRepeatedMessageID(); },
+            repeatedOverflowMessageID);
         HIFI_FCDEBUG_ID(audio(), repeatedOverflowMessageID, RING_BUFFER_OVERFLOW_DEBUG);
     }
 
@@ -307,9 +305,8 @@ int AudioRingBufferTemplate<T>::writeSamplesWithFade(ConstIterator source, int m
         _nextOutput = shiftedPositionAccomodatingWrap(_nextOutput, samplesToDelete);
         _overflowCount++;
 
-        if (++messageIDInit == 1) {
-            repeatedOverflowMessageID = LogHandler::getInstance().newRepeatedMessageID();
-        }
+        std::call_once(messageIDFlag, [](int& id) { id = LogHandler::getInstance().newRepeatedMessageID(); },
+            repeatedOverflowMessageID);
         HIFI_FCDEBUG_ID(audio(), repeatedOverflowMessageID, RING_BUFFER_OVERFLOW_DEBUG);
     }
 

--- a/libraries/audio/src/PositionalAudioStream.cpp
+++ b/libraries/audio/src/PositionalAudioStream.cpp
@@ -16,6 +16,7 @@
 
 #include <glm/detail/func_common.hpp>
 #include <QtCore/QDataStream>
+#include <QtCore/QLoggingCategory>
 
 #include <LogHandler.h>
 #include <Node.h>
@@ -80,10 +81,7 @@ int PositionalAudioStream::parsePositionalData(const QByteArray& positionalByteA
 
     // if the client sends us a bad position, flag it so that we don't consider this stream for mixing
     if (glm::isnan(_position.x) || glm::isnan(_position.y) || glm::isnan(_position.z)) {
-        static const QString INVALID_POSITION_REGEX = "PositionalAudioStream unpacked invalid position for node";
-        static QString repeatedMessage = LogHandler::getInstance().addRepeatedMessageRegex(INVALID_POSITION_REGEX);
-
-        qDebug() << "PositionalAudioStream unpacked invalid position for node" << uuidStringWithoutCurlyBraces(getNodeID());
+        HIFI_FDEBUG((*QLoggingCategory::defaultCategory()), "PositionalAudioStream unpacked invalid position for node" << uuidStringWithoutCurlyBraces(getNodeID()) );
 
         _hasValidPosition = false;
     } else {

--- a/libraries/audio/src/PositionalAudioStream.cpp
+++ b/libraries/audio/src/PositionalAudioStream.cpp
@@ -81,7 +81,7 @@ int PositionalAudioStream::parsePositionalData(const QByteArray& positionalByteA
 
     // if the client sends us a bad position, flag it so that we don't consider this stream for mixing
     if (glm::isnan(_position.x) || glm::isnan(_position.y) || glm::isnan(_position.z)) {
-        HIFI_FDEBUG((*QLoggingCategory::defaultCategory()), "PositionalAudioStream unpacked invalid position for node" << uuidStringWithoutCurlyBraces(getNodeID()) );
+        HIFI_FDEBUG("PositionalAudioStream unpacked invalid position for node" << uuidStringWithoutCurlyBraces(getNodeID()) );
 
         _hasValidPosition = false;
     } else {

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -2197,7 +2197,7 @@ void EntityItem::deserializeActionsInternal() {
                 entity->addActionInternal(simulation, action);
                 updated << actionID;
             } else {
-                HIFI_FDEBUG(entities(), "EntityItem::deserializeActionsInternal -- action creation failed for"
+                HIFI_FCDEBUG(entities(), "EntityItem::deserializeActionsInternal -- action creation failed for"
                         << getID() << _name); // getName();
                 removeActionInternal(actionID, nullptr);
             }

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -2197,10 +2197,8 @@ void EntityItem::deserializeActionsInternal() {
                 entity->addActionInternal(simulation, action);
                 updated << actionID;
             } else {
-                static QString repeatedMessage =
-                    LogHandler::getInstance().addRepeatedMessageRegex(".*action creation failed for.*");
-                qCDebug(entities) << "EntityItem::deserializeActionsInternal -- action creation failed for"
-                        << getID() << _name; // getName();
+                HIFI_FDEBUG(entities(), "EntityItem::deserializeActionsInternal -- action creation failed for"
+                        << getID() << _name); // getName();
                 removeActionInternal(actionID, nullptr);
             }
         }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1630,11 +1630,9 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                         _recentlyDeletedEntityItemIDs.insert(usecTimestampNow(), entityItemID);
                     }
                 } else {
-                    static QString repeatedMessage =
-                        LogHandler::getInstance().addRepeatedMessageRegex("^Edit failed.*");
-                    qCDebug(entities) << "Edit failed. [" << message.getType() <<"] " <<
+                    HIFI_FDEBUG(entities(), "Edit failed. [" << message.getType() <<"] " <<
                             "entity id:" << entityItemID << 
-                            "existingEntity pointer:" << existingEntity.get();
+                            "existingEntity pointer:" << existingEntity.get());
                 }
             }
 

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1630,7 +1630,7 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                         _recentlyDeletedEntityItemIDs.insert(usecTimestampNow(), entityItemID);
                     }
                 } else {
-                    HIFI_FDEBUG(entities(), "Edit failed. [" << message.getType() <<"] " <<
+                    HIFI_FCDEBUG(entities(), "Edit failed. [" << message.getType() <<"] " <<
                             "entity id:" << entityItemID << 
                             "existingEntity pointer:" << existingEntity.get());
                 }

--- a/libraries/fbx/src/FBXReader_Mesh.cpp
+++ b/libraries/fbx/src/FBXReader_Mesh.cpp
@@ -572,12 +572,12 @@ void FBXReader::buildModelMesh(FBXMesh& extractedMesh, const QString& url) {
     }
 
     if (!totalSourceIndices) {
-        HIFI_FDEBUG(modelformat(), "buildModelMesh failed -- no indices, url = " << url);
+        HIFI_FCDEBUG(modelformat(), "buildModelMesh failed -- no indices, url = " << url);
         return;
     }
 
     if (extractedMesh.vertices.size() == 0) {
-        HIFI_FDEBUG(modelformat(), "buildModelMesh failed -- no vertices, url = " << url);
+        HIFI_FCDEBUG(modelformat(), "buildModelMesh failed -- no vertices, url = " << url);
         return;
     }
 

--- a/libraries/fbx/src/FBXReader_Mesh.cpp
+++ b/libraries/fbx/src/FBXReader_Mesh.cpp
@@ -571,13 +571,15 @@ void FBXReader::buildModelMesh(FBXMesh& extractedMesh, const QString& url) {
         totalSourceIndices += (part.quadTrianglesIndices.size() + part.triangleIndices.size());
     }
 
+    static int repeatMessageID = LogHandler::getInstance().newRepeatedMessageID();
+
     if (!totalSourceIndices) {
-        HIFI_FCDEBUG(modelformat(), "buildModelMesh failed -- no indices, url = " << url);
+        HIFI_FCDEBUG_ID(modelformat(), repeatMessageID, "buildModelMesh failed -- no indices, url = " << url);
         return;
     }
 
     if (extractedMesh.vertices.size() == 0) {
-        HIFI_FCDEBUG(modelformat(), "buildModelMesh failed -- no vertices, url = " << url);
+        HIFI_FCDEBUG_ID(modelformat(), repeatMessageID, "buildModelMesh failed -- no vertices, url = " << url);
         return;
     }
 

--- a/libraries/fbx/src/FBXReader_Mesh.cpp
+++ b/libraries/fbx/src/FBXReader_Mesh.cpp
@@ -566,20 +566,18 @@ glm::vec3 FBXReader::normalizeDirForPacking(const glm::vec3& dir) {
 }
 
 void FBXReader::buildModelMesh(FBXMesh& extractedMesh, const QString& url) {
-    static QString repeatedMessage = LogHandler::getInstance().addRepeatedMessageRegex("buildModelMesh failed -- .*");
-
     unsigned int totalSourceIndices = 0;
     foreach(const FBXMeshPart& part, extractedMesh.parts) {
         totalSourceIndices += (part.quadTrianglesIndices.size() + part.triangleIndices.size());
     }
 
     if (!totalSourceIndices) {
-        qCDebug(modelformat) << "buildModelMesh failed -- no indices, url = " << url;
+        HIFI_FDEBUG(modelformat(), "buildModelMesh failed -- no indices, url = " << url);
         return;
     }
 
     if (extractedMesh.vertices.size() == 0) {
-        qCDebug(modelformat) << "buildModelMesh failed -- no vertices, url = " << url;
+        HIFI_FDEBUG(modelformat(), "buildModelMesh failed -- no vertices, url = " << url);
         return;
     }
 

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -345,12 +345,17 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
             return true;
 
         } else {
-            static const QString UNKNOWN_REGEX = "Packet of type \\d+ \\([\\sa-zA-Z:]+\\) received from unknown node with UUID";
-            static QString repeatedMessage
-                = LogHandler::getInstance().addRepeatedMessageRegex(UNKNOWN_REGEX);
+            //static const QString UNKNOWN_REGEX = "Packet of type \\d+ \\([\\sa-zA-Z:]+\\) received from unknown node with UUID";
+            //static QString repeatedMessage
+            //    = LogHandler::getInstance().addRepeatedMessageRegex(UNKNOWN_REGEX);
+            //qCDebug(networking) << "Packet of type" << headerType
+            //    << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID);
 
-            qCDebug(networking) << "Packet of type" << headerType
-                << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID);
+            static const int repeatedIDUnknownNode = LogHandler::getInstance().newRepeatedMessageID();
+            QString logString;
+            QDebug debugString(&logString);
+            debugString << "Packet of type" << headerType << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID);
+            LogHandler::getInstance().printRepeatedMessage(repeatedIDUnknownNode, LogDebug, QMessageLogContext(), logString);
         }
     }
 

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -351,11 +351,8 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
             //qCDebug(networking) << "Packet of type" << headerType
             //    << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID);
 
-            static const int repeatedIDUnknownNode = LogHandler::getInstance().newRepeatedMessageID();
-            QString logString;
-            QDebug debugString(&logString);
-            debugString << "Packet of type" << headerType << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID);
-            LogHandler::getInstance().printRepeatedMessage(repeatedIDUnknownNode, LogDebug, QMessageLogContext(), logString);
+            HIFI_FDEBUG(networking,
+                "Packet of type" << headerType << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID));
         }
     }
 

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -277,7 +277,7 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
                 emit dataReceived(sendingNodeType, packet.getPayloadSize());
                 return true;
             } else {
-                HIFI_FDEBUG(networking(), "Replicated packet of type" << headerType
+                HIFI_FCDEBUG(networking(), "Replicated packet of type" << headerType
                     << "received from unknown upstream" << packet.getSenderSockAddr());
                 
                 return false;
@@ -340,7 +340,7 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
             return true;
 
         } else {
-            HIFI_FDEBUG(networking(),
+            HIFI_FCDEBUG(networking(),
                 "Packet of type" << headerType << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID));
         }
     }

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -277,13 +277,8 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
                 emit dataReceived(sendingNodeType, packet.getPayloadSize());
                 return true;
             } else {
-                static const QString UNSOLICITED_REPLICATED_REGEX =
-                    "Replicated packet of type \\d+ \\([\\sa-zA-Z:]+\\) received from unknown upstream";
-                static QString repeatedMessage
-                    = LogHandler::getInstance().addRepeatedMessageRegex(UNSOLICITED_REPLICATED_REGEX);
-
-                qCDebug(networking) << "Replicated packet of type" << headerType
-                    << "received from unknown upstream" << packet.getSenderSockAddr();
+                HIFI_FDEBUG(networking(), "Replicated packet of type" << headerType
+                    << "received from unknown upstream" << packet.getSenderSockAddr());
                 
                 return false;
             }
@@ -345,13 +340,7 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
             return true;
 
         } else {
-            //static const QString UNKNOWN_REGEX = "Packet of type \\d+ \\([\\sa-zA-Z:]+\\) received from unknown node with UUID";
-            //static QString repeatedMessage
-            //    = LogHandler::getInstance().addRepeatedMessageRegex(UNKNOWN_REGEX);
-            //qCDebug(networking) << "Packet of type" << headerType
-            //    << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID);
-
-            HIFI_FDEBUG(networking,
+            HIFI_FDEBUG(networking(),
                 "Packet of type" << headerType << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID));
         }
     }

--- a/libraries/networking/src/NetworkLogging.h
+++ b/libraries/networking/src/NetworkLogging.h
@@ -20,16 +20,4 @@ Q_DECLARE_LOGGING_CATEGORY(asset_client)
 Q_DECLARE_LOGGING_CATEGORY(entity_script_client)
 Q_DECLARE_LOGGING_CATEGORY(messages_client)
 
-#define HIFI_FDEBUG(category, msg) \
-    do { \
-        if (category().isDebugEnabled()) { \
-            static int repeatedMessageID_ = LogHandler::getInstance().newRepeatedMessageID(); \
-            QString logString_; \
-            QDebug debugString_(&logString_); \
-            debugString_ << msg; \
-            LogHandler::getInstance().printRepeatedMessage(repeatedMessageID_, LogDebug, QMessageLogContext(__FILE__, \
-                __LINE__, __func__, category().categoryName()), logString_); \
-        } \
-    } while (false)
-
 #endif // hifi_NetworkLogging_h

--- a/libraries/networking/src/NetworkLogging.h
+++ b/libraries/networking/src/NetworkLogging.h
@@ -20,4 +20,15 @@ Q_DECLARE_LOGGING_CATEGORY(asset_client)
 Q_DECLARE_LOGGING_CATEGORY(entity_script_client)
 Q_DECLARE_LOGGING_CATEGORY(messages_client)
 
+#define HIFI_FDEBUG(category, msg) \
+    do { \
+        if (category().isDebugEnabled()) { \
+            static int repeatedMessageID_ = LogHandler::getInstance().newRepeatedMessageID(); \
+            QString logString_; \
+            QDebug debugString_(&logString_); \
+            debugString_ << msg; \
+            LogHandler::getInstance().printRepeatedMessage(repeatedMessageID_, LogDebug, QMessageLogContext(), logString_); \
+        } \
+    } while (false)
+
 #endif // hifi_NetworkLogging_h

--- a/libraries/networking/src/NetworkLogging.h
+++ b/libraries/networking/src/NetworkLogging.h
@@ -27,7 +27,8 @@ Q_DECLARE_LOGGING_CATEGORY(messages_client)
             QString logString_; \
             QDebug debugString_(&logString_); \
             debugString_ << msg; \
-            LogHandler::getInstance().printRepeatedMessage(repeatedMessageID_, LogDebug, QMessageLogContext(), logString_); \
+            LogHandler::getInstance().printRepeatedMessage(repeatedMessageID_, LogDebug, QMessageLogContext(__FILE__, \
+                __LINE__, __func__, category().categoryName()), logString_); \
         } \
     } while (false)
 

--- a/libraries/networking/src/SequenceNumberStats.cpp
+++ b/libraries/networking/src/SequenceNumberStats.cpp
@@ -89,7 +89,7 @@ SequenceNumberStats::ArrivalInfo SequenceNumberStats::sequenceNumberReceived(qui
         } else if (absGap > MAX_REASONABLE_SEQUENCE_GAP) {
             arrivalInfo._status = Unreasonable;
 
-            HIFI_FDEBUG(networking(), "unreasonable sequence number:" << incoming << "previous:" << _lastReceivedSequence);
+            HIFI_FCDEBUG(networking(), "unreasonable sequence number:" << incoming << "previous:" << _lastReceivedSequence);
 
             _stats._unreasonable++;
             
@@ -151,7 +151,7 @@ SequenceNumberStats::ArrivalInfo SequenceNumberStats::sequenceNumberReceived(qui
 
                 arrivalInfo._status = Unreasonable;
 
-                HIFI_FDEBUG(networking(), "unreasonable sequence number:" << incoming << "(possible duplicate)");
+                HIFI_FCDEBUG(networking(), "unreasonable sequence number:" << incoming << "(possible duplicate)");
 
                 _stats._unreasonable++;
 

--- a/libraries/networking/src/SequenceNumberStats.cpp
+++ b/libraries/networking/src/SequenceNumberStats.cpp
@@ -89,10 +89,7 @@ SequenceNumberStats::ArrivalInfo SequenceNumberStats::sequenceNumberReceived(qui
         } else if (absGap > MAX_REASONABLE_SEQUENCE_GAP) {
             arrivalInfo._status = Unreasonable;
 
-            static const QString UNREASONABLE_SEQUENCE_REGEX { "unreasonable sequence number: \\d+ previous: \\d+" };
-            static QString repeatedMessage = LogHandler::getInstance().addRepeatedMessageRegex(UNREASONABLE_SEQUENCE_REGEX);
-
-            qCDebug(networking) << "unreasonable sequence number:" << incoming << "previous:" << _lastReceivedSequence;
+            HIFI_FDEBUG(networking(), "unreasonable sequence number:" << incoming << "previous:" << _lastReceivedSequence);
 
             _stats._unreasonable++;
             
@@ -154,10 +151,7 @@ SequenceNumberStats::ArrivalInfo SequenceNumberStats::sequenceNumberReceived(qui
 
                 arrivalInfo._status = Unreasonable;
 
-                static const QString UNREASONABLE_SEQUENCE_REGEX { "unreasonable sequence number: \\d+ \\(possible duplicate\\)" };
-                static QString repeatedMessage = LogHandler::getInstance().addRepeatedMessageRegex(UNREASONABLE_SEQUENCE_REGEX);
-
-                qCDebug(networking) << "unreasonable sequence number:" << incoming << "(possible duplicate)";
+                HIFI_FDEBUG(networking(), "unreasonable sequence number:" << incoming << "(possible duplicate)");
 
                 _stats._unreasonable++;
 

--- a/libraries/networking/src/udt/Packet.cpp
+++ b/libraries/networking/src/udt/Packet.cpp
@@ -107,7 +107,7 @@ Packet::Packet(std::unique_ptr<char[]> data, qint64 size, const HifiSockAddr& se
                                           QString::number(getMessagePartNumber()));
         }
 
-        HIFI_FDEBUG(networking(), debugString);
+        HIFI_FCDEBUG(networking(), debugString);
 #endif
 
         obfuscate(NoObfuscation); // Undo obfuscation

--- a/libraries/networking/src/udt/Packet.cpp
+++ b/libraries/networking/src/udt/Packet.cpp
@@ -107,8 +107,7 @@ Packet::Packet(std::unique_ptr<char[]> data, qint64 size, const HifiSockAddr& se
                                           QString::number(getMessagePartNumber()));
         }
 
-        static QString repeatedMessage = LogHandler::getInstance().addRepeatedMessageRegex("^Unobfuscating packet .*");
-        qCDebug(networking) << qPrintable(debugString);
+        HIFI_FDEBUG(networking(), debugString);
 #endif
 
         obfuscate(NoObfuscation); // Undo obfuscation

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -479,7 +479,7 @@ bool SendQueue::maybeResendPacket() {
                         debugString = debugString.arg(QString::number(resendPacket.getMessageNumber()),
                                                       QString::number(resendPacket.getMessagePartNumber()));
                     }
-                    HIFI_FDEBUG((*QLoggingCategory::defaultCategory()), debugString);
+                    HIFI_FDEBUG(debugString);
 #endif
 
                     // Create copy of the packet

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -479,8 +479,7 @@ bool SendQueue::maybeResendPacket() {
                         debugString = debugString.arg(QString::number(resendPacket.getMessageNumber()),
                                                       QString::number(resendPacket.getMessagePartNumber()));
                     }
-                    static QString repeatedMessage = LogHandler::getInstance().addRepeatedMessageRegex("^Obfuscating packet .*");
-                    qCritical() << qPrintable(debugString);
+                    HIFI_FDEBUG((*QLoggingCategory::defaultCategory()), debugString);
 #endif
 
                     // Create copy of the packet

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -229,7 +229,7 @@ qint64 Socket::writeDatagram(const QByteArray& datagram, const HifiSockAddr& soc
 
     if (bytesWritten < 0) {
         // when saturating a link this isn't an uncommon message - suppress it so it doesn't bomb the debug
-        HIFI_FDEBUG(networking(), "Socket::writeDatagram" << _udpSocket.error() << "-" << qPrintable(_udpSocket.errorString()) );
+        HIFI_FCDEBUG(networking(), "Socket::writeDatagram" << _udpSocket.error() << "-" << qPrintable(_udpSocket.errorString()) );
     }
 
     return bytesWritten;
@@ -513,7 +513,7 @@ std::vector<HifiSockAddr> Socket::getConnectionSockAddrs() {
 }
 
 void Socket::handleSocketError(QAbstractSocket::SocketError socketError) {
-    HIFI_FDEBUG(networking(), "udt::Socket error - " << socketError << _udpSocket.errorString());
+    HIFI_FCDEBUG(networking(), "udt::Socket error - " << socketError << _udpSocket.errorString());
 }
 
 void Socket::handleStateChanged(QAbstractSocket::SocketState socketState) {

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -229,11 +229,7 @@ qint64 Socket::writeDatagram(const QByteArray& datagram, const HifiSockAddr& soc
 
     if (bytesWritten < 0) {
         // when saturating a link this isn't an uncommon message - suppress it so it doesn't bomb the debug
-        static const QString WRITE_ERROR_REGEX = "Socket::writeDatagram QAbstractSocket::NetworkError - Unable to send a message";
-        static QString repeatedMessage
-            = LogHandler::getInstance().addRepeatedMessageRegex(WRITE_ERROR_REGEX);
-
-        qCDebug(networking) << "Socket::writeDatagram" << _udpSocket.error() << "-" << qPrintable(_udpSocket.errorString());
+        HIFI_FDEBUG(networking(), "Socket::writeDatagram" << _udpSocket.error() << "-" << qPrintable(_udpSocket.errorString()) );
     }
 
     return bytesWritten;
@@ -517,11 +513,7 @@ std::vector<HifiSockAddr> Socket::getConnectionSockAddrs() {
 }
 
 void Socket::handleSocketError(QAbstractSocket::SocketError socketError) {
-    static const QString SOCKET_REGEX = "udt::Socket error - ";
-    static QString repeatedMessage
-        = LogHandler::getInstance().addRepeatedMessageRegex(SOCKET_REGEX);
-
-    qCDebug(networking) << "udt::Socket error - " << socketError << _udpSocket.errorString();
+    HIFI_FDEBUG(networking(), "udt::Socket error - " << socketError << _udpSocket.errorString());
 }
 
 void Socket::handleStateChanged(QAbstractSocket::SocketState socketState) {

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -121,11 +121,7 @@ void Octree::recurseTreeWithPostOperation(const RecurseOctreeOperation& operatio
 void Octree::recurseElementWithOperation(const OctreeElementPointer& element, const RecurseOctreeOperation& operation, void* extraData,
                         int recursionCount) {
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        static QString repeatedMessage
-            = LogHandler::getInstance().addRepeatedMessageRegex(
-                    "Octree::recurseElementWithOperation\\(\\) reached DANGEROUSLY_DEEP_RECURSION, bailing!");
-
-        qCDebug(octree) << "Octree::recurseElementWithOperation() reached DANGEROUSLY_DEEP_RECURSION, bailing!";
+        HIFI_FDEBUG(octree(), "Octree::recurseElementWithOperation() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return;
     }
 
@@ -143,11 +139,7 @@ void Octree::recurseElementWithOperation(const OctreeElementPointer& element, co
 void Octree::recurseElementWithPostOperation(const OctreeElementPointer& element, const RecurseOctreeOperation& operation,
                                              void* extraData, int recursionCount) {
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        static QString repeatedMessage
-            = LogHandler::getInstance().addRepeatedMessageRegex(
-                    "Octree::recurseElementWithPostOperation\\(\\) reached DANGEROUSLY_DEEP_RECURSION, bailing!");
-
-        qCDebug(octree) << "Octree::recurseElementWithPostOperation() reached DANGEROUSLY_DEEP_RECURSION, bailing!";
+        HIFI_FDEBUG(octree(), "Octree::recurseElementWithPostOperation() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return;
     }
 
@@ -173,11 +165,7 @@ void Octree::recurseElementWithOperationDistanceSorted(const OctreeElementPointe
                                                        const glm::vec3& point, void* extraData, int recursionCount) {
 
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        static QString repeatedMessage
-            = LogHandler::getInstance().addRepeatedMessageRegex(
-                    "Octree::recurseElementWithOperationDistanceSorted\\(\\) reached DANGEROUSLY_DEEP_RECURSION, bailing!");
-
-        qCDebug(octree) << "Octree::recurseElementWithOperationDistanceSorted() reached DANGEROUSLY_DEEP_RECURSION, bailing!";
+        HIFI_FDEBUG(octree(), "Octree::recurseElementWithOperationDistanceSorted() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return;
     }
 
@@ -215,11 +203,7 @@ void Octree::recurseTreeWithOperator(RecurseOctreeOperator* operatorObject) {
 bool Octree::recurseElementWithOperator(const OctreeElementPointer& element,
                                         RecurseOctreeOperator* operatorObject, int recursionCount) {
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        static QString repeatedMessage
-            = LogHandler::getInstance().addRepeatedMessageRegex(
-                    "Octree::recurseElementWithOperator\\(\\) reached DANGEROUSLY_DEEP_RECURSION, bailing!");
-
-        qCDebug(octree) << "Octree::recurseElementWithOperator() reached DANGEROUSLY_DEEP_RECURSION, bailing!";
+        HIFI_FDEBUG(octree(), "Octree::recurseElementWithOperator() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return false;
     }
 
@@ -285,11 +269,7 @@ OctreeElementPointer Octree::createMissingElement(const OctreeElementPointer& la
                                                   const unsigned char* codeToReach, int recursionCount) {
 
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        static QString repeatedMessage
-            = LogHandler::getInstance().addRepeatedMessageRegex(
-                    "Octree::createMissingElement\\(\\) reached DANGEROUSLY_DEEP_RECURSION, bailing!");
-
-        qCDebug(octree) << "Octree::createMissingElement() reached DANGEROUSLY_DEEP_RECURSION, bailing!";
+        HIFI_FDEBUG(octree(), "Octree::createMissingElement() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return lastParentElement;
     }
     int indexOfNewChild = branchIndexWithDescendant(lastParentElement->getOctalCode(), codeToReach);
@@ -446,16 +426,9 @@ void Octree::readBitstreamToTree(const unsigned char * bitstream, uint64_t buffe
                                                                      (unsigned char *)bitstreamAt, NULL);
         int numberOfThreeBitSectionsInStream = numberOfThreeBitSectionsInCode(bitstreamAt, bufferSizeBytes);
         if (numberOfThreeBitSectionsInStream > UNREASONABLY_DEEP_RECURSION) {
-            static QString repeatedMessage
-                = LogHandler::getInstance().addRepeatedMessageRegex(
-                        "UNEXPECTED: parsing of the octal code would make UNREASONABLY_DEEP_RECURSION... "
-                        "numberOfThreeBitSectionsInStream: \\d+ This buffer is corrupt. Returning."
-                    );
-
-
-            qCDebug(octree) << "UNEXPECTED: parsing of the octal code would make UNREASONABLY_DEEP_RECURSION... "
+            HIFI_FDEBUG(octree(), "UNEXPECTED: parsing of the octal code would make UNREASONABLY_DEEP_RECURSION... "
                         "numberOfThreeBitSectionsInStream:" << numberOfThreeBitSectionsInStream <<
-                        "This buffer is corrupt. Returning.";
+                        "This buffer is corrupt. Returning.");
             return;
         }
 

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -121,7 +121,7 @@ void Octree::recurseTreeWithPostOperation(const RecurseOctreeOperation& operatio
 void Octree::recurseElementWithOperation(const OctreeElementPointer& element, const RecurseOctreeOperation& operation, void* extraData,
                         int recursionCount) {
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        HIFI_FDEBUG(octree(), "Octree::recurseElementWithOperation() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
+        HIFI_FCDEBUG(octree(), "Octree::recurseElementWithOperation() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return;
     }
 
@@ -139,7 +139,7 @@ void Octree::recurseElementWithOperation(const OctreeElementPointer& element, co
 void Octree::recurseElementWithPostOperation(const OctreeElementPointer& element, const RecurseOctreeOperation& operation,
                                              void* extraData, int recursionCount) {
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        HIFI_FDEBUG(octree(), "Octree::recurseElementWithPostOperation() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
+        HIFI_FCDEBUG(octree(), "Octree::recurseElementWithPostOperation() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return;
     }
 
@@ -165,7 +165,7 @@ void Octree::recurseElementWithOperationDistanceSorted(const OctreeElementPointe
                                                        const glm::vec3& point, void* extraData, int recursionCount) {
 
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        HIFI_FDEBUG(octree(), "Octree::recurseElementWithOperationDistanceSorted() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
+        HIFI_FCDEBUG(octree(), "Octree::recurseElementWithOperationDistanceSorted() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return;
     }
 
@@ -203,7 +203,7 @@ void Octree::recurseTreeWithOperator(RecurseOctreeOperator* operatorObject) {
 bool Octree::recurseElementWithOperator(const OctreeElementPointer& element,
                                         RecurseOctreeOperator* operatorObject, int recursionCount) {
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        HIFI_FDEBUG(octree(), "Octree::recurseElementWithOperator() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
+        HIFI_FCDEBUG(octree(), "Octree::recurseElementWithOperator() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return false;
     }
 
@@ -269,7 +269,7 @@ OctreeElementPointer Octree::createMissingElement(const OctreeElementPointer& la
                                                   const unsigned char* codeToReach, int recursionCount) {
 
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        HIFI_FDEBUG(octree(), "Octree::createMissingElement() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
+        HIFI_FCDEBUG(octree(), "Octree::createMissingElement() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return lastParentElement;
     }
     int indexOfNewChild = branchIndexWithDescendant(lastParentElement->getOctalCode(), codeToReach);
@@ -426,7 +426,7 @@ void Octree::readBitstreamToTree(const unsigned char * bitstream, uint64_t buffe
                                                                      (unsigned char *)bitstreamAt, NULL);
         int numberOfThreeBitSectionsInStream = numberOfThreeBitSectionsInCode(bitstreamAt, bufferSizeBytes);
         if (numberOfThreeBitSectionsInStream > UNREASONABLY_DEEP_RECURSION) {
-            HIFI_FDEBUG(octree(), "UNEXPECTED: parsing of the octal code would make UNREASONABLY_DEEP_RECURSION... "
+            HIFI_FCDEBUG(octree(), "UNEXPECTED: parsing of the octal code would make UNREASONABLY_DEEP_RECURSION... "
                         "numberOfThreeBitSectionsInStream:" << numberOfThreeBitSectionsInStream <<
                         "This buffer is corrupt. Returning.");
             return;

--- a/libraries/octree/src/OctreeElement.cpp
+++ b/libraries/octree/src/OctreeElement.cpp
@@ -401,11 +401,7 @@ OctreeElementPointer OctreeElement::addChildAtIndex(int childIndex) {
 bool OctreeElement::safeDeepDeleteChildAtIndex(int childIndex, int recursionCount) {
     bool deleteApproved = false;
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        static QString repeatedMessage
-            = LogHandler::getInstance().addRepeatedMessageRegex(
-                    "OctreeElement::safeDeepDeleteChildAtIndex\\(\\) reached DANGEROUSLY_DEEP_RECURSION, bailing!");
-
-        qCDebug(octree) << "OctreeElement::safeDeepDeleteChildAtIndex() reached DANGEROUSLY_DEEP_RECURSION, bailing!";
+        HIFI_FDEBUG(octree(), "OctreeElement::safeDeepDeleteChildAtIndex() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return deleteApproved;
     }
     OctreeElementPointer childToDelete = getChildAtIndex(childIndex);

--- a/libraries/octree/src/OctreeElement.cpp
+++ b/libraries/octree/src/OctreeElement.cpp
@@ -401,7 +401,7 @@ OctreeElementPointer OctreeElement::addChildAtIndex(int childIndex) {
 bool OctreeElement::safeDeepDeleteChildAtIndex(int childIndex, int recursionCount) {
     bool deleteApproved = false;
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        HIFI_FDEBUG(octree(), "OctreeElement::safeDeepDeleteChildAtIndex() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
+        HIFI_FCDEBUG(octree(), "OctreeElement::safeDeepDeleteChildAtIndex() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
         return deleteApproved;
     }
     OctreeElementPointer childToDelete = getChildAtIndex(childIndex);

--- a/libraries/octree/src/OctreeSceneStats.cpp
+++ b/libraries/octree/src/OctreeSceneStats.cpp
@@ -636,12 +636,8 @@ void OctreeSceneStats::trackIncomingOctreePacket(ReceivedMessage& message, bool 
     const qint64 MAX_RESONABLE_FLIGHT_TIME = 200 * USECS_PER_SECOND; // 200 seconds is more than enough time for a packet to arrive
     const qint64 MIN_RESONABLE_FLIGHT_TIME = -1 * (qint64)USECS_PER_SECOND; // more than 1 second of "reverse flight time" would be unreasonable
     if (flightTime > MAX_RESONABLE_FLIGHT_TIME || flightTime < MIN_RESONABLE_FLIGHT_TIME) {
-        static QString repeatedMessage
-            = LogHandler::getInstance().addRepeatedMessageRegex(
-                    "ignoring unreasonable packet... flightTime: -?\\d+ nodeClockSkewUsec: -?\\d+ usecs");
-
-        qCDebug(octree) << "ignoring unreasonable packet... flightTime:" << flightTime
-                    << "nodeClockSkewUsec:" << nodeClockSkewUsec << "usecs";;
+        HIFI_FDEBUG(octree(), "ignoring unreasonable packet... flightTime:" << flightTime
+                    << "nodeClockSkewUsec:" << nodeClockSkewUsec << "usecs");
         return; // ignore any packets that are unreasonable
     }
 

--- a/libraries/octree/src/OctreeSceneStats.cpp
+++ b/libraries/octree/src/OctreeSceneStats.cpp
@@ -636,7 +636,7 @@ void OctreeSceneStats::trackIncomingOctreePacket(ReceivedMessage& message, bool 
     const qint64 MAX_RESONABLE_FLIGHT_TIME = 200 * USECS_PER_SECOND; // 200 seconds is more than enough time for a packet to arrive
     const qint64 MIN_RESONABLE_FLIGHT_TIME = -1 * (qint64)USECS_PER_SECOND; // more than 1 second of "reverse flight time" would be unreasonable
     if (flightTime > MAX_RESONABLE_FLIGHT_TIME || flightTime < MIN_RESONABLE_FLIGHT_TIME) {
-        HIFI_FDEBUG(octree(), "ignoring unreasonable packet... flightTime:" << flightTime
+        HIFI_FCDEBUG(octree(), "ignoring unreasonable packet... flightTime:" << flightTime
                     << "nodeClockSkewUsec:" << nodeClockSkewUsec << "usecs");
         return; // ignore any packets that are unreasonable
     }

--- a/libraries/physics/src/ObjectConstraintBallSocket.cpp
+++ b/libraries/physics/src/ObjectConstraintBallSocket.cpp
@@ -85,12 +85,9 @@ btTypedConstraint* ObjectConstraintBallSocket::getConstraint() {
         return constraint;
     }
 
-    static QString repeatedBallSocketNoRigidBody = LogHandler::getInstance().addRepeatedMessageRegex(
-        "ObjectConstraintBallSocket::getConstraint -- no rigidBody.*");
-
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        qCDebug(physics) << "ObjectConstraintBallSocket::getConstraint -- no rigidBodyA";
+        HIFI_FDEBUG(physics(), "ObjectConstraintBallSocket::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -99,7 +96,7 @@ btTypedConstraint* ObjectConstraintBallSocket::getConstraint() {
 
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            qCDebug(physics) << "ObjectConstraintBallSocket::getConstraint -- no rigidBodyB";
+            HIFI_FDEBUG(physics(), "ObjectConstraintBallSocket::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintBallSocket.cpp
+++ b/libraries/physics/src/ObjectConstraintBallSocket.cpp
@@ -85,9 +85,11 @@ btTypedConstraint* ObjectConstraintBallSocket::getConstraint() {
         return constraint;
     }
 
+    static int repeatMessageID = LogHandler::getInstance().newRepeatedMessageID();
+
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        HIFI_FCDEBUG(physics(), "ObjectConstraintBallSocket::getConstraint -- no rigidBodyA");
+        HIFI_FCDEBUG_ID(physics(), repeatMessageID, "ObjectConstraintBallSocket::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -96,7 +98,7 @@ btTypedConstraint* ObjectConstraintBallSocket::getConstraint() {
 
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            HIFI_FCDEBUG(physics(), "ObjectConstraintBallSocket::getConstraint -- no rigidBodyB");
+            HIFI_FCDEBUG_ID(physics(), repeatMessageID, "ObjectConstraintBallSocket::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintBallSocket.cpp
+++ b/libraries/physics/src/ObjectConstraintBallSocket.cpp
@@ -87,7 +87,7 @@ btTypedConstraint* ObjectConstraintBallSocket::getConstraint() {
 
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        HIFI_FDEBUG(physics(), "ObjectConstraintBallSocket::getConstraint -- no rigidBodyA");
+        HIFI_FCDEBUG(physics(), "ObjectConstraintBallSocket::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -96,7 +96,7 @@ btTypedConstraint* ObjectConstraintBallSocket::getConstraint() {
 
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            HIFI_FDEBUG(physics(), "ObjectConstraintBallSocket::getConstraint -- no rigidBodyB");
+            HIFI_FCDEBUG(physics(), "ObjectConstraintBallSocket::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintConeTwist.cpp
+++ b/libraries/physics/src/ObjectConstraintConeTwist.cpp
@@ -96,12 +96,9 @@ btTypedConstraint* ObjectConstraintConeTwist::getConstraint() {
         return constraint;
     }
 
-    static QString repeatedConeTwistNoRigidBody = LogHandler::getInstance().addRepeatedMessageRegex(
-        "ObjectConstraintConeTwist::getConstraint -- no rigidBody.*");
-
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        qCDebug(physics) << "ObjectConstraintConeTwist::getConstraint -- no rigidBodyA";
+        HIFI_FDEBUG(physics(), "ObjectConstraintConeTwist::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -130,7 +127,7 @@ btTypedConstraint* ObjectConstraintConeTwist::getConstraint() {
 
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            qCDebug(physics) << "ObjectConstraintConeTwist::getConstraint -- no rigidBodyB";
+            HIFI_FDEBUG(physics(), "ObjectConstraintConeTwist::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintConeTwist.cpp
+++ b/libraries/physics/src/ObjectConstraintConeTwist.cpp
@@ -98,7 +98,7 @@ btTypedConstraint* ObjectConstraintConeTwist::getConstraint() {
 
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        HIFI_FDEBUG(physics(), "ObjectConstraintConeTwist::getConstraint -- no rigidBodyA");
+        HIFI_FCDEBUG(physics(), "ObjectConstraintConeTwist::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -127,7 +127,7 @@ btTypedConstraint* ObjectConstraintConeTwist::getConstraint() {
 
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            HIFI_FDEBUG(physics(), "ObjectConstraintConeTwist::getConstraint -- no rigidBodyB");
+            HIFI_FCDEBUG(physics(), "ObjectConstraintConeTwist::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintConeTwist.cpp
+++ b/libraries/physics/src/ObjectConstraintConeTwist.cpp
@@ -96,9 +96,11 @@ btTypedConstraint* ObjectConstraintConeTwist::getConstraint() {
         return constraint;
     }
 
+    static int repeatMessageID = LogHandler::getInstance().newRepeatedMessageID();
+
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        HIFI_FCDEBUG(physics(), "ObjectConstraintConeTwist::getConstraint -- no rigidBodyA");
+        HIFI_FCDEBUG_ID(physics(), repeatMessageID, "ObjectConstraintConeTwist::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -127,7 +129,7 @@ btTypedConstraint* ObjectConstraintConeTwist::getConstraint() {
 
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            HIFI_FCDEBUG(physics(), "ObjectConstraintConeTwist::getConstraint -- no rigidBodyB");
+            HIFI_FCDEBUG_ID(physics(), repeatMessageID, "ObjectConstraintConeTwist::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintHinge.cpp
+++ b/libraries/physics/src/ObjectConstraintHinge.cpp
@@ -95,12 +95,9 @@ btTypedConstraint* ObjectConstraintHinge::getConstraint() {
         return constraint;
     }
 
-    static QString repeatedHingeNoRigidBody = LogHandler::getInstance().addRepeatedMessageRegex(
-        "ObjectConstraintHinge::getConstraint -- no rigidBody.*");
-
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        qCDebug(physics) << "ObjectConstraintHinge::getConstraint -- no rigidBodyA";
+        HIFI_FDEBUG(physics(), "ObjectConstraintHinge::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -115,7 +112,7 @@ btTypedConstraint* ObjectConstraintHinge::getConstraint() {
         // This hinge is between two entities... find the other rigid body.
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            qCDebug(physics) << "ObjectConstraintHinge::getConstraint -- no rigidBodyB";
+            HIFI_FDEBUG(physics(), "ObjectConstraintHinge::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintHinge.cpp
+++ b/libraries/physics/src/ObjectConstraintHinge.cpp
@@ -97,7 +97,7 @@ btTypedConstraint* ObjectConstraintHinge::getConstraint() {
 
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        HIFI_FDEBUG(physics(), "ObjectConstraintHinge::getConstraint -- no rigidBodyA");
+        HIFI_FCDEBUG(physics(), "ObjectConstraintHinge::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -112,7 +112,7 @@ btTypedConstraint* ObjectConstraintHinge::getConstraint() {
         // This hinge is between two entities... find the other rigid body.
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            HIFI_FDEBUG(physics(), "ObjectConstraintHinge::getConstraint -- no rigidBodyB");
+            HIFI_FCDEBUG(physics(), "ObjectConstraintHinge::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintHinge.cpp
+++ b/libraries/physics/src/ObjectConstraintHinge.cpp
@@ -94,10 +94,12 @@ btTypedConstraint* ObjectConstraintHinge::getConstraint() {
     if (constraint) {
         return constraint;
     }
+    
+    static int repeatMessageID = LogHandler::getInstance().newRepeatedMessageID();
 
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        HIFI_FCDEBUG(physics(), "ObjectConstraintHinge::getConstraint -- no rigidBodyA");
+        HIFI_FCDEBUG_ID(physics(), repeatMessageID, "ObjectConstraintHinge::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -112,7 +114,7 @@ btTypedConstraint* ObjectConstraintHinge::getConstraint() {
         // This hinge is between two entities... find the other rigid body.
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            HIFI_FCDEBUG(physics(), "ObjectConstraintHinge::getConstraint -- no rigidBodyB");
+            HIFI_FCDEBUG_ID(physics(), repeatMessageID, "ObjectConstraintHinge::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintSlider.cpp
+++ b/libraries/physics/src/ObjectConstraintSlider.cpp
@@ -87,9 +87,11 @@ btTypedConstraint* ObjectConstraintSlider::getConstraint() {
         return constraint;
     }
 
+    static int repeatMessageID = LogHandler::getInstance().newRepeatedMessageID();
+
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        HIFI_FCDEBUG(physics(), "ObjectConstraintSlider::getConstraint -- no rigidBodyA");
+        HIFI_FCDEBUG_ID(physics(), repeatMessageID, "ObjectConstraintSlider::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -118,7 +120,7 @@ btTypedConstraint* ObjectConstraintSlider::getConstraint() {
 
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            HIFI_FCDEBUG(physics(), "ObjectConstraintSlider::getConstraint -- no rigidBodyB");
+            HIFI_FCDEBUG_ID(physics(), repeatMessageID, "ObjectConstraintSlider::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintSlider.cpp
+++ b/libraries/physics/src/ObjectConstraintSlider.cpp
@@ -87,12 +87,9 @@ btTypedConstraint* ObjectConstraintSlider::getConstraint() {
         return constraint;
     }
 
-    static QString repeatedSliderNoRigidBody = LogHandler::getInstance().addRepeatedMessageRegex(
-        "ObjectConstraintSlider::getConstraint -- no rigidBody.*");
-
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        qCDebug(physics) << "ObjectConstraintSlider::getConstraint -- no rigidBodyA";
+        HIFI_FDEBUG(physics(), "ObjectConstraintSlider::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -121,7 +118,7 @@ btTypedConstraint* ObjectConstraintSlider::getConstraint() {
 
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            qCDebug(physics) << "ObjectConstraintSlider::getConstraint -- no rigidBodyB";
+            HIFI_FDEBUG(physics(), "ObjectConstraintSlider::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/physics/src/ObjectConstraintSlider.cpp
+++ b/libraries/physics/src/ObjectConstraintSlider.cpp
@@ -89,7 +89,7 @@ btTypedConstraint* ObjectConstraintSlider::getConstraint() {
 
     btRigidBody* rigidBodyA = getRigidBody();
     if (!rigidBodyA) {
-        HIFI_FDEBUG(physics(), "ObjectConstraintSlider::getConstraint -- no rigidBodyA");
+        HIFI_FCDEBUG(physics(), "ObjectConstraintSlider::getConstraint -- no rigidBodyA");
         return nullptr;
     }
 
@@ -118,7 +118,7 @@ btTypedConstraint* ObjectConstraintSlider::getConstraint() {
 
         btRigidBody* rigidBodyB = getOtherRigidBody(otherEntityID);
         if (!rigidBodyB) {
-            HIFI_FDEBUG(physics(), "ObjectConstraintSlider::getConstraint -- no rigidBodyB");
+            HIFI_FCDEBUG(physics(), "ObjectConstraintSlider::getConstraint -- no rigidBodyB");
             return nullptr;
         }
 

--- a/libraries/render-utils/src/BackgroundStage.cpp
+++ b/libraries/render-utils/src/BackgroundStage.cpp
@@ -126,9 +126,6 @@ void DrawBackgroundStage::run(const render::RenderContextPointer& renderContext,
             if (defaultSkyboxAmbientTexture) {
                 sceneKeyLight->setAmbientSphere(defaultSkyboxAmbientTexture->getIrradiance());
                 sceneKeyLight->setAmbientMap(defaultSkyboxAmbientTexture);
-            } else {
-                static QString repeatedMessage = LogHandler::getInstance().addRepeatedMessageRegex(
-                    "Failed to get a valid Default Skybox Ambient Texture ? probably because it couldn't be find during initialization step");
             }
             // fall through: render defaults skybox
         } else {

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -60,8 +60,8 @@ void renderShape(RenderArgs* args, const ShapePlumberPointer& shapeContext, cons
     } else if (key.hasOwnPipeline()) {
         item.render(args);
     } else {
-        std::call_once(messageIDFlag, [](int& id) { id = LogHandler::getInstance().newRepeatedMessageID(); },
-                           repeatedInvalidKeyMessageID);
+        std::call_once(messageIDFlag, [](int* id) { *id = LogHandler::getInstance().newRepeatedMessageID(); },
+                           &repeatedInvalidKeyMessageID);
         HIFI_FCDEBUG_ID(renderlogging(), repeatedInvalidKeyMessageID, "Item could not be rendered with invalid key" << key);
     }
     args->_itemShapeKey = 0;
@@ -113,8 +113,8 @@ void render::renderStateSortShapes(const RenderContextPointer& renderContext,
             } else if (key.hasOwnPipeline()) {
                 ownPipelineBucket.push_back( std::make_tuple(item, key) );
             } else {
-                std::call_once(messageIDFlag, [](int& id) { id = LogHandler::getInstance().newRepeatedMessageID(); },
-                    repeatedInvalidKeyMessageID);
+                std::call_once(messageIDFlag, [](int* id) { *id = LogHandler::getInstance().newRepeatedMessageID(); },
+                    &repeatedInvalidKeyMessageID);
                 HIFI_FCDEBUG_ID(renderlogging(), repeatedInvalidKeyMessageID, "Item could not be rendered with invalid key" << key);
             }
         }

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -55,9 +55,7 @@ void renderShape(RenderArgs* args, const ShapePlumberPointer& shapeContext, cons
     } else if (key.hasOwnPipeline()) {
         item.render(args);
     } else {
-        qCDebug(renderlogging) << "Item could not be rendered with invalid key" << key;
-        static QString repeatedCouldNotBeRendered = LogHandler::getInstance().addRepeatedMessageRegex(
-            "Item could not be rendered with invalid key.*");
+        HIFI_FDEBUG(renderlogging(), "Item could not be rendered with invalid key" << key);
     }
     args->_itemShapeKey = 0;
 }
@@ -108,9 +106,7 @@ void render::renderStateSortShapes(const RenderContextPointer& renderContext,
             } else if (key.hasOwnPipeline()) {
                 ownPipelineBucket.push_back( std::make_tuple(item, key) );
             } else {
-                static QString repeatedCouldNotBeRendered = LogHandler::getInstance().addRepeatedMessageRegex(
-                    "Item could not be rendered with invalid key.*");
-                qCDebug(renderlogging) << "Item could not be rendered with invalid key" << key;
+                HIFI_FDEBUG(renderlogging(), "Item could not be rendered with invalid key" << key);
             }
         }
     }

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -55,7 +55,7 @@ void renderShape(RenderArgs* args, const ShapePlumberPointer& shapeContext, cons
     } else if (key.hasOwnPipeline()) {
         item.render(args);
     } else {
-        HIFI_FDEBUG(renderlogging(), "Item could not be rendered with invalid key" << key);
+        HIFI_FCDEBUG(renderlogging(), "Item could not be rendered with invalid key" << key);
     }
     args->_itemShapeKey = 0;
 }
@@ -106,7 +106,7 @@ void render::renderStateSortShapes(const RenderContextPointer& renderContext,
             } else if (key.hasOwnPipeline()) {
                 ownPipelineBucket.push_back( std::make_tuple(item, key) );
             } else {
-                HIFI_FDEBUG(renderlogging(), "Item could not be rendered with invalid key" << key);
+                HIFI_FCDEBUG(renderlogging(), "Item could not be rendered with invalid key" << key);
             }
         }
     }

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -41,6 +41,11 @@ void render::renderItems(const RenderContextPointer& renderContext, const ItemBo
     }
 }
 
+namespace {
+    int repeatedInvalidKeyMessageID = 0;
+    std::atomic<int> messageIDInit = 0;
+}
+
 void renderShape(RenderArgs* args, const ShapePlumberPointer& shapeContext, const Item& item, const ShapeKey& globalKey) {
     assert(item.getKey().isShape());
     auto key = item.getShapeKey() | globalKey;
@@ -55,7 +60,10 @@ void renderShape(RenderArgs* args, const ShapePlumberPointer& shapeContext, cons
     } else if (key.hasOwnPipeline()) {
         item.render(args);
     } else {
-        HIFI_FCDEBUG(renderlogging(), "Item could not be rendered with invalid key" << key);
+        if (++messageIDInit == 1) {
+            repeatedInvalidKeyMessageID = LogHandler::getInstance().newRepeatedMessageID();
+        }
+        HIFI_FCDEBUG_ID(renderlogging(), repeatedInvalidKeyMessageID, "Item could not be rendered with invalid key" << key);
     }
     args->_itemShapeKey = 0;
 }
@@ -106,7 +114,10 @@ void render::renderStateSortShapes(const RenderContextPointer& renderContext,
             } else if (key.hasOwnPipeline()) {
                 ownPipelineBucket.push_back( std::make_tuple(item, key) );
             } else {
-                HIFI_FCDEBUG(renderlogging(), "Item could not be rendered with invalid key" << key);
+                if (++messageIDInit == 1) {
+                    repeatedInvalidKeyMessageID = LogHandler::getInstance().newRepeatedMessageID();
+                }
+                HIFI_FCDEBUG_ID(renderlogging(), repeatedInvalidKeyMessageID, "Item could not be rendered with invalid key" << key);
             }
         }
     }

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -114,21 +114,6 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
     }
     QMutexLocker lock(&_mutex);
 
-    if (type == LogDebug) {
-        // see if this message is one we should only print once
-        for (auto& onceOnly : _onetimeMessages) {
-            if (onceOnly.regexp.indexIn(message) != -1) {
-                if (onceOnly.messageCount++ == 0) {
-                    // we have a match and haven't yet printed this message.
-                    break;
-                } else {
-                    // We've already printed this message, don't print it again.
-                    return QString();
-                }
-            }
-        }
-    }
-
     // log prefix is in the following format
     // [TIMESTAMP] [DEBUG] [PID] [TID] [TARGET] logged string
 
@@ -182,14 +167,6 @@ void LogHandler::setupRepeatedMessageFlusher() {
         connect(logFlushTimer, &QTimer::timeout, this, &LogHandler::flushRepeatedMessages);
         logFlushTimer->start(VERBOSE_LOG_INTERVAL_SECONDS * 1000);
     });
-}
-
-const QString& LogHandler::addOnlyOnceMessageRegex(const QString& regexString) {
-    QMutexLocker lock(&_mutex);
-    OnceOnlyMessage onetimeMessage;
-    onetimeMessage.regexp = QRegExp(regexString);
-    _onetimeMessages.push_back(onetimeMessage);
-    return regexString;
 }
 
 int LogHandler::newRepeatedMessageID() {

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -36,6 +36,9 @@ LogHandler::LogHandler() {
     // when the log handler is first setup we should print our timezone
     QString timezoneString = "Time zone: " + QDateTime::currentDateTime().toString("t");
     printMessage(LogMsgType::LogInfo, QMessageLogContext(), timezoneString);
+
+    // make sure we setup the repeated message flusher, but do it on the LogHandler thread	
+    QMetaObject::invokeMethod(this, "setupRepeatedMessageFlusher");
 }
 
 LogHandler::~LogHandler() {

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -111,8 +111,8 @@ void LogHandler::flushRepeatedMessages() {
     // New repeat-supress scheme:
     for (int m = 0; m < (int)_repeatCounts.size(); ++m) {
         int repeatCount = _repeatCounts[m];
-        if (m > 1) {
-            QString repeatLogMessage = QString(m) + " repeated log entries - Last entry: \"" + _repeatedMessageStrings[m]
+        if (repeatCount > 1) {
+            QString repeatLogMessage = QString(repeatCount) + " repeated log entries - Last entry: \"" + _repeatedMessageStrings[m]
                 + "\"";
             printMessage(LogSuppressed, QMessageLogContext(), repeatLogMessage);
             _repeatCounts[m] = 0;

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -112,8 +112,8 @@ void LogHandler::flushRepeatedMessages() {
     for (int m = 0; m < (int)_repeatCounts.size(); ++m) {
         int repeatCount = _repeatCounts[m];
         if (repeatCount > 1) {
-            QString repeatLogMessage = QString(repeatCount) + " repeated log entries - Last entry: \"" + _repeatedMessageStrings[m]
-                + "\"";
+            QString repeatLogMessage = QString().setNum(repeatCount) + " repeated log entries - Last entry: \"" 
+                    + _repeatedMessageStrings[m] + "\"";
             printMessage(LogSuppressed, QMessageLogContext(), repeatLogMessage);
             _repeatCounts[m] = 0;
             _repeatedMessageStrings[m] = QString();
@@ -239,8 +239,8 @@ int LogHandler::newRepeatedMessageID() {
     return newMessageId;
 }
 
-void LogHandler::printRepeatedMessage(int messageID, LogMsgType type, const QMessageLogContext & context,
-                                      const QString & message) {
+void LogHandler::printRepeatedMessage(int messageID, LogMsgType type, const QMessageLogContext& context,
+                                      const QString& message) {
     QMutexLocker lock(&_mutex);
     if (messageID >= _currentMessageID) {
         return;

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -173,7 +173,7 @@ int LogHandler::newRepeatedMessageID() {
     QMutexLocker lock(&_mutex);
     int newMessageId = _currentMessageID;
     ++_currentMessageID;
-    RepeatedMessageRecord newRecord { 0 };
+    RepeatedMessageRecord newRecord { 0, QString() };
     _repeatedMessageRecords.push_back(newRecord);
     return newMessageId;
 }

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -53,6 +53,8 @@ public:
 
     const QString& addRepeatedMessageRegex(const QString& regexString);
     const QString& addOnlyOnceMessageRegex(const QString& regexString);
+    int newRepeatedMessageID();
+    void printRepeatedMessage(int messageID, LogMsgType type, const QMessageLogContext& context, const QString &message);
 
 private slots:
     void setupRepeatedMessageFlusher();
@@ -81,6 +83,9 @@ private:
     };
     std::vector<OnceOnlyMessage> _onetimeMessages;
 
+    int _currentMessageID { 0 };
+    std::vector<int> _repeatCounts;
+    std::vector<QString> _repeatedMessageStrings;
     static QMutex _mutex;
 };
 

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -89,4 +89,27 @@ private:
     static QMutex _mutex;
 };
 
+#define HIFI_FDEBUG(category, message) \
+    do { \
+        if (category().isDebugEnabled()) { \
+            static int repeatedMessageID_ = LogHandler::getInstance().newRepeatedMessageID(); \
+            QString logString_; \
+            QDebug debugStringReceiver_(&logString_); \
+            debugStringReceiver_ << message; \
+            LogHandler::getInstance().printRepeatedMessage(repeatedMessageID_, LogDebug, QMessageLogContext(__FILE__, \
+                __LINE__, __func__, category().categoryName()), logString_); \
+        } \
+    } while (false)
+
+#define HIFI_FDEBUG_ID(category, messageID, message) \
+    do { \
+        if (category().isDebugEnabled()) { \
+            QString logString_; \
+            QDebug debugStringReceiver_(&logString_); \
+            debugStringReceiver_ << message; \
+            LogHandler::getInstance().printRepeatedMessage(messageID, LogDebug, QMessageLogContext(__FILE__, \
+                __LINE__, __func__, category().categoryName()), logString_); \
+        } \
+    } while (false)
+
 #endif // hifi_LogHandler_h

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -76,8 +76,11 @@ private:
     std::vector<OnceOnlyMessage> _onetimeMessages;
 
     int _currentMessageID { 0 };
-    std::vector<int> _repeatCounts;
-    std::vector<QString> _repeatedMessageStrings;
+    struct RepeatedMessageRecord {
+        int repeatCount;
+        QString repeatString;
+    };
+    std::vector<RepeatedMessageRecord> _repeatedMessageRecords;
     static QMutex _mutex;
 };
 
@@ -106,6 +109,6 @@ private:
         } \
     } while (false)
 
-#define HIFI_FDEBUG_ID(message) HIFI_FCDEBUG_ID((*QLoggingCategory::defaultCategory()), message)
+#define HIFI_FDEBUG_ID(messageID, message) HIFI_FCDEBUG_ID((*QLoggingCategory::defaultCategory()), messageID, message)
 
 #endif // hifi_LogHandler_h

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -81,7 +81,7 @@ private:
     static QMutex _mutex;
 };
 
-#define HIFI_FDEBUG(category, message) \
+#define HIFI_FCDEBUG(category, message) \
     do { \
         if (category.isDebugEnabled()) { \
             static int repeatedMessageID_ = LogHandler::getInstance().newRepeatedMessageID(); \
@@ -93,9 +93,11 @@ private:
         } \
     } while (false)
 
-#define HIFI_FDEBUG_ID(category, messageID, message) \
+#define HIFI_FDEBUG(message) HIFI_FCDEBUG((*QLoggingCategory::defaultCategory()), message)
+   
+#define HIFI_FCDEBUG_ID(category, messageID, message) \
     do { \
-        if (category().isDebugEnabled()) { \
+        if (category.isDebugEnabled()) { \
             QString logString_; \
             QDebug debugStringReceiver_(&logString_); \
             debugStringReceiver_ << message; \
@@ -103,5 +105,7 @@ private:
                 __LINE__, __func__, category().categoryName()), logString_); \
         } \
     } while (false)
+
+#define HIFI_FDEBUG_ID(message) HIFI_FCDEBUG_ID((*QLoggingCategory::defaultCategory()), message)
 
 #endif // hifi_LogHandler_h

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -51,7 +51,6 @@ public:
     /// prints various process, message type, and time information
     static void verboseMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &message);
 
-    const QString& addRepeatedMessageRegex(const QString& regexString);
     const QString& addOnlyOnceMessageRegex(const QString& regexString);
     int newRepeatedMessageID();
     void printRepeatedMessage(int messageID, LogMsgType type, const QMessageLogContext& context, const QString &message);
@@ -70,13 +69,6 @@ private:
     bool _shouldOutputThreadID { false };
     bool _shouldDisplayMilliseconds { false };
 
-    struct RepeatedMessage {
-        QRegExp regexp;
-        int messageCount { 0 };
-        QString lastMessage;
-    };
-    std::vector<RepeatedMessage> _repeatedMessages;
-
     struct OnceOnlyMessage {
         QRegExp regexp;
         int messageCount { 0 };
@@ -91,7 +83,7 @@ private:
 
 #define HIFI_FDEBUG(category, message) \
     do { \
-        if (category().isDebugEnabled()) { \
+        if (category.isDebugEnabled()) { \
             static int repeatedMessageID_ = LogHandler::getInstance().newRepeatedMessageID(); \
             QString logString_; \
             QDebug debugStringReceiver_(&logString_); \

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -51,7 +51,6 @@ public:
     /// prints various process, message type, and time information
     static void verboseMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString &message);
 
-    const QString& addOnlyOnceMessageRegex(const QString& regexString);
     int newRepeatedMessageID();
     void printRepeatedMessage(int messageID, LogMsgType type, const QMessageLogContext& context, const QString &message);
 
@@ -68,12 +67,6 @@ private:
     bool _shouldOutputProcessID { false };
     bool _shouldOutputThreadID { false };
     bool _shouldDisplayMilliseconds { false };
-
-    struct OnceOnlyMessage {
-        QRegExp regexp;
-        int messageCount { 0 };
-    };
-    std::vector<OnceOnlyMessage> _onetimeMessages;
 
     int _currentMessageID { 0 };
     struct RepeatedMessageRecord {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/13901/

This PR removes the addRepeatedMessageRegex mechanism and uses a simpler scheme that employs a static ID at the point of message creation. This avoids the regex matching on each print, but the semantics are slightly different as the regex  could match logging at different sites, and also due to no longer using qCDebug().

I haven't touched the one-time scheme yet.