### PR TITLE
RC67: MS14951: Fix Snapshot hotkey sound playback

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2093,7 +2093,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         return entityServerNode && !isPhysicsEnabled();
     });
 
-    _snapshotSound = DependencyManager::get<SoundCache>()->getSound(PathUtils::resourcesUrl("sounds/snap.wav"));
+    _snapshotSound = DependencyManager::get<SoundCache>()->getSound(PathUtils::resourcesUrl("sounds/snapshot/snap.wav"));
 
     QVariant testProperty = property(hifi::properties::TEST);
     qDebug() << testProperty;


### PR DESCRIPTION
This was broken because of [#12924](https://github.com/highfidelity/hifi/pull/12924). I don't believe that Application.cpp should be the place where the Snapshot hotkey is handled - I think that should be in `snapshot.js` along with most of the other Snapshot logic. But - that is a problem for another time.