### PR TITLE
remove highlight on entity when point to the sky

### DIFF
--- a/scripts/system/controllers/controllerModules/farActionGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farActionGrabEntity.js
@@ -564,6 +564,9 @@ Script.include("/~/system/libraries/Xform.js");
                     }
                 } else if (this.distanceRotating) {
                     this.distanceRotate(otherFarGrabModule);
+                } else if (this.highlightedEntity) {
+                    Selection.removeFromSelectedItemsList(DISPATCHER_HOVERING_LIST, "entity", this.highlightedEntity);
+                    this.highlightedEntity = null;
                 }
             }
             return this.exitIfDisabled(controllerData);

--- a/scripts/system/controllers/controllerModules/mouseHighlightEntities.js
+++ b/scripts/system/controllers/controllerModules/mouseHighlightEntities.js
@@ -63,6 +63,9 @@
                             this.highlightedEntity = targetEntityID;
                         }
                     }
+                } else if (this.highlightedEntity) {
+                    dispatcherUtils.unhighlightTargetEntity(this.highlightedEntity);
+                    this.highlightedEntity = null;
                 }
             }
 


### PR DESCRIPTION
Ticket - https://highfidelity.manuscript.com/f/cases/14896/Moving-laser-or-cursor-from-grabbable-object-to-the-sky-keeps-the-object-highlighted-temporarily