### PR TITLE
[BugFix] EntityList UncaughtException in that.sendUpdate

### DIFF
--- a/scripts/system/libraries/entityList.js
+++ b/scripts/system/libraries/entityList.js
@@ -90,12 +90,17 @@ EntityListTool = function(opts) {
                     url: url,
                     locked: properties.locked,
                     visible: properties.visible,
-                    verticesCount: valueIfDefined(properties.renderInfo.verticesCount),
-                    texturesCount: valueIfDefined(properties.renderInfo.texturesCount),
-                    texturesSize: valueIfDefined(properties.renderInfo.texturesSize),
-                    hasTransparent: valueIfDefined(properties.renderInfo.hasTransparent),
+                    verticesCount: (properties.renderInfo !== undefined ? 
+                        valueIfDefined(properties.renderInfo.verticesCount) : ""),
+                    texturesCount: (properties.renderInfo !== undefined ? 
+                        valueIfDefined(properties.renderInfo.texturesCount) : ""),
+                    texturesSize: (properties.renderInfo !== undefined ? 
+                        valueIfDefined(properties.renderInfo.texturesSize) : ""),
+                    hasTransparent: (properties.renderInfo !== undefined ? 
+                        valueIfDefined(properties.renderInfo.hasTransparent) : ""),
                     isBaked: properties.type == "Model" ? url.toLowerCase().endsWith(".baked.fbx") : false,
-                    drawCalls: valueIfDefined(properties.renderInfo.drawCalls),
+                    drawCalls: (properties.renderInfo !== undefined ? 
+                        valueIfDefined(properties.renderInfo.drawCalls) : ""),
                     hasScript: properties.script !== ""
                 });
             }


### PR DESCRIPTION
* Adds safety checks to properties.renderInfo to prevent invalid access when undefined.
    * Error trace prior to guards:
        [04/27 13:16:19] [CRITICAL] [hifi.scriptengine] [defaultScripts.js] [UncaughtException signalHandlerException] Error: Result of expression 'properties.renderInfo' [undefined] is not an object. in .../build/interface/RelWithDebInfo/scripts/system/libraries/entityList.js:93
        [04/27 13:16:19] [CRITICAL] [hifi.scriptengine] [Backtrace]
        [04/27 13:16:19] [CRITICAL] [hifi.scriptengine]     <anonymous>() at .../build/interface/RelWithDebInfo/scripts/system/libraries/entityList.js:93
        [04/27 13:16:19] [CRITICAL] [hifi.scriptengine]     <anonymous>(data = [object Object]) at .../build/interface/RelWithDebInfo/scripts/system/libraries/entityList.js:149
        [04/27 13:16:19] [CRITICAL] [hifi.scriptengine]     <global>() at -1