### PR TITLE
Worklist #21774: Fix Windows.browseAssets() bugs

### DIFF
--- a/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
+++ b/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
@@ -255,7 +255,8 @@ Item {
                     filterListEnd = filter.indexOf(")");
                     if (filterListStart !== -1 && filterListEnd !== -1) {
                         var FIRST_EXTENSION_OFFSET = 2;
-                        fileTypeFilters = filter.substring(filterListStart + FIRST_EXTENSION_OFFSET, filterListEnd).toLowerCase().split("*");
+                        fileTypeFilters = filter.substring(filterListStart + FIRST_EXTENSION_OFFSET
+                            , filterListEnd).toLowerCase().split("*");
                     } else if (filter !== "") {
                         fileTypeFilters[0] = filter.replace("*", "").toLowerCase();
                     }

--- a/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
+++ b/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
@@ -254,7 +254,8 @@ Item {
                     filterListStart = filter.indexOf("(");
                     filterListEnd = filter.indexOf(")");
                     if (filterListStart !== -1 && filterListEnd !== -1) {
-                        fileTypeFilters = filter.substring(filterListStart + 2, filterListEnd).toLowerCase().split("*");
+                        var FIRST_EXTENSION_OFFSET = 2;
+                        fileTypeFilters = filter.substring(filterListStart + FIRST_EXTENSION_OFFSET, filterListEnd).toLowerCase().split("*");
                     } else if (filter !== "") {
                         fileTypeFilters[0] = filter.replace("*", "").toLowerCase();
                     }

--- a/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
+++ b/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
@@ -19,14 +19,14 @@ import "../fileDialog"
 Item {
     // Set from OffscreenUi::assetDialog()
     property alias dir: assetTableModel.folder
-    property alias filter: selectionType.filtersString  // FIXME: Currently only supports simple filters, "*.xxx".
+    property alias filter: selectionType.filtersString
     property int options  // Not used.
 
     property bool selectDirectory: false
 
     // Not implemented.
-    //property bool saveDialog: false;
-    //property bool multiSelect: false;
+    // property bool saveDialog: false;
+    // property bool multiSelect: false;
 
     property bool singleClickNavigate: false
 
@@ -84,7 +84,7 @@ Item {
                 size: 28
                 width: height
                 enabled: destination !== ""
-                //onClicked: d.navigateHome();
+                // onClicked: d.navigateHome();
                 onClicked: assetTableModel.folder = destination;
             }
         }
@@ -227,7 +227,9 @@ Item {
 
             function onGetAllMappings(error, map) {
                 var mappings,
-                    fileTypeFilter,
+                    fileTypeFilters = [],
+                    filterListStart,
+                    filterListEnd,
                     index,
                     path,
                     fileName,
@@ -248,7 +250,14 @@ Item {
 
                 if (error === "") {
                     mappings = Object.keys(map);
-                    fileTypeFilter = filter.replace("*", "").toLowerCase();
+                    filter = filter.replace(/\s/g, '');
+                    filterListStart = filter.indexOf("(");
+                    filterListEnd = filter.indexOf(")");
+                    if (filterListStart !== -1 && filterListEnd !== -1) {
+                        fileTypeFilters = filter.substring(filterListStart + 2, filterListEnd).toLowerCase().split("*");
+                    } else if (filter !== "") {
+                        fileTypeFilters[0] = filter.replace("*", "").toLowerCase();
+                    }
 
                     for (i = 0, length = mappings.length; i < length; i++) {
                         index = mappings[i].lastIndexOf("/");
@@ -259,7 +268,24 @@ Item {
                         fileIsDir = false;
                         isValid = false;
 
-                        if (fileType.toLowerCase() === fileTypeFilter) {
+                        if (fileTypeFilters.length > 1) {
+                            if (fileTypeFilters.indexOf(fileType.toLowerCase()) !== -1) {
+                                if (path === folder) {
+                                    isValid = !selectDirectory;
+                                } else if (path.length > folder.length) {
+                                    subDirectory = path.slice(folder.length);
+                                    index = subDirectory.indexOf("/");
+                                    if (index === subDirectory.lastIndexOf("/")) {
+                                        fileName = subDirectory.slice(0, index);
+                                        if (subDirectories.indexOf(fileName) === -1) {
+                                            fileIsDir = true;
+                                            isValid = true;
+                                            subDirectories.push(fileName);
+                                        }
+                                    }
+                                }
+                            }
+                        } else if (fileType.toLowerCase() === fileTypeFilters[0] || fileTypeFilters.length === 0) {
                             if (path === folder) {
                                 isValid = !selectDirectory;
                             } else if (path.length > folder.length) {

--- a/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
+++ b/interface/resources/qml/dialogs/assetDialog/AssetDialogContent.qml
@@ -20,14 +20,8 @@ Item {
     // Set from OffscreenUi::assetDialog()
     property alias dir: assetTableModel.folder
     property alias filter: selectionType.filtersString
-    property int options  // Not used.
 
     property bool selectDirectory: false
-
-    // Not implemented.
-    // property bool saveDialog: false;
-    // property bool multiSelect: false;
-
     property bool singleClickNavigate: false
 
     HifiConstants { id: hifi }
@@ -84,7 +78,6 @@ Item {
                 size: 28
                 width: height
                 enabled: destination !== ""
-                // onClicked: d.navigateHome();
                 onClicked: assetTableModel.folder = destination;
             }
         }


### PR DESCRIPTION
Added support for list of filters using formatting consistent with other implementations, e.g: (*.png *.jpg)

**Test Plan:**
Window.browseAssets allows the selection of files from ATP.
Suitable files should first be uploaded for testing. If there are .png and .jpg files available the following script example could be used for testing.

`var asset = Window.browseAssets("Select ATP File", "/", "TestFiles(*.pNG *.jpg)");`

The first parameter is to set the window title, second is for specifying a start directory, the third is for filtering.

The extension check should be case insensitive, as with the example above.
The filter list of extensions are checked within the parentheses (  ) characters.

If filters are omitted all files should be visible, the filter parameter can also just be a single extension such as "*.png".
