### PR TITLE
Remove lock file recovery in entity server

### DIFF
--- a/libraries/octree/src/OctreePersistThread.cpp
+++ b/libraries/octree/src/OctreePersistThread.cpp
@@ -192,17 +192,12 @@ bool OctreePersistThread::process() {
             QString lockFileName = _filename + ".lock";
             std::ifstream lockFile(qPrintable(lockFileName), std::ios::in | std::ios::binary | std::ios::ate);
             if (lockFile.is_open()) {
-                qCDebug(octree) << "WARNING: Octree lock file detected at startup:" << lockFileName
-                    << "-- Attempting to restore from previous backup file.";
-
-                // This is where we should attempt to find the most recent backup and restore from
-                // that file as our persist file.
-                restoreFromMostRecentBackup();
+                qCDebug(octree) << "WARNING: Octree lock file detected at startup:" << lockFileName;
 
                 lockFile.close();
-                qCDebug(octree) << "Loading Octree... lock file closed:" << lockFileName;
+                qCDebug(octree) << "Removing lock file:" << lockFileName;
                 remove(qPrintable(lockFileName));
-                qCDebug(octree) << "Loading Octree... lock file removed:" << lockFileName;
+                qCDebug(octree) << "Lock file removed:" << lockFileName;
             }
 
             persistentFileRead = _tree->readFromFile(qPrintable(_filename.toLocal8Bit()));


### PR DESCRIPTION
Hotfix to prevent backup process from including the lock file, which was resulting in misplaced content

  * We no longer make backups at the ES, so there is no backup to
  recover from if we crash during persist to disk.
  * When loading the most recent backup we look for files that match our
  backup rules. If we have no backup rules we end up grabbing
  everything.
  * Because we grab everything, we are at risk of grabbing the lock file
  and treating it as a backup. In the case where we crash on persist, we
  end up replacing the models.json.gz file with the lock file (!!).

This commit makes a small change to not do the recovery on startup. In a
future update we will remove the backup-related code on the ES
altogether.