### PR TITLE
RC66: Exposing more texture memory budget options

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -447,6 +447,9 @@ Menu::Menu() {
     textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTexture512MB, 0, false));
     textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTexture1024MB, 0, false));
     textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTexture2048MB, 0, false));
+    textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTexture4096MB, 0, false));
+    textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTexture6144MB, 0, false));
+    textureGroup->addAction(addCheckableActionToQMenuAndActionHash(textureMenu, MenuOption::RenderMaxTexture8192MB, 0, false));
     connect(textureGroup, &QActionGroup::triggered, [textureGroup] {
         auto checked = textureGroup->checkedAction();
         auto text = checked->text();
@@ -463,6 +466,12 @@ Menu::Menu() {
             newMaxTextureMemory = MB_TO_BYTES(1024);
         } else if (MenuOption::RenderMaxTexture2048MB == text) {
             newMaxTextureMemory = MB_TO_BYTES(2048);
+        } else if (MenuOption::RenderMaxTexture4096MB == text) {
+            newMaxTextureMemory = MB_TO_BYTES(4096);
+        } else if (MenuOption::RenderMaxTexture6144MB == text) {
+            +newMaxTextureMemory = MB_TO_BYTES(6144);
+        } else if (MenuOption::RenderMaxTexture8192MB == text) {
+            newMaxTextureMemory = MB_TO_BYTES(8192);
         }
         gpu::Texture::setAllowedGPUMemoryUsage(newMaxTextureMemory);
     });

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -469,7 +469,7 @@ Menu::Menu() {
         } else if (MenuOption::RenderMaxTexture4096MB == text) {
             newMaxTextureMemory = MB_TO_BYTES(4096);
         } else if (MenuOption::RenderMaxTexture6144MB == text) {
-            +newMaxTextureMemory = MB_TO_BYTES(6144);
+            newMaxTextureMemory = MB_TO_BYTES(6144);
         } else if (MenuOption::RenderMaxTexture8192MB == text) {
             newMaxTextureMemory = MB_TO_BYTES(8192);
         }

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -155,6 +155,10 @@ namespace MenuOption {
     const QString RenderMaxTexture512MB = "512 MB";
     const QString RenderMaxTexture1024MB = "1024 MB";
     const QString RenderMaxTexture2048MB = "2048 MB";
+    const QString RenderMaxTexture3072MB = "3072 MB";
+    const QString RenderMaxTexture4096MB = "4096 MB";
+    const QString RenderMaxTexture6144MB = "6144 MB";
+    const QString RenderMaxTexture8192MB = "8192 MB";
     const QString RenderResolution = "Scale Resolution";
     const QString RenderResolutionOne = "1";
     const QString RenderResolutionTwoThird = "2/3";


### PR DESCRIPTION
Adding more budget options for memory texture to be able to handle larger scenes

## TEST PLAN ##
Enabling the developer menu,
in Render/ Maximum Texture Memory
you should see a bunch of new options compared to RC66 tip build (4Mb, 6Mb, 8Mb):
![image](https://user-images.githubusercontent.com/2230265/38754043-29742a7c-3f15-11e8-88cc-14c4740eb48d.png)
