### PR TITLE
fix divide-by-zero asan warning in LODManager::autoAdjustLOD

### DIFF
--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -70,7 +70,7 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
     // Note: we MUST clamp the blend to 1.0 for stability
     float blend = (realTimeDelta < LOD_ADJUST_RUNNING_AVG_TIMESCALE) ? realTimeDelta / LOD_ADJUST_RUNNING_AVG_TIMESCALE : 1.0f;
     _avgRenderTime = (1.0f - blend) * _avgRenderTime + blend * maxRenderTime; // msec
-    if (!_automaticLODAdjust) {
+    if (!_automaticLODAdjust || _avgRenderTime == 0.0f) {
         // early exit
         return;
     }


### PR DESCRIPTION
- fix divide-by-zero asan warning in LODManager::autoAdjustLOD

https://highfidelity.fogbugz.com/f/cases/14860/autoAdjustLOD-asan-warning
