### PR TITLE
Close 'goto'  app on pressing 'forward' / 'backward' buttons

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
@@ -141,7 +141,10 @@ StackView {
             bottom: parent.bottom
         }
 
-        onHostChanged: updateLocationTextTimer.restart();
+        onHostChanged: {
+            updateLocationTextTimer.restart();
+            DialogsManager.hideAddressBar();
+        }
 
         Rectangle {
             id: navBar


### PR DESCRIPTION
**Test plan**

0) Switch to desktop
1) Open Go To and navigate to a different domain
2) Open Go To and select the back button to navigate back to previously visited domain
3) Ensure Go To window closed
4) Open Go To and select forward to navigate to previously visited domain
3) Ensure Go To window closed

https://highfidelity.manuscript.com/f/cases/14015/Go-To-app-does-not-close-when-selecting-forward-and-back-arrows-on-desktop