### PR TITLE
Go to tablet home / close Create menu when changing domains

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -457,6 +457,7 @@ var toolBar = (function () {
         Window.domainChanged.connect(function () {
             that.setActive(false);
             that.clearEntityList();
+            tablet.gotoHomeScreen();
         });
 
         Entities.canAdjustLocksChanged.connect(function (canAdjustLocks) {

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -452,16 +452,15 @@ var toolBar = (function () {
         }
     }
 
+    function clearWindow() {
+        tablet.gotoHomeScreen();
+    };
+
     function initialize() {
         Script.scriptEnding.connect(cleanup);
         Window.domainChanged.connect(function () {
             that.setActive(false);
             that.clearEntityList();
-            tablet.gotoHomeScreen();
-        });
-
-        Window.domainConnectionRefused.connect(function () {
-            tablet.gotoHomeScreen();
         });
 
         Entities.canAdjustLocksChanged.connect(function (canAdjustLocks) {
@@ -723,6 +722,8 @@ var toolBar = (function () {
             cameraManager.disable();
             selectionDisplay.triggerMapping.disable();
             tablet.landscape = false;
+            Window.domainChanged.disconnect(clearWindow);
+            Window.domainConnectionRefused.disconnect(clearWindow);
         } else {
             tablet.loadQMLSource("hifi/tablet/Edit.qml", true);
             UserActivityLogger.enabledEdit();
@@ -734,6 +735,8 @@ var toolBar = (function () {
             print("starting tablet in landscape mode");
             tablet.landscape = true;
             entityIconOverlayManager.setIconsSelectable(null,false);
+            Window.domainChanged.connect(clearWindow);
+            Window.domainConnectionRefused.connect(clearWindow);
             // Not sure what the following was meant to accomplish, but it currently causes
             // everybody else to think that Interface has lost focus overall. fogbugzid:558
             // Window.setFocus();

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -452,13 +452,12 @@ var toolBar = (function () {
         }
     }
 
-    function clearWindow() {
-        tablet.gotoHomeScreen();
-    };
-
     function initialize() {
         Script.scriptEnding.connect(cleanup);
         Window.domainChanged.connect(function () {
+            if (isActive) {
+                tablet.gotoHomeScreen();
+            }
             that.setActive(false);
             that.clearEntityList();
         });
@@ -722,8 +721,6 @@ var toolBar = (function () {
             cameraManager.disable();
             selectionDisplay.triggerMapping.disable();
             tablet.landscape = false;
-            Window.domainChanged.disconnect(clearWindow);
-            Window.domainConnectionRefused.disconnect(clearWindow);
         } else {
             tablet.loadQMLSource("hifi/tablet/Edit.qml", true);
             UserActivityLogger.enabledEdit();
@@ -735,8 +732,6 @@ var toolBar = (function () {
             print("starting tablet in landscape mode");
             tablet.landscape = true;
             entityIconOverlayManager.setIconsSelectable(null,false);
-            Window.domainChanged.connect(clearWindow);
-            Window.domainConnectionRefused.connect(clearWindow);
             // Not sure what the following was meant to accomplish, but it currently causes
             // everybody else to think that Interface has lost focus overall. fogbugzid:558
             // Window.setFocus();

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -460,6 +460,10 @@ var toolBar = (function () {
             tablet.gotoHomeScreen();
         });
 
+        Window.domainConnectionRefused.connect(function() {
+            tablet.gotoHomeScreen();
+        });
+
         Entities.canAdjustLocksChanged.connect(function (canAdjustLocks) {
             if (isActive && !canAdjustLocks) {
                 that.setActive(false);

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -460,7 +460,7 @@ var toolBar = (function () {
             tablet.gotoHomeScreen();
         });
 
-        Window.domainConnectionRefused.connect(function() {
+        Window.domainConnectionRefused.connect(function () {
             tablet.gotoHomeScreen();
         });
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/14058/Editor-stays-opened-without-permission-after-teleport-by-web-direct