### PR TITLE
Prevent Interface from crashing when a Snapshot upload fails

### DIFF
--- a/interface/src/ui/SnapshotUploader.cpp
+++ b/interface/src/ui/SnapshotUploader.cpp
@@ -75,6 +75,8 @@ void SnapshotUploader::uploadFailure(QNetworkReply& reply) {
     if (replyString.size() == 0) {
         replyString = reply.errorString();
     }
+    replyString = replyString.left(1000); // Only print first 1000 characters of error
+    qDebug() << "Snapshot upload reply error (truncated):" << replyString;
     emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(true, replyString); // maybe someday include _inWorldLocation, _filename?
     this->deleteLater();
 }
@@ -87,10 +89,12 @@ void SnapshotUploader::createStorySuccess(QNetworkReply& reply) {
 
 void SnapshotUploader::createStoryFailure(QNetworkReply& reply) {
     QString replyString = reply.readAll();
-    qDebug() << "Error " << reply.errorString() << " uploading snapshot " << _pathname << " from " << _inWorldLocation;
+    qDebug() << "Error " << reply.errorString() << " uploading snapshot story " << _pathname << " from " << _inWorldLocation;
     if (replyString.size() == 0) {
         replyString = reply.errorString();
     }
+    replyString = replyString.left(1000); // Only print first 1000 characters of error
+    qDebug() << "Snapshot story upload reply error (truncated):" << replyString;
     emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(true, replyString);
     this->deleteLater();
 }

--- a/interface/src/ui/SnapshotUploader.cpp
+++ b/interface/src/ui/SnapshotUploader.cpp
@@ -65,7 +65,7 @@ void SnapshotUploader::uploadSuccess(QNetworkReply& reply) {
 
     } else {
         emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(true, contents);
-        delete this;
+        this->deleteLater();
     }
 }
 
@@ -76,13 +76,13 @@ void SnapshotUploader::uploadFailure(QNetworkReply& reply) {
         replyString = reply.errorString();
     }
     emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(true, replyString); // maybe someday include _inWorldLocation, _filename?
-    delete this;
+    this->deleteLater();
 }
 
 void SnapshotUploader::createStorySuccess(QNetworkReply& reply) {
     QString replyString = reply.readAll();
     emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(false, replyString);
-    delete this;
+    this->deleteLater();
 }
 
 void SnapshotUploader::createStoryFailure(QNetworkReply& reply) {
@@ -92,6 +92,6 @@ void SnapshotUploader::createStoryFailure(QNetworkReply& reply) {
         replyString = reply.errorString();
     }
     emit DependencyManager::get<WindowScriptingInterface>()->snapshotShared(true, replyString);
-    delete this;
+    this->deleteLater();
 }
 

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -411,8 +411,6 @@ function snapshotUploaded(isError, reply) {
         } else {
             print('Ignoring snapshotUploaded() callback for stale ' + (isGif ? 'GIF' : 'Still' ) + ' snapshot. Stale story ID:', storyID);
         }
-    } else {
-        print(reply);
     }
     isUploadingPrintableStill = false;
 }


### PR DESCRIPTION
Previously, `snapshot.js` would attempt to print any error string that it received from the backend. In the case of a snapshot upload error, that error string would be thousands of characters in length. Attempting to print this string would result in Interface freezing. After this fix, that is no longer a problem.