### PR TITLE
RC66: Reverting TAA to FXAA in rc66 until we fix the aa on tablet

### DIFF
--- a/libraries/render-utils/src/AntialiasingEffect.h
+++ b/libraries/render-utils/src/AntialiasingEffect.h
@@ -26,7 +26,11 @@ class JitterSampleConfig : public render::Job::Config {
         Q_PROPERTY(bool stop MEMBER stop NOTIFY dirty)
         Q_PROPERTY(int index READ getIndex NOTIFY dirty)
 public:
-    JitterSampleConfig() : render::Job::Config(true) {}
+    JitterSampleConfig() : render::Job::Config(true) {
+        // FIXME: For RC66 disable Taa by default
+        // Disable jitter by default for now by default:
+        none();
+    }
 
     float scale{ 0.5f };
     bool stop{ false };
@@ -113,7 +117,10 @@ public:
     bool feedbackColor{ false };
 
     float debugX{ 0.0f };
-    float debugFXAAX{ 1.0f };
+    // FIXME: For RC66 disable Taa by default
+    // Fall back to FXAA :(
+    // float debugFXAAX{ 1.0f };
+    float debugFXAAX{ 0.0f };
     float debugShowVelocityThreshold{ 1.0f };
     glm::vec2 debugCursorTexcoord{ 0.5f, 0.5f };
     float debugOrbZoom{ 2.0f };

--- a/scripts/developer/utilities/render/antialiasing.qml
+++ b/scripts/developer/utilities/render/antialiasing.qml
@@ -36,7 +36,7 @@ Rectangle {
             Row {
                 spacing: 10
                 id: fxaaOnOff
-                property bool debugFXAA: false
+                property bool debugFXAA: true
                 HifiControls.Button {
                     text: {
                         if (fxaaOnOff.debugFXAA) {


### PR DESCRIPTION
With TAA, the tablet surface content is too blurry
WE are reverting to FXAA until we fix it

## TEST PLAN 
Bring the tablet in this pr build, the quality of the content displayed should be back and comparable to rc65.1

Of course all the benefits of TAA are lost for now... :(