### PR TITLE
Fixed crash when importing entities from JSON multiple times

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -112,6 +112,11 @@ void EntityTree::eraseAllOctreeElements(bool createNewRoot) {
 
     resetClientEditStats();
     clearDeletedEntities();
+
+    {
+        QWriteLocker locker(&_needsParentFixupLock);
+        _needsParentFixup.clear();
+    }
 }
 
 void EntityTree::readBitstreamToTree(const unsigned char* bitstream,


### PR DESCRIPTION
When using the "Import Entities" command several times in a row, Interface often crashes. And when it doesn't crash, a different problem often occurs: after the first import, subsequently imported entities may appear very far from the user (instead of right in front of him).

Both problems occur because the Clipboard isn't completely cleared between uses.

This bug can be reproduced by repeatedly importing entities using "Import Entities". I've included the sample JSON file that I used for testing this, but I believe that any JSON file containing entities would cause this problem (possibly only if it contains 2+ entities).
[3-boxes.zip](https://github.com/highfidelity/hifi/files/1919727/3-boxes.zip)

