### PR TITLE
Fixed procedural shaders

### DIFF
--- a/libraries/render-utils/src/forward_simple.slf
+++ b/libraries/render-utils/src/forward_simple.slf
@@ -16,10 +16,20 @@
 <@include ForwardGlobalLight.slh@>
 <$declareEvalSkyboxGlobalColor()$>
 
+
 // the interpolated normal
 in vec3 _normalWS;
+in vec3 _normalMS;
 in vec4 _color;
+in vec2 _texCoord0;
+in vec4 _positionMS;
 in vec4 _positionES;
+
+// For retro-compatibility
+#define _normal      _normalWS
+#define _modelNormal _normalMS
+#define _position    _positionMS
+#define _eyePosition _positionES
 
 layout(location = 0) out vec4 _fragColor0;
 

--- a/libraries/render-utils/src/forward_simple_transparent.slf
+++ b/libraries/render-utils/src/forward_simple_transparent.slf
@@ -18,8 +18,17 @@
 
 // the interpolated normal
 in vec3 _normalWS;
+in vec3 _normalMS;
 in vec4 _color;
+in vec2 _texCoord0;
+in vec4 _positionMS;
 in vec4 _positionES;
+
+// For retro-compatibility
+#define _normal      _normalWS
+#define _modelNormal _normalMS
+#define _position    _positionMS
+#define _eyePosition _positionES
 
 layout(location = 0) out vec4 _fragColor0;
 

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -16,7 +16,17 @@
 
 // the interpolated normal
 in vec3 _normalWS;
+in vec3 _normalMS;
 in vec4 _color;
+in vec2 _texCoord0;
+in vec4 _positionMS;
+in vec4 _positionES;
+
+// For retro-compatibility
+#define _normal			_normalWS
+#define _modelNormal	_normalMS
+#define _position		_positionMS
+#define _eyePosition	_positionES
 
 //PROCEDURAL_COMMON_BLOCK
 

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -23,10 +23,10 @@ in vec4 _positionMS;
 in vec4 _positionES;
 
 // For retro-compatibility
-#define _normal			_normalWS
-#define _modelNormal	_normalMS
-#define _position		_positionMS
-#define _eyePosition	_positionES
+#define _normal      _normalWS
+#define _modelNormal _normalMS
+#define _position    _positionMS
+#define _eyePosition _positionES
 
 //PROCEDURAL_COMMON_BLOCK
 

--- a/libraries/render-utils/src/simple_fade.slf
+++ b/libraries/render-utils/src/simple_fade.slf
@@ -27,10 +27,10 @@ in vec4 _positionES;
 in vec4 _positionWS;
 
 // For retro-compatibility
-#define _normal			_normalWS
-#define _modelNormal	_normalMS
-#define _position		_positionMS
-#define _eyePosition	_positionES
+#define _normal      _normalWS
+#define _modelNormal _normalMS
+#define _position    _positionMS
+#define _eyePosition _positionES
 
 //PROCEDURAL_COMMON_BLOCK
 

--- a/libraries/render-utils/src/simple_fade.slf
+++ b/libraries/render-utils/src/simple_fade.slf
@@ -19,8 +19,18 @@
 
 // the interpolated normal
 in vec3 _normalWS;
+in vec3 _normalMS;
 in vec4 _color;
+in vec2 _texCoord0;
+in vec4 _positionMS;
+in vec4 _positionES;
 in vec4 _positionWS;
+
+// For retro-compatibility
+#define _normal			_normalWS
+#define _modelNormal	_normalMS
+#define _position		_positionMS
+#define _eyePosition	_positionES
 
 //PROCEDURAL_COMMON_BLOCK
 

--- a/libraries/render-utils/src/simple_transparent.slf
+++ b/libraries/render-utils/src/simple_transparent.slf
@@ -16,7 +16,17 @@
 
 // the interpolated normal
 in vec3 _normalWS;
+in vec3 _normalMS;
 in vec4 _color;
+in vec2 _texCoord0;
+in vec4 _positionMS;
+in vec4 _positionES;
+
+// For retro-compatibility
+#define _normal      _normalWS
+#define _modelNormal _normalMS
+#define _position    _positionMS
+#define _eyePosition _positionES
 
 //PROCEDURAL_COMMON_BLOCK
 


### PR DESCRIPTION
This PR fixes procedural shaders when they are referencing position and normal attributes comming out of vertex shader.

# TEST PLAN
The PR "in theory" shouldn't break things as it just adds new stuff without removing anything, but should still be tested on a maximum of procedural shaders (such as simple water shader).

visit hifi://eschatology/113.381,1.45159,69.1119/0,-0.808067,0,0.58909 and see that the hex pattern on the box is working.

https://highfidelity.fogbugz.com/f/cases/14812/shaders-that-use-_position-are-broken