### PR TITLE
update RC67 serverless content to include default path

### DIFF
--- a/cmake/externals/serverless-content/CMakeLists.txt
+++ b/cmake/externals/serverless-content/CMakeLists.txt
@@ -4,8 +4,8 @@ set(EXTERNAL_NAME serverless-content)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC67-v3.zip
-  URL_MD5 327292eb87bc249cbb4d670d8a6ce746
+  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC67-v4.zip
+  URL_MD5 ba32aed18bfeaac4ccaf5ebb8ea3e804
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""


### PR DESCRIPTION
Serverless domain JSONs can specify a default path to enter at. The previously added serverless zip for RC67 (https://github.com/highfidelity/hifi/pull/12977) did not include a default path, so users are facing the left wall when starting the serverless tutorial instead of the first step. This adds paths to the serverless JSON so that the user faces the correct way when starting the tutorial.