### PR TITLE
MS14878: Prevent wallet passphrase leak in specific case

### DIFF
--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -789,10 +789,14 @@ var selectionDisplay = null; // for gridTool.js to ignore
     var savedDisablePreviewOptionLocked = false;
     var savedDisablePreviewOption = Menu.isOptionChecked("Disable Preview");;
     function maybeEnableHMDPreview() {
-        setTabletVisibleInSecondaryCamera(true);
-        DesktopPreviewProvider.setPreviewDisabledReason("USER");
-        Menu.setIsOptionChecked("Disable Preview", savedDisablePreviewOption);
-        savedDisablePreviewOptionLocked = false;
+        // Set a small timeout to prevent sensitive data from being shown during
+        // UI fade
+        Script.setTimeout(function () {
+            setTabletVisibleInSecondaryCamera(true);
+            DesktopPreviewProvider.setPreviewDisabledReason("USER");
+            Menu.setIsOptionChecked("Disable Preview", savedDisablePreviewOption);
+            savedDisablePreviewOptionLocked = false;
+        }, 150);
     }
 
     // Function Name: fromQml()


### PR DESCRIPTION
Fixes [MS14878](https://highfidelity.manuscript.com/f/cases/14878/After-entering-passphrase-in-VR-desktop-preview-reveals-passphrase-for-one-frame).

In VR mode, when entering the wallet's passphrase, the preview is disabled for privacy. However, without this PR, when submitting it, the preview is re-enabled too early. The completed passphrase screen was thus shown for one frame.