### PR TITLE
Fix MS14640: Default audio meter overlay to "on"

### DIFF
--- a/interface/src/ui/AvatarInputs.cpp
+++ b/interface/src/ui/AvatarInputs.cpp
@@ -18,7 +18,7 @@
 
 static AvatarInputs* INSTANCE{ nullptr };
 
-Setting::Handle<bool> showAudioToolsSetting { QStringList { "AvatarInputs", "showAudioTools" }, false };
+Setting::Handle<bool> showAudioToolsSetting { QStringList { "AvatarInputs", "showAudioTools" }, true };
 
 AvatarInputs* AvatarInputs::getInstance() {
     if (!INSTANCE) {


### PR DESCRIPTION
From a clean install, the audio meter overlay should be on by default to assist new users.

https://highfidelity.manuscript.com/f/cases/14640/Default-audio-meter-overlay-to-on