### PR TITLE
don't spam resetSensors function when holding down Qt::Key_Apostrophe

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3554,7 +3554,7 @@ void Application::keyPressEvent(QKeyEvent* event) {
                     } else {
                         showCursor(Cursor::Icon::DEFAULT);
                     }
-                } else {
+                } else if (!event->isAutoRepeat()){
                     resetSensors(true);
                 }
                 break;


### PR DESCRIPTION
If the user holds down `Qt::Key_Apostrophe` interface will spam call the function `resetSensors`. If the button held to long the avatar will be stuck in the T pose or interface will crash

- ticket - https://highfidelity.manuscript.com/f/cases/14340/Client-crashes-when-holding-down-the-key