### PR TITLE
Two fixes for arm64 on linux

### DIFF
--- a/libraries/audio/src/AudioDynamics.h
+++ b/libraries/audio/src/AudioDynamics.h
@@ -10,6 +10,7 @@
 // Inline functions to implement audio dynamics processing
 //
 
+#include <stddef.h>
 #include <math.h>
 #include <stdint.h>
 

--- a/libraries/shared/src/OctalCode.cpp
+++ b/libraries/shared/src/OctalCode.cpp
@@ -213,7 +213,7 @@ void setOctalCodeSectionValue(unsigned char* octalCode, int section, char sectio
     int byteForSection = (BITS_IN_OCTAL * section / BITS_IN_BYTE);
     unsigned char* byteAt = octalCode + 1 + byteForSection;
     char bitInByte = (BITS_IN_OCTAL * section) % BITS_IN_BYTE;
-    char shiftBy = BITS_IN_BYTE - bitInByte - BITS_IN_OCTAL;
+    int8_t shiftBy = BITS_IN_BYTE - bitInByte - BITS_IN_OCTAL;
     const unsigned char UNSHIFTED_MASK = 0x07;
     unsigned char shiftedMask;
     unsigned char shiftedValue;


### PR DESCRIPTION
1) size_t is not defined by default in gcc, so stddef.h needed to be added
to AudioDynamics.h to handle some size_t usage.
2) gcc defaults char to unsigned, where windows defaults to signed.  OctalCode.cpp
was assuming signed