### PR TITLE
Fixed null pointer exception if importing an entity from JSON fails

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -2282,7 +2282,10 @@ bool EntityTree::sendEntitiesOperation(const OctreeElementPointer& element, void
         if (args->otherTree) {
             args->otherTree->withWriteLock([&] {
                 EntityItemPointer entity = args->otherTree->addEntity(newID, properties);
-                entity->deserializeActions();
+                if (entity) {
+                    entity->deserializeActions();
+                }
+                // else: there was an error adding this entity
             });
         }
         return newID;


### PR DESCRIPTION
When importing entities from JSON: if an entity fails to import then addEntity() returns null. We need to check for this case, otherwise Interface crashes due to a null pointer exception.

I don't remember what caused addEntity() to fail for me. Perhaps bad values in the JSON? In any case, this check needs to be added for robustness.