### PR TITLE
Support per-avatar gain adjustment on stereo input streams

### DIFF
--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -327,8 +327,9 @@ void AudioMixerSlave::addStream(AudioMixerClientData& listenerNodeData, const QU
         auto& hrtf = listenerNodeData.hrtfForStream(sourceNodeID, streamToAdd.getStreamIdentifier());
         gain *= hrtf.getGainAdjustment();
 
-        for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_STEREO; ++i) {
-            _mixSamples[i] += float(streamPopOutput[i] * gain / AudioConstants::MAX_SAMPLE_VALUE);
+        for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL; i++) {
+            _mixSamples[2*i+0] += (float)streamPopOutput[2*i+0] * gain * (1/32768.0f);
+            _mixSamples[2*i+1] += (float)streamPopOutput[2*i+1] * gain * (1/32768.0f);
         }
 
         ++stats.manualStereoMixes;
@@ -337,10 +338,10 @@ void AudioMixerSlave::addStream(AudioMixerClientData& listenerNodeData, const QU
 
     // echo sources are not passed through HRTF
     if (isEcho) {
-        for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_STEREO; i += 2) {
-            auto monoSample = float(streamPopOutput[i / 2] * gain / AudioConstants::MAX_SAMPLE_VALUE);
-            _mixSamples[i] += monoSample;
-            _mixSamples[i + 1] += monoSample;
+        for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL; i++) {
+            float sample = (float)streamPopOutput[i] * gain * (1/32768.0f);
+            _mixSamples[2*i+0] += sample;
+            _mixSamples[2*i+1] += sample;
         }
 
         ++stats.manualEchoMixes;

--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -322,6 +322,11 @@ void AudioMixerSlave::addStream(AudioMixerClientData& listenerNodeData, const QU
 
     // stereo sources are not passed through HRTF
     if (streamToAdd.isStereo()) {
+
+        // apply the avatar gain adjustment
+        auto& hrtf = listenerNodeData.hrtfForStream(sourceNodeID, streamToAdd.getStreamIdentifier());
+        gain *= hrtf.getGainAdjustment();
+
         for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_STEREO; ++i) {
             _mixSamples[i] += float(streamPopOutput[i] * gain / AudioConstants::MAX_SAMPLE_VALUE);
         }

--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -327,9 +327,11 @@ void AudioMixerSlave::addStream(AudioMixerClientData& listenerNodeData, const QU
         auto& hrtf = listenerNodeData.hrtfForStream(sourceNodeID, streamToAdd.getStreamIdentifier());
         gain *= hrtf.getGainAdjustment();
 
+        const float scale = 1/32768.0f; // int16_t to float
+
         for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL; i++) {
-            _mixSamples[2*i+0] += (float)streamPopOutput[2*i+0] * gain * (1/32768.0f);
-            _mixSamples[2*i+1] += (float)streamPopOutput[2*i+1] * gain * (1/32768.0f);
+            _mixSamples[2*i+0] += (float)streamPopOutput[2*i+0] * gain * scale;
+            _mixSamples[2*i+1] += (float)streamPopOutput[2*i+1] * gain * scale;
         }
 
         ++stats.manualStereoMixes;
@@ -338,8 +340,11 @@ void AudioMixerSlave::addStream(AudioMixerClientData& listenerNodeData, const QU
 
     // echo sources are not passed through HRTF
     if (isEcho) {
+
+        const float scale = 1/32768.0f; // int16_t to float
+
         for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL; i++) {
-            float sample = (float)streamPopOutput[i] * gain * (1/32768.0f);
+            float sample = (float)streamPopOutput[i] * gain * scale;
             _mixSamples[2*i+0] += sample;
             _mixSamples[2*i+1] += sample;
         }


### PR DESCRIPTION
This adds support for per-avatar gain adjustments (via the PAL sliders) for an avatar with a stereo input stream. The gain slider should behave the same, whether an avatar has a mono or stereo stream.

### Test Plan
1) Run the server from this PR as your local domain.
2) With Interface, join the domain and set your audio input device to stereo.
    This can be a stereo device, or a virtual device (using Virtual Audio Cable) to a media player.
    Stereo is enabled in the Audio menu, with the "Enable stereo input" checkbox.
3) Join again from another machine, and verify you can adjust the volume of the stereo stream. 
    The slider is in the People tab, in the list of avatars.

