### PR TITLE
Add support for multifrustum entity queries

### DIFF
--- a/assignment-client/src/entities/EntityPriorityQueue.cpp
+++ b/assignment-client/src/entities/EntityPriorityQueue.cpp
@@ -62,6 +62,10 @@ void ConicalView::set(const DiffTraversal::View& view) {
 }
 
 float ConicalView::computePriority(const AACube& cube) const {
+    if (_conicalViewFrustums.empty()) {
+        return PrioritizedEntity::WHEN_IN_DOUBT_PRIORITY;
+    }
+
     float priority = PrioritizedEntity::DO_NOT_SEND;
 
     for (const auto& view : _conicalViewFrustums) {

--- a/assignment-client/src/entities/EntityPriorityQueue.h
+++ b/assignment-client/src/entities/EntityPriorityQueue.h
@@ -22,7 +22,7 @@
 const float SQRT_TWO_OVER_TWO = 0.7071067811865f;
 const float DEFAULT_VIEW_RADIUS = 10.0f;
 
-// ConicalView is an approximation of a ViewFrustum for fast calculation of sort priority.
+// ConicalViewFrustum is an approximation of a ViewFrustum for fast calculation of sort priority.
 class ConicalViewFrustum {
 public:
     ConicalViewFrustum() {}
@@ -37,6 +37,7 @@ private:
     float _radius { DEFAULT_VIEW_RADIUS };
 };
 
+// Simple wrapper around a set of conical view frustums
 class ConicalView {
 public:
     ConicalView() {}
@@ -113,7 +114,7 @@ private:
                                               PrioritizedEntity::Compare>;
 
     PriorityQueue _queue;
-    // Keep dictionary of al the entities in the queue for fast contain checks.
+    // Keep dictionary of all the entities in the queue for fast contain checks.
     std::unordered_set<const EntityItem*> _entities;
 
 };

--- a/assignment-client/src/entities/EntityPriorityQueue.h
+++ b/assignment-client/src/entities/EntityPriorityQueue.h
@@ -15,16 +15,17 @@
 #include <queue>
 
 #include <AACube.h>
+#include <DiffTraversal.h>
 #include <EntityTreeElement.h>
 
 const float SQRT_TWO_OVER_TWO = 0.7071067811865f;
 const float DEFAULT_VIEW_RADIUS = 10.0f;
 
 // ConicalView is an approximation of a ViewFrustum for fast calculation of sort priority.
-class ConicalView {
+class ConicalViewFrustum {
 public:
-    ConicalView() {}
-    ConicalView(const ViewFrustum& viewFrustum) { set(viewFrustum); }
+    ConicalViewFrustum() {}
+    ConicalViewFrustum(const ViewFrustum& viewFrustum) { set(viewFrustum); }
     void set(const ViewFrustum& viewFrustum);
     float computePriority(const AACube& cube) const;
 private:
@@ -33,6 +34,15 @@ private:
     float _sinAngle { SQRT_TWO_OVER_TWO };
     float _cosAngle { SQRT_TWO_OVER_TWO };
     float _radius { DEFAULT_VIEW_RADIUS };
+};
+
+class ConicalView {
+public:
+    ConicalView() {}
+    void set(const DiffTraversal::View& view);
+    float computePriority(const AACube& cube) const;
+private:
+    std::vector<ConicalViewFrustum> _conicalViewFrustums;
 };
 
 // PrioritizedEntity is a placeholder in a sorted queue.

--- a/assignment-client/src/entities/EntityTreeSendThread.cpp
+++ b/assignment-client/src/entities/EntityTreeSendThread.cpp
@@ -138,7 +138,6 @@ void EntityTreeSendThread::traverseTreeAndSendContents(SharedNodePointer node, O
                 if (entity) {
                     float priority = PrioritizedEntity::DO_NOT_SEND;
 
-
                     if (forceRemove) {
                         priority = PrioritizedEntity::FORCE_REMOVE;
                     } else {
@@ -153,7 +152,6 @@ void EntityTreeSendThread::traverseTreeAndSendContents(SharedNodePointer node, O
                             priority = PrioritizedEntity::WHEN_IN_DOUBT_PRIORITY;
                         }
                     }
-
 
                     if (priority != PrioritizedEntity::DO_NOT_SEND) {
                         _sendQueue.emplace(entity, priority, forceRemove);
@@ -305,7 +303,8 @@ void EntityTreeSendThread::startNewTraversal(const DiffTraversal::View& view, En
                             } else {
                                 priority = PrioritizedEntity::WHEN_IN_DOUBT_PRIORITY;
                             }
-                        } else if (entity->getLastEdited() > knownTimestamp->second) {
+                        } else if (entity->getLastEdited() > knownTimestamp->second ||
+                                   entity->getLastChangedOnServer() > knownTimestamp->second) {
                             // it is known and it changed --> put it on the queue with any priority
                             // TODO: sort these correctly
                             priority = PrioritizedEntity::WHEN_IN_DOUBT_PRIORITY;
@@ -339,15 +338,13 @@ void EntityTreeSendThread::startNewTraversal(const DiffTraversal::View& view, En
                             // See the DiffTraversal::First case for an explanation of the "entity is too small" check
                             if ((next.intersection == ViewFrustum::INSIDE || view.intersects(cube)) &&
                                 view.isBigEnough(cube)) {
-                                    // If this entity wasn't in the last view or
-                                    // If this entity was skipped last time because it was too small, we still need to send it
                                     priority = _conicalView.computePriority(cube);
                             }
                         } else {
                             priority = PrioritizedEntity::WHEN_IN_DOUBT_PRIORITY;
                         }
-                    } else if (entity->getLastEdited() > knownTimestamp->second
-                            || entity->getLastChangedOnServer() > knownTimestamp->second) {
+                    } else if (entity->getLastEdited() > knownTimestamp->second ||
+                               entity->getLastChangedOnServer() > knownTimestamp->second) {
                         // it is known and it changed --> put it on the queue with any priority
                         // TODO: sort these correctly
                         priority = PrioritizedEntity::WHEN_IN_DOUBT_PRIORITY;

--- a/assignment-client/src/entities/EntityTreeSendThread.h
+++ b/assignment-client/src/entities/EntityTreeSendThread.h
@@ -50,7 +50,6 @@ private:
 
     DiffTraversal _traversal;
     EntityPriorityQueue _sendQueue;
-    std::unordered_set<EntityItem*> _entitiesInQueue;
     std::unordered_map<EntityItem*, uint64_t> _knownState;
     ConicalView _conicalView; // cached optimized view for fast priority calculations
 

--- a/assignment-client/src/entities/EntityTreeSendThread.h
+++ b/assignment-client/src/entities/EntityTreeSendThread.h
@@ -41,8 +41,7 @@ private:
     bool addAncestorsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
     bool addDescendantsToExtraFlaggedEntities(const QUuid& filteredEntityID, EntityItem& entityItem, EntityNodeData& nodeData);
 
-    void startNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset, 
-        bool usesViewFrustum);
+    void startNewTraversal(const DiffTraversal::View& viewFrustum, EntityTreeElementPointer root);
     bool traverseTreeAndBuildNextPacketPayload(EncodeBitstreamParams& params, const QJsonObject& jsonFilters) override;
 
     void preDistributionProcessing() override;

--- a/assignment-client/src/octree/OctreeHeadlessViewer.cpp
+++ b/assignment-client/src/octree/OctreeHeadlessViewer.cpp
@@ -23,14 +23,7 @@ void OctreeHeadlessViewer::queryOctree() {
     char serverType = getMyNodeType();
     PacketType packetType = getMyQueryMessageType();
 
-    _octreeQuery.setCameraPosition(_viewFrustum.getPosition());
-    _octreeQuery.setCameraOrientation(_viewFrustum.getOrientation());
-    _octreeQuery.setCameraFov(_viewFrustum.getFieldOfView());
-    _octreeQuery.setCameraAspectRatio(_viewFrustum.getAspectRatio());
-    _octreeQuery.setCameraNearClip(_viewFrustum.getNearClip());
-    _octreeQuery.setCameraFarClip(_viewFrustum.getFarClip());
-    _octreeQuery.setCameraEyeOffsetPosition(glm::vec3());
-    _octreeQuery.setCameraCenterRadius(_viewFrustum.getCenterRadius());
+    _octreeQuery.setMainViewFrustum(_viewFrustum);
     _octreeQuery.setOctreeSizeScale(_voxelSizeScale);
     _octreeQuery.setBoundaryLevelAdjust(_boundaryLevelAdjust);
 

--- a/assignment-client/src/octree/OctreeHeadlessViewer.cpp
+++ b/assignment-client/src/octree/OctreeHeadlessViewer.cpp
@@ -14,25 +14,18 @@
 #include <NodeList.h>
 #include <OctreeLogging.h>
 
-
-OctreeHeadlessViewer::OctreeHeadlessViewer() {
-    _viewFrustum.setProjection(glm::perspective(glm::radians(DEFAULT_FIELD_OF_VIEW_DEGREES), DEFAULT_ASPECT_RATIO, DEFAULT_NEAR_CLIP, DEFAULT_FAR_CLIP));
-}
-
 void OctreeHeadlessViewer::queryOctree() {
     char serverType = getMyNodeType();
     PacketType packetType = getMyQueryMessageType();
 
-    _octreeQuery.setMainViewFrustum(_viewFrustum);
-    _octreeQuery.setOctreeSizeScale(_voxelSizeScale);
-    _octreeQuery.setBoundaryLevelAdjust(_boundaryLevelAdjust);
+    if (_hasViewFrustum) {
+        _octreeQuery.setMainViewFrustum(_viewFrustum);
+    }
 
     auto nodeList = DependencyManager::get<NodeList>();
 
     auto node = nodeList->soloNodeOfType(serverType);
     if (node && node->getActiveSocket()) {
-        _octreeQuery.setMaxQueryPacketsPerSecond(getMaxPacketsPerSecond());
-
         auto queryPacket = NLPacket::create(packetType);
 
         // encode the query data

--- a/assignment-client/src/octree/OctreeHeadlessViewer.h
+++ b/assignment-client/src/octree/OctreeHeadlessViewer.h
@@ -20,9 +20,6 @@
 class OctreeHeadlessViewer : public OctreeProcessor {
     Q_OBJECT
 public:
-    OctreeHeadlessViewer();
-    virtual ~OctreeHeadlessViewer() {};
-    
     OctreeQuery& getOctreeQuery() { return _octreeQuery; }
 
     static int parseOctreeStats(QSharedPointer<ReceivedMessage> message, SharedNodePointer sourceNode);
@@ -32,34 +29,32 @@ public slots:
     void queryOctree();
 
     // setters for camera attributes
-    void setPosition(const glm::vec3& position) { _viewFrustum.setPosition(position); }
-    void setOrientation(const glm::quat& orientation) { _viewFrustum.setOrientation(orientation); }
-    void setCenterRadius(float radius) { _viewFrustum.setCenterRadius(radius); }
-    void setKeyholeRadius(float radius) { _viewFrustum.setCenterRadius(radius); } // TODO: remove this legacy support
+    void setPosition(const glm::vec3& position) { _hasViewFrustum = true; _viewFrustum.setPosition(position); }
+    void setOrientation(const glm::quat& orientation) { _hasViewFrustum = true; _viewFrustum.setOrientation(orientation); }
+    void setCenterRadius(float radius) { _hasViewFrustum = true; _viewFrustum.setCenterRadius(radius); }
+    void setKeyholeRadius(float radius) { _hasViewFrustum = true; _viewFrustum.setCenterRadius(radius); } // TODO: remove this legacy support
 
     // setters for LOD and PPS
-    void setVoxelSizeScale(float sizeScale) { _voxelSizeScale = sizeScale; }
-    void setBoundaryLevelAdjust(int boundaryLevelAdjust) { _boundaryLevelAdjust = boundaryLevelAdjust; }
-    void setMaxPacketsPerSecond(int maxPacketsPerSecond) { _maxPacketsPerSecond = maxPacketsPerSecond; }
+    void setVoxelSizeScale(float sizeScale) { _octreeQuery.setOctreeSizeScale(sizeScale) ; }
+    void setBoundaryLevelAdjust(int boundaryLevelAdjust) { _octreeQuery.setBoundaryLevelAdjust(boundaryLevelAdjust); }
+    void setMaxPacketsPerSecond(int maxPacketsPerSecond) { _octreeQuery.setMaxQueryPacketsPerSecond(maxPacketsPerSecond); }
 
     // getters for camera attributes
     const glm::vec3& getPosition() const { return _viewFrustum.getPosition(); }
     const glm::quat& getOrientation() const { return _viewFrustum.getOrientation(); }
 
     // getters for LOD and PPS
-    float getVoxelSizeScale() const { return _voxelSizeScale; }
-    int getBoundaryLevelAdjust() const { return _boundaryLevelAdjust; }
-    int getMaxPacketsPerSecond() const { return _maxPacketsPerSecond; }
+    float getVoxelSizeScale() const { return _octreeQuery.getOctreeSizeScale(); }
+    int getBoundaryLevelAdjust() const { return _octreeQuery.getBoundaryLevelAdjust(); }
+    int getMaxPacketsPerSecond() const { return _octreeQuery.getMaxQueryPacketsPerSecond(); }
 
     unsigned getOctreeElementsCount() const { return _tree->getOctreeElementsCount(); }
 
 private:
     OctreeQuery _octreeQuery;
 
+    bool _hasViewFrustum { false };
     ViewFrustum _viewFrustum;
-    float _voxelSizeScale { DEFAULT_OCTREE_SIZE_SCALE };
-    int _boundaryLevelAdjust { 0 };
-    int _maxPacketsPerSecond { DEFAULT_MAX_OCTREE_PPS };
 };
 
 #endif // hifi_OctreeHeadlessViewer_h

--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -330,8 +330,9 @@ int OctreeSendThread::packetDistributor(SharedNodePointer node, OctreeQueryNode*
     } else {
         // we aren't forcing a full scene, check if something else suggests we should
         isFullScene = nodeData->haveJSONParametersChanged() ||
-            (nodeData->getUsesFrustum()
-             && ((!viewFrustumChanged && nodeData->getViewFrustumJustStoppedChanging()) || nodeData->hasLodChanged()));
+                      (nodeData->hasMainViewFrustum() &&
+                       (nodeData->getViewFrustumJustStoppedChanging() ||
+                        nodeData->hasLodChanged()));
     }
 
     if (nodeData->isPacketWaiting()) {
@@ -445,7 +446,6 @@ void OctreeSendThread::traverseTreeAndSendContents(SharedNodePointer node, Octre
     params.trackSend = [this](const QUuid& dataID, quint64 dataEdited) {
         _myServer->trackSend(dataID, dataEdited, _nodeUuid);
     };
-    nodeData->copyCurrentViewFrustum(params.viewFrustum);
 
     bool somethingToSend = true; // assume we have something
     bool hadSomething = hasSomethingToSend(nodeData);

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -294,7 +294,6 @@ void EntityScriptServer::run() {
     queryJSONParameters[EntityJSONQueryProperties::FLAGS_PROPERTY] = queryFlags;
     
     // setup the JSON parameters so that OctreeQuery does not use a frustum and uses our JSON filter
-    _entityViewer.getOctreeQuery().setUsesFrustum(false);
     _entityViewer.getOctreeQuery().setJSONParameters(queryJSONParameters);
 
     entityScriptingInterface->setEntityTree(_entityViewer.getTree());

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5534,6 +5534,9 @@ void Application::update(float deltaTime) {
         _myCamera.loadViewFrustum(_viewFrustum);
 
 
+        // TODO: Fix this by modeling the way the secondary camera works on how the main camera works
+        // ie. Use a camera object stored in the game logic and informs the Engine on where the secondary
+        // camera should be.
         auto renderConfig = _renderEngine->getConfiguration();
         assert(renderConfig);
         auto secondaryCamera = dynamic_cast<SecondaryCameraJobConfig*>(renderConfig->getConfig("SecondaryCamera"));

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5791,14 +5791,8 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType) {
 
     ViewFrustum viewFrustum;
     copyViewFrustum(viewFrustum);
-    _octreeQuery.setCameraPosition(viewFrustum.getPosition());
-    _octreeQuery.setCameraOrientation(viewFrustum.getOrientation());
-    _octreeQuery.setCameraFov(viewFrustum.getFieldOfView());
-    _octreeQuery.setCameraAspectRatio(viewFrustum.getAspectRatio());
-    _octreeQuery.setCameraNearClip(viewFrustum.getNearClip());
-    _octreeQuery.setCameraFarClip(viewFrustum.getFarClip());
-    _octreeQuery.setCameraEyeOffsetPosition(glm::vec3());
-    _octreeQuery.setCameraCenterRadius(viewFrustum.getCenterRadius());
+    _octreeQuery.setMainViewFrustum(viewFrustum);
+
     auto lodManager = DependencyManager::get<LODManager>();
     _octreeQuery.setOctreeSizeScale(lodManager->getOctreeSizeScale());
     _octreeQuery.setBoundaryLevelAdjust(lodManager->getBoundaryLevelAdjust());

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5622,6 +5622,8 @@ void Application::update(float deltaTime) {
         const quint64 TOO_LONG_SINCE_LAST_QUERY = 3 * USECS_PER_SECOND;
         bool queryIsDue = sinceLastQuery > TOO_LONG_SINCE_LAST_QUERY;
         bool viewIsDifferentEnough = !_lastQueriedViewFrustum.isVerySimilar(_viewFrustum);
+        viewIsDifferentEnough |= _hasSecondaryViewFrustum && !_lastQueriedSecondaryViewFrustum.isVerySimilar(_secondaryViewFrustum);
+        
         // if it's been a while since our last query or the view has significantly changed then send a query, otherwise suppress it
         if (queryIsDue || viewIsDifferentEnough) {
             _lastQueriedTime = now;
@@ -5630,6 +5632,7 @@ void Application::update(float deltaTime) {
             }
             sendAvatarViewFrustum();
             _lastQueriedViewFrustum = _viewFrustum;
+            _lastQueriedSecondaryViewFrustum = _secondaryViewFrustum;
         }
     }
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -557,9 +557,10 @@ private:
 
     mutable QMutex _viewMutex { QMutex::Recursive };
     ViewFrustum _viewFrustum; // current state of view frustum, perspective, orientation, etc.
-    ViewFrustum _lastQueriedViewFrustum; /// last view frustum used to query octree servers (voxels)
+    ViewFrustum _lastQueriedViewFrustum; // last view frustum used to query octree servers
     ViewFrustum _displayViewFrustum;
     ViewFrustum _secondaryViewFrustum;
+    ViewFrustum _lastQueriedSecondaryViewFrustum; // last secondary view frustum used to query octree servers
     bool _hasSecondaryViewFrustum;
     quint64 _lastQueriedTime;
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -149,6 +149,8 @@ public:
     void initializeRenderEngine();
     void initializeUi();
 
+    void updateSecondaryCameraViewFrustum();
+
     void updateCamera(RenderArgs& renderArgs, float deltaTime);
     void paintGL();
     void resizeGL();

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -178,6 +178,9 @@ public:
     // which might be different from the viewFrustum, i.e. shadowmap
     // passes, mirror window passes, etc
     void copyDisplayViewFrustum(ViewFrustum& viewOut) const;
+    void copySecondaryViewFrustum(ViewFrustum& viewOut) const;
+    bool hasSecondaryViewFrustum() const { return _hasSecondaryViewFrustum; }
+
     const OctreePacketProcessor& getOctreePacketProcessor() const { return _octreeProcessor; }
     QSharedPointer<EntityTreeRenderer> getEntities() const { return DependencyManager::get<EntityTreeRenderer>(); }
     QUndoStack* getUndoStack() { return &_undoStack; }
@@ -554,6 +557,8 @@ private:
     ViewFrustum _viewFrustum; // current state of view frustum, perspective, orientation, etc.
     ViewFrustum _lastQueriedViewFrustum; /// last view frustum used to query octree servers (voxels)
     ViewFrustum _displayViewFrustum;
+    ViewFrustum _secondaryViewFrustum;
+    bool _hasSecondaryViewFrustum;
     quint64 _lastQueriedTime;
 
     OctreeQuery _octreeQuery { true }; // NodeData derived class for querying octee cells from octree servers

--- a/libraries/entities/src/DiffTraversal.cpp
+++ b/libraries/entities/src/DiffTraversal.cpp
@@ -37,15 +37,14 @@ void DiffTraversal::Waypoint::getNextVisibleElementFirstTime(DiffTraversal::Visi
                 EntityTreeElementPointer nextElement = element->getChildAtIndex(_nextIndex);
                 ++_nextIndex;
                 if (nextElement) {
-                    if (!view.usesViewFrustum) {
+                    const auto& cube = nextElement->getAACube();
+                    if (!view.usesViewFrustums()) {
                         // No LOD truncation if we aren't using the view frustum
                         next.element = nextElement;
                         return;
-                    } else if (view.viewFrustum.cubeIntersectsKeyhole(nextElement->getAACube())) {
+                    } else if (view.intersects(cube)) {
                         // check for LOD truncation
-                        float distance = glm::distance(view.viewFrustum.getPosition(), nextElement->getAACube().calcCenter()) + MIN_VISIBLE_DISTANCE;
-                        float angularDiameter = nextElement->getAACube().getScale() / distance;
-                        if (angularDiameter > MIN_ELEMENT_ANGULAR_DIAMETER * view.lodScaleFactor) {
+                        if (view.isBigEnough(cube, MIN_ELEMENT_ANGULAR_DIAMETER)) {
                             next.element = nextElement;
                             return;
                         }
@@ -76,17 +75,16 @@ void DiffTraversal::Waypoint::getNextVisibleElementRepeat(
                 EntityTreeElementPointer nextElement = element->getChildAtIndex(_nextIndex);
                 ++_nextIndex;
                 if (nextElement && nextElement->getLastChanged() > lastTime) {
-                    if (!view.usesViewFrustum) {
+                    if (!view.usesViewFrustums()) {
                         // No LOD truncation if we aren't using the view frustum
                         next.element = nextElement;
                         next.intersection = ViewFrustum::INSIDE;
                         return;
                     } else {
                         // check for LOD truncation
-                        float distance = glm::distance(view.viewFrustum.getPosition(), nextElement->getAACube().calcCenter()) + MIN_VISIBLE_DISTANCE;
-                        float angularDiameter = nextElement->getAACube().getScale() / distance;
-                        if (angularDiameter > MIN_ELEMENT_ANGULAR_DIAMETER * view.lodScaleFactor) {
-                            ViewFrustum::intersection intersection = view.viewFrustum.calculateCubeKeyholeIntersection(nextElement->getAACube());
+                        const auto& cube = nextElement->getAACube();
+                        if (view.isBigEnough(cube, MIN_ELEMENT_ANGULAR_DIAMETER)) {
+                            ViewFrustum::intersection intersection = view.calculateIntersection(cube);
                             if (intersection != ViewFrustum::OUTSIDE) {
                                 next.element = nextElement;
                                 next.intersection = intersection;
@@ -118,14 +116,13 @@ void DiffTraversal::Waypoint::getNextVisibleElementDifferential(DiffTraversal::V
                 EntityTreeElementPointer nextElement = element->getChildAtIndex(_nextIndex);
                 ++_nextIndex;
                 if (nextElement) {
-                    AACube cube = nextElement->getAACube();
                     // check for LOD truncation
-                    float distance = glm::distance(view.viewFrustum.getPosition(), cube.calcCenter()) + MIN_VISIBLE_DISTANCE;
-                    float angularDiameter = cube.getScale() / distance;
-                    if (angularDiameter > MIN_ELEMENT_ANGULAR_DIAMETER * view.lodScaleFactor) {
-                        if (view.viewFrustum.calculateCubeKeyholeIntersection(cube) != ViewFrustum::OUTSIDE) {
+                    const auto& cube = nextElement->getAACube();
+                    if (view.isBigEnough(cube, MIN_ELEMENT_ANGULAR_DIAMETER)) {
+                        ViewFrustum::intersection intersection = view.calculateIntersection(cube);
+                        if (intersection != ViewFrustum::OUTSIDE) {
                             next.element = nextElement;
-                            next.intersection = ViewFrustum::OUTSIDE;
+                            next.intersection = intersection;
                             return;
                         }
                     }
@@ -137,13 +134,83 @@ void DiffTraversal::Waypoint::getNextVisibleElementDifferential(DiffTraversal::V
     next.intersection = ViewFrustum::OUTSIDE;
 }
 
+bool DiffTraversal::View::isBigEnough(const AACube& cube, float minDiameter) const {
+    if (viewFrustums.empty()) {
+        // Everything is big enough when not using view frustums
+        return true;
+    }
+
+    for (const auto& viewFrustum : viewFrustums) {
+        if (isAngularSizeBigEnough(viewFrustum.getPosition(), cube, lodScaleFactor, minDiameter)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool DiffTraversal::View::intersects(const AACube& cube) const {
+    if (viewFrustums.empty()) {
+        // Everything intersects when not using view frustums
+        return true;
+    }
+
+    for (const auto& viewFrustum : viewFrustums) {
+        if (viewFrustum.cubeIntersectsKeyhole(cube)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+ViewFrustum::intersection DiffTraversal::View::calculateIntersection(const AACube& cube) const {
+    if (viewFrustums.empty()) {
+        // Everything is inside when not using view frustums
+        return ViewFrustum::INSIDE;
+    }
+
+    ViewFrustum::intersection intersection = ViewFrustum::OUTSIDE;
+
+    for (const auto& viewFrustum : viewFrustums) {
+        switch (viewFrustum.calculateCubeKeyholeIntersection(cube)) {
+            case ViewFrustum::INSIDE:
+                return ViewFrustum::INSIDE;
+            case ViewFrustum::INTERSECT:
+                intersection = ViewFrustum::INTERSECT;
+                break;
+            default:
+                // DO NOTHING
+                break;
+        }
+    }
+    return intersection;
+}
+
+bool DiffTraversal::View::usesViewFrustums() const {
+    return !viewFrustums.empty();
+}
+
+bool DiffTraversal::View::isVerySimilar(const View& view) const {
+    auto size = view.viewFrustums.size();
+
+    if (view.lodScaleFactor != lodScaleFactor ||
+        viewFrustums.size() != size) {
+        return false;
+    }
+
+    for (size_t i = 0; i < size; ++i) {
+        if (!viewFrustums[i].isVerySimilar(view.viewFrustums[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 DiffTraversal::DiffTraversal() {
     const int32_t MIN_PATH_DEPTH = 16;
     _path.reserve(MIN_PATH_DEPTH);
 }
 
-DiffTraversal::Type DiffTraversal::prepareNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, 
-        int32_t lodLevelOffset, bool usesViewFrustum) {
+DiffTraversal::Type DiffTraversal::prepareNewTraversal(const DiffTraversal::View& view, EntityTreeElementPointer root) {
     assert(root);
     // there are three types of traversal:
     //
@@ -155,33 +222,29 @@ DiffTraversal::Type DiffTraversal::prepareNewTraversal(const ViewFrustum& viewFr
     //
     //   _getNextVisibleElementCallback = identifies elements that need to be traversed,
     //        updates VisibleElement ref argument with pointer-to-element and view-intersection
-    //        (INSIDE, INTERSECT, or OUTSIDE)
+    //        (INSIDE, INTERSECtT, or OUTSIDE)
     //
     // external code should update the _scanElementCallback after calling prepareNewTraversal
     //
-    _currentView.usesViewFrustum = usesViewFrustum;
-    float lodScaleFactor = powf(2.0f, lodLevelOffset);
 
     Type type;
     // If usesViewFrustum changes, treat it as a First traversal
-    if (_completedView.startTime == 0 || _currentView.usesViewFrustum != _completedView.usesViewFrustum) {
+    if (_completedView.startTime == 0 || _currentView.usesViewFrustums() != _completedView.usesViewFrustums()) {
         type = Type::First;
-        _currentView.viewFrustum = viewFrustum;
-        _currentView.lodScaleFactor = lodScaleFactor;
+        _currentView.viewFrustums = std::move(view.viewFrustums);
+        _currentView.lodScaleFactor = view.lodScaleFactor;
         _getNextVisibleElementCallback = [this](DiffTraversal::VisibleElement& next) {
             _path.back().getNextVisibleElementFirstTime(next, _currentView);
         };
-    } else if (!_currentView.usesViewFrustum ||
-               (_completedView.viewFrustum.isVerySimilar(viewFrustum) &&
-                lodScaleFactor == _completedView.lodScaleFactor)) {
+    } else if (!_currentView.usesViewFrustums() || _completedView.isVerySimilar(view)) {
         type = Type::Repeat;
         _getNextVisibleElementCallback = [this](DiffTraversal::VisibleElement& next) {
             _path.back().getNextVisibleElementRepeat(next, _completedView, _completedView.startTime);
         };
     } else {
         type = Type::Differential;
-        _currentView.viewFrustum = viewFrustum;
-        _currentView.lodScaleFactor = lodScaleFactor;
+        _currentView.viewFrustums = std::move(view.viewFrustums);
+        _currentView.lodScaleFactor = view.lodScaleFactor;
         _getNextVisibleElementCallback = [this](DiffTraversal::VisibleElement& next) {
             _path.back().getNextVisibleElementDifferential(next, _currentView, _completedView);
         };

--- a/libraries/entities/src/DiffTraversal.cpp
+++ b/libraries/entities/src/DiffTraversal.cpp
@@ -221,7 +221,7 @@ DiffTraversal::Type DiffTraversal::prepareNewTraversal(const DiffTraversal::View
     //
     //   _getNextVisibleElementCallback = identifies elements that need to be traversed,
     //        updates VisibleElement ref argument with pointer-to-element and view-intersection
-    //        (INSIDE, INTERSECtT, or OUTSIDE)
+    //        (INSIDE, INTERSECT, or OUTSIDE)
     //
     // external code should update the _scanElementCallback after calling prepareNewTraversal
     //

--- a/libraries/entities/src/DiffTraversal.h
+++ b/libraries/entities/src/DiffTraversal.h
@@ -30,10 +30,15 @@ public:
     // View is a struct with a ViewFrustum and LOD parameters
     class View {
     public:
-        ViewFrustum viewFrustum;
+        bool isBigEnough(const AACube& cube, float minDiameter = MIN_ENTITY_ANGULAR_DIAMETER) const;
+        bool intersects(const AACube& cube) const;
+        bool usesViewFrustums() const;
+        bool isVerySimilar(const View& view) const;
+        ViewFrustum::intersection calculateIntersection(const AACube& cube) const;
+
+        std::vector<ViewFrustum> viewFrustums;
         uint64_t startTime { 0 };
         float lodScaleFactor { 1.0f };
-        bool usesViewFrustum { true };
     };
 
     // Waypoint is an bookmark in a "path" of waypoints during a traversal.
@@ -57,15 +62,12 @@ public:
 
     DiffTraversal();
 
-    Type prepareNewTraversal(const ViewFrustum& viewFrustum, EntityTreeElementPointer root, int32_t lodLevelOffset, 
-        bool usesViewFrustum);
+    Type prepareNewTraversal(const DiffTraversal::View& view, EntityTreeElementPointer root);
 
-    const ViewFrustum& getCurrentView() const { return _currentView.viewFrustum; }
-    const ViewFrustum& getCompletedView() const { return _completedView.viewFrustum; }
+    const View& getCurrentView() const { return _currentView; }
+    const View& getCompletedView() const { return _completedView; }
 
-    bool doesCurrentUseViewFrustum() const { return _currentView.usesViewFrustum; }
-    float getCurrentLODScaleFactor() const { return _currentView.lodScaleFactor; }
-    float getCompletedLODScaleFactor() const { return _completedView.lodScaleFactor; }
+    bool doesCurrentUseViewFrustum() const { return _currentView.usesViewFrustums(); }
 
     uint64_t getStartOfCompletedTraversal() const { return _completedView.startTime; }
     bool finished() const { return _path.empty(); }

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -27,9 +27,6 @@ using EntityTreePointer = std::shared_ptr<EntityTree>;
 #include "MovingEntitiesOperator.h"
 
 class EntityEditFilters;
-class Model;
-using ModelPointer = std::shared_ptr<Model>;
-using ModelWeakPointer = std::weak_ptr<Model>;
 
 class EntitySimulation;
 

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -34,7 +34,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::EntityPhysics:
             return static_cast<PacketVersion>(EntityVersion::MaterialData);
         case PacketType::EntityQuery:
-            return static_cast<PacketVersion>(EntityQueryPacketVersion::RemovedJurisdictions);
+            return static_cast<PacketVersion>(EntityQueryPacketVersion::MultiFrustumQuery);
         case PacketType::AvatarIdentity:
         case PacketType::AvatarData:
         case PacketType::BulkAvatarData:

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -244,7 +244,8 @@ enum class EntityQueryPacketVersion: PacketVersion {
     JSONFilter = 18,
     JSONFilterWithFamilyTree = 19,
     ConnectionIdentifier = 20,
-    RemovedJurisdictions = 21
+    RemovedJurisdictions = 21,
+    MultiFrustumQuery = 22
 };
 
 enum class AssetServerPacketVersion: PacketVersion {

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -59,7 +59,6 @@ const int LOW_RES_MOVING_ADJUST  = 1;
 
 class EncodeBitstreamParams {
 public:
-    ViewFrustum viewFrustum;
     bool includeExistsBits;
     NodeData* nodeData;
 

--- a/libraries/octree/src/OctreeQuery.h
+++ b/libraries/octree/src/OctreeQuery.h
@@ -12,16 +12,14 @@
 #ifndef hifi_OctreeQuery_h
 #define hifi_OctreeQuery_h
 
-#include <inttypes.h>
-
-#include <glm/glm.hpp>
-#include <glm/gtc/quaternion.hpp>
-
 #include <QtCore/QJsonObject>
 #include <QtCore/QReadWriteLock>
 
 #include <NodeData.h>
 
+#include <ViewFrustum.h>
+
+#include "OctreeConstants.h"
 
 class OctreeQuery : public NodeData {
     Q_OBJECT
@@ -30,31 +28,22 @@ public:
     OctreeQuery(bool randomizeConnectionID = false);
     virtual ~OctreeQuery() {}
 
+    OctreeQuery(const OctreeQuery&) = delete;
+    OctreeQuery& operator=(const OctreeQuery&) = delete;
+
     int getBroadcastData(unsigned char* destinationBuffer);
     int parseData(ReceivedMessage& message) override;
 
-    // getters for camera details
-    const glm::vec3& getCameraPosition() const { return _cameraPosition; }
-    const glm::quat& getCameraOrientation() const { return _cameraOrientation; }
-    float getCameraFov() const { return _cameraFov; }
-    float getCameraAspectRatio() const { return _cameraAspectRatio; }
-    float getCameraNearClip() const { return _cameraNearClip; }
-    float getCameraFarClip() const { return _cameraFarClip; }
-    const glm::vec3& getCameraEyeOffsetPosition() const { return _cameraEyeOffsetPosition; }
-    float getCameraCenterRadius() const { return _cameraCenterRadius; }
+    bool hasMainViewFrustum() const { return _hasMainFrustum; }
+    void setMainViewFrustum(const ViewFrustum& viewFrustum) { _hasMainFrustum = true; _mainViewFrustum = viewFrustum; }
+    void clearMainViewFrustum() { _hasMainFrustum = false; }
+    const ViewFrustum& getMainViewFrustum() const { return _mainViewFrustum; }
 
-    glm::vec3 calculateCameraDirection() const;
+    bool hasSecondaryViewFrustum() const { return _hasSecondaryFrustum; }
+    void setSecondaryViewFrustum(const ViewFrustum& viewFrustum) { _hasSecondaryFrustum = true; _secondaryViewFrustum = viewFrustum; }
+    void clearSecondaryViewFrustum() { _hasSecondaryFrustum = false; }
+    const ViewFrustum& getSecondaryViewFrustum() const { return _secondaryViewFrustum; }
 
-    // setters for camera details
-    void setCameraPosition(const glm::vec3& position) { _cameraPosition = position; }
-    void setCameraOrientation(const glm::quat& orientation) { _cameraOrientation = orientation; }
-    void setCameraFov(float fov) { _cameraFov = fov; }
-    void setCameraAspectRatio(float aspectRatio) { _cameraAspectRatio = aspectRatio; }
-    void setCameraNearClip(float nearClip) { _cameraNearClip = nearClip; }
-    void setCameraFarClip(float farClip) { _cameraFarClip = farClip; }
-    void setCameraEyeOffsetPosition(const glm::vec3& eyeOffsetPosition) { _cameraEyeOffsetPosition = eyeOffsetPosition; }
-    void setCameraCenterRadius(float radius) { _cameraCenterRadius = radius; }
-    
     // getters/setters for JSON filter
     QJsonObject getJSONParameters() { QReadLocker locker { &_jsonParametersLock }; return _jsonParameters; }
     void setJSONParameters(const QJsonObject& jsonParameters)
@@ -64,9 +53,6 @@ public:
     int getMaxQueryPacketsPerSecond() const { return _maxQueryPPS; }
     float getOctreeSizeScale() const { return _octreeElementSizeScale; }
     int getBoundaryLevelAdjust() const { return _boundaryLevelAdjust; }
-    
-    bool getUsesFrustum() { return _usesFrustum; }
-    void setUsesFrustum(bool usesFrustum) { _usesFrustum = usesFrustum; }
 
     void incrementConnectionID() { ++_connectionID; }
 
@@ -81,33 +67,22 @@ public slots:
     void setBoundaryLevelAdjust(int boundaryLevelAdjust) { _boundaryLevelAdjust = boundaryLevelAdjust; }
 
 protected:
-    // camera details for the avatar
-    glm::vec3 _cameraPosition { glm::vec3(0.0f) };
-    glm::quat _cameraOrientation { glm::quat() };
-    float _cameraFov;
-    float _cameraAspectRatio;
-    float _cameraNearClip;
-    float _cameraFarClip;
-    float _cameraCenterRadius;
-    glm::vec3 _cameraEyeOffsetPosition { glm::vec3(0.0f) };
+    bool _hasMainFrustum { false };
+    ViewFrustum _mainViewFrustum;
+    bool _hasSecondaryFrustum { false };
+    ViewFrustum _secondaryViewFrustum;
 
     // octree server sending items
     int _maxQueryPPS = DEFAULT_MAX_OCTREE_PPS;
     float _octreeElementSizeScale = DEFAULT_OCTREE_SIZE_SCALE; /// used for LOD calculations
     int _boundaryLevelAdjust = 0; /// used for LOD calculations
-    
-    uint8_t _usesFrustum = true;
+
     uint16_t _connectionID; // query connection ID, randomized to start, increments with each new connection to server
     
     QJsonObject _jsonParameters;
     QReadWriteLock _jsonParametersLock;
 
     bool _hasReceivedFirstQuery { false };
-    
-private:
-    // privatize the copy constructor and assignment operator so they cannot be called
-    OctreeQuery(const OctreeQuery&);
-    OctreeQuery& operator= (const OctreeQuery&);
 };
 
 #endif // hifi_OctreeQuery_h

--- a/libraries/octree/src/OctreeQueryNode.cpp
+++ b/libraries/octree/src/OctreeQueryNode.cpp
@@ -139,9 +139,14 @@ void OctreeQueryNode::writeToPacket(const unsigned char* buffer, unsigned int by
     }
 }
 
-void OctreeQueryNode::copyCurrentViewFrustum(ViewFrustum& viewOut) const {
+void OctreeQueryNode::copyCurrentMainViewFrustum(ViewFrustum& viewOut) const {
     QMutexLocker viewLocker(&_viewMutex);
-    viewOut = _currentViewFrustum;
+    viewOut = _currentMainViewFrustum;
+}
+
+void OctreeQueryNode::copyCurrentSecondaryViewFrustum(ViewFrustum& viewOut) const {
+    QMutexLocker viewLocker(&_viewMutex);
+    viewOut = _currentSecondaryViewFrustum;
 }
 
 bool OctreeQueryNode::updateCurrentViewFrustum() {
@@ -150,70 +155,50 @@ bool OctreeQueryNode::updateCurrentViewFrustum() {
         return false;
     }
     
-    if (!_usesFrustum) {
+    if (!_hasMainFrustum && !_hasSecondaryFrustum) {
         // this client does not use a view frustum so the view frustum for this query has not changed
         return false;
-    } else {
-        bool currentViewFrustumChanged = false;
-        
-        ViewFrustum newestViewFrustum;
-        // get position and orientation details from the camera
-        newestViewFrustum.setPosition(getCameraPosition());
-        newestViewFrustum.setOrientation(getCameraOrientation());
-        
-        newestViewFrustum.setCenterRadius(getCameraCenterRadius());
-        
-        // Also make sure it's got the correct lens details from the camera
-        float originalFOV = getCameraFov();
-        float wideFOV = originalFOV + VIEW_FRUSTUM_FOV_OVERSEND;
-        
-        if (0.0f != getCameraAspectRatio() &&
-            0.0f != getCameraNearClip() &&
-            0.0f != getCameraFarClip() &&
-            getCameraNearClip() != getCameraFarClip()) {
-            newestViewFrustum.setProjection(glm::perspective(
-                                                             glm::radians(wideFOV), // hack
-                                                             getCameraAspectRatio(),
-                                                             getCameraNearClip(),
-                                                             getCameraFarClip()));
-            newestViewFrustum.calculate();
-        }
-        
-        
-        { // if there has been a change, then recalculate
-            QMutexLocker viewLocker(&_viewMutex);
-            if (!newestViewFrustum.isVerySimilar(_currentViewFrustum)) {
-                _currentViewFrustum = newestViewFrustum;
-                currentViewFrustumChanged = true;
-            }
-        }
-        
-        // Also check for LOD changes from the client
-        if (_lodInitialized) {
-            if (_lastClientBoundaryLevelAdjust != getBoundaryLevelAdjust()) {
-                _lastClientBoundaryLevelAdjust = getBoundaryLevelAdjust();
-                _lodChanged = true;
-            }
-            if (_lastClientOctreeSizeScale != getOctreeSizeScale()) {
-                _lastClientOctreeSizeScale = getOctreeSizeScale();
-                _lodChanged = true;
-            }
-        } else {
-            _lodInitialized = true;
-            _lastClientOctreeSizeScale = getOctreeSizeScale();
-            _lastClientBoundaryLevelAdjust = getBoundaryLevelAdjust();
-            _lodChanged = false;
-        }
-        
-        // When we first detect that the view stopped changing, we record this.
-        // but we don't change it back to false until we've completely sent this
-        // scene.
-        if (_viewFrustumChanging && !currentViewFrustumChanged) {
-            _viewFrustumJustStoppedChanging = true;
-        }
-        _viewFrustumChanging = currentViewFrustumChanged;
-        return currentViewFrustumChanged;
     }
+
+    bool currentViewFrustumChanged = false;
+
+    { // if there has been a change, then recalculate
+        QMutexLocker viewLocker(&_viewMutex);
+        if (_hasMainFrustum && !_mainViewFrustum.isVerySimilar(_currentMainViewFrustum)) {
+            _currentMainViewFrustum = _mainViewFrustum;
+            currentViewFrustumChanged = true;
+        }
+        if (_hasSecondaryFrustum && !_secondaryViewFrustum.isVerySimilar(_currentSecondaryViewFrustum)) {
+            _currentSecondaryViewFrustum = _secondaryViewFrustum;
+            currentViewFrustumChanged = true;
+        }
+    }
+
+    // Also check for LOD changes from the client
+    if (_lodInitialized) {
+        if (_lastClientBoundaryLevelAdjust != getBoundaryLevelAdjust()) {
+            _lastClientBoundaryLevelAdjust = getBoundaryLevelAdjust();
+            _lodChanged = true;
+        }
+        if (_lastClientOctreeSizeScale != getOctreeSizeScale()) {
+            _lastClientOctreeSizeScale = getOctreeSizeScale();
+            _lodChanged = true;
+        }
+    } else {
+        _lodInitialized = true;
+        _lastClientOctreeSizeScale = getOctreeSizeScale();
+        _lastClientBoundaryLevelAdjust = getBoundaryLevelAdjust();
+        _lodChanged = false;
+    }
+
+    // When we first detect that the view stopped changing, we record this.
+    // but we don't change it back to false until we've completely sent this
+    // scene.
+    if (_viewFrustumChanging && !currentViewFrustumChanged) {
+        _viewFrustumJustStoppedChanging = true;
+    }
+    _viewFrustumChanging = currentViewFrustumChanged;
+    return currentViewFrustumChanged;
 }
 
 void OctreeQueryNode::setViewSent(bool viewSent) {

--- a/libraries/octree/src/OctreeQueryNode.h
+++ b/libraries/octree/src/OctreeQueryNode.h
@@ -49,7 +49,8 @@ public:
 
     OctreeElementExtraEncodeData extraEncodeData;
 
-    void copyCurrentViewFrustum(ViewFrustum& viewOut) const;
+    void copyCurrentMainViewFrustum(ViewFrustum& viewOut) const;
+    void copyCurrentSecondaryViewFrustum(ViewFrustum& viewOut) const;
 
     // These are not classic setters because they are calculating and maintaining state
     // which is set asynchronously through the network receive
@@ -87,9 +88,6 @@ public:
     void setShouldForceFullScene(bool shouldForceFullScene) { _shouldForceFullScene = shouldForceFullScene; }
 
 private:
-    OctreeQueryNode(const OctreeQueryNode &);
-    OctreeQueryNode& operator= (const OctreeQueryNode&);
-
     bool _viewSent { false };
     std::unique_ptr<NLPacket> _octreePacket;
     bool _octreePacketWaiting;
@@ -99,7 +97,8 @@ private:
     quint64 _firstSuppressedPacket { usecTimestampNow() };
 
     mutable QMutex _viewMutex { QMutex::Recursive };
-    ViewFrustum _currentViewFrustum;
+    ViewFrustum _currentMainViewFrustum;
+    ViewFrustum _currentSecondaryViewFrustum;
     bool _viewFrustumChanging { false };
     bool _viewFrustumJustStoppedChanging { true };
 

--- a/libraries/octree/src/OctreeUtils.cpp
+++ b/libraries/octree/src/OctreeUtils.cpp
@@ -16,6 +16,7 @@
 #include <glm/glm.hpp>
 
 #include <AABox.h>
+#include <AACube.h>
 
 float calculateRenderAccuracy(const glm::vec3& position,
         const AABox& bounds,
@@ -73,4 +74,10 @@ float getOrthographicAccuracySize(float octreeSizeScale, int boundaryLevelAdjust
     // Smallest visible element is 1cm
     const float smallestSize = 0.01f;
     return (smallestSize * MAX_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT) / boundaryDistanceForRenderLevel(boundaryLevelAdjust, octreeSizeScale);
+}
+
+bool isAngularSizeBigEnough(glm::vec3 position, const AACube& cube, float lodScaleFactor, float minDiameter) {
+    float distance = glm::distance(cube.calcCenter(), position) + MIN_VISIBLE_DISTANCE;
+    float angularDiameter = cube.getScale() / distance;
+    return angularDiameter > minDiameter * lodScaleFactor;
 }

--- a/libraries/octree/src/OctreeUtils.h
+++ b/libraries/octree/src/OctreeUtils.h
@@ -15,6 +15,7 @@
 #include "OctreeConstants.h"
 
 class AABox;
+class AACube;
 class QJsonDocument;
 
 /// renderAccuracy represents a floating point "visibility" of an object based on it's view from the camera. At a simple
@@ -35,5 +36,7 @@ const float MIN_ELEMENT_ANGULAR_DIAMETER = 0.0043301f; // radians
 const float SQRT_THREE = 1.73205080f;
 const float MIN_ENTITY_ANGULAR_DIAMETER = MIN_ELEMENT_ANGULAR_DIAMETER * SQRT_THREE;
 const float MIN_VISIBLE_DISTANCE = 0.0001f; // helps avoid divide-by-zero check
+
+bool isAngularSizeBigEnough(glm::vec3 position, const AACube& cube, float lodScaleFactor, float minDiameter);
 
 #endif // hifi_OctreeUtils_h

--- a/libraries/shared/src/ViewFrustum.cpp
+++ b/libraries/shared/src/ViewFrustum.cpp
@@ -75,6 +75,10 @@ void ViewFrustum::setProjection(const glm::mat4& projection) {
     _width = _corners[TOP_RIGHT_NEAR].x - _corners[TOP_LEFT_NEAR].x;
 }
 
+void ViewFrustum::setProjection(float cameraFov, float cameraAspectRatio, float cameraNearClip, float cameraFarClip) {
+    setProjection(glm::perspective(glm::radians(cameraFov), cameraAspectRatio, cameraNearClip, cameraFarClip));
+}
+
 // ViewFrustum::calculate()
 //
 // Description: this will calculate the view frustum bounds for a given position and direction
@@ -168,12 +172,8 @@ int ViewFrustum::fromByteArray(const QByteArray& input) {
         0.0f != cameraNearClip &&
         0.0f != cameraFarClip &&
         cameraNearClip != cameraFarClip) {
-        setProjection(glm::perspective(
-            glm::radians(cameraFov),
-            cameraAspectRatio,
-            cameraNearClip,
-            cameraFarClip));
 
+        setProjection(cameraFov, cameraAspectRatio, cameraNearClip, cameraFarClip);
         calculate();
     }
 

--- a/libraries/shared/src/ViewFrustum.cpp
+++ b/libraries/shared/src/ViewFrustum.cpp
@@ -134,7 +134,7 @@ const char* ViewFrustum::debugPlaneName (int plane) const {
     return "Unknown";
 }
 
-void ViewFrustum::fromByteArray(const QByteArray& input) {
+int ViewFrustum::fromByteArray(const QByteArray& input) {
 
     // From the wire!
     glm::vec3 cameraPosition;
@@ -176,6 +176,8 @@ void ViewFrustum::fromByteArray(const QByteArray& input) {
 
         calculate();
     }
+
+    return sourceBuffer - startPosition;
 }
 
 

--- a/libraries/shared/src/ViewFrustum.h
+++ b/libraries/shared/src/ViewFrustum.h
@@ -48,6 +48,7 @@ public:
 
     // setters for lens attributes
     void setProjection(const glm::mat4 & projection);
+    void setProjection(float cameraFov, float cameraAspectRatio, float cameraNearClip, float cameraFarClip);
     void setFocalLength(float focalLength) { _focalLength = focalLength; }
     bool isPerspective() const;
 

--- a/libraries/shared/src/ViewFrustum.h
+++ b/libraries/shared/src/ViewFrustum.h
@@ -147,7 +147,7 @@ public:
     void invalidate(); // causes all reasonable intersection tests to fail
 
     QByteArray toByteArray();
-    void fromByteArray(const QByteArray& input);
+    int fromByteArray(const QByteArray& input);
 
 private:
     glm::mat4 _view;


### PR DESCRIPTION
This is the first step in fixing the spectator camera having objects and avatars freeze in its view because they are out of the main camera view.