### PR TITLE
Added a missing 'break' in AnimExpression::evalUnaryMinus()

### DIFF
--- a/libraries/animation/src/AnimExpression.cpp
+++ b/libraries/animation/src/AnimExpression.cpp
@@ -588,6 +588,7 @@ void AnimExpression::evalUnaryMinus(const AnimVariantMap& map, std::stack<OpCode
             PUSH(false);
             break;
         }
+        break;
     }
     case OpCode::Int:
         PUSH(-rhs.intVal);


### PR DESCRIPTION
I added what I believe is a missing 'break' statement in AnimExpression::evalUnaryMinus().

I don't actually deal with animations, so I don't know what effect (if any) the missing 'break' has. I only noticed this because gcc 7.3 complained about a fallthrough in the switch. It looks like a mistake to me, but this code hasn't been touched since 2015 and no one has complained, so perhaps this was intentional. If so then please replace the 'break' with the following code fragment in order to eliminate the warning:

#if defined(__GNUC__)
    [[gnu::fallthrough]];
#endif
