### PR TITLE
Model overlay fixes

### DIFF
--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -358,15 +358,15 @@ vectorType ModelOverlay::mapJoints(mapFunction<itemType> function) const {
  * @property {Vec3} dimensions - The dimensions of the overlay. Synonym: <code>size</code>.
  * @property {Vec3} scale - The scale factor applied to the model's dimensions.
  * @property {object.<name, url>} textures - Maps the named textures in the model to the JPG or PNG images in the urls.
- * @property {Array.<string>} jointNames - The names of the joints - if any - in the model. <em>Read-only</em>
+ * @property {Array.<string>} jointNames - The names of the joints - if any - in the model. <em>Read-only.</em>
  * @property {Array.<Quat>} jointRotations - The relative rotations of the model's joints. <em>Not copied if overlay is 
  *     cloned.</em>
  * @property {Array.<Vec3>} jointTranslations - The relative translations of the model's joints. <em>Not copied if overlay is 
  *     cloned.</em>
  * @property {Array.<Quat>} jointOrientations - The absolute orientations of the model's joints, in world coordinates.
- *     <em>Read-only</em>
+ *     <em>Read-only.</em>
  * @property {Array.<Vec3>} jointPositions - The absolute positions of the model's joints, in world coordinates.
- *     <em>Read-only</em>
+ *     <em>Read-only.</em>
  * @property {string} animationSettings.url="" - The URL of an FBX file containing an animation to play.
  * @property {number} animationSettings.fps=0 - The frame rate (frames/sec) to play the animation at. 
  * @property {number} animationSettings.firstFrame=0 - The frame to start playing at.

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -353,6 +353,8 @@ vectorType ModelOverlay::mapJoints(mapFunction<itemType> function) const {
  *     <code>parentID</code> is an avatar skeleton. A value of <code>65535</code> means "no joint".
  *
  * @property {string} url - The URL of the FBX or OBJ model used for the overlay.
+ * @property {number} loadPriority=0.0 - The priority for loading and displaying the overlay. Overlays with higher values load 
+ *     first.
  * @property {Vec3} dimensions - The dimensions of the overlay. Synonym: <code>size</code>.
  * @property {Vec3} scale - The scale factor applied to the model's dimensions.
  * @property {object.<name, url>} textures - Maps the named textures in the model to the JPG or PNG images in the urls.
@@ -394,6 +396,10 @@ QVariant ModelOverlay::getProperty(const QString& property) {
         } else {
             return QVariant();
         }
+    }
+
+    if (property == "loadPriority") {
+        return _loadPriority;
     }
 
     if (property == "jointNames") {

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -35,7 +35,19 @@ ModelOverlay::ModelOverlay(const ModelOverlay* modelOverlay) :
     _url(modelOverlay->_url),
     _updateModel(false),
     _scaleToFit(modelOverlay->_scaleToFit),
-    _loadPriority(modelOverlay->_loadPriority)
+    _loadPriority(modelOverlay->_loadPriority),
+
+    _animationURL(modelOverlay->_animationURL),
+    _animationFPS(modelOverlay->_animationFPS),
+    _animationCurrentFrame(modelOverlay->_animationCurrentFrame),
+    _animationFirstFrame(modelOverlay->_animationFirstFrame),
+    _animationLastFrame(modelOverlay->_animationLastFrame),
+    _animationRunning(modelOverlay->_animationRunning),
+    _animationLoop(modelOverlay->_animationLoop),
+    _animationHold(modelOverlay->_animationHold),
+    _animationAllowTranslation(modelOverlay->_animationAllowTranslation)
+
+    // Joint translations and rotations aren't copied because the model needs to load before they can be applied.
 {
     _model->setLoadingPriority(_loadPriority);
     if (_url.isValid()) {

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -369,6 +369,7 @@ vectorType ModelOverlay::mapJoints(mapFunction<itemType> function) const {
  * @property {number} animationSettings.fps=0 - The frame rate (frames/sec) to play the animation at. 
  * @property {number} animationSettings.firstFrame=0 - The frame to start playing at.
  * @property {number} animationSettings.lastFrame=0 - The frame to finish playing at.
+ * @property {number} animationSettings.currentFrame=0 - The current frame being played.
  * @property {boolean} animationSettings.running=false - Whether or not the animation is playing.
  * @property {boolean} animationSettings.loop=false - Whether or not the animation should repeat in a loop.
  * @property {boolean} animationSettings.hold=false - Whether or not when the animation finishes, the rotations and 

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -359,8 +359,10 @@ vectorType ModelOverlay::mapJoints(mapFunction<itemType> function) const {
  * @property {Vec3} scale - The scale factor applied to the model's dimensions.
  * @property {object.<name, url>} textures - Maps the named textures in the model to the JPG or PNG images in the urls.
  * @property {Array.<string>} jointNames - The names of the joints - if any - in the model. <em>Read-only</em>
- * @property {Array.<Quat>} jointRotations - The relative rotations of the model's joints.
- * @property {Array.<Vec3>} jointTranslations - The relative translations of the model's joints.
+ * @property {Array.<Quat>} jointRotations - The relative rotations of the model's joints. <em>Not copied if overlay is 
+ *     cloned.</em>
+ * @property {Array.<Vec3>} jointTranslations - The relative translations of the model's joints. <em>Not copied if overlay is 
+ *     cloned.</em>
  * @property {Array.<Quat>} jointOrientations - The absolute orientations of the model's joints, in world coordinates.
  *     <em>Read-only</em>
  * @property {Array.<Vec3>} jointPositions - The absolute positions of the model's joints, in world coordinates.

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -40,10 +40,10 @@ ModelOverlay::ModelOverlay(const ModelOverlay* modelOverlay) :
     _animationURL(modelOverlay->_animationURL),
     _animationFPS(modelOverlay->_animationFPS),
     _animationCurrentFrame(modelOverlay->_animationCurrentFrame),
-    _animationFirstFrame(modelOverlay->_animationFirstFrame),
-    _animationLastFrame(modelOverlay->_animationLastFrame),
     _animationRunning(modelOverlay->_animationRunning),
     _animationLoop(modelOverlay->_animationLoop),
+    _animationFirstFrame(modelOverlay->_animationFirstFrame),
+    _animationLastFrame(modelOverlay->_animationLastFrame),
     _animationHold(modelOverlay->_animationHold),
     _animationAllowTranslation(modelOverlay->_animationAllowTranslation)
 


### PR DESCRIPTION
- Make cloning a model overlay clone its animation properties.
- Add missing property "get" for "loadPriority" property.
- Some JSDoc updates.