### PR TITLE
Allow gifting of Pending items; remove PoP verification rescheduling on Pending items

### DIFF
--- a/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
@@ -239,7 +239,6 @@ Item {
                     width: 62;
 
                     onLoaded: {
-                        item.enabled = (root.purchaseStatus === "confirmed");
                         item.buttonGlyphText = hifi.glyphs.gift;
                         item.buttonText = "Gift";
                         item.buttonClicked = function() {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1172,16 +1172,6 @@ void EntityTree::startChallengeOwnershipTimer(const EntityItemID& entityItemID) 
     _challengeOwnershipTimeoutTimer->start(5000);
 }
 
-void EntityTree::startPendingTransferStatusTimer(const QString& certID, const EntityItemID& entityItemID, const SharedNodePointer& senderNode) {
-    qCDebug(entities) << "'transfer_status' is 'pending', checking again in 90 seconds..." << entityItemID;
-    QTimer* transferStatusRetryTimer = new QTimer(this);
-    connect(transferStatusRetryTimer, &QTimer::timeout, this, [=]() {
-        validatePop(certID, entityItemID, senderNode, true);
-    });
-    transferStatusRetryTimer->setSingleShot(true);
-    transferStatusRetryTimer->start(90000);
-}
-
 QByteArray EntityTree::computeNonce(const QString& certID, const QString ownerKey) {
     QUuid nonce = QUuid::createUuid();  //random, 5-hex value, separated by "-"
     QByteArray nonceBytes = nonce.toByteArray();
@@ -1321,7 +1311,7 @@ void EntityTree::sendChallengeOwnershipRequestPacket(const QByteArray& certID, c
     nodeList->sendPacket(std::move(challengeOwnershipPacket), *(nodeList->nodeWithUUID(QUuid::fromRfc4122(nodeToChallenge))));
 }
 
-void EntityTree::validatePop(const QString& certID, const EntityItemID& entityItemID, const SharedNodePointer& senderNode, bool isRetryingValidation) {
+void EntityTree::validatePop(const QString& certID, const EntityItemID& entityItemID, const SharedNodePointer& senderNode) {
     // Start owner verification.
     auto nodeList = DependencyManager::get<NodeList>();
     //     First, asynchronously hit "proof_of_purchase_status?transaction_type=transfer" endpoint.
@@ -1352,30 +1342,13 @@ void EntityTree::validatePop(const QString& certID, const EntityItemID& entityIt
                 withWriteLock([&] {
                     deleteEntity(entityItemID, true);
                 });
-            } else if (jsonObject["transfer_status"].toArray().first().toString() == "pending") {
-                if (isRetryingValidation) {
-                    qCDebug(entities) << "'transfer_status' is 'pending' after retry, deleting entity" << entityItemID;
-                    withWriteLock([&] {
-                        deleteEntity(entityItemID, true);
-                    });
-                } else {
-                    if (thread() != QThread::currentThread()) {
-                        QMetaObject::invokeMethod(this, "startPendingTransferStatusTimer",
-                            Q_ARG(const QString&, certID),
-                            Q_ARG(const EntityItemID&, entityItemID),
-                            Q_ARG(const SharedNodePointer&, senderNode));
-                        return;
-                    } else {
-                        startPendingTransferStatusTimer(certID, entityItemID, senderNode);
-                    }
-                }
             } else {
                 // Second, challenge ownership of the PoP cert
+                // (ignore pending status; a failure will be cleaned up during DDV)
                 sendChallengeOwnershipPacket(certID,
                     jsonObject["transfer_recipient_key"].toString(),
                     entityItemID,
                     senderNode);
-
             }
         } else {
             qCDebug(entities) << "Call to" << networkReply->url() << "failed with error" << networkReply->error() << "; deleting entity" << entityItemID
@@ -1619,7 +1592,7 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                                 // Delete the entity we just added if it doesn't pass static certificate verification
                                 deleteEntity(entityItemID, true);
                             } else {
-                                validatePop(properties.getCertificateID(), entityItemID, senderNode, false);
+                                validatePop(properties.getCertificateID(), entityItemID, senderNode);
                             }
                         }
 

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -397,12 +397,11 @@ protected:
     QHash<EntityItemID, EntityItemPointer> _entitiesToAdd;
 
     Q_INVOKABLE void startChallengeOwnershipTimer(const EntityItemID& entityItemID);
-    Q_INVOKABLE void startPendingTransferStatusTimer(const QString& certID, const EntityItemID& entityItemID, const SharedNodePointer& senderNode);
 
 private:
     void sendChallengeOwnershipPacket(const QString& certID, const QString& ownerKey, const EntityItemID& entityItemID, const SharedNodePointer& senderNode);
     void sendChallengeOwnershipRequestPacket(const QByteArray& certID, const QByteArray& text, const QByteArray& nodeToChallenge, const SharedNodePointer& senderNode);
-    void validatePop(const QString& certID, const EntityItemID& entityItemID, const SharedNodePointer& senderNode, bool isRetryingValidation);
+    void validatePop(const QString& certID, const EntityItemID& entityItemID, const SharedNodePointer& senderNode);
 
     std::shared_ptr<AvatarData> _myAvatar{ nullptr };
 


### PR DESCRIPTION
There will be an RC67 version of this PR as well.

Fixes https://highfidelity.fogbugz.com/f/cases/14603/domain-server-deletes-delays-dynamic-ownership-challenge-by-90-seconds-if-transaction-still-pending and https://highfidelity.fogbugz.com/f/cases/14606/Cannot-gift-while-pending