### PR TITLE
fix grab.js unable to grab other entities

### DIFF
--- a/scripts/system/controllers/grab.js
+++ b/scripts/system/controllers/grab.js
@@ -8,7 +8,7 @@
 //
 //  Grab's physically moveable entities with the mouse, by applying a spring force.
 //
-//  Updated November 22, 2016 by Philip Rosedale:  Add distance attenuation of grab effect 
+//  Updated November 22, 2016 by Philip Rosedale:  Add distance attenuation of grab effect
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -444,6 +444,7 @@ Grabber.prototype.releaseEvent = function(event) {
         this.actionID = null;
 
         Pointers.setRenderState(this.mouseRayEntities, "");
+        Pointers.setLockEndUUID(this.mouseRayEntities, null, false);
 
         var args = "mouse";
         Entities.callEntityMethod(this.entityID, "releaseGrab", args);


### PR DESCRIPTION
fix grab.js unable to grab other entities other than the first grabbed entity