### PR TITLE
ktxInitialDataRequestFinished call to qcDebug(networking) - only in DEBUG

### DIFF
--- a/interface/src/scripting/TestScriptingInterface.cpp
+++ b/interface/src/scripting/TestScriptingInterface.cpp
@@ -156,3 +156,7 @@ void TestScriptingInterface::profileRange(const QString& name, QScriptValue fn) 
     fn.call();
 }
 
+void TestScriptingInterface::clearCaches() {
+	qApp->reloadResourceCaches();
+}
+

--- a/interface/src/scripting/TestScriptingInterface.h
+++ b/interface/src/scripting/TestScriptingInterface.h
@@ -78,6 +78,11 @@ public slots:
 
     Q_INVOKABLE void profileRange(const QString& name, QScriptValue function);
 
+    /**jsdoc
+    * Clear all caches (menu command Reload Content)
+    */
+    void clearCaches();
+
 private:
     bool waitForCondition(qint64 maxWaitMs, std::function<bool()> condition);
 };

--- a/libraries/model-networking/src/model-networking/TextureCache.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCache.cpp
@@ -642,8 +642,12 @@ void NetworkTexture::ktxInitialDataRequestFinished() {
     }
 
     if (result == ResourceRequest::Success) {
+
+// This is an expensive operation that we do not want in release.
+#ifdef DEBUG
         auto extraInfo = _url == _activeUrl ? "" : QString(", %1").arg(_activeUrl.toDisplayString());
         qCDebug(networking).noquote() << QString("Request finished for %1%2").arg(_url.toDisplayString(), extraInfo);
+#endif
 
         _ktxHeaderData = _ktxHeaderRequest->getData();
         _ktxHighMipData = _ktxMipRequest->getData();


### PR DESCRIPTION
# Description:
This is a time consuming call that is only needed for debug.
Before:
![b](https://user-images.githubusercontent.com/29026026/38470571-b7b5f5cc-3b19-11e8-858f-6efaf85ce10b.PNG)
After:
![a](https://user-images.githubusercontent.com/29026026/38470573-bd18826e-3b19-11e8-9b6c-119274a0ca6d.PNG)

# Testing:
A script command has been added for debug: Test.clearCaches().  To test - enter any domain, and run this command from the JavaScript console (ALT + J).  This should clear the contents and trigger a reload.

This pr is iproving performance in a specific case>
we "Engine Team" are taking responsability for QA ing it