### PR TITLE
Fix asserts on domain switch

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -62,7 +62,7 @@ EntityItem::EntityItem(const EntityItemID& entityItemID) :
 EntityItem::~EntityItem() {
     // these pointers MUST be correct at delete, else we probably have a dangling backpointer
     // to this EntityItem in the corresponding data structure.
-    assert(!_simulated);
+    assert(!_simulated || (!_element && !_physicsInfo));
     assert(!_element);
     assert(!_physicsInfo);
 }

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -158,7 +158,6 @@ void PhysicalEntitySimulation::clearEntitiesInternal() {
         EntityMotionState* motionState = static_cast<EntityMotionState*>(&(*stateItr));
         assert(motionState);
         EntityItemPointer entity = motionState->getEntity();
-        entity->setPhysicsInfo(nullptr);
         // TODO: someday when we invert the entities/physics lib dependencies we can let EntityItem delete its own PhysicsInfo
         // until then we must do it here
         delete motionState;


### PR DESCRIPTION
On Android we were hitting two asserts on domain switch/reload (presumably on desktop, too).  These are because the codepath is slightly different on entity tree reset vs. individual entity deletion.  These changes should fix the asserts without changing any behavior.

Test plan:
- Switch domains a few times.  You shouldn't crash.