### PR TITLE
Workload: Splitting the creation of the Workload engine from the setup

### DIFF
--- a/interface/src/workload/GameWorkload.cpp
+++ b/interface/src/workload/GameWorkload.cpp
@@ -35,7 +35,7 @@ GameWorkload::~GameWorkload() {
 void GameWorkload::startup(const workload::SpacePointer& space,
         const render::ScenePointer& scene,
         const PhysicalEntitySimulationPointer& simulation) {
-    _engine.reset(new workload::Engine(std::make_shared<GameWorkloadContext>(space, scene, simulation)));
+    _engine->reset(std::make_shared<GameWorkloadContext>(space, scene, simulation));
 
     auto output = _engine->getOutput();
     _engine->addJob<GameSpaceToRender>("SpaceToRender");

--- a/interface/src/workload/GameWorkload.h
+++ b/interface/src/workload/GameWorkload.h
@@ -39,7 +39,7 @@ public:
 
     void updateViews(const ViewFrustum& frustum);
 
-    workload::EnginePointer _engine;
+    workload::EnginePointer _engine { std::make_shared<workload::Engine>() };
 };
 
 #endif // hifi_GameWorkload_h

--- a/interface/src/workload/PhysicsBoundary.h
+++ b/interface/src/workload/PhysicsBoundary.h
@@ -45,21 +45,22 @@ public:
     }
 
     void run(const workload::WorkloadContextPointer& context, const Inputs& inputs) {
+        const auto& regionChanges = inputs.get1();
         auto space = context->_space;
         if (!space) {
             return;
         }
-        uint32_t listSize = (uint32_t)inputs.size();
+        uint32_t listSize = (uint32_t)regionChanges.size();
         uint32_t totalTransitions = 0;
         for (uint32_t i = 0; i < listSize; ++i) {
-            totalTransitions += (uint32_t)inputs[i].size();
+            totalTransitions += (uint32_t)regionChanges[i].size();
         }
         // we're interested in things entering/leaving R3
         uint32_t regionIndex = workload::Region::R3;
         uint32_t exitIndex = 2 * regionIndex;
-        uint32_t numExits = (uint32_t)inputs[exitIndex].size();
+        uint32_t numExits = (uint32_t)regionChanges[exitIndex].size();
         for (uint32_t i = 0; i < numExits; ++i) {
-            int32_t proxyID = inputs[exitIndex][i];
+            int32_t proxyID = regionChanges[exitIndex][i];
             void* owner = space->getOwner(proxyID).get();
             if (owner) {
                 EntityItem* entity = static_cast<EntityItem*>(owner);
@@ -71,9 +72,9 @@ public:
         }
 
         uint32_t enterIndex = exitIndex + 1;
-        uint32_t numEntries = (uint32_t)inputs[enterIndex].size();
+        uint32_t numEntries = (uint32_t)regionChanges[enterIndex].size();
         for (uint32_t i = 0; i < numEntries; ++i) {
-            int32_t proxyID = inputs[enterIndex][i];
+            int32_t proxyID = regionChanges[enterIndex][i];
             void* owner = space->getOwner(proxyID).get();
             if (owner) {
                 EntityItem* entity = static_cast<EntityItem*>(owner);

--- a/libraries/workload/src/workload/Engine.cpp
+++ b/libraries/workload/src/workload/Engine.cpp
@@ -28,16 +28,20 @@ namespace workload {
         void build(JobModel& model, const Varying& in, Varying& out) {
             model.addJob<SetupViews>("setupViews", in);
             model.addJob<PerformSpaceTransaction>("updateSpace");
-            const auto regionChanges = model.addJob<RegionTracker>("regionTracker");
+            const auto regionTrackerOut = model.addJob<RegionTracker>("regionTracker");
+            const auto regionChanges = regionTrackerOut.getN<RegionTracker::Outputs>(1);
             model.addJob<RegionState>("regionState", regionChanges);
-            out = regionChanges;
+            out = regionTrackerOut;
         }
     };
 
-    Engine::Engine(const WorkloadContextPointer& context) : Task("Engine", EngineBuilder::JobModel::create()),
-            _context(context) {
+    Engine::Engine() : Task("Engine", EngineBuilder::JobModel::create()),
+            _context(nullptr) {
     }
 
+    void Engine::reset(const WorkloadContextPointer& context) {
+        _context = context;
+    }
 
     void PerformSpaceTransaction::configure(const Config& config) {
 

--- a/libraries/workload/src/workload/Engine.h
+++ b/libraries/workload/src/workload/Engine.h
@@ -37,10 +37,12 @@ namespace workload {
 
     class Engine : public Task {
     public:
-        Engine(const WorkloadContextPointer& context);
+        Engine();
         ~Engine() = default;
 
-        void run() { assert(_context); run(_context); }
+        void reset(const WorkloadContextPointer& context);
+
+        void run() { if (_context) { run(_context); } }
 
     protected:
         void run(const WorkloadContextPointer& context) override { assert(_context); Task::run(_context); }

--- a/libraries/workload/src/workload/RegionTracker.cpp
+++ b/libraries/workload/src/workload/RegionTracker.cpp
@@ -21,22 +21,29 @@ void RegionTracker::configure(const Config& config) {
 }
 
 void RegionTracker::run(const WorkloadContextPointer& context, Outputs& outputs) {
-    outputs.clear();
+    auto& outChanges = outputs.edit0();
+    auto& outRegionChanges = outputs.edit1();
+
+
+    outChanges.clear();
+    outRegionChanges.clear();
+
     auto space = context->_space;
     if (space) {
-        Changes changes;
-        space->categorizeAndGetChanges(changes);
+        //Changes changes;
+        space->categorizeAndGetChanges(outChanges);
+
         // use exit/enter lists for each region less than Region::UNKNOWN
-        outputs.resize(2 * (workload::Region::NUM_CLASSIFICATIONS - 1));
-        for (uint32_t i = 0; i < changes.size(); ++i) {
-            Space::Change& change = changes[i];
+        outRegionChanges.resize(2 * (workload::Region::NUM_CLASSIFICATIONS - 1));
+        for (uint32_t i = 0; i < outChanges.size(); ++i) {
+            Space::Change& change = outChanges[i];
             if (change.prevRegion < Region::UNKNOWN) {
                 // EXIT list index = 2 * regionIndex
-                outputs[2 * change.prevRegion].push_back(change.proxyId);
+                outRegionChanges[2 * change.prevRegion].push_back(change.proxyId);
             }
             if (change.region < Region::UNKNOWN) {
                 // ENTER list index = 2 * regionIndex + 1
-                outputs[2 * change.region + 1].push_back(change.proxyId);
+                outRegionChanges[2 * change.region + 1].push_back(change.proxyId);
             }
         }
     }

--- a/libraries/workload/src/workload/RegionTracker.h
+++ b/libraries/workload/src/workload/RegionTracker.h
@@ -29,7 +29,7 @@ namespace workload {
     class RegionTracker {
     public:
         using Config = RegionTrackerConfig;
-        using Outputs = IndexVectors;
+        using Outputs = VaryingSet2<Changes, IndexVectors>;
         using JobModel = workload::Job::ModelO<RegionTracker, Outputs, Config>;
 
         RegionTracker() {}


### PR DESCRIPTION
 and configuration, so we can create the enigne, register the root configuration for the WOrkload engine and reset the context later
changing the output from region tracker