### PR TITLE
allow download of serverless content for specific campaign

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,6 +20,7 @@ To produce an executable installer on Windows, the following are required:
 - [Inetc Plug-in for Nullsoft](http://nsis.sourceforge.net/Inetc_plug-in) - 1.0
 - [NSISpcre Plug-in for Nullsoft](http://nsis.sourceforge.net/NSISpcre_plug-in) - 1.0
 - [nsisSlideshow Plug-in for Nullsoft](http://nsis.sourceforge.net/NsisSlideshow_plug-in) - 1.7
+- [Nsisunz plug-in for Nullsoft](http://nsis.sourceforge.net/Nsisunz_plug-in)
 
 Run the `package` target to create an executable installer using the Nullsoft Scriptable Install System.
 

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -1005,6 +1005,23 @@ Function HandlePostInstallOptions
   ${EndIf}
 FunctionEnd
 
+Function OptionallyDownloadCampaignServerless
+  ${If} $CampaignName != ""
+    InitPluginsDir
+
+    NSISdl::download_quiet http://cdn.highfidelity.com/installer/serverless/$CampaignName.zip $PLUGINSDIR\$CampaignName.zip
+
+    ${If} ${FileExists} $PLUGINSDIR\$CampaignName.zip
+      ; replace the installed serverless content with the campaign content
+
+      RMDir /r "$INSTDIR\resources\serverless"
+      CreateDirectory "$INSTDIR\resources\serverless"
+      nsisunz::Unzip "$PLUGINSDIR\$CampaignName.zip" "$INSTDIR\resources\serverless"
+    ${EndIf}
+
+  ${Endif}
+FunctionEnd
+
 ;--------------------------------
 ;Installer Sections
 
@@ -1157,6 +1174,9 @@ Section "-Core installation"
   !insertmacro MUI_STARTMENU_WRITE_END
 
   @CPACK_NSIS_EXTRA_INSTALL_COMMANDS@
+
+  ; see if we have a campaign that we might need to grab special content for
+  Call OptionallyDownloadCampaignServerless
 
   ; Handle whichever post install options were set
   Call HandlePostInstallOptions


### PR DESCRIPTION
#### Test Plan

1. Run the installer from this PR. Run Interface and confirm that on first launch you get the default serverless tutorial. Close interface without changing domains.

2. Rename the installer to `HighFidelity-Fake-Beta-Interface-PR12951-...` (adding "Fake" in-between "HighFidelity" and "Beta"). Run the renamed installer. Run Interface and confirm that you are in an empty serverless domain that only has a box at 0, -12, 0. Close Interface without changing domains.

3. Disconnect your machine from the internet. Run the test installer again while disconnected from the internet. Run Interface and confirm that you get the default serverless tutorial (you may reconnect to the internet before running Interface).
