### PR TITLE
Log a warning if an entity's property is too large

### DIFF
--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -119,7 +119,10 @@ void EntityEditPacketSender::queueEditEntityMessage(PacketType type,
     while (encodeResult == OctreeElement::PARTIAL) {
         encodeResult = EntityItemProperties::encodeEntityEditPacket(type, entityItemID, propertiesCopy, bufferOut, requestedProperties, didntFitProperties);
 
-        if (encodeResult != OctreeElement::NONE) {
+        if (encodeResult == OctreeElement::NONE) {
+            qCWarning(entities).nospace() << "queueEditEntityMessage: some of the properties don't fit and can't be sent. entityID=" << uuidStringWithoutCurlyBraces(entityItemID);
+        }
+        else {
             #ifdef WANT_DEBUG
                 qCDebug(entities) << "calling queueOctreeEditMessage()...";
                 qCDebug(entities) << "    id:" << entityItemID;

--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -125,8 +125,7 @@ void EntityEditPacketSender::queueEditEntityMessage(PacketType type,
             // 2. The requested properties don't exist in this entity type (e.g., 'modelUrl' in a Zone Entity).
             // Since case #1 is more likely (and more critical), that's the one we warn about.
             qCWarning(entities).nospace() << "queueEditEntityMessage: some of the properties don't fit and can't be sent. entityID=" << uuidStringWithoutCurlyBraces(entityItemID);
-        }
-        else {
+        } else {
             #ifdef WANT_DEBUG
                 qCDebug(entities) << "calling queueOctreeEditMessage()...";
                 qCDebug(entities) << "    id:" << entityItemID;

--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -120,6 +120,10 @@ void EntityEditPacketSender::queueEditEntityMessage(PacketType type,
         encodeResult = EntityItemProperties::encodeEntityEditPacket(type, entityItemID, propertiesCopy, bufferOut, requestedProperties, didntFitProperties);
 
         if (encodeResult == OctreeElement::NONE) {
+            // This can happen for two reasons:
+            // 1. One of the properties is too large to fit in a single packet.
+            // 2. The requested properties don't exist in this entity type (e.g., 'modelUrl' in a Zone Entity).
+            // Since case #1 is more likely (and more critical), that's the one we warn about.
             qCWarning(entities).nospace() << "queueEditEntityMessage: some of the properties don't fit and can't be sent. entityID=" << uuidStringWithoutCurlyBraces(entityItemID);
         }
         else {


### PR DESCRIPTION
This is related to https://github.com/highfidelity/hifi/issues/12794. If an entity's property is larger than a UDP packet then it can't be sent from Interface to the Entity Server. Currently this problem happens silently, so it's unclear when (or if) it happens. This PR adds a warning to the log when the problem occurs.