### PR TITLE
Fix size calculation of compressed textures

### DIFF
--- a/libraries/gpu/src/gpu/Format.h
+++ b/libraries/gpu/src/gpu/Format.h
@@ -50,47 +50,49 @@ enum Type : uint8_t {
 };
 // Array providing the size in bytes for a given scalar type
 static const int TYPE_SIZE[NUM_TYPES] = {
-    4,
-    4,
-    4,
-    2,
-    2,
-    2,
-    1,
-    1,
+    4, // FLOAT
+    4, // INT32
+    4, // UINT32
+    2, // HALF
+    2, // INT16
+    2, // UINT16
+    1, // INT8
+    1, // UINT8
 
     // normalized values
-    4,
-    4,
-    2,
-    2,
-    1,
-    1,
-    4,
+    4, // NINT32
+    4, // NUINT32
+    2, // NINT16 
+    2, // NUINT16
+    1, // NINT8
+    1, // NUINT8
+    1, // NUINT2
+    4, // NINT2_10_10_10
 
-    1
+    1, // COMPRESSED
 };
 // Array answering the question Does this type is integer or not 
 static const bool TYPE_IS_INTEGER[NUM_TYPES] = {
-    false,
-    true,
-    true,
-    false,
-    true,
-    true,
-    true,
-    true,
+    false, // FLOAT
+    true, // INT32
+    true, // UINT32
+    false, // HALF
+    true, // INT16
+    true, // UINT16
+    true, // INT8
+    true, // UINT8
 
     // Normalized values
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
+    false, // NINT32
+    false, // NUINT32
+    false, // NINT16 
+    false, // NUINT16
+    false, // NINT8
+    false, // NUINT8
+    false, // NUINT2
+    false, // NINT2_10_10_10
 
-    false,
+    false, // COMPRESSED
 };
 
 // Dimension of an Element
@@ -319,7 +321,7 @@ public:
     uint8 getLocationScalarCount() const { return DIMENSION_SCALAR_COUNT_PER_LOCATION[(Dimension)_dimension]; }
     uint32 getLocationSize() const { return DIMENSION_SCALAR_COUNT_PER_LOCATION[_dimension] * TYPE_SIZE[_type]; }
 
-    uint16 getRaw() const { return *((uint16*) (this)); }
+    uint32 getRaw() const { return *((uint32*) (this)); }
 
     
     bool operator ==(const Element& right) const {
@@ -366,10 +368,11 @@ public:
     static const Element INDEX_INT32;
     static const Element PART_DRAWCALL;
     
- protected:
+protected:
     uint8 _semantic;
-    uint8 _dimension : 4;
-    uint8 _type : 4;
+    uint8 _dimension;
+    uint8 _type;
+    uint8 _padding { 0 };
 };
 
   


### PR DESCRIPTION
Fix for [FB14897](https://highfidelity.manuscript.com/f/cases/14897/After-texture-transfer-is-done-allocated-and-populated-texture-memory-don-t-always-match)

A recent change to the supported formats for GPU data caused the number of total types of format to exceed 16, but the value stored in `gpu::Element` was being stored in a `uint8 _type : 4` field.  This meant that all compressed textures were having their size calculated incorrectly (multiplied by a factor of 4, since the value of 16 for `COMPRESSED` was being interpreted as `FLOAT` and thus each pixel was assumed to cost 4 bytes).  Because the texture management system would believe that we were using 4 times as much memory for any given compressed texture as we actually were this also means that textures that could have fit in memory were potentially not being uploaded.

This PR fixes the issue by changing the the `gpu::Element` structure from 16 to 32 bits, ensuring that the type field is large enough to contain the `COMPRESSED` value.  Additionally it adds missing elements to the `TYPE_IS_INTEGER` and `TYPE_SIZE` fields that were apparently missed when added `NUINT2`.



## Testing

Open interface and go to a domain with compressed textures.  Ensure the stats display is on (toggle with the `/` key).  Wait for the domain to finish loading and then wait for the textures to fully upload (the `pending` stat in the 4th column of the stats display will fall to zero.

In master builds, the allocated and populated values will not be the same.  Allocated will be higher, even after pending has dropped to zero.  In this PR build, once pending drops to zero, the allocated and pending values should be the same.  