### PR TITLE
Fix non-client-only material entities applied to avatar by session ID not being removed on domain switch

### DIFF
--- a/libraries/entities/src/MaterialEntityItem.cpp
+++ b/libraries/entities/src/MaterialEntityItem.cpp
@@ -27,6 +27,10 @@ MaterialEntityItem::MaterialEntityItem(const EntityItemID& entityItemID) : Entit
     _type = EntityTypes::Material;
 }
 
+MaterialEntityItem::~MaterialEntityItem() {
+    removeMaterial();
+}
+
 EntityItemProperties MaterialEntityItem::getProperties(EntityPropertyFlags desiredProperties) const {
     EntityItemProperties properties = EntityItem::getProperties(desiredProperties); // get the properties from our base class
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(materialURL, getMaterialURL);
@@ -326,11 +330,6 @@ void MaterialEntityItem::applyMaterial() {
 void MaterialEntityItem::postParentFixup() {
     removeMaterial();
     applyMaterial();
-}
-
-void MaterialEntityItem::preDelete() {
-    EntityItem::preDelete();
-    removeMaterial();
 }
 
 void MaterialEntityItem::update(const quint64& now) {

--- a/libraries/entities/src/MaterialEntityItem.h
+++ b/libraries/entities/src/MaterialEntityItem.h
@@ -21,6 +21,7 @@ public:
     static EntityItemPointer factory(const EntityItemID& entityID, const EntityItemProperties& properties);
 
     MaterialEntityItem(const EntityItemID& entityItemID);
+    ~MaterialEntityItem();
 
     ALLOW_INSTANTIATION // This class can be instantiated
 
@@ -84,7 +85,6 @@ public:
     void removeMaterial();
 
     void postParentFixup() override;
-    void preDelete() override;
 
 private:
     // URL for this material.  Currently, only JSON format is supported.  Set to "userData" to use the user data to live edit a material.


### PR DESCRIPTION
(long winded title for an extremely specific bug)

https://highfidelity.fogbugz.com/f/cases/13722/Material-Entity-keeps-changes-on-an-avatar-locally-when-a-user-changes-domains

Test plan:
- Wear the mannequin avatar.  Run [this](https://gist.githubusercontent.com/SamGondelman/47fc1d534d0dc9b20c0224ac774fb6dd/raw/f8ac2fbbbc557016a138b687985a4c49553c66c4/MaterialAvatarTest.js).  You should become red and transparent.
- Go to another domain.
- You should return to your normal material.