### PR TITLE
MS3128: Remove vestigial Edit menu item

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1165,17 +1165,11 @@ function setupModelMenus() {
         });
         modelMenuAddedDelete = true;
     }
-    Menu.addMenuItem({
-        menuName: "Edit",
-        menuItemName: "Entity List...",
-        afterItem: "Entities",
-        grouping: "Advanced"
-    });
 
     Menu.addMenuItem({
         menuName: "Edit",
         menuItemName: "Parent Entity to Last",
-        afterItem: "Entity List...",
+        afterItem: "Entities",
         grouping: "Advanced"
     });
 
@@ -1297,7 +1291,6 @@ function cleanupModelMenus() {
 
     Menu.removeMenuItem("Edit", "Parent Entity to Last");
     Menu.removeMenuItem("Edit", "Unparent Entity");
-    Menu.removeMenuItem("Edit", "Entity List...");
     Menu.removeMenuItem("Edit", "Allow Selecting of Large Models");
     Menu.removeMenuItem("Edit", "Allow Selecting of Small Models");
     Menu.removeMenuItem("Edit", "Allow Selecting of Lights");
@@ -1659,8 +1652,6 @@ function handeMenuEvent(menuItem) {
             Window.promptTextChanged.connect(onPromptTextChanged);
             Window.promptAsync("URL of SVO to import", "");
         }
-    } else if (menuItem === "Entity List...") {
-        entityListTool.toggleVisible();
     } else if (menuItem === "Select All Entities In Box") {
         selectAllEtitiesInCurrentSelectionBox(false);
     } else if (menuItem === "Select All Entities Touching Box") {


### PR DESCRIPTION
"Fixes" [MS3128](https://highfidelity.fogbugz.com/f/cases/3128/User-should-not-be-able-to-delete-non-local-entities-if-edit-permissions-do-not-exist) by removing a vestigial Edit menu item that hasn't actually functioned for a while anyway.