### PR TITLE
Don't populate user list in pal until you connect the events up

### DIFF
--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -715,7 +715,6 @@ function onTabletScreenChanged(type, url) {
 
         ContextOverlay.enabled = false;
         Users.requestsDomainListData = true;
-        populateNearbyUserList();
 
         audioTimer = createAudioInterval(conserveResources ? AUDIO_LEVEL_CONSERVED_UPDATE_INTERVAL_MS : AUDIO_LEVEL_UPDATE_INTERVAL_MS);
 
@@ -726,6 +725,7 @@ function onTabletScreenChanged(type, url) {
         Users.usernameFromIDReply.connect(usernameFromIDReply);
         triggerMapping.enable();
         triggerPressMapping.enable();
+        populateNearbyUserList();
     } else {
         off();
         ContextOverlay.enabled = true;


### PR DESCRIPTION
what ended up happening is the first time you opened the PAL, you didn't see the fingerprints of the users that are anonymous, if you are an admin. 

fixes https://highfidelity.manuscript.com/f/cases/14375/anonymous-user-entry-doesn-t-give-fingerprint-to-administrative-pal-users