### PR TITLE
Fix overlay asan warning

### DIFF
--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -60,7 +60,7 @@ public:
     bool intersects { false };
     OverlayID overlayID { UNKNOWN_OVERLAY_ID };
     float distance { 0 };
-    BoxFace face;
+    BoxFace face { UNKNOWN_FACE };
     glm::vec3 surfaceNormal;
     glm::vec3 intersection;
     QVariantMap extraInfo;

--- a/tests-manual/render-texture-load/src/GLIHelpers.h
+++ b/tests-manual/render-texture-load/src/GLIHelpers.h
@@ -15,7 +15,7 @@
 // Work around for a bug in the MSVC compiler that chokes when you use GLI and Qt headers together.
 #define gli glm
 
-#ifdef Q_OS_MAC
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wignored-qualifiers"
@@ -33,7 +33,7 @@
 
 #include <gli/gli.hpp>
 
-#ifdef Q_OS_MAC
+#if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 


### PR DESCRIPTION
- fix uninitialized variable

https://highfidelity.fogbugz.com/f/cases/14680/RayToOverlayIntersectionResultToScriptValue-asan-warning
