### PR TITLE
MS14699: Prevent Wallet passcode from being sticky in certain cases

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/PassphraseModal.qml
@@ -47,6 +47,13 @@ Item {
 
         onWalletAuthenticatedStatusResult: {
             submitPassphraseInputButton.enabled = true;
+
+            // It's not possible to auth with a blank passphrase,
+            // so bail early if we get this signal without anything in the passphrase field
+            if (passphraseField.text === "") {
+                return;
+            }
+
             if (!isAuthenticated) {
                 errorText.text = "Authentication failed - please try again.";
                 passphraseField.error = true;
@@ -211,6 +218,10 @@ Item {
                     error = false;
                     focus = true;
                     forceActiveFocus();
+                } else {
+                    showPassphrase.checked = false;
+                    passphraseField.text = "";
+                    error = false;
                 }
             }
 


### PR DESCRIPTION
Fixes [MS14699](https://highfidelity.fogbugz.com/f/cases/14699/Wallet-passcode-remains-after-signing-out-and-back-in-while-wallet-is-open).