### PR TITLE
Fix AMD shader compilation

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
@@ -452,7 +452,7 @@ protected:
     // Backend dependant compilation of the shader
     virtual GLShader* compileBackendProgram(const Shader& program, const Shader::CompilationHandler& handler);
     virtual GLShader* compileBackendShader(const Shader& shader, const Shader::CompilationHandler& handler);
-    virtual std::string getBackendShaderHeader() const;
+    virtual std::string getBackendShaderHeader() const = 0;
     virtual void makeProgramBindings(ShaderObject& shaderObject);
     class ElementResource {
     public:

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendShader.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendShader.cpp
@@ -12,27 +12,6 @@
 using namespace gpu;
 using namespace gpu::gl;
 
-// GLSL version
-std::string GLBackend::getBackendShaderHeader() const {
-
-#if defined(USE_GLES)
-    static const std::string header(
-R"SHADER(#version 310 es
-#extension GL_EXT_texture_buffer : enable
-precision lowp float; // check precision 2
-precision lowp samplerBuffer;
-precision lowp sampler2DShadow;
-)SHADER");
-#else
-    static const std::string header(
-R"SHADER(#version 410 core
-)SHADER");
-#endif
-
-    return header;
-}
-
-
 // Shader domain
 static const size_t NUM_SHADER_DOMAINS = 3;
 static_assert(Shader::Type::NUM_DOMAINS == NUM_SHADER_DOMAINS, "GL shader domains must equal defined GPU shader domains");

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendShader.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendShader.cpp
@@ -14,7 +14,13 @@ using namespace gpu::gl41;
 
 // GLSL version
 std::string GL41Backend::getBackendShaderHeader() const {
-    return std::string("#version 410 core\n#define GPU_GL410 1");
+    static const std::string header(
+        R"SHADER(#version 410 core
+        #define GPU_GL410
+        #define PRECISIONQ
+        #define BITFIELD int
+        )SHADER");
+    return header;
 }
 
 int GL41Backend::makeResourceBufferSlots(GLuint glprogram, const Shader::BindingSet& slotBindings,Shader::SlotSet& resourceBuffers) {

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendShader.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendShader.cpp
@@ -15,15 +15,17 @@ using namespace gpu::gl45;
 
 // GLSL version
 std::string GL45Backend::getBackendShaderHeader() const {
-    const char header[] = 
-R"GLSL(#version 450 core
-#define GPU_GL450
-)GLSL"
+    static const std::string header(
+        R"SHADER(#version 450 core
+        #define GPU_GL450
+        #define PRECISIONQ
+        #define BITFIELD int
+        )SHADER"
 #ifdef GPU_SSBO_TRANSFORM_OBJECT
-        R"GLSL(#define GPU_SSBO_TRANSFORM_OBJECT 1)GLSL"
+        R"SHADER(#define GPU_SSBO_TRANSFORM_OBJECT)SHADER"
 #endif
-    ;
-    return std::string(header);
+    );
+    return header;
 }
 
 int GL45Backend::makeResourceBufferSlots(GLuint glprogram, const Shader::BindingSet& slotBindings,Shader::SlotSet& resourceBuffers) {

--- a/libraries/gpu-gles/src/gpu/gles/GLESBackendShader.cpp
+++ b/libraries/gpu-gles/src/gpu/gles/GLESBackendShader.cpp
@@ -14,7 +14,16 @@ using namespace gpu::gles;
 
 // GLSL version
 std::string GLESBackend::getBackendShaderHeader() const {
-    return Parent::getBackendShaderHeader();
+    static const std::string header(
+        R"SHADER(#version 310 es
+        #extension GL_EXT_texture_buffer : enable
+        precision lowp float; // check precision 2
+        precision lowp samplerBuffer;
+        precision lowp sampler2DShadow;
+        #define PRECISIONQ highp
+        #define BITFIELD highp int
+        )SHADER");
+    return header;
 }
 
 int GLESBackend::makeResourceBufferSlots(GLuint glprogram, const Shader::BindingSet& slotBindings,Shader::SlotSet& resourceBuffers) {

--- a/libraries/graphics/src/graphics/Light.slh
+++ b/libraries/graphics/src/graphics/Light.slh
@@ -29,16 +29,9 @@ vec3 getLightColor(Light l) { return lightIrradiance_getColor(l.irradiance); }
 float getLightIntensity(Light l) { return lightIrradiance_getIntensity(l.irradiance); }
 vec3 getLightIrradiance(Light l) { return lightIrradiance_getIrradiance(l.irradiance); }
 
-// AMbient lighting needs extra info provided from a different Buffer
+// Ambient lighting needs extra info provided from a different Buffer
 <@include graphics/SphericalHarmonics.shared.slh@>
 // Light Ambient
-#ifndef PRECISIONQ
-#ifdef GL_ES
-#define PRECISIONQ highp
-#else
-#define PRECISIONQ
-#endif
-#endif
 
 struct LightAmbient {
     PRECISIONQ vec4 _ambient;

--- a/libraries/graphics/src/graphics/LightIrradiance.shared.slh
+++ b/libraries/graphics/src/graphics/LightIrradiance.shared.slh
@@ -12,13 +12,7 @@
 
 
 #define LightIrradianceConstRef LightIrradiance
-#ifndef PRECISIONQ
-#ifdef GL_ES
-#define PRECISIONQ highp
-#else
-#define PRECISIONQ
-#endif
-#endif
+
 struct LightIrradiance {
     PRECISIONQ vec4 colorIntensity;
     // falloffRadius, cutoffRadius, falloffSpot, spare

--- a/libraries/graphics/src/graphics/LightVolume.shared.slh
+++ b/libraries/graphics/src/graphics/LightVolume.shared.slh
@@ -15,14 +15,6 @@
 
 #define LightVolumeConstRef LightVolume
 
-#ifndef PRECISIONQ
-#ifdef GL_ES
-#define PRECISIONQ highp
-#else
-#define PRECISIONQ
-#endif
-#endif
-
 struct LightVolume {
     PRECISIONQ vec4 positionRadius;
     PRECISIONQ vec4 directionSpotCos;

--- a/libraries/graphics/src/graphics/Material.slh
+++ b/libraries/graphics/src/graphics/Material.slh
@@ -13,14 +13,7 @@
 
 // The material values (at least the material key) must be precisely bitwise accurate
 // to what is provided by the uniform buffer, or the material key has the wrong bits
-#ifdef GL_ES
-precision highp float;
-#define BITFIELD highp int
-#define PRECISIONQ highp
-#else
-#define BITFIELD int
-#define PRECISIONQ 
-#endif
+
 struct Material {
     PRECISIONQ vec4 _emissiveOpacity;
     PRECISIONQ vec4 _albedoRoughness;

--- a/libraries/graphics/src/graphics/SphericalHarmonics.shared.slh
+++ b/libraries/graphics/src/graphics/SphericalHarmonics.shared.slh
@@ -15,14 +15,6 @@
 
 #define SphericalHarmonicsConstRef SphericalHarmonics
 
-#ifndef PRECISIONQ
-#ifdef GL_ES
-#define PRECISIONQ highp
-#else
-#define PRECISIONQ
-#endif
-#endif
-
 struct SphericalHarmonics {
     PRECISIONQ vec4 L00;
     PRECISIONQ vec4 L1m1;

--- a/libraries/render-utils/src/LightingModel.slh
+++ b/libraries/render-utils/src/LightingModel.slh
@@ -13,14 +13,6 @@
 
 <@func declareLightingModel()@>
 
-#ifndef PRECISIONQ
-#ifdef GL_ES
-#define PRECISIONQ highp
-#else
-#define PRECISIONQ
-#endif
-#endif
-
 struct LightingModel {
     PRECISIONQ vec4 _UnlitEmissiveLightmapBackground;
     PRECISIONQ vec4 _ScatteringDiffuseSpecularAlbedo;


### PR DESCRIPTION
This should fix some shader compilation issues on AMD cards.

Test plan:
- Run Interface on: Windows (NVIDIA and AMD cards), mac, and android.  Check logs for shader compilation errors.  You shouldn't see any.