### PR TITLE
hide desktop windows when switching into HMD mode

### DIFF
--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -327,7 +327,10 @@ FocusScope {
         for (var index = 0; index < desktop.visibleChildren.length; index++) {
             var child = desktop.visibleChildren[index];
             if (child.topLevelWindow && child.hasOwnProperty("modality")) {
-                child.setShown(false);
+                var TOOLBAR_NAME = "com.highfidelity.interface.toolbar.system"
+                if (child.objectName !== TOOLBAR_NAME) {
+                    child.setShown(false);
+                }
             }
         }
     }

--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -327,7 +327,6 @@ FocusScope {
         for (var index = 0; index < desktop.visibleChildren.length; index++) {
             var child = desktop.visibleChildren[index];
             if (child.topLevelWindow && child.hasOwnProperty("modality")) {
-                console.log(child);
                 child.setShown(false);
             }
         }

--- a/interface/resources/qml/desktop/Desktop.qml
+++ b/interface/resources/qml/desktop/Desktop.qml
@@ -323,6 +323,16 @@ FocusScope {
         return false;
     }
 
+    function hideDesktopWindows() {
+        for (var index = 0; index < desktop.visibleChildren.length; index++) {
+            var child = desktop.visibleChildren[index];
+            if (child.topLevelWindow && child.hasOwnProperty("modality")) {
+                console.log(child);
+                child.setShown(false);
+            }
+        }
+    }
+
     function setPinned(newPinned) {
         pinned = newPinned
     }

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -154,6 +154,13 @@ void OffscreenUi::show(const QUrl& url, const QString& name, std::function<void(
     }
 }
 
+void OffscreenUi::hideDesktopWindows() {
+    if (QThread::currentThread() != thread()) {
+        BLOCKING_INVOKE_METHOD(this, "hideDesktopWindows");
+    }
+    QMetaObject::invokeMethod(_desktop, "hideDesktopWindows");
+}
+
 void OffscreenUi::toggle(const QUrl& url, const QString& name, std::function<void(QQmlContext*, QObject*)> f) {
     QQuickItem* item = getRootItem()->findChild<QQuickItem*>(name);
     if (!item) {

--- a/libraries/ui/src/OffscreenUi.h
+++ b/libraries/ui/src/OffscreenUi.h
@@ -60,6 +60,7 @@ public:
     void createDesktop(const QUrl& url);
     void show(const QUrl& url, const QString& name, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
     void hide(const QString& name);
+    void hideDesktopWindows();
     bool isVisible(const QString& name);
     void toggle(const QUrl& url, const QString& name, std::function<void(QQmlContext*, QObject*)> f = [](QQmlContext*, QObject*) {});
     bool shouldSwallowShortcut(QEvent* event);

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -387,6 +387,8 @@ void TabletProxy::setToolbarMode(bool toolbarMode) {
             offscreenUi->hide("RunningScripts");
             _showRunningScripts = true;
         }
+
+        offscreenUi->hideDesktopWindows();
         // destroy desktop window
         if (_desktopWindow) {
             _desktopWindow->deleteLater();


### PR DESCRIPTION
This PR makes sure to hide any topLevelWindow on the HUD when switching to HMD mode

ticket - https://highfidelity.fogbugz.com/f/cases/13686/Opening-Asset-Browser-in-desktop-and-switching-to-HMD-causes-unexpected-behavior