### PR TITLE
Backtrace Attributes

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1394,6 +1394,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         userActivityLogger.disable(false);
     }
 
+    QString machineFingerPrint = uuidStringWithoutCurlyBraces(FingerprintUtils::getMachineFingerprint());
+
     if (userActivityLogger.isEnabled()) {
         // sessionRunTime will be reset soon by loadSettings. Grab it now to get previous session value.
         // The value will be 0 if the user blew away settings this session, which is both a feature and a bug.
@@ -1441,10 +1443,12 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         properties["first_run"] = firstRun.get();
 
         // add the user's machine ID to the launch event
-        properties["machine_fingerprint"] = uuidStringWithoutCurlyBraces(FingerprintUtils::getMachineFingerprint());
+        properties["machine_fingerprint"] = machineFingerPrint;
 
         userActivityLogger.logAction("launch", properties);
     }
+
+    setCrashAnnotation("machine_fingerprint", machineFingerPrint.toStdString());
 
     _entityEditSender.setMyAvatar(myAvatar.get());
 

--- a/interface/src/DiscoverabilityManager.cpp
+++ b/interface/src/DiscoverabilityManager.cpp
@@ -20,6 +20,7 @@
 #include <UserActivityLogger.h>
 #include <UUID.h>
 
+#include "Crashpad.h"
 #include "DiscoverabilityManager.h"
 #include "Menu.h"
 
@@ -127,10 +128,12 @@ void DiscoverabilityManager::updateLocation() {
                                    QNetworkAccessManager::PutOperation, callbackParameters);
     }
 
-    // Update Steam
+    // Update Steam and crash logger
+    QUrl currentAddress = addressManager->currentFacingPublicAddress();
     if (auto steamClient = PluginManager::getInstance()->getSteamClientPlugin()) {
-        steamClient->updateLocation(domainHandler.getHostname(), addressManager->currentFacingPublicAddress());
+        steamClient->updateLocation(domainHandler.getHostname(), currentAddress);
     }
+    setCrashAnnotation("address", currentAddress.toString().toStdString());
 }
 
 void DiscoverabilityManager::handleHeartbeatResponse(QNetworkReply& requestReply) {


### PR DESCRIPTION
- add crash annotation for session-id, domain-id, avatar-url, domain-url, current location, username, launched from steam or not, display plugin name, hmd or not, machine fingerprint

https://highfidelity.fogbugz.com/f/cases/13326/Backtrace-reports-should-be-associated-with-user-data