### PR TITLE
MS14758: Fix avatar reset when gifting worn avatar

### DIFF
--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -729,7 +729,7 @@ Rectangle {
                                 }
                                 lightboxPopup.button2text = "CONFIRM";
                                 lightboxPopup.button2method = function() {
-                                    MyAvatar.skeletonModelURL = '';
+                                    MyAvatar.useFullAvatarURL('');
                                     root.activeView = "giftAsset";
                                     lightboxPopup.visible = false;
                                 };


### PR DESCRIPTION
Fixes [MS14758](https://highfidelity.manuscript.com/f/cases/14758/Avatar-URL-is-not-removed-when-user-gifts-an-avatar-they-are-wearing).