### PR TITLE
Reset pending domain check-in count more frequently 

### DIFF
--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -239,7 +239,6 @@ void DomainHandler::activateICELocalSocket() {
     _domainURL.setHost(_sockAddr.getAddress().toString());
     emit domainURLChanged(_domainURL);
     emit completedSocketDiscovery();
-    clearPendingCheckins();  // Clear outstanding count.
 }
 
 void DomainHandler::activateICEPublicSocket() {
@@ -249,7 +248,6 @@ void DomainHandler::activateICEPublicSocket() {
     _domainURL.setHost(_sockAddr.getAddress().toString());
     emit domainURLChanged(_domainURL);
     emit completedSocketDiscovery();
-    clearPendingCheckins();  // Clear outstanding count.
 }
 
 QString DomainHandler::getViewPointFromNamedPath(QString namedPath) {
@@ -341,7 +339,6 @@ void DomainHandler::processSettingsPacketList(QSharedPointer<ReceivedMessage> pa
         qCDebug(networking) << "Received domain settings: \n" << _settingsObject;
     }
 
-    clearPendingCheckins();  // Reset outstanding check-ins.
     emit settingsReceived(_settingsObject);
 }
 

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -239,6 +239,7 @@ void DomainHandler::activateICELocalSocket() {
     _domainURL.setHost(_sockAddr.getAddress().toString());
     emit domainURLChanged(_domainURL);
     emit completedSocketDiscovery();
+    clearPendingCheckins();  // Clear outstanding count.
 }
 
 void DomainHandler::activateICEPublicSocket() {
@@ -248,6 +249,7 @@ void DomainHandler::activateICEPublicSocket() {
     _domainURL.setHost(_sockAddr.getAddress().toString());
     emit domainURLChanged(_domainURL);
     emit completedSocketDiscovery();
+    clearPendingCheckins();  // Clear outstanding count.
 }
 
 QString DomainHandler::getViewPointFromNamedPath(QString namedPath) {
@@ -339,6 +341,7 @@ void DomainHandler::processSettingsPacketList(QSharedPointer<ReceivedMessage> pa
         qCDebug(networking) << "Received domain settings: \n" << _settingsObject;
     }
 
+    clearPendingCheckins();  // Reset outstanding check-ins.
     emit settingsReceived(_settingsObject);
 }
 

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -97,7 +97,7 @@ public:
 
     int getCheckInPacketsSinceLastReply() const { return _checkInPacketsSinceLastReply; }
     void sentCheckInPacket();
-    void domainListReceived() { _checkInPacketsSinceLastReply = 0; }
+    void clearPendingCheckins() { _checkInPacketsSinceLastReply = 0; }
 
     /**jsdoc
      * <p>The reasons that you may be refused connection to a domain are defined by numeric values:</p>

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -534,6 +534,8 @@ void NodeList::processDomainServerPathResponse(QSharedPointer<ReceivedMessage> m
         qCDebug(networking) << "Could not go to viewpoint" << viewpoint
             << "which was the lookup result for path" << pathQuery;
     }
+
+    _domainHandler.clearPendingCheckins();
 }
 
 void NodeList::handleICEConnectionToDomainServer() {
@@ -594,6 +596,8 @@ void NodeList::processDomainServerConnectionTokenPacket(QSharedPointer<ReceivedM
     }
     // read in the connection token from the packet, then send domain-server checkin
     _domainHandler.setConnectionToken(QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID)));
+
+    _domainHandler.clearPendingCheckins();
     sendDomainServerCheckIn();
 }
 
@@ -605,7 +609,7 @@ void NodeList::processDomainServerList(QSharedPointer<ReceivedMessage> message) 
     }
 
     // this is a packet from the domain server, reset the count of un-replied check-ins
-    _domainHandler.domainListReceived();
+    _domainHandler.clearPendingCheckins();
 
     // emit our signal so listeners know we just heard from the DS
     emit receivedDomainServerList();

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -534,8 +534,6 @@ void NodeList::processDomainServerPathResponse(QSharedPointer<ReceivedMessage> m
         qCDebug(networking) << "Could not go to viewpoint" << viewpoint
             << "which was the lookup result for path" << pathQuery;
     }
-
-    _domainHandler.clearPendingCheckins();
 }
 
 void NodeList::handleICEConnectionToDomainServer() {


### PR DESCRIPTION
The domain connection is reset when the number of outstanding check-ins reaches five. Sending of check-in packets can be initiated by a periodic 1 s counter, by the local or public ICE sockets being created, by successful lookup of the domain's hostname, by an account key-pair being generated and other reasons.

In a low-end environment the various triggers might conspire to push the pending check-ins over the limit.

This PR resets the count when other packets are received from the domain server, since they indicate that the DS is still alive, and when the ICE sockets are activated.

https://highfidelity.manuscript.com/f/cases/14394/
