### PR TITLE
In Material resources, support relative paths for 'emissiveMap'

### DIFF
--- a/libraries/model-networking/src/model-networking/MaterialCache.cpp
+++ b/libraries/model-networking/src/model-networking/MaterialCache.cpp
@@ -194,7 +194,7 @@ std::pair<std::string, std::shared_ptr<NetworkMaterial>> NetworkMaterialResource
         } else if (key == "emissiveMap") {
             auto value = materialJSON.value(key);
             if (value.isString()) {
-                material->setEmissiveMap(value.toString());
+                material->setEmissiveMap(baseUrl.resolved(value.toString()));
             }
         } else if (key == "albedoMap") {
             auto value = materialJSON.value(key);


### PR DESCRIPTION
All of the other URLs support relative paths, except for this one.