### PR TITLE
Fix client-only materials on non-avatars

### DIFF
--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -18,7 +18,7 @@ bool MaterialEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityP
     if (entity->getMaterial() != _drawMaterial) {
         return true;
     }
-    if (entity->getParentID() != _parentID || entity->getClientOnly() != _clientOnly || entity->getOwningAvatarID() != _owningAvatarID) {
+    if (entity->getParentID() != _parentID) {
         return true;
     }
     if (entity->getMaterialMappingPos() != _materialMappingPos || entity->getMaterialMappingScale() != _materialMappingScale || entity->getMaterialMappingRot() != _materialMappingRot) {
@@ -31,8 +31,6 @@ void MaterialEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& 
     withWriteLock([&] {
         _drawMaterial = entity->getMaterial();
         _parentID = entity->getParentID();
-        _clientOnly = entity->getClientOnly();
-        _owningAvatarID = entity->getOwningAvatarID();
         _materialMappingPos = entity->getMaterialMappingPos();
         _materialMappingScale = entity->getMaterialMappingScale();
         _materialMappingRot = entity->getMaterialMappingRot();
@@ -102,7 +100,7 @@ void MaterialEntityRenderer::doRender(RenderArgs* args) {
     graphics::MaterialPointer drawMaterial;
     Transform textureTransform;
     withReadLock([&] {
-        parentID = _clientOnly ? _owningAvatarID : _parentID;
+        parentID = _parentID;
         renderTransform = _renderTransform;
         drawMaterial = _drawMaterial;
         textureTransform.setTranslation(glm::vec3(_materialMappingPos, 0));

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.h
@@ -32,8 +32,6 @@ private:
     ShapeKey getShapeKey() override;
 
     QUuid _parentID;
-    bool _clientOnly;
-    QUuid _owningAvatarID;
     glm::vec2 _materialMappingPos;
     glm::vec2 _materialMappingScale;
     float _materialMappingRot;

--- a/libraries/entities/src/MaterialEntityItem.cpp
+++ b/libraries/entities/src/MaterialEntityItem.cpp
@@ -249,28 +249,12 @@ void MaterialEntityItem::setParentID(const QUuid& parentID) {
     }
 }
 
-void MaterialEntityItem::setClientOnly(bool clientOnly) {
-    if (getClientOnly() != clientOnly) {
-        removeMaterial();
-        EntityItem::setClientOnly(clientOnly);
-        applyMaterial();
-    }
-}
-
-void MaterialEntityItem::setOwningAvatarID(const QUuid& owningAvatarID) {
-    if (getOwningAvatarID() != owningAvatarID) {
-        removeMaterial();
-        EntityItem::setOwningAvatarID(owningAvatarID);
-        applyMaterial();
-    }
-}
-
 void MaterialEntityItem::removeMaterial() {
     graphics::MaterialPointer material = getMaterial();
     if (!material) {
         return;
     }
-    QUuid parentID = getClientOnly() ? getOwningAvatarID() : getParentID();
+    QUuid parentID = getParentID();
     if (parentID.isNull()) {
         return;
     }
@@ -294,7 +278,7 @@ void MaterialEntityItem::removeMaterial() {
 void MaterialEntityItem::applyMaterial() {
     _retryApply = false;
     graphics::MaterialPointer material = getMaterial();
-    QUuid parentID = getClientOnly() ? getOwningAvatarID() : getParentID();
+    QUuid parentID = getParentID();
     if (!material || parentID.isNull()) {
         return;
     }

--- a/libraries/entities/src/MaterialEntityItem.h
+++ b/libraries/entities/src/MaterialEntityItem.h
@@ -77,8 +77,6 @@ public:
 
     void setUserData(const QString& userData) override;
     void setParentID(const QUuid& parentID) override;
-    void setClientOnly(bool clientOnly) override;
-    void setOwningAvatarID(const QUuid& owningAvatarID) override;
 
     void applyMaterial();
     void removeMaterial();


### PR DESCRIPTION
Before:
- a client-only material could only affect your avatar

Now:
- a client-only material still uses its parentID, so it can affect anything

https://highfidelity.fogbugz.com/f/cases/13988/Client-only-material-entity-does-not-affect-client-only-entities-affects-the-avatar-only

Test plan:
- Run [this](https://gist.githubusercontent.com/SamGondelman/131a8cef5bfb48b3708231cbaaff84b0/raw/7df3d8bcbc4600aafe662b5131c207cb9e72231e/MaterialClient.js).
- All four cubes should be textured.