### PR TITLE
Cleanup 'Private' HMD Preview State Machine Logic

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/SecurityImageChange.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/SecurityImageChange.qml
@@ -43,18 +43,6 @@ Item {
             }
         }
     }
-    
-    // This will cause a bug -- if you bring up security image selection in HUD mode while
-    // in HMD while having HMD preview enabled, then move, then finish passphrase selection,
-    // HMD preview will stay off.
-    // TODO: Fix this unlikely bug
-    onVisibleChanged: {
-        if (visible) {
-            sendSignalToWallet({method: 'disableHmdPreview'});
-        } else {
-            sendSignalToWallet({method: 'maybeEnableHmdPreview'});
-        }
-    }    
 
     // Security Image
     Item {

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -77,7 +77,7 @@ Item {
         UserActivityLogger.commerceWalletSetupProgress(timestamp, root.setupAttemptID,
             Math.round((timestamp - root.startingTimestamp)/1000), currentStepNumber, root.setupStepNames[currentStepNumber - 1]);
 
-        if (root.activeView === "step_2" || root.activeView === "step_3") {
+        if (root.activeView === "step_3") {
             sendSignalToWallet({method: 'disableHmdPreview'});
         } else {
             sendSignalToWallet({method: 'maybeEnableHmdPreview'});


### PR DESCRIPTION
DNM because this is going to cause merge conflicts with #12736 and I'd rather fix this PR than that one.

This PR implements the logic outlined in [this](https://highfidelity.atlassian.net/wiki/spaces/HOME/pages/276135960/Private+HMD+Preview+Behavior) `"Private" HMD Preview Behavior` Confluence document.