### PR TITLE
Fix debug assert in manipulating thread local data to store GL surfaces

### DIFF
--- a/libraries/gl/src/gl/OffscreenGLCanvas.h
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.h
@@ -39,6 +39,8 @@ private slots:
     void onMessageLogged(const QOpenGLDebugMessage &debugMessage);
 
 protected:
+    void clearThreadContext();
+
     std::once_flag _reportOnce;
     QOpenGLContext* _context{ nullptr };
     QOffscreenSurface* _offscreenSurface{ nullptr };


### PR DESCRIPTION
I was looking into [this bug](https://highfidelity.manuscript.com/f/cases/14099) because I was hopeful the debug assert might be related to the current crash behavior related to QML web rendering, but it appears to be a completely distinct issue.  

The problem was in using `QThread::currentThread()->setProperty`.  Apparently setting a property on a thread _from that thread_ is forbidden, because technically the thread's owner thread is still wherever it was created.  Calling `setProperty` in this fashion ended up triggering an assertion failure, which in debug builds will cause a message box to pop up and event processing to continue.  This has the effect of causing functions that aren't intended to be recursive to be recursed into, typically causing a crash shortly after the dialog appears.

The fix is to use a dedicated `QThreadStorage` class to store offscreen GL surfaces associated with specific threads.  

## Testing

This PR shouldn't have any effect on the perceived behavior of master, because the change only impacts the behavior of _debug_ builds.  However, the code touched is used for rendering screenshots and secondary camera buffers, so please test:

* Startup & shutdown behave as normal, or at least no more broken than is currently in master
* Screenshot functionality works
* Secondary camera works
