### PR TITLE
Android: Hide menu and fix shader compilation

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2654,6 +2654,12 @@ void Application::initializeUi() {
     // Now that the menu is instantiated, ensure the display plugin menu is properly updated
     updateDisplayMode();
     flushMenuUpdates();
+
+    // The display plugins are created before the menu now, so we need to do this here to hide the menu bar
+    // now that it exists
+    if (_window && _window->isFullScreen()) {
+        setFullscreen(nullptr, true);
+    }
 }
 
 

--- a/libraries/render-utils/src/directional_ambient_light.slf
+++ b/libraries/render-utils/src/directional_ambient_light.slf
@@ -36,8 +36,8 @@ void main(void) {
     } else if (frag.mode == FRAG_MODE_LIGHTMAPPED) {
         discard;
     } else {
-        vec4 midNormalCurvature;
-        vec4 lowNormalCurvature;
+        vec4 midNormalCurvature = vec4(0);
+        vec4 lowNormalCurvature = vec4(0);
         if (frag.mode == FRAG_MODE_SCATTERING) {
             unpackMidLowNormalCurvature(_texCoord0, midNormalCurvature, lowNormalCurvature);
         }

--- a/libraries/render-utils/src/directional_ambient_light_shadow.slf
+++ b/libraries/render-utils/src/directional_ambient_light_shadow.slf
@@ -37,8 +37,8 @@ void main(void) {
     } else if (frag.mode == FRAG_MODE_LIGHTMAPPED) {
         discard;
     } else {
-        vec4 midNormalCurvature;
-        vec4 lowNormalCurvature;
+        vec4 midNormalCurvature = vec4(0);
+        vec4 lowNormalCurvature = vec4(0);
         if (frag.mode == FRAG_MODE_SCATTERING) {
             unpackMidLowNormalCurvature(_texCoord0, midNormalCurvature, lowNormalCurvature);
         }

--- a/libraries/render-utils/src/directional_skybox_light.slf
+++ b/libraries/render-utils/src/directional_skybox_light.slf
@@ -33,8 +33,8 @@ void main(void) {
     } else if (frag.mode == FRAG_MODE_LIGHTMAPPED) {
         discard;
     } else {
-        vec4 midNormalCurvature;
-        vec4 lowNormalCurvature;
+        vec4 midNormalCurvature = vec4(0);
+        vec4 lowNormalCurvature = vec4(0);
         if (frag.mode == FRAG_MODE_SCATTERING) {
             unpackMidLowNormalCurvature(_texCoord0, midNormalCurvature, lowNormalCurvature);
         }

--- a/libraries/render-utils/src/directional_skybox_light_shadow.slf
+++ b/libraries/render-utils/src/directional_skybox_light_shadow.slf
@@ -38,8 +38,8 @@ void main(void) {
     } else if (frag.mode == FRAG_MODE_LIGHTMAPPED) {
         discard;
     } else {
-        vec4 midNormalCurvature;
-        vec4 lowNormalCurvature;
+        vec4 midNormalCurvature = vec4(0);
+        vec4 lowNormalCurvature = vec4(0);
         if (frag.mode == FRAG_MODE_SCATTERING) {
             unpackMidLowNormalCurvature(_texCoord0, midNormalCurvature, lowNormalCurvature);
         }

--- a/libraries/render-utils/src/forward_model.slf
+++ b/libraries/render-utils/src/forward_model.slf
@@ -22,10 +22,10 @@
 <@include MaterialTextures.slh@>
 <$declareMaterialTextures(ALBEDO, ROUGHNESS, _SCRIBE_NULL, METALLIC, EMISSIVE, OCCLUSION)$>
 
-in vec4 _position;
+in vec4 _positionES;
 in vec2 _texCoord0;
 in vec2 _texCoord1;
-in vec3 _normal;
+in vec3 _normalWS;
 in vec3 _color;
 
 layout(location = 0) out vec4 _fragColor0;
@@ -54,8 +54,8 @@ void main(void) {
     <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;
     vec3 fresnel = getFresnelF0(metallic, albedo);
 
-    vec3 fragPosition = _position.xyz;
-    vec3 fragNormal = normalize(_normal);
+    vec3 fragPosition = _positionES.xyz;
+    vec3 fragNormal = normalize(_normalWS);
 
     TransformCamera cam = getTransformCamera();
 

--- a/libraries/render-utils/src/forward_model_translucent.slf
+++ b/libraries/render-utils/src/forward_model_translucent.slf
@@ -26,8 +26,8 @@
 
 in vec2 _texCoord0;
 in vec2 _texCoord1;
-in vec4 _position;
-in vec3 _normal;
+in vec4 _positionES;
+in vec3 _normalWS;
 in vec3 _color;
 in float _alpha;
 
@@ -56,8 +56,8 @@ void main(void) {
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
-    vec3 fragPosition = _position.xyz;
-    vec3 fragNormal = normalize(_normal);
+    vec3 fragPosition = _positionES.xyz;
+    vec3 fragNormal = normalize(_normalWS);
 
     TransformCamera cam = getTransformCamera();
 

--- a/libraries/render-utils/src/forward_model_unlit.slf
+++ b/libraries/render-utils/src/forward_model_unlit.slf
@@ -19,9 +19,7 @@
 <$declareMaterialTextures(ALBEDO)$>
 
 in vec2 _texCoord0;
-in vec3 _normal;
 in vec3 _color;
-in float _alpha;
 
 layout(location = 0) out vec4 _fragColor0;
 

--- a/libraries/render-utils/src/forward_simple.slf
+++ b/libraries/render-utils/src/forward_simple.slf
@@ -17,12 +17,9 @@
 <$declareEvalSkyboxGlobalColor()$>
 
 // the interpolated normal
-in vec3 _normal;
-in vec3 _modelNormal;
+in vec3 _normalWS;
 in vec4 _color;
-in vec2 _texCoord0;
-in vec4 _position;
-in vec4 _eyePosition;
+in vec4 _positionES;
 
 layout(location = 0) out vec4 _fragColor0;
 
@@ -33,7 +30,7 @@ layout(location = 0) out vec4 _fragColor0;
 
 #line 2030
 void main(void) {
-    vec3 normal = normalize(_normal.xyz);
+    vec3 normal = normalize(_normalWS.xyz);
     vec3 diffuse = _color.rgb;
     vec3 specular = DEFAULT_SPECULAR;
     float shininess = DEFAULT_SHININESS;
@@ -53,7 +50,7 @@ void main(void) {
 #endif
 
     TransformCamera cam = getTransformCamera();
-    vec3 fragPosition = _eyePosition.xyz;
+    vec3 fragPosition = _positionES.xyz;
 
     if (emissiveAmount > 0.0) {
         _fragColor0 = vec4(evalSkyboxGlobalColor(

--- a/libraries/render-utils/src/forward_simple_textured.slf
+++ b/libraries/render-utils/src/forward_simple_textured.slf
@@ -23,10 +23,10 @@
 uniform sampler2D originalTexture;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec4 _color;
 in vec2 _texCoord0;
-in vec4 _eyePosition;
+in vec4 _positionES;
 
 layout(location = 0) out vec4 _fragColor0;
 
@@ -35,14 +35,14 @@ void main(void) {
     float colorAlpha = _color.a * texel.a;
 
     TransformCamera cam = getTransformCamera();
-    vec3 fragPosition = _eyePosition.xyz;
+    vec3 fragPosition = _positionES.xyz;
 
     _fragColor0 = vec4(evalSkyboxGlobalColor(
         cam._viewInverse,
         1.0,
         DEFAULT_OCCLUSION,
         fragPosition,
-        normalize(_normal),
+        normalize(_normalWS),
         _color.rgb * texel.rgb,
         DEFAULT_FRESNEL,
         DEFAULT_METALLIC,

--- a/libraries/render-utils/src/forward_simple_textured_transparent.slf
+++ b/libraries/render-utils/src/forward_simple_textured_transparent.slf
@@ -23,10 +23,10 @@
 uniform sampler2D originalTexture;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec4 _color;
 in vec2 _texCoord0;
-in vec4 _eyePosition;
+in vec4 _positionES;
 
 layout(location = 0) out vec4 _fragColor0;
 
@@ -35,14 +35,14 @@ void main(void) {
     float colorAlpha = _color.a * texel.a;
 
     TransformCamera cam = getTransformCamera();
-    vec3 fragPosition = _eyePosition.xyz;
+    vec3 fragPosition = _positionES.xyz;
 
     _fragColor0 = vec4(evalGlobalLightingAlphaBlendedWithHaze(
         cam._viewInverse,
         1.0,
         DEFAULT_OCCLUSION,
         fragPosition,
-        normalize(_normal),
+        normalize(_normalWS),
         _color.rgb * texel.rgb,
         DEFAULT_FRESNEL,
         DEFAULT_METALLIC,

--- a/libraries/render-utils/src/forward_simple_transparent.slf
+++ b/libraries/render-utils/src/forward_simple_transparent.slf
@@ -17,11 +17,9 @@
 <$declareEvalGlobalLightingAlphaBlended()$>
 
 // the interpolated normal
-in vec3 _normal;
-in vec3 _modelNormal;
+in vec3 _normalWS;
 in vec4 _color;
-in vec2 _texCoord0;
-in vec4 _eyePosition;
+in vec4 _positionES;
 
 layout(location = 0) out vec4 _fragColor0;
 
@@ -32,7 +30,7 @@ layout(location = 0) out vec4 _fragColor0;
 
 #line 2030
 void main(void) {
-    vec3 normal = normalize(_normal.xyz);
+    vec3 normal = normalize(_normalWS.xyz);
     vec3 diffuse = _color.rgb;
     vec3 specular = DEFAULT_SPECULAR;
     float shininess = DEFAULT_SHININESS;
@@ -52,7 +50,7 @@ void main(void) {
 #endif
 
     TransformCamera cam = getTransformCamera();
-    vec3 fragPosition = _eyePosition.xyz;
+    vec3 fragPosition = _positionES.xyz;
 
     if (emissiveAmount > 0.0) {
         _fragColor0 = vec4(evalGlobalLightingAlphaBlendedWithHaze(

--- a/libraries/render-utils/src/local_lights_drawOutline.slf
+++ b/libraries/render-utils/src/local_lights_drawOutline.slf
@@ -62,6 +62,7 @@ void main(void) {
     // Frag to eye vec
     vec4 fragEyeVector = invViewMat * vec4(-frag.position.xyz, 0.0);
     vec3 fragEyeDir = normalize(fragEyeVector.xyz);
+    _fragColor = vec4(0, 0, 0, 1);
     
     int numLightTouching = 0;
     int lightClusterOffset = cluster.z;

--- a/libraries/render-utils/src/local_lights_shading.slf
+++ b/libraries/render-utils/src/local_lights_shading.slf
@@ -45,8 +45,8 @@ void main(void) {
         discard;
     }
 
-    vec4 midNormalCurvature;
-    vec4 lowNormalCurvature;
+    vec4 midNormalCurvature = vec4(0);
+    vec4 lowNormalCurvature = vec4(0);
     if (frag.mode == FRAG_MODE_SCATTERING) {
         unpackMidLowNormalCurvature(texCoord, midNormalCurvature, lowNormalCurvature);
     }

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -19,10 +19,9 @@
 <@include MaterialTextures.slh@>
 <$declareMaterialTextures(ALBEDO, ROUGHNESS, _SCRIBE_NULL, METALLIC, EMISSIVE, OCCLUSION, SCATTERING)$>
 
-in vec4 _position;
 in vec2 _texCoord0;
 in vec2 _texCoord1;
-in vec3 _normal;
+in vec3 _normalWS;
 in vec3 _color;
 
 
@@ -53,7 +52,7 @@ void main(void) {
     <$evalMaterialScattering(scatteringTex, scattering, matKey, scattering)$>;
 
     packDeferredFragment(
-        normalize(_normal), 
+        normalize(_normalWS), 
         opacity,
         albedo,
         roughness,

--- a/libraries/render-utils/src/model.slv
+++ b/libraries/render-utils/src/model.slv
@@ -23,8 +23,8 @@ out vec3 _color;
 out float _alpha;
 out vec2 _texCoord0;
 out vec2 _texCoord1;
-out vec4 _position;
-out vec3 _normal;
+out vec4 _positionES;
+out vec3 _normalWS;
 
 void main(void) {
     _color = color_sRGBToLinear(inColor.xyz);
@@ -37,6 +37,6 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _position, gl_Position)$>
-    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normal)$>
+    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _positionES, gl_Position)$>
+    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normalWS)$>
 }

--- a/libraries/render-utils/src/model_fade.slf
+++ b/libraries/render-utils/src/model_fade.slf
@@ -22,7 +22,6 @@
 <@include Fade.slh@>
 <$declareFadeFragment()$>
 
-in vec4 _positionES;
 in vec2 _texCoord0;
 in vec2 _texCoord1;
 in vec3 _normalWS;

--- a/libraries/render-utils/src/model_lightmap.slf
+++ b/libraries/render-utils/src/model_lightmap.slf
@@ -20,10 +20,9 @@
 <$declareMaterialTextures(ALBEDO, ROUGHNESS, _SCRIBE_NULL, METALLIC)$>
 <$declareMaterialLightmap()$>
 
-in vec4 _position;
 in vec2 _texCoord0;
 in vec2 _texCoord1;
-in vec3 _normal;
+in vec3 _normalWS;
 in vec3 _color;
 
 void main(void) {
@@ -33,7 +32,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmapVal)$>
 
     packDeferredFragmentLightmap(
-        normalize(_normal), 
+        normalize(_normalWS), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), albedo.a),
         getMaterialAlbedo(mat) * albedo.rgb * _color,
         getMaterialRoughness(mat) * roughness,

--- a/libraries/render-utils/src/model_lightmap.slv
+++ b/libraries/render-utils/src/model_lightmap.slv
@@ -20,10 +20,10 @@
 <@include MaterialTextures.slh@>
 <$declareMaterialTexMapArrayBuffer()$>
 
-out vec4 _position;
+out vec4 _positionES;
 out vec2 _texCoord0;
 out vec2 _texCoord1;
-out vec3 _normal;
+out vec3 _normalWS;
 out vec3 _color;
 
 void main(void) {
@@ -38,7 +38,6 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _position, gl_Position)$>
-    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normal)$>
+    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _positionES, gl_Position)$>
+    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normalWS)$>
 }
-

--- a/libraries/render-utils/src/model_lightmap_fade.slf
+++ b/libraries/render-utils/src/model_lightmap_fade.slf
@@ -23,19 +23,18 @@
 <@include Fade.slh@>
 <$declareFadeFragment()$>
 
-in vec4 _position;
 in vec2 _texCoord0;
 in vec2 _texCoord1;
-in vec3 _normal;
+in vec3 _normalWS;
 in vec3 _color;
-in vec4 _worldPosition;
+in vec4 _positionWS;
 
 void main(void) {
     vec3 fadeEmissive;
     FadeObjectParams fadeParams;
 
     <$fetchFadeObjectParams(fadeParams)$>
-    applyFade(fadeParams, _worldPosition.xyz, fadeEmissive);
+    applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
 
     Material mat = getMaterial();
     BITFIELD matKey = getMaterialKey(mat);
@@ -43,7 +42,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmapVal)$>
 
     packDeferredFragmentLightmap(
-        normalize(_normal), 
+        normalize(_normalWS), 
         evalOpaqueFinalAlpha(getMaterialOpacity(mat), albedo.a),
         getMaterialAlbedo(mat) * albedo.rgb * _color,
         getMaterialRoughness(mat) * roughness,

--- a/libraries/render-utils/src/model_lightmap_fade.slv
+++ b/libraries/render-utils/src/model_lightmap_fade.slv
@@ -20,12 +20,12 @@
 <@include MaterialTextures.slh@>
 <$declareMaterialTexMapArrayBuffer()$>
 
-out vec4 _position;
+out vec4 _positionES;
 out vec2 _texCoord0;
 out vec2 _texCoord1;
-out vec3 _normal;
+out vec3 _normalWS;
 out vec3 _color;
-out vec4 _worldPosition;
+out vec4 _positionWS;
 
 void main(void) {
     // pass along the color in linear space
@@ -39,8 +39,8 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _position, gl_Position)$>
-    <$transformModelToWorldPos(obj, inPosition, _worldPosition)$>
-    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normal)$>
+    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _positionES, gl_Position)$>
+    <$transformModelToWorldPos(obj, inPosition, _positionWS)$>
+    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normalWS)$>
 }
 

--- a/libraries/render-utils/src/model_lightmap_normal_map.slf
+++ b/libraries/render-utils/src/model_lightmap_normal_map.slf
@@ -20,11 +20,11 @@
 <$declareMaterialTextures(ALBEDO, ROUGHNESS, NORMAL, METALLIC)$>
 <$declareMaterialLightmap()$>
 
-in vec4 _position;
+in vec4 _positionES;
 in vec2 _texCoord0;
 in vec2 _texCoord1;
-in vec3 _normal;
-in vec3 _tangent;
+in vec3 _normalWS;
+in vec3 _tangentWS;
 in vec3 _color;
 
 void main(void) {
@@ -34,7 +34,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmapVal)$>
     
     vec3 fragNormal;
-    <$evalMaterialNormalLOD(_position, normalTexel, _normal, _tangent, fragNormal)$>
+    <$evalMaterialNormalLOD(_positionES, normalTexel, _normalWS, _tangentWS, fragNormal)$>
 
     packDeferredFragmentLightmap(
         normalize(fragNormal.xyz),

--- a/libraries/render-utils/src/model_lightmap_normal_map.slv
+++ b/libraries/render-utils/src/model_lightmap_normal_map.slv
@@ -20,11 +20,11 @@
 <@include MaterialTextures.slh@>
 <$declareMaterialTexMapArrayBuffer()$>
 
-out vec4 _position;
+out vec4 _positionES;
 out vec2 _texCoord0;
 out vec2 _texCoord1;
-out vec3 _normal;
-out vec3 _tangent;
+out vec3 _normalWS;
+out vec3 _tangentWS;
 out vec3 _color;
 
 void main(void) {
@@ -38,7 +38,7 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _position, gl_Position)$>
-    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normal)$>
-    <$transformModelToWorldDir(cam, obj, inTangent.xyz, _tangent)$>
+    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _positionES, gl_Position)$>
+    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normalWS)$>
+    <$transformModelToWorldDir(cam, obj, inTangent.xyz, _tangentWS)$>
 }

--- a/libraries/render-utils/src/model_lightmap_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_lightmap_normal_map_fade.slf
@@ -23,20 +23,20 @@
 <@include Fade.slh@>
 <$declareFadeFragment()$>
 
-in vec4 _position;
+in vec4 _positionES;
 in vec2 _texCoord0;
 in vec2 _texCoord1;
-in vec3 _normal;
-in vec3 _tangent;
+in vec3 _normalWS;
+in vec3 _tangentWS;
 in vec3 _color;
-in vec4 _worldPosition;
+in vec4 _positionWS;
 
 void main(void) {
     vec3 fadeEmissive;
     FadeObjectParams fadeParams;
 
     <$fetchFadeObjectParams(fadeParams)$>
-    applyFade(fadeParams, _worldPosition.xyz, fadeEmissive);
+    applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
 
     Material mat = getMaterial();
     BITFIELD matKey = getMaterialKey(mat);
@@ -44,7 +44,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmapVal)$>
     
     vec3 fragNormal;
-    <$evalMaterialNormalLOD(_position, normalTexel, _normal, _tangent, fragNormal)$>
+    <$evalMaterialNormalLOD(_positionES, normalTexel, _normalWS, _tangentWS, fragNormal)$>
 
     packDeferredFragmentLightmap(
         normalize(fragNormal.xyz),

--- a/libraries/render-utils/src/model_lightmap_normal_map_fade.slv
+++ b/libraries/render-utils/src/model_lightmap_normal_map_fade.slv
@@ -20,13 +20,13 @@
 <@include MaterialTextures.slh@>
 <$declareMaterialTexMapArrayBuffer()$>
 
-out vec4 _position;
+out vec4 _positionES;
 out vec2 _texCoord0;
 out vec2 _texCoord1;
-out vec3 _normal;
-out vec3 _tangent;
+out vec3 _normalWS;
+out vec3 _tangentWS;
 out vec3 _color;
-out vec4 _worldPosition;
+out vec4 _positionWS;
 
 void main(void) {
     // pass along the color in linear space
@@ -39,8 +39,8 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _position, gl_Position)$>
-    <$transformModelToWorldPos(obj, inPosition, _worldPosition)$>
-    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normal)$>
-    <$transformModelToWorldDir(cam, obj, inTangent.xyz, _tangent)$>
+    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _positionES, gl_Position)$>
+    <$transformModelToWorldPos(obj, inPosition, _positionWS)$>
+    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normalWS)$>
+    <$transformModelToWorldDir(cam, obj, inTangent.xyz, _tangentWS)$>
 }

--- a/libraries/render-utils/src/model_shadow_fade.slf
+++ b/libraries/render-utils/src/model_shadow_fade.slf
@@ -17,13 +17,13 @@
 
 layout(location = 0) out vec4 _fragColor;
 
-in vec4 _worldPosition;
+in vec4 _positionWS;
 
 void main(void) {
     FadeObjectParams fadeParams;
 
     <$fetchFadeObjectParams(fadeParams)$>
-    applyFadeClip(fadeParams, _worldPosition.xyz);
+    applyFadeClip(fadeParams, _positionWS.xyz);
 
     // pass-through to set z-buffer
     _fragColor = vec4(1.0, 1.0, 1.0, 0.0);

--- a/libraries/render-utils/src/model_shadow_fade.slv
+++ b/libraries/render-utils/src/model_shadow_fade.slv
@@ -18,12 +18,12 @@
 
 <$declareStandardTransform()$>
 
-out vec4 _worldPosition;
+out vec4 _positionWS;
 
 void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
     <$transformModelToClipPos(cam, obj, inPosition, gl_Position)$>
-    <$transformModelToWorldPos(obj, inPosition, _worldPosition)$>
+    <$transformModelToWorldPos(obj, inPosition, _positionWS)$>
 }

--- a/libraries/render-utils/src/model_unlit.slf
+++ b/libraries/render-utils/src/model_unlit.slf
@@ -20,7 +20,7 @@
 <$declareMaterialTextures(ALBEDO)$>
 
 in vec2 _texCoord0;
-in vec3 _normal;
+in vec3 _normalWS;
 in vec3 _color;
 in float _alpha;
 
@@ -39,7 +39,7 @@ void main(void) {
     albedo *= _color;
 
     packDeferredFragmentUnlit(
-        normalize(_normal), 
+        normalize(_normalWS), 
         opacity,
         albedo * isUnlitEnabled());
 }

--- a/libraries/render-utils/src/overlay3D.slf
+++ b/libraries/render-utils/src/overlay3D.slf
@@ -34,8 +34,6 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 a
     LightAmbient ambient = getLightAmbient();
 
     TransformCamera cam = getTransformCamera();
-    vec3 fragNormal;
-    <$transformEyeToWorldDir(cam, normal, fragNormal)$>
     vec3 fragEyeVectorView = normalize(-position);
     vec3 fragEyeDir;
     <$transformEyeToWorldDir(cam, fragEyeVectorView, fragEyeDir)$>
@@ -57,8 +55,8 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 a
 uniform sampler2D originalTexture;
 
 in vec2 _texCoord0;
-in vec4 _position;
-in vec3 _normal;
+in vec4 _positionES;
+in vec3 _normalWS;
 in vec3 _color;
 in float _alpha;
 
@@ -67,8 +65,8 @@ out vec4 _fragColor;
 void main(void) {
     vec4 albedo = texture(originalTexture, _texCoord0);
 
-    vec3 fragPosition = _position.xyz;
-    vec3 fragNormal = normalize(_normal);
+    vec3 fragPosition = _positionES.xyz;
+    vec3 fragNormal = normalize(_normalWS);
     vec3 fragAlbedo = albedo.rgb * _color;
     float fragMetallic = 0.0;
     vec3 fragSpecular = vec3(0.1);

--- a/libraries/render-utils/src/overlay3D.slv
+++ b/libraries/render-utils/src/overlay3D.slv
@@ -19,8 +19,8 @@
 out vec3 _color;
 out float _alpha;
 out vec2 _texCoord0;
-out vec4 _position;
-out vec3 _normal;
+out vec4 _positionES;
+out vec3 _normalWS;
 
 void main(void) {
     _color = color_sRGBToLinear(inColor.xyz);
@@ -31,6 +31,6 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _position, gl_Position)$>
-    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normal)$>
+    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _positionES, gl_Position)$>
+    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normalWS)$>
 }

--- a/libraries/render-utils/src/overlay3D_model.slf
+++ b/libraries/render-utils/src/overlay3D_model.slf
@@ -24,8 +24,8 @@
 
 in vec2 _texCoord0;
 in vec2 _texCoord1;
-in vec4 _position;
-in vec3 _normal;
+in vec4 _positionES;
+in vec3 _normalWS;
 in vec3 _color;
 in float _alpha;
 
@@ -55,19 +55,16 @@ void main(void) {
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
 
-    vec3 fragPosition = _position.xyz;
-    //vec3 fragNormal = normalize(_normal);
+    vec3 fragPosition = _positionES.xyz;
 
     TransformCamera cam = getTransformCamera();
-    vec3 fragNormal;
-    <$transformEyeToWorldDir(cam, _normal, fragNormal)$>;
 
     vec4 color = vec4(evalSkyboxGlobalColor(
         cam._viewInverse,
         1.0,
         occlusionTex,
         fragPosition,
-        fragNormal,
+        normalize(_normalWS),
         albedo,
         fresnel,
         metallic,

--- a/libraries/render-utils/src/overlay3D_model_translucent.slf
+++ b/libraries/render-utils/src/overlay3D_model_translucent.slf
@@ -23,10 +23,9 @@
 
 in vec2 _texCoord0;
 in vec2 _texCoord1;
-in vec4 _position;
-in vec3 _normal;
+in vec4 _positionES;
+in vec3 _normalWS;
 in vec3 _color;
-in float _alpha;
 
 out vec4 _fragColor;
 
@@ -52,19 +51,15 @@ void main(void) {
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
-
-    vec3 fragPosition = _position.xyz;
-
+    vec3 fragPosition = _positionES.xyz;
     TransformCamera cam = getTransformCamera();
-    vec3 fragNormal;
-    <$transformEyeToWorldDir(cam, _normal, fragNormal)$>
 
     vec4 color = vec4(evalGlobalLightingAlphaBlendedWithHaze(
         cam._viewInverse,
         1.0,
         occlusionTex,
         fragPosition,
-        fragNormal,
+        normalize(_normalWS),
         albedo,
         fresnel,
         metallic,

--- a/libraries/render-utils/src/overlay3D_model_translucent_unlit.slf
+++ b/libraries/render-utils/src/overlay3D_model_translucent_unlit.slf
@@ -18,9 +18,7 @@
 <$declareMaterialTextures(ALBEDO)$>
 
 in vec2 _texCoord0;
-in vec3 _normal;
 in vec3 _color;
-in float _alpha;
 
 out vec4 _fragColor;
 

--- a/libraries/render-utils/src/overlay3D_model_unlit.slf
+++ b/libraries/render-utils/src/overlay3D_model_unlit.slf
@@ -18,9 +18,7 @@
 <$declareMaterialTextures(ALBEDO)$>
 
 in vec2 _texCoord0;
-in vec3 _normal;
 in vec3 _color;
-in float _alpha;
 
 out vec4 _fragColor;
 

--- a/libraries/render-utils/src/overlay3D_translucent.slf
+++ b/libraries/render-utils/src/overlay3D_translucent.slf
@@ -34,8 +34,6 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 a
     LightAmbient ambient = getLightAmbient();
 
     TransformCamera cam = getTransformCamera();
-    vec3 fragNormal;
-    <$transformEyeToWorldDir(cam, normal, fragNormal)$>
     vec3 fragEyeVectorView = normalize(-position);
     vec3 fragEyeDir;
     <$transformEyeToWorldDir(cam, fragEyeVectorView, fragEyeDir)$>
@@ -57,8 +55,8 @@ vec4 evalGlobalColor(float shadowAttenuation, vec3 position, vec3 normal, vec3 a
 uniform sampler2D originalTexture;
 
 in vec2 _texCoord0;
-in vec4 _position;
-in vec3 _normal;
+in vec4 _positionES;
+in vec3 _normalWS;
 in vec3 _color;
 in float _alpha;
 
@@ -67,8 +65,8 @@ out vec4 _fragColor;
 void main(void) {
     vec4 albedo = texture(originalTexture, _texCoord0);
 
-    vec3 fragPosition = _position.xyz;
-    vec3 fragNormal = normalize(_normal);
+    vec3 fragPosition = _positionES.xyz;
+    vec3 fragNormal = normalize(_normalWS);
     vec3 fragAlbedo = albedo.rgb * _color;
     float fragMetallic = 0.0;
     vec3 fragSpecular = vec3(0.1);

--- a/libraries/render-utils/src/sdf_text3D.slf
+++ b/libraries/render-utils/src/sdf_text3D.slf
@@ -17,7 +17,7 @@ uniform bool Outline;
 uniform vec4 Color;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec2 _texCoord0;
 
 const float gamma = 2.2;
@@ -47,7 +47,7 @@ void main() {
     }
 
     packDeferredFragment(
-        normalize(_normal),
+        normalize(_normalWS),
         a * Color.a,
         Color.rgb,
         DEFAULT_ROUGHNESS,

--- a/libraries/render-utils/src/sdf_text3D.slv
+++ b/libraries/render-utils/src/sdf_text3D.slv
@@ -17,7 +17,7 @@
 <$declareStandardTransform()$>
 
 // the interpolated normal
-out vec3 _normal;
+out vec3 _normalWS;
 out vec2 _texCoord0;
 
 void main() {
@@ -28,5 +28,5 @@ void main() {
     TransformObject obj = getTransformObject();
     <$transformModelToClipPos(cam, obj, inPosition, gl_Position)$>
     const vec3 normal = vec3(0, 0, 1);
-    <$transformModelToWorldDir(cam, obj, normal, _normal)$>
+    <$transformModelToWorldDir(cam, obj, normal, _normalWS)$>
 }

--- a/libraries/render-utils/src/sdf_text3D_transparent.slf
+++ b/libraries/render-utils/src/sdf_text3D_transparent.slf
@@ -17,7 +17,7 @@ uniform bool Outline;
 uniform vec4 Color;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec2 _texCoord0;
 
 const float gamma = 2.2;
@@ -47,7 +47,7 @@ void main() {
     }
 
     packDeferredFragmentTranslucent(
-        normalize(_normal),
+        normalize(_normalWS),
         a * Color.a,
         Color.rgb,
         DEFAULT_FRESNEL,

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -15,11 +15,8 @@
 <@include DeferredBufferWrite.slh@>
 
 // the interpolated normal
-in vec3 _normal;
-in vec3 _modelNormal;
+in vec3 _normalWS;
 in vec4 _color;
-in vec2 _texCoord0;
-in vec4 _position;
 
 //PROCEDURAL_COMMON_BLOCK
 
@@ -28,7 +25,7 @@ in vec4 _position;
 
 #line 2030
 void main(void) {
-    vec3 normal = normalize(_normal.xyz);
+    vec3 normal = normalize(_normalWS.xyz);
     vec3 diffuse = _color.rgb;
     vec3 specular = DEFAULT_SPECULAR;
     float shininess = DEFAULT_SHININESS;

--- a/libraries/render-utils/src/simple.slv
+++ b/libraries/render-utils/src/simple.slv
@@ -18,22 +18,22 @@
 <$declareStandardTransform()$>
 
 // the interpolated normal
-out vec3 _normal;
-out vec3 _modelNormal;
+out vec3 _normalWS;
+out vec3 _normalMS;
 out vec4 _color;
 out vec2 _texCoord0;
-out vec4 _position;
-out vec4 _eyePosition;
+out vec4 _positionMS;
+out vec4 _positionES;
 
 void main(void) {
     _color = color_sRGBAToLinear(inColor);
     _texCoord0 = inTexCoord0.st;
-    _position = inPosition;
-    _modelNormal = inNormal.xyz;
+    _positionMS = inPosition;
+    _normalMS = inNormal.xyz;
 
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _eyePosition, gl_Position)$>
-    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normal)$>
+    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _positionES, gl_Position)$>
+    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normalWS)$>
 }

--- a/libraries/render-utils/src/simple_fade.slf
+++ b/libraries/render-utils/src/simple_fade.slf
@@ -18,12 +18,9 @@
 <$declareFadeFragmentInstanced()$>
 
 // the interpolated normal
-in vec3 _normal;
-in vec3 _modelNormal;
+in vec3 _normalWS;
 in vec4 _color;
-in vec2 _texCoord0;
-in vec4 _position;
-in vec4 _worldPosition;
+in vec4 _positionWS;
 
 //PROCEDURAL_COMMON_BLOCK
 
@@ -36,9 +33,9 @@ void main(void) {
     FadeObjectParams fadeParams;
 
     <$fetchFadeObjectParamsInstanced(fadeParams)$>
-    applyFade(fadeParams, _worldPosition.xyz, fadeEmissive);
+    applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
 
-    vec3 normal = normalize(_normal.xyz); 
+    vec3 normal = normalize(_normalWS.xyz); 
     vec3 diffuse = _color.rgb; 
     vec3 specular = DEFAULT_SPECULAR;
     float shininess = DEFAULT_SHININESS;

--- a/libraries/render-utils/src/simple_fade.slv
+++ b/libraries/render-utils/src/simple_fade.slv
@@ -21,25 +21,25 @@
 <$declareFadeVertexInstanced()$>
 
 // the interpolated normal
-out vec3 _normal;
-out vec3 _modelNormal;
+out vec3 _normalWS;
+out vec3 _normalMS;
 out vec4 _color;
 out vec2 _texCoord0;
-out vec4 _position;
-out vec4 _eyePosition;
-out vec4 _worldPosition;
+out vec4 _positionMS;
+out vec4 _positionES;
+out vec4 _positionWS;
 
 void main(void) {
     _color = color_sRGBAToLinear(inColor);
     _texCoord0 = inTexCoord0.st;
-    _position = inPosition;
-    _modelNormal = inNormal.xyz;
+    _positionMS = inPosition;
+    _normalMS = inNormal.xyz;
 
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _eyePosition, gl_Position)$>
-    <$transformModelToWorldPos(obj, inPosition, _worldPosition)$>
-    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normal)$>
+    <$transformModelToEyeAndClipPos(cam, obj, inPosition, _positionES, gl_Position)$>
+    <$transformModelToWorldPos(obj, inPosition, _positionWS)$>
+    <$transformModelToWorldDir(cam, obj, inNormal.xyz, _normalWS)$>
     <$passThroughFadeObjectParams()$>
 }

--- a/libraries/render-utils/src/simple_opaque_web_browser.slf
+++ b/libraries/render-utils/src/simple_opaque_web_browser.slf
@@ -19,12 +19,12 @@
 uniform sampler2D originalTexture;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec4 _color;
 in vec2 _texCoord0;
 
 void main(void) {
     vec4 texel = texture(originalTexture, _texCoord0.st);
     texel = color_sRGBAToLinear(texel);
-    packDeferredFragmentUnlit(normalize(_normal), 1.0, _color.rgb * texel.rgb);
+    packDeferredFragmentUnlit(normalize(_normalWS), 1.0, _color.rgb * texel.rgb);
 }

--- a/libraries/render-utils/src/simple_textured.slf
+++ b/libraries/render-utils/src/simple_textured.slf
@@ -18,7 +18,7 @@
 uniform sampler2D originalTexture;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec4 _color;
 in vec2 _texCoord0;
 
@@ -26,7 +26,7 @@ void main(void) {
     vec4 texel = texture(originalTexture, _texCoord0);
 
     packDeferredFragment(
-        normalize(_normal),
+        normalize(_normalWS),
         1.0,
         _color.rgb * texel.rgb,
         DEFAULT_ROUGHNESS,

--- a/libraries/render-utils/src/simple_textured_fade.slf
+++ b/libraries/render-utils/src/simple_textured_fade.slf
@@ -21,10 +21,10 @@
 uniform sampler2D originalTexture;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec4 _color;
 in vec2 _texCoord0;
-in vec4 _worldPosition;
+in vec4 _positionWS;
 
 // Declare after all samplers to prevent sampler location mix up with originalTexture
 <$declareFadeFragmentInstanced()$>
@@ -34,7 +34,7 @@ void main(void) {
     FadeObjectParams fadeParams;
 
     <$fetchFadeObjectParamsInstanced(fadeParams)$>
-    applyFade(fadeParams, _worldPosition.xyz, fadeEmissive);
+    applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
 
     vec4 texel = texture(originalTexture, _texCoord0);
     float colorAlpha = _color.a;
@@ -46,14 +46,14 @@ void main(void) {
     const float ALPHA_THRESHOLD = 0.999;
     if (colorAlpha * texel.a < ALPHA_THRESHOLD) {
         packDeferredFragmentTranslucent(
-            normalize(_normal),
+            normalize(_normalWS),
             colorAlpha * texel.a,
             _color.rgb * texel.rgb + fadeEmissive,
             DEFAULT_FRESNEL,
             DEFAULT_ROUGHNESS);
     } else {
         packDeferredFragment(
-            normalize(_normal),
+            normalize(_normalWS),
             1.0,
             _color.rgb * texel.rgb,
             DEFAULT_ROUGHNESS,

--- a/libraries/render-utils/src/simple_textured_unlit.slf
+++ b/libraries/render-utils/src/simple_textured_unlit.slf
@@ -19,7 +19,7 @@
 uniform sampler2D originalTexture;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec4 _color;
 in vec2 _texCoord0;
 
@@ -34,14 +34,14 @@ void main(void) {
     const float ALPHA_THRESHOLD = 0.999;
     if (colorAlpha * texel.a < ALPHA_THRESHOLD) {
        packDeferredFragmentTranslucent(
-            normalize(_normal),
+            normalize(_normalWS),
             colorAlpha * texel.a,
             _color.rgb * texel.rgb,
             DEFAULT_FRESNEL,
             DEFAULT_ROUGHNESS);
     } else {
         packDeferredFragmentUnlit(
-            normalize(_normal),
+            normalize(_normalWS),
             1.0,
             _color.rgb * texel.rgb);
     }

--- a/libraries/render-utils/src/simple_textured_unlit_fade.slf
+++ b/libraries/render-utils/src/simple_textured_unlit_fade.slf
@@ -21,10 +21,10 @@
 uniform sampler2D originalTexture;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec4 _color;
 in vec2 _texCoord0;
-in vec4 _worldPosition;
+in vec4 _positionWS;
 
 // Declare after all samplers to prevent sampler location mix up with originalTexture
 <$declareFadeFragmentInstanced()$>
@@ -34,7 +34,7 @@ void main(void) {
     FadeObjectParams fadeParams;
 
     <$fetchFadeObjectParamsInstanced(fadeParams)$>
-    applyFade(fadeParams, _worldPosition.xyz, fadeEmissive);
+    applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
 
     vec4 texel = texture(originalTexture, _texCoord0.st);
     float colorAlpha = _color.a;
@@ -46,14 +46,14 @@ void main(void) {
     const float ALPHA_THRESHOLD = 0.999;
     if (colorAlpha * texel.a < ALPHA_THRESHOLD) {
        packDeferredFragmentTranslucent(
-            normalize(_normal),
+            normalize(_normalWS),
             colorAlpha * texel.a,
             _color.rgb * texel.rgb+fadeEmissive,
             DEFAULT_FRESNEL,
             DEFAULT_ROUGHNESS);
     } else {
         packDeferredFragmentUnlit(
-            normalize(_normal),
+            normalize(_normalWS),
             1.0,
             _color.rgb * texel.rgb+fadeEmissive);
     }

--- a/libraries/render-utils/src/simple_transparent.slf
+++ b/libraries/render-utils/src/simple_transparent.slf
@@ -15,11 +15,8 @@
 <@include DeferredBufferWrite.slh@>
 
 // the interpolated normal
-in vec3 _normal;
-in vec3 _modelNormal;
+in vec3 _normalWS;
 in vec4 _color;
-in vec2 _texCoord0;
-in vec4 _position;
 
 //PROCEDURAL_COMMON_BLOCK
 
@@ -28,7 +25,7 @@ in vec4 _position;
 
 #line 2030
 void main(void) {
-    vec3 normal = normalize(_normal.xyz);
+    vec3 normal = normalize(_normalWS.xyz);
     vec3 diffuse = _color.rgb;
     vec3 specular = DEFAULT_SPECULAR;
     float shininess = DEFAULT_SHININESS;

--- a/libraries/render-utils/src/simple_transparent_textured.slf
+++ b/libraries/render-utils/src/simple_transparent_textured.slf
@@ -18,7 +18,7 @@
 uniform sampler2D originalTexture;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec4 _color;
 in vec2 _texCoord0;
 
@@ -27,7 +27,7 @@ void main(void) {
     float colorAlpha = _color.a * texel.a;
 
     packDeferredFragmentTranslucent(
-        normalize(_normal),
+        normalize(_normalWS),
         colorAlpha,
         _color.rgb * texel.rgb,
         DEFAULT_FRESNEL,

--- a/libraries/render-utils/src/simple_transparent_textured_fade.slf
+++ b/libraries/render-utils/src/simple_transparent_textured_fade.slf
@@ -26,12 +26,11 @@
 // the albedo texture
 uniform sampler2D originalTexture;
 
-// the interpolated normal
-in vec4 _position;
-in vec3 _normal;
+in vec4 _positionES;
+in vec3 _normalWS;
 in vec4 _color;
 in vec2 _texCoord0;
-in vec4 _worldPosition;
+in vec4 _positionWS;
 
 // Declare after all samplers to prevent sampler location mix up with originalTexture
 <$declareFadeFragmentInstanced()$>
@@ -41,7 +40,7 @@ void main(void) {
     FadeObjectParams fadeParams;
 
     <$fetchFadeObjectParamsInstanced(fadeParams)$>
-    applyFade(fadeParams, _worldPosition.xyz, fadeEmissive);
+    applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
 
     vec4 texel = texture(originalTexture, _texCoord0.st);
     float opacity = _color.a;
@@ -52,8 +51,8 @@ void main(void) {
     opacity *= texel.a;
     vec3 albedo = _color.rgb * texel.rgb;
 
-    vec3 fragPosition = _position.xyz;
-    vec3 fragNormal = normalize(_normal);
+    vec3 fragPosition = _positionES.xyz;
+    vec3 fragNormal = normalize(_normalWS);
 
     TransformCamera cam = getTransformCamera();
 

--- a/libraries/render-utils/src/simple_transparent_textured_unlit.slf
+++ b/libraries/render-utils/src/simple_transparent_textured_unlit.slf
@@ -17,11 +17,8 @@
 // the albedo texture
 uniform sampler2D originalTexture;
 
-// the interpolated normal
-in vec3 _normal;
 in vec4 _color;
 in vec2 _texCoord0;
-
 
 layout(location = 0) out vec4 _fragColor0;
 

--- a/libraries/render-utils/src/simple_transparent_textured_unlit_fade.slf
+++ b/libraries/render-utils/src/simple_transparent_textured_unlit_fade.slf
@@ -19,11 +19,9 @@
 // the albedo texture
 uniform sampler2D originalTexture;
 
-// the interpolated normal
-in vec3 _normal;
 in vec4 _color;
 in vec2 _texCoord0;
-in vec4 _worldPosition;
+in vec4 _positionWS;
 
 layout(location = 0) out vec4 _fragColor0;
 
@@ -35,7 +33,7 @@ void main(void) {
     FadeObjectParams fadeParams;
 
     <$fetchFadeObjectParamsInstanced(fadeParams)$>
-    applyFade(fadeParams, _worldPosition.xyz, fadeEmissive);
+    applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
 
     vec4 texel = texture(originalTexture, _texCoord0.st);
     float colorAlpha = _color.a;
@@ -43,5 +41,5 @@ void main(void) {
         texel = color_sRGBAToLinear(texel);
         colorAlpha = -_color.a;
     }
-    _fragColor0 = vec4(_color.rgb * texel.rgb+fadeEmissive, colorAlpha * texel.a);
+    _fragColor0 = vec4(_color.rgb * texel.rgb + fadeEmissive, colorAlpha * texel.a);
 }

--- a/libraries/render-utils/src/simple_transparent_web_browser.slf
+++ b/libraries/render-utils/src/simple_transparent_web_browser.slf
@@ -19,7 +19,7 @@
 uniform sampler2D originalTexture;
 
 // the interpolated normal
-in vec3 _normal;
+in vec3 _normalWS;
 in vec4 _color;
 in vec2 _texCoord0;
 
@@ -27,7 +27,7 @@ void main(void) {
     vec4 texel = texture(originalTexture, _texCoord0.st);
     texel = color_sRGBAToLinear(texel);
     packDeferredFragmentTranslucent(
-        normalize(_normal),
+        normalize(_normalWS),
         _color.a,
         _color.rgb * texel.rgb,
         DEFAULT_FRESNEL,

--- a/libraries/render-utils/src/skin_model.slv
+++ b/libraries/render-utils/src/skin_model.slv
@@ -23,10 +23,10 @@
 <@include MaterialTextures.slh@>
 <$declareMaterialTexMapArrayBuffer()$>
 
-out vec4 _position;
+out vec4 _positionES;
 out vec2 _texCoord0;
 out vec2 _texCoord1;
-out vec3 _normal;
+out vec3 _normalWS;
 out vec3 _color;
 out float _alpha;
 
@@ -47,6 +47,6 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, position, _position, gl_Position)$>
-    <$transformModelToWorldDir(cam, obj, interpolatedNormal.xyz, _normal.xyz)$>
+    <$transformModelToEyeAndClipPos(cam, obj, position, _positionES, gl_Position)$>
+    <$transformModelToWorldDir(cam, obj, interpolatedNormal.xyz, _normalWS.xyz)$>
 }

--- a/libraries/render-utils/src/skin_model_dq.slv
+++ b/libraries/render-utils/src/skin_model_dq.slv
@@ -23,10 +23,10 @@
 <@include MaterialTextures.slh@>
 <$declareMaterialTexMapArrayBuffer()$>
 
-out vec4 _position;
+out vec4 _positionES;
 out vec2 _texCoord0;
 out vec2 _texCoord1;
-out vec3 _normal;
+out vec3 _normalWS;
 out vec3 _color;
 out float _alpha;
 
@@ -47,6 +47,6 @@ void main(void) {
     // standard transform
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
-    <$transformModelToEyeAndClipPos(cam, obj, position, _position, gl_Position)$>
-    <$transformModelToWorldDir(cam, obj, interpolatedNormal.xyz, _normal.xyz)$>
+    <$transformModelToEyeAndClipPos(cam, obj, position, _positionES, gl_Position)$>
+    <$transformModelToWorldDir(cam, obj, interpolatedNormal.xyz, _normalWS.xyz)$>
 }

--- a/libraries/render-utils/src/skin_model_shadow_fade.slf
+++ b/libraries/render-utils/src/skin_model_shadow_fade.slf
@@ -15,7 +15,7 @@
 <@include Fade.slh@>
 <$declareFadeFragment()$>
 
-in vec4 _worldPosition;
+in vec4 _positionWS;
 
 layout(location = 0) out vec4 _fragColor;
 
@@ -23,7 +23,7 @@ void main(void) {
     FadeObjectParams fadeParams;
 
     <$fetchFadeObjectParams(fadeParams)$>
-    applyFadeClip(fadeParams, _worldPosition.xyz);
+    applyFadeClip(fadeParams, _positionWS.xyz);
 
     // pass-through to set z-buffer
     _fragColor = vec4(1.0, 1.0, 1.0, 0.0);

--- a/libraries/render-utils/src/skin_model_shadow_fade.slv
+++ b/libraries/render-utils/src/skin_model_shadow_fade.slv
@@ -19,7 +19,7 @@
 <@include Skinning.slh@>
 <$declareUseDualQuaternionSkinning()$>
 
-out vec4 _worldPosition;
+out vec4 _positionWS;
 
 void main(void) {
     vec4 position = vec4(0.0, 0.0, 0.0, 0.0);
@@ -29,5 +29,5 @@ void main(void) {
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
     <$transformModelToClipPos(cam, obj, position, gl_Position)$>
-    <$transformModelToWorldPos(obj, position, _worldPosition)$>
+    <$transformModelToWorldPos(obj, position, _positionWS)$>
 }

--- a/libraries/render-utils/src/skin_model_shadow_fade_dq.slv
+++ b/libraries/render-utils/src/skin_model_shadow_fade_dq.slv
@@ -19,7 +19,7 @@
 <@include Skinning.slh@>
 <$declareUseDualQuaternionSkinning(1)$>
 
-out vec4 _worldPosition;
+out vec4 _positionWS;
 
 void main(void) {
     vec4 position = vec4(0.0, 0.0, 0.0, 0.0);
@@ -29,5 +29,5 @@ void main(void) {
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
     <$transformModelToClipPos(cam, obj, position, gl_Position)$>
-    <$transformModelToWorldPos(obj, position, _worldPosition)$>
+    <$transformModelToWorldPos(obj, position, _positionWS)$>
 }


### PR DESCRIPTION
Fixes issues caused by https://github.com/highfidelity/hifi/pull/12911 and https://github.com/highfidelity/hifi/pull/12873

Lots of small shader changes but they're purely renaming variables for consistency because we use different combinations of them and the varyings need to match.  Shouldn't need to test beyond a sanity check.

Test plan:
- Open Interface (Windows and Mac, NVIDIA and AMD).  Check your logs.  You shouldn't see any shader compilation warnings.
- Open Interface on Android.  You shouldn't see the menu bar (File, Edit, etc.) at the top.  The logs shouldn't have any shader compilation errors.