### PR TITLE
Attempt to shutdown web surfaces more consistently

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4741,7 +4741,7 @@ void Application::updateLOD(float deltaTime) const {
     }
 }
 
-void Application::pushPostUpdateLambda(void* key, std::function<void()> func) {
+void Application::pushPostUpdateLambda(void* key, const std::function<void()>& func) {
     std::unique_lock<std::mutex> guard(_postUpdateLambdasLock);
     _postUpdateLambdas[key] = func;
 }
@@ -7351,12 +7351,21 @@ void Application::windowMinimizedChanged(bool minimized) {
     }
 }
 
-void Application::postLambdaEvent(std::function<void()> f) {
+void Application::postLambdaEvent(const std::function<void()>& f) {
     if (this->thread() == QThread::currentThread()) {
         f();
     } else {
         QCoreApplication::postEvent(this, new LambdaEvent(f));
     }
+}
+
+void Application::sendLambdaEvent(const std::function<void()>& f) {
+    if (this->thread() == QThread::currentThread()) {
+        f();
+    } else {
+        LambdaEvent event(f);
+        QCoreApplication::sendEvent(this, &event);
+    } 
 }
 
 void Application::initPlugins(const QStringList& arguments) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -136,7 +136,8 @@ public:
     Application(int& argc, char** argv, QElapsedTimer& startup_time, bool runningMarkerExisted);
     ~Application();
 
-    void postLambdaEvent(std::function<void()> f) override;
+    void postLambdaEvent(const std::function<void()>& f) override;
+    void sendLambdaEvent(const std::function<void()>& f) override;
 
     QString getPreviousScriptLocation();
     void setPreviousScriptLocation(const QString& previousScriptLocation);
@@ -240,7 +241,7 @@ public:
 
     qint64 getCurrentSessionRuntime() const { return _sessionRunTimer.elapsed(); }
 
-    bool isAboutToQuit() const override { return _aboutToQuit; }
+    bool isAboutToQuit() const { return _aboutToQuit; }
     bool isPhysicsEnabled() const { return _physicsEnabled; }
 
     // the isHMDMode is true whenever we use the interface from an HMD and not a standard flat display
@@ -264,7 +265,7 @@ public:
     render::EnginePointer getRenderEngine() override { return _renderEngine; }
     gpu::ContextPointer getGPUContext() const { return _gpuContext; }
 
-    virtual void pushPostUpdateLambda(void* key, std::function<void()> func) override;
+    virtual void pushPostUpdateLambda(void* key, const std::function<void()>& func) override;
 
     void updateMyAvatarLookAtPosition();
 

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -65,14 +65,10 @@ const QString Web3DOverlay::TYPE = "web3d";
 const QString Web3DOverlay::QML = "Web3DOverlay.qml";
 
 static auto qmlSurfaceDeleter = [](OffscreenQmlSurface* surface) {
-    AbstractViewStateInterface::instance()->postLambdaEvent([surface] {
-        if (AbstractViewStateInterface::instance()->isAboutToQuit()) {
-            // WebEngineView may run other threads (wasapi), so they must be deleted for a clean shutdown
-            // if the application has already stopped its event loop, delete must be explicit
-            delete surface;
-        } else {
-            surface->deleteLater();
-        }
+    AbstractViewStateInterface::instance()->sendLambdaEvent([surface] {
+        // WebEngineView may run other threads (wasapi), so they must be deleted for a clean shutdown
+        // if the application has already stopped its event loop, delete must be explicit
+        delete surface;
     });
 };
 

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -25,7 +25,7 @@
 #include <EntityScriptingInterface.h>
 
 #include "EntitiesRendererLogging.h"
-
+#include <NetworkingConstants.h>
 
 using namespace render;
 using namespace render::entities;
@@ -45,6 +45,7 @@ static int DEFAULT_MAX_FPS = 10;
 static int YOUTUBE_MAX_FPS = 30;
 
 static QTouchDevice _touchDevice;
+static const char* URL_PROPERTY = "url";
 
 WebEntityRenderer::ContentType WebEntityRenderer::getContentType(const QString& urlString) {
     if (urlString.isEmpty()) {
@@ -52,7 +53,7 @@ WebEntityRenderer::ContentType WebEntityRenderer::getContentType(const QString& 
     }
 
     const QUrl url(urlString);
-    if (url.scheme() == "http" || url.scheme() == "https" ||
+    if (url.scheme() == URL_SCHEME_HTTP || url.scheme() == URL_SCHEME_HTTPS ||
         urlString.toLower().endsWith(".htm") || urlString.toLower().endsWith(".html")) {
         return ContentType::HtmlContent;
     }
@@ -164,6 +165,8 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
         if (urlChanged) {
             if (newContentType != ContentType::HtmlContent || currentContentType != ContentType::HtmlContent) {
                 destroyWebSurface();
+                // If we destroyed the surface, the URL change will be implicitly handled by the re-creation
+                urlChanged = false;
             }
 
             withWriteLock([&] {
@@ -185,8 +188,8 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
             return;
         }
         
-        if (urlChanged) {
-            _webSurface->getRootItem()->setProperty("url", _lastSourceUrl);
+        if (urlChanged && _contentType == ContentType::HtmlContent) {
+            _webSurface->getRootItem()->setProperty(URL_PROPERTY, _lastSourceUrl);
         }
 
         if (_contextPosition != entity->getWorldPosition()) {
@@ -254,6 +257,14 @@ bool WebEntityRenderer::hasWebSurface() {
     return (bool)_webSurface && _webSurface->getRootItem();
 }
 
+static const auto WebSurfaceDeleter = [](OffscreenQmlSurface* webSurface) {
+    AbstractViewStateInterface::instance()->sendLambdaEvent([webSurface] {
+        // WebEngineView may run other threads (wasapi), so they must be deleted for a clean shutdown
+        // if the application has already stopped its event loop, delete must be explicit
+        delete webSurface;
+    });
+};
+
 bool WebEntityRenderer::buildWebSurface(const TypedEntityPointer& entity) {
     if (_currentWebCount >= MAX_CONCURRENT_WEB_VIEWS) {
         qWarning() << "Too many concurrent web views to create new view";
@@ -261,20 +272,9 @@ bool WebEntityRenderer::buildWebSurface(const TypedEntityPointer& entity) {
     }
 
     ++_currentWebCount;
-    auto deleter = [](OffscreenQmlSurface* webSurface) {
-        AbstractViewStateInterface::instance()->postLambdaEvent([webSurface] {
-            if (AbstractViewStateInterface::instance()->isAboutToQuit()) {
-                // WebEngineView may run other threads (wasapi), so they must be deleted for a clean shutdown
-                // if the application has already stopped its event loop, delete must be explicit
-                delete webSurface;
-            } else {
-                webSurface->deleteLater();
-            }
-        });
-    };
 
     // FIXME use the surface cache instead of explicit creation
-    _webSurface = QSharedPointer<OffscreenQmlSurface>(new OffscreenQmlSurface(), deleter);
+    _webSurface = QSharedPointer<OffscreenQmlSurface>(new OffscreenQmlSurface(), WebSurfaceDeleter);
     // FIXME, the max FPS could be better managed by being dynamic (based on the number of current surfaces
     // and the current rendering load)
     _webSurface->setMaxFps(DEFAULT_MAX_FPS);
@@ -302,7 +302,7 @@ bool WebEntityRenderer::buildWebSurface(const TypedEntityPointer& entity) {
             _webSurface->setMaxFps(DEFAULT_MAX_FPS);
         }
         _webSurface->load("controls/WebEntityView.qml", [this](QQmlContext* context, QObject* item) {
-            item->setProperty("url", _lastSourceUrl);
+            item->setProperty(URL_PROPERTY, _lastSourceUrl);
         });
     } else if (_contentType == ContentType::QmlContent) {
         _webSurface->load(_lastSourceUrl, [this](QQmlContext* context, QObject* item) {
@@ -327,6 +327,11 @@ void WebEntityRenderer::destroyWebSurface() {
     if (webSurface) {
         --_currentWebCount;
         QQuickItem* rootItem = webSurface->getRootItem();
+        // Explicitly set the web URL to an empty string, in an effort to get a 
+        // faster shutdown of any chromium processes interacting with audio
+        if (rootItem && _contentType == ContentType::HtmlContent) {
+            rootItem->setProperty(URL_PROPERTY, "");
+        }
 
         if (rootItem && rootItem->objectName() == "tabletRoot") {
             auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();

--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -67,7 +67,6 @@ OffscreenSurface::OffscreenSurface()
 
 OffscreenSurface::~OffscreenSurface() {
     delete _sharedObject;
-    const_cast<SharedObject*>(_sharedObject) = nullptr;
 }
 
 bool OffscreenSurface::fetchTexture(TextureAndFence& textureAndFence) {

--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -66,14 +66,11 @@ OffscreenSurface::OffscreenSurface()
 }
 
 OffscreenSurface::~OffscreenSurface() {
-    disconnect(qApp);
-    _sharedObject->destroy();
+    delete _sharedObject;
+    const_cast<SharedObject*>(_sharedObject) = nullptr;
 }
 
 bool OffscreenSurface::fetchTexture(TextureAndFence& textureAndFence) {
-    if (!_sharedObject) {
-        return false;
-    }
     hifi::qml::impl::TextureAndFence typedTextureAndFence;
     bool result = _sharedObject->fetchTexture(typedTextureAndFence);
     textureAndFence = typedTextureAndFence;

--- a/libraries/qml/src/qml/impl/RenderEventHandler.cpp
+++ b/libraries/qml/src/qml/impl/RenderEventHandler.cpp
@@ -49,8 +49,8 @@ RenderEventHandler::RenderEventHandler(SharedObject* shared, QThread* targetThre
         qFatal("Unable to create new offscreen GL context");
     }
 
-    moveToThread(targetThread);
     _canvas.moveToThreadWithContext(targetThread);
+    moveToThread(targetThread);
 }
 
 void RenderEventHandler::onInitalize() {
@@ -160,11 +160,8 @@ void RenderEventHandler::onQuit() {
     }
 
     _shared->shutdownRendering(_canvas, _currentSize);
-    // Release the reference to the shared object.  This will allow it to 
-    // be destroyed (should happen on it's own thread).
-    _shared->deleteLater();
-
-    deleteLater();
-
+    _canvas.doneCurrent();
+    _canvas.moveToThreadWithContext(qApp->thread());
+    moveToThread(qApp->thread());
     QThread::currentThread()->quit();
 }

--- a/libraries/render-utils/src/AbstractViewStateInterface.h
+++ b/libraries/render-utils/src/AbstractViewStateInterface.h
@@ -37,15 +37,25 @@ public:
 
     virtual glm::vec3 getAvatarPosition() const = 0;
 
-    virtual bool isAboutToQuit() const = 0;
-    virtual void postLambdaEvent(std::function<void()> f) = 0;
+    // Unfortunately, having this here is a bad idea.  Lots of objects connect to 
+    // the aboutToQuit signal, and it's impossible to know the order in which 
+    // the receivers will be called, so this might return false negatives
+    //virtual bool isAboutToQuit() const = 0;
+
+    // Queue code to execute on the main thread. 
+    // If called from the main thread, the lambda will execute synchronously
+    virtual void postLambdaEvent(const std::function<void()>& f) = 0;
+    // Synchronously execute code on the main thread.  This function will
+    // not return until the code is executed, regardles of which thread it 
+    // is called from
+    virtual void sendLambdaEvent(const std::function<void()>& f) = 0;
 
     virtual qreal getDevicePixelRatio() = 0;
 
     virtual render::ScenePointer getMain3DScene() = 0;
     virtual render::EnginePointer getRenderEngine() = 0;
 
-    virtual void pushPostUpdateLambda(void* key, std::function<void()> func) = 0;
+    virtual void pushPostUpdateLambda(void* key, const std::function<void()>& func) = 0;
 
     virtual bool isHMDMode() const = 0;
 
@@ -54,5 +64,4 @@ public:
     static void setInstance(AbstractViewStateInterface* instance);
 };
 
-
-#endif // hifi_AbstractViewStateInterface_h
+#endif  // hifi_AbstractViewStateInterface_h

--- a/tests/render-perf/src/main.cpp
+++ b/tests/render-perf/src/main.cpp
@@ -453,8 +453,8 @@ protected:
         return vec3();
     }
 
-    bool isAboutToQuit() const override { return false; }
-    void postLambdaEvent(std::function<void()> f) override {}
+    void postLambdaEvent(const std::function<void()>& f) override {}
+    void sendLambdaEvent(const std::function<void()>& f) override {}
 
     qreal getDevicePixelRatio() override {
         return 1.0f;
@@ -469,7 +469,7 @@ protected:
     }
 
     std::map<void*, std::function<void()>> _postUpdateLambdas;
-    void pushPostUpdateLambda(void* key, std::function<void()> func) override {
+    void pushPostUpdateLambda(void* key, const std::function<void()>& func) override {
         _postUpdateLambdas[key] = func;
     }
 


### PR DESCRIPTION
There have been a large number of web / QML related crashes in recent builds.  This PR is an attempt to resolve the issues by making the deconstruction of QML surfaces more consistent.

It makes a number of changes

* When destroying the surface for a web entity (displaying web content, not QML content) set the URL to an empty string before destruction.  This will hopefully trigger the backing chromium process to destroy any audio resources for the rendered page earlier.  See [FB 14104](https://highfidelity.manuscript.com/f/cases/14104/Audio-from-web-entity-continues-to-play-after-leaving-domain) and [FB 14380](https://highfidelity.manuscript.com/f/cases/14380/crash-in-shutdown-in-66-in-Browser-Audio-media-AudioManagerBase-AudioManagerBase)
* Eliminate `bool AbstractViewStateInterface::isAboutToQuit()`.  This function is probably not as reliable as we'd want it to be.  The problem is that many things in the application individually connect to the `QCoreApplication::aboutToQuit` signal, and there's no guarantee of the order in which those signal handlers will be called.  Because of this, code that's directly or indirectly running in response to `QCoreApplication::aboutToQuit` might call `bool AbstractViewStateInterface::isAboutToQuit()` and get a false negative because the `Application::onAboutToQuit` handler hasn't yet been called.  
* Add `void AbstractViewStateInterface::sendLambdaEvent(const std::function<void()>& f)`.  This function is similar to the `AbstractViewStateInterface::postLambdaEvent` except that it's guaranteed not to return until the code in the lambda has executed, regardless of what thread it's called from.  
* Modify the code in Web3DOverlay and WebEntityRenderer to delete their QML surfaces in a more consistent fashion.  The removal of `isAboutToQuit` means these classes will now always do an immediate delete of the QML surface, rather than deferring it with a call to `deleteLater`.  Further, the code uses the new `AbstractViewStateInterface::sendLambdaEvent` to ensure that regardless of what thread pointer is destroyed on, the thread will stop and wait for the QML surface to be deleted before continuing.  In theory this should not affect the application, since the intent of the current design is that the deleter is only ever called on the main thread.  However, if there is an edge case where the deleter is being called on a background thread, this change should help us produce better stack traces to identify why this is happening.  
* Refactor `hifi::qml::OffscreenSurface` shutdown logic, using the Qt multi-threaded QQuickControl [example](http://doc.qt.io/qt-5/qtquick-rendercontrol-window-multithreaded-cpp.html) as a template

## Testing

Try to reproduce any of ...
* [FB 14104](https://highfidelity.manuscript.com/f/cases/14104/Audio-from-web-entity-continues-to-play-after-leaving-domain)
* [FB 14380](https://highfidelity.manuscript.com/f/cases/14380/crash-in-shutdown-in-66-in-Browser-Audio-media-AudioManagerBase-AudioManagerBase)
* [FB 14381](https://highfidelity.manuscript.com/f/cases/14381/crash-on-shutdown-in-QQuickRenderControl-QQuickRenderControl)
* [FB 14382](https://highfidelity.manuscript.com/f/cases/14382/crash-on-exit-in-hifi-qml-OffscreenSurface-OffscreenSurface) 

...with this build.  

In particular, try going to domains that contain WebEntity content, especially those with audio or a/v playback, and test entering and leaving the domain repeatedly, as well as entering the domain and then exiting the application while a web entity is in view and playing audio or video.  

Testing should focus on lower end machines as they are the most likely to encounter issues arising from timing problems or race conditions with multiple threads.  

Please also test on Mac, as there are reports that this platform always crashes on exit.  
