### PR TITLE
Fix for auto-reopening of closed query dialogs (aka hack-on-top-of-hack)

### DIFF
--- a/interface/resources/qml/dialogs/CustomQueryDialog.qml
+++ b/interface/resources/qml/dialogs/CustomQueryDialog.qml
@@ -272,6 +272,8 @@ ModalWindow {
                 root.canceled();
                 // FIXME we are leaking memory to avoid a crash
                 // root.destroy();
+
+                root.disableFade = true
                 visible = false;
             }
         }
@@ -296,6 +298,8 @@ ModalWindow {
                 root.selected(root.result);
                 // FIXME we are leaking memory to avoid a crash
                 // root.destroy();
+
+                root.disableFade = true
                 visible = false;
             }
         }

--- a/interface/resources/qml/dialogs/QueryDialog.qml
+++ b/interface/resources/qml/dialogs/QueryDialog.qml
@@ -171,6 +171,8 @@ ModalWindow {
                 root.canceled();
                 // FIXME we are leaking memory to avoid a crash
                 // root.destroy();
+
+                root.disableFade = true
                 visible = false;
             }
         }
@@ -183,6 +185,8 @@ ModalWindow {
                 root.selected(root.result);
                 // FIXME we are leaking memory to avoid a crash
                 // root.destroy();
+
+                root.disableFade = true
                 visible = false;
             }
         }

--- a/interface/resources/qml/windows/Fadable.qml
+++ b/interface/resources/qml/windows/Fadable.qml
@@ -39,7 +39,7 @@ FocusScope {
         // If someone directly set the visibility to false
         // toggle it back on and use the targetVisible flag to transition
         // via fading.
-        if ((!visible && fadeTargetProperty != 0.0) || (visible && fadeTargetProperty == 0.0)) {
+        if (!disableFade && ((!visible && fadeTargetProperty != 0.0) || (visible && fadeTargetProperty == 0.0))) {
             var target = visible;
             visible = !visible;
             fadeTargetProperty = target ? 1.0 : 0.0;


### PR DESCRIPTION
Test plan: 

1) Switch to desktop
2) Enable advanced settings and go to Edit
3) Go to Import Entities from URL and paste this in the pop up dialogue box http://mpassets.highfidelity.com/9e0267fa-69c8-455a-ad81-fc0f82cab599-v1/guitar.json
4) Press ok to apply url and close the dialog
5) Create should open and the json should load 
6) Move your avatar around, ensure dialog from item 3 doesn't self-reopen

https://highfidelity.manuscript.com/f/cases/13962/Import-Entity-URL-Dialogue-Box-Will-not-Disappear