### PR TITLE
Fix FBX vertex colors not being read correctly

### DIFF
--- a/libraries/fbx/src/FBXReader_Mesh.cpp
+++ b/libraries/fbx/src/FBXReader_Mesh.cpp
@@ -249,7 +249,7 @@ ExtractedMesh FBXReader::extractMesh(const FBXNode& object, unsigned int& meshIn
                     indexToDirect = true;
                 }
             }
-            if (indexToDirect && data.normalIndices.isEmpty()) {
+            if (indexToDirect && data.colorIndices.isEmpty()) {
                 // hack to work around wacky Makehuman exports
                 data.colorsByVertex = true;
             }


### PR DESCRIPTION
I found this while working on other FBX changes. Untested.