### PR TITLE
Fix a bug when switching shadow on/off in front of mirror

### DIFF
--- a/libraries/gpu/src/gpu/Texture.h
+++ b/libraries/gpu/src/gpu/Texture.h
@@ -128,6 +128,7 @@ public:
         uint8 _wrapModeV = WRAP_REPEAT;
         uint8 _wrapModeW = WRAP_REPEAT;
             
+        uint8 _mipOffset = 0;
         uint8 _minMip = 0;
         uint8 _maxMip = MAX_MIP_LEVEL;
 
@@ -142,6 +143,7 @@ public:
                 _wrapModeU == other._wrapModeU &&
                 _wrapModeV == other._wrapModeV &&
                 _wrapModeW == other._wrapModeW &&
+                _mipOffset == other._mipOffset &&
                 _minMip == other._minMip &&
                 _maxMip == other._maxMip;
         }
@@ -164,6 +166,7 @@ public:
     ComparisonFunction getComparisonFunction() const { return ComparisonFunction(_desc._comparisonFunc); }
     bool doComparison() const { return getComparisonFunction() != ALWAYS; }
 
+    uint8 getMipOffset() const { return _desc._mipOffset; }
     uint8 getMinMip() const { return _desc._minMip; }
     uint8 getMaxMip() const { return _desc._maxMip; }
 

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -532,7 +532,7 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
             }
         }
 
-        auto& program = deferredLightingEffect->_directionalSkyboxLight;
+        auto program = deferredLightingEffect->_directionalSkyboxLight;
         LightLocationsPtr locations = deferredLightingEffect->_directionalSkyboxLightLocations;
 
         auto keyLight = lightAndShadow.first;


### PR DESCRIPTION
THis pr addresses this Bug: https://highfidelity.fogbugz.com/f/cases/13106/Shadow-on-off-setting-switching-triggers-a-crash-when-the-Secondary-View-is-running

Fixing this bug i also addressed the logging of messages related to program, and shadow sampler with invalid texture bound.

And i also restored the Sampler::Desc layout, bringing back the mipOffset.
removing it changed the size and layout of the Sampler Desc in the ktx cache field that we add to our ktx and that would create problems during deserialization.
Looking for a bug number for it.

## TEST PLAN #
In front of a mirror where you can see the reflection, in a zone where shadow is enabled, got in the menu developer /Render.
turn on /off the menu item "Shadow"
this should globally enable disable the shadow and never crash

IN master this is crashing
