### PR TITLE
RC67: Fix for crash deep in QML after useFullAvatarURL

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -55,6 +55,7 @@ public:
 
     virtual bool areTexturesLoaded() const;
     const QUrl& getAnimGraphOverrideUrl() const { return _animGraphOverrideUrl; }
+    const QVariantHash& getMapping() const { return _mapping; }
 
 protected:
     friend class GeometryMappingResource;
@@ -68,6 +69,7 @@ protected:
     NetworkMaterials _materials;
 
     QUrl _animGraphOverrideUrl;
+    QVariantHash _mapping;  // parsed contents of FST file.
 
 private:
     mutable bool _areTexturesLoaded { false };


### PR DESCRIPTION
Here we avoid calling FSTReader::downloadMapping() from within MyAvatar::useFullAvatarURL().
This prevents the error case where a QEventLoop is entered during QML execution.

Fixes [MS14639](https://highfidelity.manuscript.com/f/cases/14639/crash-deep-in-QML-after-useFullAvatar).