### PR TITLE
fix bug 349

### DIFF
--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -273,9 +273,9 @@ QVariantList ScriptEngines::getRunning() {
         } else {
             displayURLString = displayURL.toDisplayString(QUrl::FormattingOptions(QUrl::FullyEncoded));
         }
-        resultNode.insert("url", displayURLString);
         // The path contains the exact path/URL of the script, which also is used in the stopScript function.
-        resultNode.insert("path", normalizeScriptURL(runningScript).toString());
+        resultNode.insert("path", displayURLString);
+        resultNode.insert("url", normalizeScriptURL(runningScript).toString());
         resultNode.insert("local", runningScriptURL.isLocalFile());
         result.append(resultNode);
     }


### PR DESCRIPTION
fixes this issue: https://highfidelity.fogbugz.com/f/cases/349/ScriptEngines-getRunning-transposes-path-and-url-properties

Test plan:
- run the repro case in the bug
- make sure any test plans related to Running Scripts still work
- test the running script dialog in both desktop and HMD and verify same behavior as master