### PR TITLE
MS14937: Fix Replace button for content sets during Checkout

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -787,7 +787,7 @@ Rectangle {
                     }
                     lightboxPopup.button2text = "CONFIRM";
                     lightboxPopup.button2method = function() {
-                        Commerce.replaceContentSet(root.itemHref);
+                        Commerce.replaceContentSet(root.itemHref, root.certificateId);
                         lightboxPopup.visible = false;
                         rezzedNotifContainer.visible = true;
                         rezzedNotifContainerTimer.start();


### PR DESCRIPTION
Fixes [MS14937](https://highfidelity.manuscript.com/f/cases/14937/Replace-Content-Set-Confirm-Button-has-no-action). Was broken due to a silly mistake.