### PR TITLE
Fix audio level meter

### DIFF
--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -147,7 +147,7 @@ void Audio::setInputVolume(float volume) {
 }
 
 float Audio::getInputLevel() const {
-    return resultWithReadLock<bool>([&] {
+    return resultWithReadLock<float>([&] {
         return _inputLevel;
     });
 }


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/14458/on-HUD-audio-input-level-meter-is-either-at-zero-or-max

Test plan:
- Enable the audio level meter in the audio app.
- Talk.  The levels should seem correct (not slammed to 0 or 1).