### PR TITLE
66.1 fix: use the correct joint count for other avatar last sent

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -115,11 +115,7 @@ public:
     uint64_t getLastOtherAvatarEncodeTime(QUuid otherAvatar) const;
     void setLastOtherAvatarEncodeTime(const QUuid& otherAvatar, const uint64_t& time);
 
-    QVector<JointData>& getLastOtherAvatarSentJoints(QUuid otherAvatar) {
-        auto& lastOtherAvatarSentJoints = _lastOtherAvatarSentJoints[otherAvatar];
-        lastOtherAvatarSentJoints.resize(_avatar->getJointCount());
-        return lastOtherAvatarSentJoints;
-    }
+    QVector<JointData>& getLastOtherAvatarSentJoints(QUuid otherAvatar) { return _lastOtherAvatarSentJoints[otherAvatar]; }
 
     void queuePacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer node);
     int processPackets(); // returns number of packets processed

--- a/assignment-client/src/avatars/AvatarMixerSlave.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlave.cpp
@@ -381,6 +381,9 @@ void AvatarMixerSlave::broadcastAvatarDataToAgent(const SharedNodePointer& node)
         bool includeThisAvatar = true;
         auto lastEncodeForOther = nodeData->getLastOtherAvatarEncodeTime(otherNode->getUUID());
         QVector<JointData>& lastSentJointsForOther = nodeData->getLastOtherAvatarSentJoints(otherNode->getUUID());
+
+        lastSentJointsForOther.resize(otherAvatar->getJointCount());
+
         bool distanceAdjust = true;
         glm::vec3 viewerPosition = myPosition;
         AvatarDataPacket::HasFlags hasFlagsOut; // the result of the toByteArray


### PR DESCRIPTION
Fixes a potential crash in the avatar mixer. 

Previously when looking at the joint data for avatar B we were resizing the last sent joint data to the number of joints for avatar A. This change corrects that so that we resized to the number of joints we currently have for avatar B.