### PR TITLE
Create app: Save light selection menu option properly

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1293,7 +1293,7 @@ Script.scriptEnding.connect(function () {
     Settings.setValue(SETTING_EDIT_PREFIX + MENU_CREATE_ENTITIES_GRABBABLE, Menu.isOptionChecked(MENU_CREATE_ENTITIES_GRABBABLE));
     Settings.setValue(SETTING_EDIT_PREFIX + MENU_ALLOW_SELECTION_LARGE, Menu.isOptionChecked(MENU_ALLOW_SELECTION_LARGE));
     Settings.setValue(SETTING_EDIT_PREFIX + MENU_ALLOW_SELECTION_SMALL, Menu.isOptionChecked(MENU_ALLOW_SELECTION_SMALL));
-    Settings.setValue(SETTING_EDIT_PREFIX + MENU_ALLOW_SELECTION_LIGHTS, Menu.isOptionChecked(GRABBABLE_ENTITIES_MENU_ITEM));
+    Settings.setValue(SETTING_EDIT_PREFIX + MENU_ALLOW_SELECTION_LIGHTS, Menu.isOptionChecked(MENU_ALLOW_SELECTION_LIGHTS));
 
 
     progressDialog.cleanup();


### PR DESCRIPTION
Fixes https://highfidelity.fogbugz.com/f/cases/assign/14286/edit-js-script-shutdown-yields-error

## Test Plan

1. Install the build from this PR
2. Enabled 'Advanced' and 'Developer' Menus
3. Confirm that the following options are checked: 

| Option | Checked |
| ------------- |:-------------:|
| Create Entities as Grabbable | YES |
| Allow Selecting of Small | YES | 
| Allow Selecting of Large | YES | 
| Allow Selecting of Lights | NO |

4. In Create mode, confirm that you can select small and large models, that you only can select a light by clicking the icon for it. Confirm that new items you make are grabbable.
5. In the Edit menu, toggle off the menu items and test the inverse of the above settings.
6. Confirmed that while unchecked in Create mode, you do not create grabbable items, you cannot select small entities or large entities, and that you can select a light by clicking in the vicinity of the light icon.
7. Please reverse the default checkbox options by checking the boxes in the following way:

| Option | Checked |
| ------------- |:-------------:|
| Create Entities as Grabbable | NO |
| Allow Selecting of Small | NO | 
| Allow Selecting of Large | NO | 
| Allow Selecting of Lights | YES |

8. Restart Interface.
9. Confirm that the menu items remain in their reversed configuration and persist across a restart. 
 (See 7. for the reversed options) _Note that if Interface crashes on exit, these may not get saved._
10. Confirm that if you reset your settings in Interface that the default checked options return. (See 3. for the default options)