### PR TITLE
when in serverless mode, short-circuit simulation ownership bids

### DIFF
--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -77,7 +77,6 @@ void EntityEditPacketSender::queueEditAvatarEntityMessage(PacketType type,
     _myAvatar->updateAvatarEntity(entityItemID, binaryProperties);
 
     entity->setLastBroadcast(usecTimestampNow());
-    return;
 }
 
 
@@ -85,10 +84,6 @@ void EntityEditPacketSender::queueEditEntityMessage(PacketType type,
                                                     EntityTreePointer entityTree,
                                                     EntityItemID entityItemID,
                                                     const EntityItemProperties& properties) {
-    if (!_shouldSend) {
-        return; // bail early
-    }
-
     if (properties.getClientOnly() && properties.getOwningAvatarID() == _myAvatar->getID()) {
         // this is an avatar-based entity --> update our avatar-data rather than sending to the entity-server
         queueEditAvatarEntityMessage(type, entityTree, entityItemID, properties);
@@ -147,9 +142,6 @@ void EntityEditPacketSender::queueEditEntityMessage(PacketType type,
 }
 
 void EntityEditPacketSender::queueEraseEntityMessage(const EntityItemID& entityItemID) {
-    if (!_shouldSend) {
-        return; // bail early
-    }
 
     // in case this was a clientOnly entity:
     if(_myAvatar) {

--- a/libraries/octree/src/OctreeEditPacketSender.cpp
+++ b/libraries/octree/src/OctreeEditPacketSender.cpp
@@ -23,7 +23,6 @@ const int OctreeEditPacketSender::DEFAULT_MAX_PENDING_MESSAGES = PacketSender::D
 
 
 OctreeEditPacketSender::OctreeEditPacketSender() :
-    _shouldSend(true),
     _maxPendingMessages(DEFAULT_MAX_PENDING_MESSAGES),
     _releaseQueuedMessagesPending(false)
 {
@@ -146,10 +145,6 @@ void OctreeEditPacketSender::queuePendingPacketToNodes(std::unique_ptr<NLPacket>
 }
 
 void OctreeEditPacketSender::queuePacketToNodes(std::unique_ptr<NLPacket> packet) {
-    if (!_shouldSend) {
-        return; // bail early
-    }
-
     assert(serversExist()); // we must have servers to be here!!
 
     auto node = DependencyManager::get<NodeList>()->soloNodeOfType(getMyNodeType());
@@ -161,10 +156,6 @@ void OctreeEditPacketSender::queuePacketToNodes(std::unique_ptr<NLPacket> packet
 
 // NOTE: editMessage - is JUST the octcode/color and does not contain the packet header
 void OctreeEditPacketSender::queueOctreeEditMessage(PacketType type, QByteArray& editMessage) {
-
-    if (!_shouldSend) {
-        return; // bail early
-    }
 
     // If we don't have servers, then we will simply queue up all of these packets and wait till we have
     // servers for processing

--- a/libraries/octree/src/OctreeEditPacketSender.h
+++ b/libraries/octree/src/OctreeEditPacketSender.h
@@ -41,12 +41,10 @@ public:
 
     /// are we in sending mode. If we're not in sending mode then all packets and messages will be ignored and
     /// not queued and not sent
-    bool getShouldSend() const { return _shouldSend; }
 
     /// set sending mode. By default we are set to shouldSend=TRUE and packets will be sent. If shouldSend=FALSE, then we'll
     /// switch to not sending mode, and all packets and messages will be ignored, not queued, and not sent. This might be used
     /// in an application like interface when all octree features are disabled.
-    void setShouldSend(bool shouldSend) { _shouldSend = shouldSend; }
 
     /// if you're running in non-threaded mode, you must call this method regularly
     virtual bool process() override;
@@ -76,7 +74,6 @@ public slots:
 protected:
     using EditMessagePair = std::pair<PacketType, QByteArray>;
 
-    bool _shouldSend;
     void queuePacketToNode(const QUuid& nodeID, std::unique_ptr<NLPacket> packet);
     void queuePacketListToNode(const QUuid& nodeUUID, std::unique_ptr<NLPacketList> packetList);
 

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -349,7 +349,7 @@ bool EntityMotionState::remoteSimulationOutOfSync(uint32_t simulationStep) {
 
     if (_numInactiveUpdates > 0) {
         const uint8_t MAX_NUM_INACTIVE_UPDATES = 20;
-        if (_numInactiveUpdates > MAX_NUM_INACTIVE_UPDATES) {
+        if (_numInactiveUpdates > MAX_NUM_INACTIVE_UPDATES || isServerlessMode()) {
             // clear local ownership (stop sending updates) and let the server clear itself
             _entity->clearSimulationOwnership();
             return false;
@@ -832,4 +832,10 @@ void EntityMotionState::clearObjectVelocities() const {
         }
     }
     _entity->setAcceleration(glm::vec3(0.0f));
+}
+
+bool EntityMotionState::isServerlessMode() {
+    EntityTreeElementPointer element = _entity->getElement();
+    EntityTreePointer tree = element ? element->getTree() : nullptr;
+    return tree ? tree->isServerlessMode() : false;
 }

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -156,6 +156,8 @@ protected:
     uint8_t _numInactiveUpdates { 1 };
     uint8_t _bidPriority { 0 };
     bool _serverVariablesSet { false };
+
+    bool isServerlessMode();
 };
 
 #endif // hifi_EntityMotionState_h


### PR DESCRIPTION
- when in serverless mode, short-circuit simulation ownership bids


https://highfidelity.manuscript.com/f/cases/14927/Dynamic-Entities-in-Serverless-Tutorial-snap-back-to-their-point-of-release-after-being-thrown-or-bumped-by-the-user

this is the "master" version of https://github.com/highfidelity/hifi/pull/13137
