### PR TITLE
Prevent call of getDomainLocalID() by domain server itself more robustly

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -314,9 +314,9 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
         QUuid sourceID = sourceNode ? sourceNode->getUUID() : QUuid();
 
         if (!sourceNode &&
-            sourceLocalID == getDomainLocalID() &&
             packet.getSenderSockAddr() == getDomainSockAddr() &&
-            PacketTypeEnum::getDomainSourcedPackets().contains(headerType)) {
+            PacketTypeEnum::getDomainSourcedPackets().contains(headerType) &&
+            sourceLocalID == getDomainLocalID()) {
             // This is a packet sourced by the domain server
 
             emit dataReceived(NodeType::Unassigned, packet.getPayloadSize());

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -314,9 +314,10 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
         QUuid sourceID = sourceNode ? sourceNode->getUUID() : QUuid();
 
         if (!sourceNode &&
+            !isDomainServer() &&
+            sourceLocalID == getDomainLocalID() &&
             packet.getSenderSockAddr() == getDomainSockAddr() &&
-            PacketTypeEnum::getDomainSourcedPackets().contains(headerType) &&
-            sourceLocalID == getDomainLocalID()) {
+            PacketTypeEnum::getDomainSourcedPackets().contains(headerType)) {
             // This is a packet sourced by the domain server
 
             emit dataReceived(NodeType::Unassigned, packet.getPayloadSize());


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/14465/

This PR simply rearranges the order of the booleans in a conditional to prevent LimitedNodeList::getDomainLocalID() getting called, as it asserts in debug builds.

This shouldn't be possible in the existing code, but has been reported. 