### PR TITLE
Fix for bug #12979: Setting colors [0, 0, 254] from js api ends up as black color

### DIFF
--- a/libraries/shared/src/ColorUtils.h
+++ b/libraries/shared/src/ColorUtils.h
@@ -102,7 +102,7 @@ inline float ColorUtils::tosRGBFloat(const float &linear) {
     } else if (0 < linear && linear < SRGB_ELBOW_INV) {
         sRGBValue = 12.92f * linear;
     } else if (SRGB_ELBOW_INV <= linear && linear < 1) {
-        sRGBValue = 1.055f * powf(linear, 0.41666f - 0.055f);
+        sRGBValue = 1.055f * powf(linear, 0.41666f) - 0.055f;
     } else {
         sRGBValue = 1.0f;
     }


### PR DESCRIPTION
# Description
Fix for bug #12979
Corrected tosRGBFloat() computation.
Original code: sRGBValue = 1.055f * powf(linear, 0.41666f - 0.055f);
Corrected code: sRGBValue = 1.055f * powf(linear, 0.41666f) - 0.055f;

This is per https://www.khronos.org/registry/OpenGL/specs/gl/glspec44.core.pdf, section 17.3.9.  The problem was that sRGBValue became larger than 1.0 when the original value was in [240 .. 254].

# Testing
1. Create a sphere primitive.
2. ESet R to 254 while the other color channels have 0.
3. Examine the sphere - should be red.
4. ESet G to 250 while the other color channels have 0.
5. Examine the sphere - should be green.
6. Set B to 245 while the other color channels have 0.
7. Examine the sphere - should be blue.
8. Play around with different colour combinations (especially in the range [240 .. 254]).