### PR TITLE
66.2: make home go to DEFAULT_HIFI_ADDRESS by default

### DIFF
--- a/interface/src/ui/AddressBarDialog.cpp
+++ b/interface/src/ui/AddressBarDialog.cpp
@@ -58,9 +58,8 @@ void AddressBarDialog::loadHome() {
     qDebug() << "Called LoadHome";
     auto locationBookmarks = DependencyManager::get<LocationBookmarks>();
     QString homeLocation = locationBookmarks->addressForBookmark(LocationBookmarks::HOME_BOOKMARK);
-    const QString DEFAULT_HOME_LOCATION = "localhost";
     if (homeLocation == "") {
-        homeLocation = DEFAULT_HOME_LOCATION;
+        homeLocation = DEFAULT_HIFI_ADDRESS;
     }
     DependencyManager::get<AddressManager>()->handleLookupString(homeLocation);
 }


### PR DESCRIPTION
When the serverless tutorial was made the default launch address we did not change the home behaviour in goto to use the serverless instead of the sandbox. This PR changes the behaviour of the home button in goto to use the serverless, unless it has been overriden by the user setting a new home bookmark.