### PR TITLE
Limits for alpha sliders in particle explorer

### DIFF
--- a/scripts/system/particle_explorer/particleExplorer.js
+++ b/scripts/system/particle_explorer/particleExplorer.js
@@ -321,7 +321,8 @@
                 {
                     id: "alpha",
                     name: "Alpha",
-                    type: "SliderFloat"
+                    type: "SliderFloat",
+                    max: 1.0
                 },
                 {
                     type: "Row"
@@ -329,7 +330,8 @@
                 {
                     id: "alphaSpread",
                     name: "Alpha Spread",
-                    type: "SliderFloat"
+                    type: "SliderFloat",
+                    max: 1.0
                 },
                 {
                     type: "Row"
@@ -337,7 +339,8 @@
                 {
                     id: "alphaStart",
                     name: "Alpha Start",
-                    type: "SliderFloat"
+                    type: "SliderFloat",
+                    max: 1.0
                 },
                 {
                     type: "Row"
@@ -345,7 +348,8 @@
                 {
                     id: "alphaFinish",
                     name: "Alpha Finish",
-                    type: "SliderFloat"
+                    type: "SliderFloat",
+                    max: 1.0
                 },
                 {
                     type: "Row"


### PR DESCRIPTION
Fixes the following manuscript case: 

https://highfidelity.fogbugz.com/f/cases/4518/Particle-system-values-unclear-whether-or-not-0-1-or-0-256-or-0-infinity

