### PR TITLE
Remove 'Create Items as Grabbable' Menu item in cleanup for edit

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1291,6 +1291,7 @@ function cleanupModelMenus() {
     Menu.removeMenuItem("Edit", MENU_EASE_ON_FOCUS);
     Menu.removeMenuItem("Edit", MENU_SHOW_LIGHTS_AND_PARTICLES_IN_EDIT_MODE);
     Menu.removeMenuItem("Edit", MENU_SHOW_ZONES_IN_EDIT_MODE);
+    Menu.removeMenuItem("Edit", MENU_CREATE_ENTITIES_GRABBABLE);
 }
 
 Script.scriptEnding.connect(function () {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/14614/Edit-Menu-is-duplicating-edit-Create-entities-as-grabbable-option

Fixes this bug