### PR TITLE
edit.js - remove ability to clone non-owned avatar-entities

### DIFF
--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -156,7 +156,7 @@ SelectionManager = (function() {
 
     that.duplicateSelection = function () {
         var duplicatedEntityIDs = [];
-        Object.keys(that.savedProperties).forEach(function (otherEntityID) {
+        Object.keys(that.savedProperties).forEach(function(otherEntityID) {
             var properties = that.savedProperties[otherEntityID];
             if (!properties.locked && (!properties.clientOnly || properties.owningAvatarID === MyAvatar.sessionUUID)) {
                 duplicatedEntityIDs.push({

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -13,9 +13,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-/* global HIFI_PUBLIC_BUCKET, SPACE_LOCAL, Script, SelectionManager */
-
-HIFI_PUBLIC_BUCKET = "http://s3.amazonaws.com/hifi-public/";
+/* global SPACE_LOCAL, SelectionManager */
 
 SPACE_LOCAL = "local";
 SPACE_WORLD = "world";
@@ -50,6 +48,7 @@ SelectionManager = (function() {
             messageParsed = JSON.parse(message);
         } catch (err) {
             print("ERROR: entitySelectionTool.handleEntitySelectionToolUpdates - got malformed message: " + message);
+            return;
         }
 
         if (messageParsed.method === "selectEntity") {
@@ -154,6 +153,20 @@ SelectionManager = (function() {
         that.selections = [];
         that._update(true);
     };
+
+    that.duplicateSelection = function () {
+        var duplicatedEntityIDs = [];
+        Object.keys(that.savedProperties).forEach(function (otherEntityID) {
+            var properties = that.savedProperties[otherEntityID];
+            if (!properties.locked && (!properties.clientOnly || properties.owningAvatarID === MyAvatar.sessionUUID)) {
+                duplicatedEntityIDs.push({
+                    entityID: Entities.addEntity(properties),
+                    properties: properties
+                });
+            }
+        });
+        return duplicatedEntityIDs;
+    }
 
     that._update = function(selectionUpdated) {
         var properties = null;
@@ -443,7 +456,7 @@ SelectionDisplay = (function() {
         solid: true,
         visible: false,
         ignoreRayIntersection: true,
-        drawInFront: true,
+        drawInFront: true
     }
     var handleStretchXPanel = Overlays.addOverlay("shape", handlePropertiesStretchPanel);
     Overlays.editOverlay(handleStretchXPanel, { color : COLOR_RED });
@@ -749,6 +762,7 @@ SelectionDisplay = (function() {
         } else if (overlay === handleTranslateZCylinder) {
             return handleTranslateZCone;
         }
+        return Uuid.NULL;
     };
 
     // FUNCTION: MOUSE MOVE EVENT
@@ -1038,13 +1052,13 @@ SelectionDisplay = (function() {
             var toCameraDistance = getDistanceToCamera(position);
 
             var localRotationX = Quat.fromPitchYawRollDegrees(0, 0, -90);
-            rotationX = Quat.multiply(rotation, localRotationX);
+            var rotationX = Quat.multiply(rotation, localRotationX);
             worldRotationX = rotationX;
             var localRotationY = Quat.fromPitchYawRollDegrees(0, 90, 0);
-            rotationY = Quat.multiply(rotation, localRotationY);
+            var rotationY = Quat.multiply(rotation, localRotationY);
             worldRotationY = rotationY;
             var localRotationZ = Quat.fromPitchYawRollDegrees(90, 0, 0);
-            rotationZ = Quat.multiply(rotation, localRotationZ);
+            var rotationZ = Quat.multiply(rotation, localRotationZ);
             worldRotationZ = rotationZ;
 
             // in HMD we clamp the overlays to the bounding box for now so lasers can hit them
@@ -1260,10 +1274,9 @@ SelectionDisplay = (function() {
                 dimensions: stretchPanelXDimensions
             });
             var stretchPanelYDimensions = Vec3.subtract(scaleLTNCubePositionRotated, scaleRTFCubePositionRotated);
-            var tempX = Math.abs(stretchPanelYDimensions.x);
             stretchPanelYDimensions.x = Math.abs(stretchPanelYDimensions.z);
             stretchPanelYDimensions.y = STRETCH_PANEL_WIDTH;
-            stretchPanelYDimensions.z = tempX;
+            stretchPanelYDimensions.z = Math.abs(stretchPanelYDimensions.x);
             var stretchPanelYPosition = Vec3.sum(position, Vec3.multiplyQbyV(rotation, { x:0, y:dimensions.y / 2, z:0 }));
             Overlays.editOverlay(handleStretchYPanel, { 
                 position: stretchPanelYPosition, 
@@ -1271,9 +1284,8 @@ SelectionDisplay = (function() {
                 dimensions: stretchPanelYDimensions
             });
             var stretchPanelZDimensions = Vec3.subtract(scaleLTNCubePositionRotated, scaleRBFCubePositionRotated);
-            var tempX = Math.abs(stretchPanelZDimensions.x);
             stretchPanelZDimensions.x = Math.abs(stretchPanelZDimensions.y);
-            stretchPanelZDimensions.y = tempX;
+            stretchPanelZDimensions.y = Math.abs(stretchPanelZDimensions.x);
             stretchPanelZDimensions.z = STRETCH_PANEL_WIDTH;
             var stretchPanelZPosition = Vec3.sum(position, Vec3.multiplyQbyV(rotation, { x:0, y:0, z:dimensions.z / 2 }));
             Overlays.editOverlay(handleStretchZPanel, { 
@@ -1519,17 +1531,7 @@ SelectionDisplay = (function() {
             // copy of the selected entities and move the _original_ entities, not
             // the new ones.
             if (event.isAlt || doClone) {
-                duplicatedEntityIDs = [];
-                for (var otherEntityID in SelectionManager.savedProperties) {
-                    var properties = SelectionManager.savedProperties[otherEntityID];
-                    if (!properties.locked) {
-                        var entityID = Entities.addEntity(properties);
-                        duplicatedEntityIDs.push({
-                            entityID: entityID,
-                            properties: properties
-                        });
-                    }
-                }
+                duplicatedEntityIDs = SelectionManager.duplicateSelection();
             } else {
                 duplicatedEntityIDs = null;
             }
@@ -1690,17 +1692,7 @@ SelectionDisplay = (function() {
                 // copy of the selected entities and move the _original_ entities, not
                 // the new ones.
                 if (event.isAlt) {
-                    duplicatedEntityIDs = [];
-                    for (var otherEntityID in SelectionManager.savedProperties) {
-                        var properties = SelectionManager.savedProperties[otherEntityID];
-                        if (!properties.locked) {
-                            var entityID = Entities.addEntity(properties);
-                            duplicatedEntityIDs.push({
-                                entityID: entityID,
-                                properties: properties
-                            });
-                        }
-                    }
+                    duplicatedEntityIDs = SelectionManager.duplicateSelection();
                 } else {
                     duplicatedEntityIDs = null;
                 }

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -154,7 +154,7 @@ SelectionManager = (function() {
         that._update(true);
     };
 
-    that.duplicateSelection = function () {
+    that.duplicateSelection = function() {
         var duplicatedEntityIDs = [];
         Object.keys(that.savedProperties).forEach(function(otherEntityID) {
             var properties = that.savedProperties[otherEntityID];


### PR DESCRIPTION
Avatar entities that belong to another user should not be clonable with the Create app. This PR should fix that.

Internal bug tracker: https://highfidelity.fogbugz.com/f/cases/14068/Uncertified-avatar-entities-imported-by-one-user-can-be-copied-by-other-users

## QA test

Two users are required for the test. The domain should allow the users to rez.

1) User A: Use the `Edit -> Import Entities from URL` menu option and import `https://gist.githubusercontent.com/thoys/c4468e65affc5c3bc0fca5bd8c20b6e3/raw/6434c906c91d72170354549d0d668e9d35cdc868/AvatarEntity.json`
2) User B: Open Create app and select the imported entity
3) User B: Using hotkey (PC: Alt+ Left mouse click/Mac: Option+Left mouse click) drag select imported entity
4) The entity should not be cloned now. Please verify in the Create apps entities list that there is only one `avatar entity sphere`
5) User A: Open the create menu and create a cube.
6) User B: Using hotkey (PC: Alt+ Left mouse click/Mac: Option+Left mouse click) drag select imported entity
7) The entity should be cloned now (non-avatar-entity cloning should still function after this)