### PR TITLE
Additional work on splash screen

### DIFF
--- a/interface/resources/shaders/splashSkybox.frag
+++ b/interface/resources/shaders/splashSkybox.frag
@@ -1,37 +1,47 @@
+const vec3 COLOR = vec3(0x00, 0xD8, 0x02) / vec3(0xFF);
+const float CUTOFF = 0.65;
+const float NOISE_MULT = 8.0;
+const float NOISE_POWER = 1.0;
 
-float noise3D(vec3 p)
-{
-    return fract(sin(dot(p ,vec3(12.9898,78.233,126.7235))) * 43758.5453);
+float noise4D(vec4 p) {
+	return fract(sin(dot(p ,vec4(12.9898,78.233,126.7235, 593.2241))) * 43758.5453);
 }
 
-float worley3D(vec3 p)
-{                                        
-    float r = 3.0;
-    vec3 f = floor(p);
-    vec3 x = fract(p);
-    for(int i = -1; i<=1; i++)
-    {
-        for(int j = -1; j<=1; j++)
-        {
-            for(int k = -1; k<=1; k++)
-            {
-                vec3 q = vec3(float(i),float(j),float(k));
-                vec3 v = q + vec3(noise3D((q+f)*1.11), noise3D((q+f)*1.14), noise3D((q+f)*1.17)) - x;
-                float d = dot(v, v);
-                r = min(r, d);
-            }
-        }
-    }
+float worley4D(vec4 p) {
+	float r = 3.0;
+    vec4 f = floor(p);
+    vec4 x = fract(p);
+	for(int i = -1; i<=1; i++)
+	{
+		for(int j = -1; j<=1; j++)
+		{
+			for(int k = -1; k<=1; k++)
+			{
+                for (int l = -1; l <= 1; l++) {
+                	vec4 q = vec4(float(i),float(j),float(k), float(l));
+    				vec4 v = q + vec4(noise4D((q+f)*1.11), noise4D((q+f)*1.14), noise4D((q+f)*1.17), noise4D((q+f)*1.20)) - x;
+    				float d = dot(v, v);
+					r = min(r, d);
+                }
+			}
+		}
+	}
     return sqrt(r);
-}   
+}
 
+
+vec3 mainColor(vec3 direction) {
+    float n = worley4D(vec4(direction * NOISE_MULT, iGlobalTime / 3.0));
+    n = 1.0 - n;
+    n = pow(n, NOISE_POWER);
+    if (n < CUTOFF) {
+        return vec3(0.0);
+    }
+
+    n = (n - CUTOFF) / (1.0 - CUTOFF);
+	return COLOR * (1.0 - n);
+}
 
 vec3 getSkyboxColor() {
-    vec3 color = abs(normalize(_normal));
-//    vec2 uv;
-//    uv.x = 0.5 + atan(_normal.z, _normal.x);
-//    uv.y = 0.5 - asin(_normal.y);
-//    uv *= 20.0;
-//    color.r = worley3D(vec3(uv, iGlobalTime));
-    return color;
+	return mainColor(normalize(_normal));
 }

--- a/interface/resources/shaders/splashSkybox.frag
+++ b/interface/resources/shaders/splashSkybox.frag
@@ -1,0 +1,37 @@
+
+float noise3D(vec3 p)
+{
+    return fract(sin(dot(p ,vec3(12.9898,78.233,126.7235))) * 43758.5453);
+}
+
+float worley3D(vec3 p)
+{                                        
+    float r = 3.0;
+    vec3 f = floor(p);
+    vec3 x = fract(p);
+    for(int i = -1; i<=1; i++)
+    {
+        for(int j = -1; j<=1; j++)
+        {
+            for(int k = -1; k<=1; k++)
+            {
+                vec3 q = vec3(float(i),float(j),float(k));
+                vec3 v = q + vec3(noise3D((q+f)*1.11), noise3D((q+f)*1.14), noise3D((q+f)*1.17)) - x;
+                float d = dot(v, v);
+                r = min(r, d);
+            }
+        }
+    }
+    return sqrt(r);
+}   
+
+
+vec3 getSkyboxColor() {
+    vec3 color = abs(normalize(_normal));
+//    vec2 uv;
+//    uv.x = 0.5 + atan(_normal.z, _normal.x);
+//    uv.y = 0.5 - asin(_normal.y);
+//    uv *= 20.0;
+//    color.r = worley3D(vec3(uv, iGlobalTime));
+    return color;
+}

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2646,6 +2646,9 @@ void Application::initializeDisplayPlugins() {
     updateRenderArgs(0.0f);
 
     _offscreenContext->makeCurrent();
+
+#define ENABLE_SPLASH_FRAME 0
+#if ENABLE_SPLASH_FRAME
     {
         QMutexLocker viewLocker(&_renderArgsMutex);
 
@@ -2666,14 +2669,10 @@ void Application::initializeDisplayPlugins() {
             batch.resetStages();
             batch.enableStereo(false);
             batch.setFramebuffer(finalFramebuffer);
-            batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, { 0, 1, 1, 1 });
-
+            batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, { 0, 0, 0, 1 });
             batch.enableSkybox(true);
             batch.enableStereo(_appRenderArgs._isStereo);
             batch.setViewportTransform({ 0, 0, finalFramebuffer->getSize() });
-            batch.runLambda([] {
-                // update uniform values
-            });
             procedural->render(batch, _appRenderArgs._renderArgs.getViewFrustum());
         });
         auto frame = _gpuContext->endFrame();
@@ -2685,6 +2684,7 @@ void Application::initializeDisplayPlugins() {
         };
         _displayPlugin->submitFrame(frame);
     }
+#endif
 }
 
 void Application::initializeRenderEngine() {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -144,6 +144,7 @@
 #include <trackers/EyeTracker.h>
 #include <avatars-renderer/ScriptAvatar.h>
 #include <RenderableEntityItem.h>
+#include <procedural/ProceduralSkybox.h>
 
 #include <AnimationLogging.h>
 #include <AvatarLogging.h>
@@ -385,7 +386,7 @@ Setting::Handle<int> maxOctreePacketsPerSecond("maxOctreePPS", DEFAULT_MAX_OCTRE
 static const QString MARKETPLACE_CDN_HOSTNAME = "mpassets.highfidelity.com";
 static const int INTERVAL_TO_CHECK_HMD_WORN_STATUS = 500; // milliseconds
 static const QString DESKTOP_DISPLAY_PLUGIN_NAME = "Desktop";
-
+static const QString ACTIVE_DISPLAY_PLUGIN_SETTING_NAME = "activeDisplayPlugin";
 static const QString SYSTEM_TABLET = "com.highfidelity.interface.tablet.system";
 
 const std::vector<std::pair<QString, Application::AcceptURLMethod>> Application::_acceptedExtensions {
@@ -1322,10 +1323,14 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     QCoreApplication::processEvents();
     _glWidget->createContext();
 
-    // Create the main thread context, the GPU backend, and the display plugins
+    // Create the main thread context, the GPU backend
     initializeGL();
-    DependencyManager::get<TextureCache>()->setGPUContext(_gpuContext);
-    qCDebug(interfaceapp, "Initialized Display.");
+    qCDebug(interfaceapp, "Initialized GL");
+
+    // Initialize the display plugin architecture 
+    initializeDisplayPlugins();
+    qCDebug(interfaceapp, "Initialized Display");
+
     // Create the rendering engine.  This can be slow on some machines due to lots of 
     // GPU pipeline creation.
     initializeRenderEngine();
@@ -2359,6 +2364,10 @@ void Application::onAboutToQuit() {
         }
     }
 
+    // The active display plugin needs to be loaded before the menu system is active, 
+    // so its persisted explicitly here
+    Setting::Handle<QString>{ ACTIVE_DISPLAY_PLUGIN_SETTING_NAME }.set(getActiveDisplayPlugin()->getName());
+
     getActiveDisplayPlugin()->deactivate();
     if (_autoSwitchDisplayModeSupportedHMDPlugin
         && _autoSwitchDisplayModeSupportedHMDPlugin->isSessionActive()) {
@@ -2598,10 +2607,81 @@ void Application::initializeGL() {
     _glWidget->makeCurrent();
     _gpuContext = std::make_shared<gpu::Context>();
 
+    DependencyManager::get<TextureCache>()->setGPUContext(_gpuContext);
+
     // Restore the default main thread context
     _offscreenContext->makeCurrent();
+}
 
-    updateDisplayMode();
+static const QString SPLASH_SKYBOX{ "{\"ProceduralEntity\":{ \"version\":2, \"shaderUrl\":\"qrc:///shaders/splashSkybox.frag\" } }" };
+
+void Application::initializeDisplayPlugins() {
+    auto displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
+    Setting::Handle<QString> activeDisplayPluginSetting{ ACTIVE_DISPLAY_PLUGIN_SETTING_NAME, displayPlugins.at(0)->getName() };
+    auto lastActiveDisplayPluginName = activeDisplayPluginSetting.get();
+
+    auto defaultDisplayPlugin = displayPlugins.at(0);
+    // Once time initialization code 
+    DisplayPluginPointer targetDisplayPlugin;
+    foreach(auto displayPlugin, displayPlugins) {
+        displayPlugin->setContext(_gpuContext);
+        if (displayPlugin->getName() == lastActiveDisplayPluginName) {
+            targetDisplayPlugin = displayPlugin;
+        }
+        QObject::connect(displayPlugin.get(), &DisplayPlugin::recommendedFramebufferSizeChanged,
+            [this](const QSize& size) { resizeGL(); });
+        QObject::connect(displayPlugin.get(), &DisplayPlugin::resetSensorsRequested, this, &Application::requestReset);
+    }
+
+    // The default display plugin needs to be activated first, otherwise the display plugin thread
+    // may be launched by an external plugin, which is bad 
+    setDisplayPlugin(defaultDisplayPlugin);
+
+    // Now set the desired plugin if it's not the same as the default plugin
+    if (targetDisplayPlugin != defaultDisplayPlugin) {
+        setDisplayPlugin(targetDisplayPlugin);
+    }
+
+    // Submit a default frame to render until the engine starts up
+    updateRenderArgs(0.0f);
+
+    _offscreenContext->makeCurrent();
+    {
+        QMutexLocker viewLocker(&_renderArgsMutex);
+
+        if (_appRenderArgs._isStereo) {
+            _gpuContext->enableStereo(true);
+            _gpuContext->setStereoProjections(_appRenderArgs._eyeProjections);
+            _gpuContext->setStereoViews(_appRenderArgs._eyeOffsets);
+        }
+
+        // Frame resources
+        auto framebufferCache = DependencyManager::get<FramebufferCache>();
+        gpu::FramebufferPointer finalFramebuffer = framebufferCache->getFramebuffer();
+        std::shared_ptr<ProceduralSkybox> procedural = std::make_shared<ProceduralSkybox>();
+        procedural->parse(SPLASH_SKYBOX);
+
+        _gpuContext->beginFrame(_appRenderArgs._view, _appRenderArgs._headPose);
+        gpu::doInBatch("splashFrame", _gpuContext, [&](gpu::Batch& batch) {
+            batch.resetStages();
+            batch.enableStereo(false);
+            batch.setFramebuffer(finalFramebuffer);
+            batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, { 0, 1, 1, 1 });
+
+            batch.enableSkybox(true);
+            batch.enableStereo(_appRenderArgs._isStereo);
+            batch.setViewportTransform({ 0, 0, finalFramebuffer->getSize() });
+            procedural->render(batch, _appRenderArgs._renderArgs.getViewFrustum());
+        });
+        auto frame = _gpuContext->endFrame();
+        frame->frameIndex = 0;
+        frame->framebuffer = finalFramebuffer;
+        frame->pose = _appRenderArgs._headPose;
+        frame->framebufferRecycler = [framebufferCache, procedural](const gpu::FramebufferPointer& framebuffer) {
+            framebufferCache->releaseFramebuffer(framebuffer);
+        };
+        _displayPlugin->submitFrame(frame);
+    }
 }
 
 void Application::initializeRenderEngine() {
@@ -2625,6 +2705,7 @@ void Application::initializeRenderEngine() {
 }
 
 extern void setupPreferences();
+static void addDisplayPluginToMenu(const DisplayPluginPointer& displayPlugin, bool active);
 
 void Application::initializeUi() {
     // Build a shared canvas / context for the Chromium processes
@@ -2766,9 +2847,24 @@ void Application::initializeUi() {
     offscreenSurfaceCache->reserve(TabletScriptingInterface::QML, 1);
     offscreenSurfaceCache->reserve(Web3DOverlay::QML, 2);
 
-    // Now that the menu is instantiated, ensure the display plugin menu is properly updated
-    updateDisplayMode();
     flushMenuUpdates();
+
+    // Now that the menu is instantiated, ensure the display plugin menu is properly updated
+    {
+        auto displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
+        // first sort the plugins into groupings: standard, advanced, developer
+        std::stable_sort(displayPlugins.begin(), displayPlugins.end(),
+            [](const DisplayPluginPointer& a, const DisplayPluginPointer& b)->bool { return a->getGrouping() < b->getGrouping(); });
+
+        // concatenate the groupings into a single list in the order: standard, advanced, developer
+        for(const auto& displayPlugin : displayPlugins) {
+            addDisplayPluginToMenu(displayPlugin, _displayPlugin == displayPlugin);
+        }
+
+        // after all plugins have been added to the menu, add a separator to the menu
+        auto parent = getPrimaryMenu()->getMenu(MenuOption::OutputMenu);
+        parent->addSeparator();
+    }
 
     // The display plugins are created before the menu now, so we need to do this here to hide the menu bar
     // now that it exists
@@ -5723,6 +5819,32 @@ void Application::update(float deltaTime) {
     }
 
 
+    updateRenderArgs(deltaTime);
+
+    // HACK
+    // load the view frustum
+    // FIXME: This preDisplayRender call is temporary until we create a separate render::scene for the mirror rendering.
+    // Then we can move this logic into the Avatar::simulate call.
+    myAvatar->preDisplaySide(&_appRenderArgs._renderArgs);
+
+
+    {
+        PerformanceTimer perfTimer("limitless");
+        AnimDebugDraw::getInstance().update();
+    }
+
+    {
+        PerformanceTimer perfTimer("limitless");
+        DependencyManager::get<LimitlessVoiceRecognitionScriptingInterface>()->update();
+    }
+
+    { // Game loop is done, mark the end of the frame for the scene transactions and the render loop to take over
+        PerformanceTimer perfTimer("enqueueFrame");
+        getMain3DScene()->enqueueFrame();
+    }
+}
+
+void Application::updateRenderArgs(float deltaTime) {
     editRenderArgs([this, deltaTime](AppRenderArgs& appRenderArgs) {
         PerformanceTimer perfTimer("editRenderArgs");
         appRenderArgs._headPose = getHMDSensorPose();
@@ -5746,9 +5868,9 @@ void Application::update(float deltaTime) {
                 QMutexLocker viewLocker(&_viewMutex);
                 // adjust near clip plane to account for sensor scaling.
                 auto adjustedProjection = glm::perspective(glm::radians(_fieldOfView.get()),
-                                                           getActiveDisplayPlugin()->getRecommendedAspectRatio(),
-                                                           DEFAULT_NEAR_CLIP * sensorToWorldScale,
-                                                           DEFAULT_FAR_CLIP);
+                    getActiveDisplayPlugin()->getRecommendedAspectRatio(),
+                    DEFAULT_NEAR_CLIP * sensorToWorldScale,
+                    DEFAULT_FAR_CLIP);
                 _viewFrustum.setProjection(adjustedProjection);
                 _viewFrustum.calculate();
             }
@@ -5764,8 +5886,14 @@ void Application::update(float deltaTime) {
         }
         {
             PROFILE_RANGE(render, "/resizeGL");
-            PerformanceWarning::setSuppressShortTimings(Menu::getInstance()->isOptionChecked(MenuOption::SuppressShortTimings));
-            bool showWarnings = Menu::getInstance()->isOptionChecked(MenuOption::PipelineWarnings);
+            bool showWarnings = false;
+            bool suppressShortTimings = false;
+            auto menu = Menu::getInstance();
+            if (menu) {
+                suppressShortTimings = menu->isOptionChecked(MenuOption::SuppressShortTimings);
+                showWarnings = menu->isOptionChecked(MenuOption::PipelineWarnings);
+            }
+            PerformanceWarning::setSuppressShortTimings(suppressShortTimings);
             PerformanceWarning warn(showWarnings, "Application::paintGL()");
             resizeGL();
         }
@@ -5821,12 +5949,6 @@ void Application::update(float deltaTime) {
             }
         }
 
-        // HACK
-        // load the view frustum
-        // FIXME: This preDisplayRender call is temporary until we create a separate render::scene for the mirror rendering.
-        // Then we can move this logic into the Avatar::simulate call.
-        myAvatar->preDisplaySide(&appRenderArgs._renderArgs);
-
         {
             QMutexLocker viewLocker(&_viewMutex);
             _myCamera.loadViewFrustum(_displayViewFrustum);
@@ -5838,21 +5960,6 @@ void Application::update(float deltaTime) {
             appRenderArgs._renderArgs.setViewFrustum(_displayViewFrustum);
         }
     });
-
-    {
-        PerformanceTimer perfTimer("limitless");
-        AnimDebugDraw::getInstance().update();
-    }
-
-    {
-        PerformanceTimer perfTimer("limitless");
-        DependencyManager::get<LimitlessVoiceRecognitionScriptingInterface>()->update();
-    }
-
-    { // Game loop is done, mark the end of the frame for the scene transactions and the render loop to take over
-        PerformanceTimer perfTimer("enqueueFrame");
-        getMain3DScene()->enqueueFrame();
-    }
 }
 
 void Application::queryAvatars() {
@@ -7493,15 +7600,19 @@ void Application::shareSnapshot(const QString& path, const QUrl& href) {
 }
 
 float Application::getRenderResolutionScale() const {
-    if (Menu::getInstance()->isOptionChecked(MenuOption::RenderResolutionOne)) {
+    auto menu = Menu::getInstance();
+    if (!menu) {
         return 1.0f;
-    } else if (Menu::getInstance()->isOptionChecked(MenuOption::RenderResolutionTwoThird)) {
+    }
+    if (menu->isOptionChecked(MenuOption::RenderResolutionOne)) {
+        return 1.0f;
+    } else if (menu->isOptionChecked(MenuOption::RenderResolutionTwoThird)) {
         return 0.666f;
-    } else if (Menu::getInstance()->isOptionChecked(MenuOption::RenderResolutionHalf)) {
+    } else if (menu->isOptionChecked(MenuOption::RenderResolutionHalf)) {
         return 0.5f;
-    } else if (Menu::getInstance()->isOptionChecked(MenuOption::RenderResolutionThird)) {
+    } else if (menu->isOptionChecked(MenuOption::RenderResolutionThird)) {
         return 0.333f;
-    } else if (Menu::getInstance()->isOptionChecked(MenuOption::RenderResolutionQuarter)) {
+    } else if (menu->isOptionChecked(MenuOption::RenderResolutionQuarter)) {
         return 0.25f;
     } else {
         return 1.0f;
@@ -7725,7 +7836,7 @@ DisplayPluginPointer Application::getActiveDisplayPlugin() const {
 
 static const char* EXCLUSION_GROUP_KEY = "exclusionGroup";
 
-static void addDisplayPluginToMenu(DisplayPluginPointer displayPlugin, bool active = false) {
+static void addDisplayPluginToMenu(const DisplayPluginPointer& displayPlugin, bool active) {
     auto menu = Menu::getInstance();
     QString name = displayPlugin->getName();
     auto grouping = displayPlugin->getGrouping();
@@ -7770,65 +7881,12 @@ void Application::updateDisplayMode() {
         qFatal("Attempted to switch display plugins from a non-main thread");
     }
 
-    auto displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
-
-    // Once time initialization code 
-    static std::once_flag once;
-    std::call_once(once, [&] {
-        foreach(auto displayPlugin, displayPlugins) {
-            displayPlugin->setContext(_gpuContext);
-            QObject::connect(displayPlugin.get(), &DisplayPlugin::recommendedFramebufferSizeChanged,
-                [this](const QSize& size) { resizeGL(); });
-            QObject::connect(displayPlugin.get(), &DisplayPlugin::resetSensorsRequested, this, &Application::requestReset);
-        }
-    });
-
     // Once time initialization code that depends on the UI being available
-    auto menu = Menu::getInstance();
-    if (menu) {
-        static std::once_flag onceUi;
-        std::call_once(onceUi, [&] {
-            bool first = true;
-
-            // first sort the plugins into groupings: standard, advanced, developer
-            DisplayPluginList standard;
-            DisplayPluginList advanced;
-            DisplayPluginList developer;
-            foreach(auto displayPlugin, displayPlugins) {
-                displayPlugin->setContext(_gpuContext);
-                auto grouping = displayPlugin->getGrouping();
-                switch (grouping) {
-                case Plugin::ADVANCED:
-                    advanced.push_back(displayPlugin);
-                    break;
-                case Plugin::DEVELOPER:
-                    developer.push_back(displayPlugin);
-                    break;
-                default:
-                    standard.push_back(displayPlugin);
-                    break;
-                }
-            }
-
-            // concatenate the groupings into a single list in the order: standard, advanced, developer
-            standard.insert(std::end(standard), std::begin(advanced), std::end(advanced));
-            standard.insert(std::end(standard), std::begin(developer), std::end(developer));
-
-            foreach(auto displayPlugin, standard) {
-                addDisplayPluginToMenu(displayPlugin, first);
-                first = false;
-            }
-
-            // after all plugins have been added to the menu, add a separator to the menu
-            auto parent = menu->getMenu(MenuOption::OutputMenu);
-            parent->addSeparator();
-        });
-
-    }
-
+    auto displayPlugins = getDisplayPlugins();
 
     // Default to the first item on the list, in case none of the menu items match
     DisplayPluginPointer newDisplayPlugin = displayPlugins.at(0);
+    auto menu = getPrimaryMenu();
     if (menu) {
         foreach(DisplayPluginPointer displayPlugin, PluginManager::getInstance()->getDisplayPlugins()) {
             QString name = displayPlugin->getName();
@@ -7852,6 +7910,14 @@ void Application::updateDisplayMode() {
 }
 
 void Application::setDisplayPlugin(DisplayPluginPointer newDisplayPlugin) {
+    if (newDisplayPlugin == _displayPlugin) {
+        return;
+    }
+
+    // FIXME don't have the application directly set the state of the UI,
+    // instead emit a signal that the display plugin is changing and let 
+    // the desktop lock itself.  Reduces coupling between the UI and display
+    // plugins
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     auto desktop = offscreenUi->getDesktop();
     auto menu = Menu::getInstance();
@@ -7862,8 +7928,8 @@ void Application::setDisplayPlugin(DisplayPluginPointer newDisplayPlugin) {
         bool wasRepositionLocked = false;
         if (desktop) {
             // Tell the desktop to no reposition (which requires plugin info), until we have set the new plugin, below.
-            wasRepositionLocked = offscreenUi->getDesktop()->property("repositionLocked").toBool();
-            offscreenUi->getDesktop()->setProperty("repositionLocked", true);
+            wasRepositionLocked = desktop->property("repositionLocked").toBool();
+            desktop->setProperty("repositionLocked", true);
         }
 
         if (_displayPlugin) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2671,6 +2671,9 @@ void Application::initializeDisplayPlugins() {
             batch.enableSkybox(true);
             batch.enableStereo(_appRenderArgs._isStereo);
             batch.setViewportTransform({ 0, 0, finalFramebuffer->getSize() });
+            batch.runLambda([] {
+                // update uniform values
+            });
             procedural->render(batch, _appRenderArgs._renderArgs.getViewFrustum());
         });
         auto frame = _gpuContext->endFrame();
@@ -3016,7 +3019,7 @@ void Application::updateCamera(RenderArgs& renderArgs, float deltaTime) {
             _thirdPersonHMDCameraBoomValid = false;
 
             _myCamera.setOrientation(myAvatar->getHead()->getOrientation());
-            if (Menu::getInstance()->isOptionChecked(MenuOption::CenterPlayerInView)) {
+            if (isOptionChecked(MenuOption::CenterPlayerInView)) {
                 _myCamera.setPosition(myAvatar->getDefaultEyePosition()
                     + _myCamera.getOrientation() * boomOffset);
             }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -148,6 +148,7 @@ public:
     Q_INVOKABLE QString getUserAgent();
 
     void initializeGL();
+    void initializeDisplayPlugins();
     void initializeRenderEngine();
     void initializeUi();
 
@@ -671,6 +672,7 @@ private:
 
     using RenderArgsEditor = std::function <void (AppRenderArgs&)>;
     void editRenderArgs(RenderArgsEditor editor);
+    void updateRenderArgs(float deltaTime);
 
 
     Overlays _overlays;

--- a/interface/src/Application_render.cpp
+++ b/interface/src/Application_render.cpp
@@ -13,8 +13,9 @@
 
 #include <display-plugins/CompositorHelper.h>
 #include <FramebufferCache.h>
-#include "ui/Stats.h"
+#include <plugins/PluginManager.h>
 #include <SceneScriptingInterface.h>
+#include "ui/Stats.h"
 #include "Util.h"
 
 
@@ -233,3 +234,4 @@ void Application::runRenderFrame(RenderArgs* renderArgs) {
         _renderEngine->run();
     }
 }
+

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2039,7 +2039,7 @@ void MyAvatar::postUpdate(float deltaTime, const render::ScenePointer& scene) {
     }
 }
 
-void MyAvatar::preDisplaySide(RenderArgs* renderArgs) {
+void MyAvatar::preDisplaySide(const RenderArgs* renderArgs) {
 
     // toggle using the cauterizedBones depending on where the camera is and the rendering pass type.
     const bool shouldDrawHead = shouldRenderHead(renderArgs);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -272,7 +272,7 @@ public:
 
     void update(float deltaTime);
     virtual void postUpdate(float deltaTime, const render::ScenePointer& scene) override;
-    void preDisplaySide(RenderArgs* renderArgs);
+    void preDisplaySide(const RenderArgs* renderArgs);
 
     const glm::mat4& getHMDSensorMatrix() const { return _hmdSensorMatrix; }
     const glm::vec3& getHMDSensorPosition() const { return _hmdSensorPosition; }

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -336,9 +336,8 @@ void OpenGLDisplayPlugin::deactivate() {
 
     _container->showDisplayPluginsTools(false);
     if (!_container->currentDisplayActions().isEmpty()) {
-        auto menu = _container->getPrimaryMenu();
         foreach(auto itemInfo, _container->currentDisplayActions()) {
-            menu->removeMenuItem(itemInfo.first, itemInfo.second);
+            _container->removeMenuItem(itemInfo.first, itemInfo.second);
         }
         _container->currentDisplayActions().clear();
     }

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -19,7 +19,7 @@
 #include <SharedUtil.h>
 #include <NumericalConstants.h>
 #include <GLMHelpers.h>
-
+#include <NetworkingConstants.h>
 #include "ProceduralCommon_frag.h"
 
 #include "Logging.h"
@@ -178,6 +178,8 @@ void Procedural::setProceduralData(const ProceduralData& proceduralData) {
                 return;
             }
             _shaderPath = shaderUrl.toLocalFile();
+        } else if (shaderUrl.scheme() == URL_SCHEME_QRC) {
+            _shaderPath = ":" + shaderUrl.path();
         } else {
             _networkShader = ShaderCache::instance().getShader(shaderUrl);
         }

--- a/libraries/ui-plugins/src/ui-plugins/PluginContainer.h
+++ b/libraries/ui-plugins/src/ui-plugins/PluginContainer.h
@@ -54,6 +54,12 @@ public:
     void setFullscreen(const QScreen* targetScreen, bool hideMenu = false);
     void unsetFullscreen(const QScreen* avoidScreen = nullptr);
 
+    // FIXME remove access tot he menu from the plugin container
+    // Instead let display plugins expose a structure about the kinds
+    // of actions and menu items they want to have appear when they are
+    // active and allow the application to act on that when the display
+    // plugin becomes active (or when the UI is initialized, and a 
+    // display plugin is already active)
     virtual ui::Menu* getPrimaryMenu() = 0;
     virtual void showDisplayPluginsTools(bool show = true) = 0;
     virtual void requestReset() = 0;

--- a/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusBaseDisplayPlugin.cpp
@@ -166,12 +166,11 @@ void OculusBaseDisplayPlugin::deactivateSession() {
     //_session = nullptr;
 }
 void OculusBaseDisplayPlugin::updatePresentPose() {
-    //mat4 sensorResetMat;
-    //_currentPresentFrameInfo.sensorSampleTime = ovr_GetTimeInSeconds();
-    //_currentPresentFrameInfo.predictedDisplayTime = ovr_GetPredictedDisplayTime(_session, _currentFrame->frameIndex);
-    //auto trackingState = ovr_GetTrackingState(_session, _currentRenderFrameInfo.predictedDisplayTime, ovrFalse);
-    //_currentPresentFrameInfo.presentPose = toGlm(trackingState.HeadPose.ThePose);
-    _currentPresentFrameInfo.presentPose = _currentPresentFrameInfo.renderPose;
+    _currentPresentFrameInfo.sensorSampleTime = ovr_GetTimeInSeconds();
+    _currentPresentFrameInfo.predictedDisplayTime = ovr_GetPredictedDisplayTime(_session, 0);
+    auto trackingState = ovr_GetTrackingState(_session, _currentRenderFrameInfo.predictedDisplayTime, ovrFalse);
+    _currentPresentFrameInfo.presentPose = toGlm(trackingState.HeadPose.ThePose);
+    _currentPresentFrameInfo.renderPose = _currentPresentFrameInfo.presentPose;
 }
 
 OculusBaseDisplayPlugin::~OculusBaseDisplayPlugin() {


### PR DESCRIPTION
This PR is additional work to support a splash screen frame (either on HMD or desktop).  Currently the splash frame is disabled due to stuttering issues, but the remainder of the work should be tested and merged.

## Testing

This code should have no visible effect on the application as it just changes the order of some startup code.  

* Verify startup / shutdown without crashing
* Verify display plugin setting properly preserved on shutdown / startup
* Verify that the Oculus HMD view is stable and does not judder (any more than master) as you turn your head in a typical domain.


