### PR TITLE
Fix edit icon behavior

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -452,6 +452,25 @@ var toolBar = (function () {
         }
     }
 
+    // Handles any edit mode updates required when domains have switched
+    function checkEditPermissionsAndUpdate() {
+        if ((createButton === null) || (createButton === undefined)) {
+            //--EARLY EXIT--( nothing to safely update )
+            return;
+        }
+
+        var hasRezPermissions = (Entities.canRez() || Entities.canRezTmp() || Entities.canRezCertified() || Entities.canRezTmpCertified());
+        createButton.editProperties({
+            icon: (hasRezPermissions ? CREATE_ENABLED_ICON : CREATE_DISABLED_ICON),
+            captionColor: (hasRezPermissions ? "#ffffff" : "#888888"),
+        });
+
+        if (!hasRezPermissions && isActive) {
+            that.setActive(false);
+            tablet.gotoHomeScreen();
+        }
+    }
+
     function initialize() {
         Script.scriptEnding.connect(cleanup);
         Window.domainChanged.connect(function () {
@@ -854,27 +873,6 @@ function handleOverlaySelectionToolUpdates(channel, message, sender) {
         if (entity !== null) {
             selectionManager.setSelections([entity]);
         }
-    }
-}
-
-// Handles any edit mode updates required when domains have switched
-function checkEditPermissionsAndUpdate() {
-    if ( (createButton === null) || (createButton === undefined) ){
-        //--EARLY EXIT--( nothing to safely update )
-        return;
-    }
-
-    var hasRezPermissions = (Entities.canRez() || Entities.canRezTmp() || Entities.canRezCertified() || Entities.canRezTmpCertified());
-    createButton.editProperties({
-        icon: (hasRezPermissions ? CREATE_ENABLED_ICON : CREATE_DISABLED_ICON),
-        captionColor: (hasRezPermissions ? "#ffffff" : "#888888"),
-    });
-
-    if (!hasRezPermissions) {
-        if (isActive) {
-            that.setActive(false);
-        }
-        tablet.gotoHomeScreen();
     }
 }
 

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -457,6 +457,7 @@ var toolBar = (function () {
         Window.domainChanged.connect(function () {
             that.setActive(false);
             that.clearEntityList();
+            handleDomainChange();
         });
 
         Entities.canAdjustLocksChanged.connect(function (canAdjustLocks) {
@@ -870,17 +871,12 @@ function handleMessagesReceived(channel, message, sender) {
             handleOverlaySelectionToolUpdates( channel, message, sender );
             break;
         }
-        case 'Toolbar-DomainChanged': {
-            handleDomainChange();
-            break;
-        }
         default: {
             return;
         }
     }
 }
 
-Messages.subscribe('Toolbar-DomainChanged');
 Messages.subscribe("entityToolUpdates");
 Messages.messageReceived.connect(handleMessagesReceived);
 
@@ -1314,8 +1310,6 @@ Script.scriptEnding.connect(function () {
 
     Messages.messageReceived.disconnect(handleMessagesReceived);
     Messages.unsubscribe("entityToolUpdates");
-    // Messages.unsubscribe("Toolbar-DomainChanged"); // Do not unsubscribe because the shapes.js app also subscribes and 
-    // Messages.subscribe works script engine-wide which would mess things up if they're both run in the same engine.
     createButton = null;
 });
 

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -457,14 +457,24 @@ var toolBar = (function () {
         Window.domainChanged.connect(function () {
             that.setActive(false);
             that.clearEntityList();
-            handleDomainChange();
+            checkEditPermissionsAndUpdate();
         });
 
         Entities.canAdjustLocksChanged.connect(function (canAdjustLocks) {
             if (isActive && !canAdjustLocks) {
                 that.setActive(false);
+                tablet.gotoHomeScreen();
             }
+            checkEditPermissionsAndUpdate();
         });
+
+        Entities.canRezChanged.connect(function (canRez) {
+            if (isActive && !canRez) {
+                that.setActive(false);
+                tablet.gotoHomeScreen();
+            }
+            checkEditPermissionsAndUpdate();
+        })
 
         var hasRezPermissions = (Entities.canRez() || Entities.canRezTmp() || Entities.canRezCertified() || Entities.canRezTmpCertified());
         var createButtonIconRsrc = (hasRezPermissions ? CREATE_ENABLED_ICON : CREATE_DISABLED_ICON);
@@ -852,7 +862,7 @@ function handleOverlaySelectionToolUpdates(channel, message, sender) {
 }
 
 // Handles any edit mode updates required when domains have switched
-function handleDomainChange() {
+function checkEditPermissionsAndUpdate() {
     if ( (createButton === null) || (createButton === undefined) ){
         //--EARLY EXIT--( nothing to safely update )
         return;

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -463,18 +463,14 @@ var toolBar = (function () {
         Entities.canAdjustLocksChanged.connect(function (canAdjustLocks) {
             if (isActive && !canAdjustLocks) {
                 that.setActive(false);
-                tablet.gotoHomeScreen();
             }
             checkEditPermissionsAndUpdate();
         });
 
-        Entities.canRezChanged.connect(function (canRez) {
-            if (isActive && !canRez) {
-                that.setActive(false);
-                tablet.gotoHomeScreen();
-            }
-            checkEditPermissionsAndUpdate();
-        })
+        Entities.canRezChanged.connect(checkEditPermissionsAndUpdate);
+        Entities.canRezTmpChanged.connect(checkEditPermissionsAndUpdate);
+        Entities.canRezCertifiedChanged.connect(checkEditPermissionsAndUpdate);
+        Entities.canRezTmpCertifiedChanged.connect(checkEditPermissionsAndUpdate);
 
         var hasRezPermissions = (Entities.canRez() || Entities.canRezTmp() || Entities.canRezCertified() || Entities.canRezTmpCertified());
         var createButtonIconRsrc = (hasRezPermissions ? CREATE_ENABLED_ICON : CREATE_DISABLED_ICON);
@@ -873,6 +869,13 @@ function checkEditPermissionsAndUpdate() {
         icon: (hasRezPermissions ? CREATE_ENABLED_ICON : CREATE_DISABLED_ICON),
         captionColor: (hasRezPermissions ? "#ffffff" : "#888888"),
     });
+
+    if (!hasRezPermissions) {
+        if (isActive) {
+            that.setActive(false);
+        }
+        tablet.gotoHomeScreen();
+    }
 }
 
 function handleMessagesReceived(channel, message, sender) {
@@ -2335,6 +2338,11 @@ var PopupMenu = function () {
         Controller.mousePressEvent.disconnect(self.mousePressEvent);
         Controller.mouseMoveEvent.disconnect(self.mouseMoveEvent);
         Controller.mouseReleaseEvent.disconnect(self.mouseReleaseEvent);
+
+        Entities.canRezChanged.disconnect(checkEditPermissionsAndUpdate);
+        Entities.canRezTmpChanged.disconnect(checkEditPermissionsAndUpdate);
+        Entities.canRezCertifiedChanged.disconnect(checkEditPermissionsAndUpdate);
+        Entities.canRezTmpCertifiedChanged.disconnect(checkEditPermissionsAndUpdate);
     }
 
     Controller.mousePressEvent.connect(self.mousePressEvent);


### PR DESCRIPTION
Fixes FB case 14082: "Create" icon is grayed out even when I do have rez rights in moving between domains.

Should also cover 14087

This also removed some old code that was relying on messages to determine if domains were changed instead of the Window.domainChanged signal. 

Also handles changes on the server side to editing permissions. 