### PR TITLE
Fix for null sourceNode use

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -617,7 +617,7 @@ bool DomainServer::isPacketVerified(const udt::Packet& packet) {
             }
         } else {
             HIFI_FDEBUG("Packet of type" << headerType
-                << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceNode->getUUID()));
+                << "received from unknown node with Local ID" << localSourceID);
             return false;
         }
     }

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -358,7 +358,7 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
 
         } else {
             HIFI_FCDEBUG(networking(),
-                "Packet of type" << headerType << "received from unknown node with UUID" << uuidStringWithoutCurlyBraces(sourceID));
+                "Packet of type" << headerType << "received from unknown node with Local ID" << sourceLocalID);
         }
     }
 


### PR DESCRIPTION
Was produced by an incorrect merge of the short ID & HMAC PRs.
https://github.com/highfidelity/hifi/pull/12743
https://github.com/highfidelity/hifi/pull/12690
