### PR TITLE
use baked uncompressed KTX skyboxes for macOS compatibility

### DIFF
--- a/cmake/externals/serverless-content/CMakeLists.txt
+++ b/cmake/externals/serverless-content/CMakeLists.txt
@@ -4,8 +4,8 @@ set(EXTERNAL_NAME serverless-content)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC67-v2.zip
-  URL_MD5 2c69a1df69816b4b0b81630396fbd36e
+  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC67-v3.zip
+  URL_MD5 327292eb87bc249cbb4d670d8a6ce746
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""


### PR DESCRIPTION
On macOS, baked compressed KTX skyboxes do not load. This changes the serverless content to use a baked but uncompressed KTX skybox.