### PR TITLE
Fixed banning users

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -770,10 +770,9 @@ unsigned int LimitedNodeList::broadcastToNodes(std::unique_ptr<NLPacket> packet,
     eachNode([&](const SharedNodePointer& node){
         if (node && destinationNodeTypes.contains(node->getType())) {
 			if (packet->isReliable()) {
-				auto packet1 = NLPacket::createCopy(*packet);
-				sendPacket(std::move(packet1), *node);
-			}
-			else {
+				auto packetCopy = NLPacket::createCopy(*packet);
+				sendPacket(std::move(packetCopy), *node);
+			} else {
 				sendUnreliablePacket(*packet, *node);
 			}
 			++n;

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -769,8 +769,14 @@ unsigned int LimitedNodeList::broadcastToNodes(std::unique_ptr<NLPacket> packet,
 
     eachNode([&](const SharedNodePointer& node){
         if (node && destinationNodeTypes.contains(node->getType())) {
-            sendUnreliablePacket(*packet, *node);
-            ++n;
+			if (packet->isReliable()) {
+				auto packet1 = NLPacket::createCopy(*packet);
+				sendPacket(std::move(packet1), *node);
+			}
+			else {
+				sendUnreliablePacket(*packet, *node);
+			}
+			++n;
         }
     });
 


### PR DESCRIPTION
Banning users didn't work because LimitedNodeList::broadcastToNodes() tried to send an Unreliable packet, but banning users uses a Reliable packet.