### PR TITLE
Eliminated warnings in gcc

### DIFF
--- a/assignment-client/src/assets/AssetServer.h
+++ b/assignment-client/src/assets/AssetServer.h
@@ -63,7 +63,7 @@ struct AssetMeta {
     AssetMeta() {
     }
 
-    BakeVersion bakeVersion;
+    BakeVersion bakeVersion { INITIAL_BAKE_VERSION };
     bool failedLastBake { false };
     QString lastBakeErrors;
 };

--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -149,6 +149,9 @@ int InboundAudioStream::parseData(ReceivedMessage& message) {
             lostAudioData(packetsDropped);
 
             // fall through to OnTime case
+#if defined(__GNUC__)
+            [[gnu::fallthrough]];
+#endif
         }
         case SequenceNumberStats::OnTime: {
             // Packet is on time; parse its data to the ringbuffer

--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -149,10 +149,8 @@ int InboundAudioStream::parseData(ReceivedMessage& message) {
             lostAudioData(packetsDropped);
 
             // fall through to OnTime case
-#if defined(__GNUC__)
-            [[gnu::fallthrough]];
-#endif
         }
+        // FALLTHRU
         case SequenceNumberStats::OnTime: {
             // Packet is on time; parse its data to the ringbuffer
             if (message.getType() == PacketType::SilentAudioFrame

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1402,6 +1402,9 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
 
         case PacketType::EntityAdd:
             isAdd = true;  // fall through to next case
+#if defined(__GNUC__)
+            [[gnu::fallthrough]];
+#endif
         case PacketType::EntityPhysics:
         case PacketType::EntityEdit: {
             quint64 startDecode = 0, endDecode = 0;

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1402,9 +1402,7 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
 
         case PacketType::EntityAdd:
             isAdd = true;  // fall through to next case
-#if defined(__GNUC__)
-            [[gnu::fallthrough]];
-#endif
+            // FALLTHRU
         case PacketType::EntityPhysics:
         case PacketType::EntityEdit: {
             quint64 startDecode = 0, endDecode = 0;

--- a/libraries/fbx/src/FBXWriter.cpp
+++ b/libraries/fbx/src/FBXWriter.cpp
@@ -142,7 +142,6 @@ void FBXWriter::encodeFBXProperty(QDataStream& out, const QVariant& prop) {
             out << prop.toInt();
             break;
 
-        encodeNode(out, FBXNode());
         case QMetaType::Float:
             out.device()->write("F", 1);
             out << prop.toFloat();

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -749,10 +749,8 @@ bool Resource::handleFailedRequest(ResourceRequest::Result result) {
         case ResourceRequest::Result::Timeout: {
             qCDebug(networking) << "Timed out loading" << _url << "received" << _bytesReceived << "total" << _bytesTotal;
             // Fall through to other cases
-#if defined(__GNUC__)
-            [[gnu::fallthrough]];
-#endif
         }
+        // FALLTHRU
         case ResourceRequest::Result::ServerUnavailable: {
             _attempts++;
             _attemptsRemaining--;
@@ -770,10 +768,8 @@ bool Resource::handleFailedRequest(ResourceRequest::Result result) {
                 break;
             }
             // fall through to final failure
-#if defined(__GNUC__)
-            [[gnu::fallthrough]];
-#endif
         }
+        // FALLTHRU
         default: {
             _attemptsRemaining = 0;
             qCDebug(networking) << "Error loading " << _url << "attempt:" << _attempts << "attemptsRemaining:" << _attemptsRemaining;

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -749,6 +749,9 @@ bool Resource::handleFailedRequest(ResourceRequest::Result result) {
         case ResourceRequest::Result::Timeout: {
             qCDebug(networking) << "Timed out loading" << _url << "received" << _bytesReceived << "total" << _bytesTotal;
             // Fall through to other cases
+#if defined(__GNUC__)
+            [[gnu::fallthrough]];
+#endif
         }
         case ResourceRequest::Result::ServerUnavailable: {
             _attempts++;
@@ -767,6 +770,9 @@ bool Resource::handleFailedRequest(ResourceRequest::Result result) {
                 break;
             }
             // fall through to final failure
+#if defined(__GNUC__)
+            [[gnu::fallthrough]];
+#endif
         }
         default: {
             _attemptsRemaining = 0;

--- a/libraries/shared/src/Gzip.cpp
+++ b/libraries/shared/src/Gzip.cpp
@@ -60,6 +60,9 @@ bool gunzip(QByteArray source, QByteArray &destination) {
             switch (status) {
                 case Z_NEED_DICT:
                     status = Z_DATA_ERROR;
+#if defined(__GNUC__)
+                    [[gnu::fallthrough]];
+#endif
                 case Z_DATA_ERROR:
                 case Z_MEM_ERROR:
                 case Z_STREAM_ERROR:

--- a/libraries/shared/src/Gzip.cpp
+++ b/libraries/shared/src/Gzip.cpp
@@ -60,9 +60,7 @@ bool gunzip(QByteArray source, QByteArray &destination) {
             switch (status) {
                 case Z_NEED_DICT:
                     status = Z_DATA_ERROR;
-#if defined(__GNUC__)
-                    [[gnu::fallthrough]];
-#endif
+                    // FALLTHRU
                 case Z_DATA_ERROR:
                 case Z_MEM_ERROR:
                 case Z_STREAM_ERROR:


### PR DESCRIPTION
I got these warnings when compiling on Ubuntu 18.04 using gcc 7.3.

Most of these changes are straightforward. Regarding the removed call to encodeNode() in FBXWriter.cpp: it can never be reached, so it's safe to remove it.