### PR TITLE
Bugfix for #12759 Overlays.editOverlay not applying subImage property

### DIFF
--- a/interface/resources/qml/hifi/overlays/ImageOverlay.qml
+++ b/interface/resources/qml/hifi/overlays/ImageOverlay.qml
@@ -20,17 +20,7 @@ Overlay {
             repeat: false
             running: false
             onTriggered: {
-                if (image.xSize === 0) {
-                    image.xSize = image.sourceSize.width - image.xStart;
-                }
-                if (image.ySize === 0) {
-                    image.ySize = image.sourceSize.height - image.yStart;
-                }
-
-                image.anchors.leftMargin = -image.xStart * root.width / image.xSize;
-                image.anchors.topMargin = -image.yStart * root.height / image.ySize;
-                image.anchors.rightMargin = (image.xStart + image.xSize - image.sourceSize.width) * root.width / image.xSize;
-                image.anchors.bottomMargin = (image.yStart + image.ySize - image.sourceSize.height) * root.height / image.ySize;
+               recalculateMargins();
             }
         }
 
@@ -42,6 +32,20 @@ Overlay {
         }
 
         anchors.fill: parent
+    }
+
+    function recalculateMargins() {
+        if (image.xSize === 0) {
+            image.xSize = image.sourceSize.width - image.xStart;
+        }
+        if (image.ySize === 0) {
+            image.ySize = image.sourceSize.height - image.yStart;
+        }
+
+        image.anchors.leftMargin = -image.xStart * root.width / image.xSize;
+        image.anchors.topMargin = -image.yStart * root.height / image.ySize;
+        image.anchors.rightMargin = (image.xStart + image.xSize - image.sourceSize.width) * root.width / image.xSize;
+        image.anchors.bottomMargin = (image.yStart + image.ySize - image.sourceSize.height) * root.height / image.ySize;
     }
 
     ColorOverlay {
@@ -62,7 +66,7 @@ Overlay {
                 case "height": image.ySize = value; break;
             }
         }
-        image.resizer.start();
+        recalculateMargins();
     }
 
     function updatePropertiesFromScript(properties) {

--- a/interface/resources/qml/hifi/overlays/ImageOverlay.qml
+++ b/interface/resources/qml/hifi/overlays/ImageOverlay.qml
@@ -62,6 +62,7 @@ Overlay {
                 case "height": image.ySize = value; break;
             }
         }
+        image.resizer.start();
     }
 
     function updatePropertiesFromScript(properties) {


### PR DESCRIPTION
The anchor property of image was not being recalculated after subImage was being applied from javascript.

This change moves the anchor margin calculation to its own method, and calls it in both places that it is needed.