### PR TITLE
Remove AddressManager being exposed and replace scripts with location…

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6203,7 +6203,6 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEnginePointe
     scriptEngine->registerGlobalObject("Selection", DependencyManager::get<SelectionScriptingInterface>().data());
     scriptEngine->registerGlobalObject("ContextOverlay", DependencyManager::get<ContextOverlayInterface>().data());
     scriptEngine->registerGlobalObject("Wallet", DependencyManager::get<WalletScriptingInterface>().data());
-    scriptEngine->registerGlobalObject("AddressManager", DependencyManager::get<AddressManager>().data());
 
     scriptEngine->registerGlobalObject("App", this);
 

--- a/scripts/system/controllers/controllerModules/farActionGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farActionGrabEntity.js
@@ -14,7 +14,7 @@
    PICK_MAX_DISTANCE, COLORS_GRAB_SEARCHING_HALF_SQUEEZE, COLORS_GRAB_SEARCHING_FULL_SQUEEZE, COLORS_GRAB_DISTANCE_HOLD,
    DEFAULT_SEARCH_SPHERE_DISTANCE, TRIGGER_OFF_VALUE, TRIGGER_ON_VALUE, ZERO_VEC, ensureDynamic,
    getControllerWorldLocation, projectOntoEntityXYPlane, ContextOverlay, HMD, Reticle, Overlays, isPointingAtUI
-   Picks, makeLaserLockInfo Xform, makeLaserParams, AddressManager, getEntityParents, Selection, DISPATCHER_HOVERING_LIST
+   Picks, makeLaserLockInfo Xform, makeLaserParams, location, getEntityParents, Selection, DISPATCHER_HOVERING_LIST
 */
 
 Script.include("/~/system/libraries/controllerDispatcherUtils.js");
@@ -463,7 +463,7 @@ Script.include("/~/system/libraries/Xform.js");
                             "userData", "locked", "type", "href"
                         ]);
                         if (targetProps.href !== "") {
-                            AddressManager.handleLookupString(targetProps.href);
+                            location.handleLookupString(targetProps.href);
                             return makeRunningValues(false, [], []);
                         }
 

--- a/scripts/system/controllers/controllerModules/nearGrabHyperLinkEntity.js
+++ b/scripts/system/controllers/controllerModules/nearGrabHyperLinkEntity.js
@@ -12,7 +12,7 @@
    propsArePhysical, Messages, HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, entityIsGrabbable,
    Quat, Vec3, MSECS_PER_SEC, getControllerWorldLocation, makeDispatcherModuleParameters, makeRunningValues,
    TRIGGER_OFF_VALUE, NEAR_GRAB_RADIUS, findGroupParent, entityIsCloneable, propsAreCloneDynamic, cloneEntity,
-   HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, BUMPER_ON_VALUE, AddressManager
+   HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, BUMPER_ON_VALUE, location
 */
 
 (function() {

--- a/scripts/system/controllers/controllerModules/nearGrabHyperLinkEntity.js
+++ b/scripts/system/controllers/controllerModules/nearGrabHyperLinkEntity.js
@@ -71,7 +71,7 @@
 
             if (controllerData.triggerClicks[this.hand] ||
                 controllerData.secondaryValues[this.hand] > BUMPER_ON_VALUE) {
-                AddressManager.handleLookupString(this.hyperlink);
+                location.handleLookupString(this.hyperlink);
                 return makeRunningValues(false, [], []);
             }
 


### PR DESCRIPTION
Removing AddressManager from being exposed as it was synonymous with Window.location.  

Still not sure if this is the best overall solution, but at least we can trim the API here before we find a better solution maybe using @huffman's suggestion of exposing LocationScriptingInterface instead of the Window util class. 