### PR TITLE
Reduced flickering with Temporal Anti-Aliasing

### DIFF
--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -301,6 +301,7 @@ void Antialiasing::configure(const Config& config) {
     _params.edit().regionInfo.x = config.debugX;
     _params.edit().regionInfo.z = config.debugFXAAX;
 
+    _params.edit().setAntiFlickeringEnabled(config.antiFlickering);
     _params.edit().setDebug(config.debug);
     _params.edit().setShowDebugCursor(config.showCursorPixel);
     _params.edit().setDebugCursor(config.debugCursorTexcoord);

--- a/libraries/render-utils/src/AntialiasingEffect.h
+++ b/libraries/render-utils/src/AntialiasingEffect.h
@@ -92,6 +92,7 @@ class AntialiasingConfig : public render::Job::Config {
 
     Q_PROPERTY(bool constrainColor MEMBER constrainColor NOTIFY dirty)
     Q_PROPERTY(bool feedbackColor MEMBER feedbackColor NOTIFY dirty)
+    Q_PROPERTY(bool antiFlickering MEMBER antiFlickering NOTIFY dirty)
 
     Q_PROPERTY(bool debug MEMBER debug NOTIFY dirty)
     Q_PROPERTY(float debugX MEMBER debugX NOTIFY dirty)
@@ -109,9 +110,10 @@ public:
     float blend{ 0.25f };
     float sharpen{ 0.05f };
 
-    bool constrainColor{ true };
     float covarianceGamma{ 0.65f };
+    bool constrainColor{ true };
     bool feedbackColor{ false };
+    bool antiFlickering{ true };
 
     float debugX{ 0.0f };
     float debugFXAAX{ 1.0f };
@@ -147,7 +149,10 @@ struct TAAParams {
     bool isFeedbackColor() const { return (bool)GET_BIT(flags.y, 4); }
 
     void setDebug(bool enabled) { SET_BIT(flags.x, 0, enabled); }
-    bool isDebug() const { return (bool) GET_BIT(flags.x, 0); }
+    bool isDebug() const { return (bool)GET_BIT(flags.x, 0); }
+
+    void setAntiFlickeringEnabled(bool enabled) { SET_BIT(flags.x, 2, enabled); }
+    bool isAntiFlickeringEnabled() const { return (bool)GET_BIT(flags.x, 2); }
 
     void setShowDebugCursor(bool enabled) { SET_BIT(flags.x, 1, enabled); }
     bool showDebugCursor() const { return (bool)GET_BIT(flags.x, 1); }

--- a/libraries/render-utils/src/AntialiasingEffect.h
+++ b/libraries/render-utils/src/AntialiasingEffect.h
@@ -58,7 +58,7 @@ class JitterSample {
 public:
 
     enum {
-        SEQUENCE_LENGTH = 64 
+        SEQUENCE_LENGTH = 16 
     };
 
     using Config = JitterSampleConfig;
@@ -97,7 +97,9 @@ class AntialiasingConfig : public render::Job::Config {
     Q_PROPERTY(bool debug MEMBER debug NOTIFY dirty)
     Q_PROPERTY(float debugX MEMBER debugX NOTIFY dirty)
     Q_PROPERTY(float debugFXAAX MEMBER debugFXAAX NOTIFY dirty)
-    Q_PROPERTY(float debugShowVelocityThreshold MEMBER debugShowVelocityThreshold NOTIFY dirty)
+    
+
+        Q_PROPERTY(float debugShowVelocityThreshold MEMBER debugShowVelocityThreshold NOTIFY dirty)
     Q_PROPERTY(bool showCursorPixel MEMBER showCursorPixel NOTIFY dirty)
     Q_PROPERTY(glm::vec2 debugCursorTexcoord MEMBER debugCursorTexcoord NOTIFY dirty)
     Q_PROPERTY(float debugOrbZoom MEMBER debugOrbZoom NOTIFY dirty)
@@ -110,7 +112,7 @@ public:
     float blend{ 0.25f };
     float sharpen{ 0.05f };
 
-    float covarianceGamma{ 0.65f };
+    float covarianceGamma{ 0.75f };
     bool constrainColor{ true };
     bool feedbackColor{ false };
     bool antiFlickering{ true };

--- a/libraries/render-utils/src/MaterialTextures.slh
+++ b/libraries/render-utils/src/MaterialTextures.slh
@@ -273,9 +273,25 @@ vec3 fetchLightmapMap(vec2 uv) {
 }
 <@endfunc@>
 
-<@func evalMaterialRoughness(fetchedRoughness, materialRoughness, matKey, roughness)@>
+<@func evalMaterialRoughness(normal, fetchedRoughness, materialRoughness, matKey, roughness)@>
 {
     <$roughness$> = (((<$matKey$> & ROUGHNESS_MAP_BIT) != 0) ? <$fetchedRoughness$> : <$materialRoughness$>);
+#if 1
+	{
+	// Isotropic normal distribution function filtering as proposed by Yusuke Tokuyoshi. This is used to limit aliasing of
+	// specular points.
+	// http://jp.square-enix.com/tech/library/pdf/Error%20Reduction%20and%20Simplification%20for%20Shading%20Anti-Aliasing.pdf
+	vec3 deltaU = dFdx(<$normal$>);
+	vec3 deltaV = dFdy(<$normal$>);
+	// Magic constants
+	float VARIANCE_SCALE = 0.3;
+	float KERNEL_ROUGHNESS_THRESHOLD = 1.0;
+
+	float variance = VARIANCE_SCALE * (dot(deltaU, deltaU) + dot(deltaV, deltaV));
+	float kernelSquaredRoughness = min(2.0 * variance, KERNEL_ROUGHNESS_THRESHOLD);
+	<$roughness$> = sqrt(clamp(<$roughness$> * <$roughness$> + kernelSquaredRoughness, 0.0, 1.0));
+	}
+#endif
 }
 <@endfunc@>
 

--- a/libraries/render-utils/src/forward_model.slf
+++ b/libraries/render-utils/src/forward_model.slf
@@ -44,9 +44,6 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
-    float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
-
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
@@ -56,6 +53,9 @@ void main(void) {
 
     vec3 fragPosition = _positionES.xyz;
     vec3 fragNormal = normalize(_normalWS);
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(fragNormal, roughnessTex, roughness, matKey, roughness)$>;
 
     TransformCamera cam = getTransformCamera();
 

--- a/libraries/render-utils/src/forward_model_normal_map.slf
+++ b/libraries/render-utils/src/forward_model_normal_map.slf
@@ -46,9 +46,6 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
-    float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
-
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
@@ -59,6 +56,9 @@ void main(void) {
     vec3 fragPosition = _positionES.xyz;
     vec3 fragNormal;
     <$evalMaterialNormal(normalTex, _normalWS, _tangentWS, fragNormal)$>
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(fragNormal, roughnessTex, roughness, matKey, roughness)$>;
 
     TransformCamera cam = getTransformCamera();
 

--- a/libraries/render-utils/src/forward_model_translucent.slf
+++ b/libraries/render-utils/src/forward_model_translucent.slf
@@ -46,9 +46,6 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
-    float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
-
     float metallic = getMaterialMetallic(mat);
     <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;
     vec3 fresnel = getFresnelF0(metallic, albedo);
@@ -58,6 +55,9 @@ void main(void) {
 
     vec3 fragPosition = _positionES.xyz;
     vec3 fragNormal = normalize(_normalWS);
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(fragNormal, roughnessTex, roughness, matKey, roughness)$>;
 
     TransformCamera cam = getTransformCamera();
 

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -39,8 +39,9 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
+	vec3 fragNormal = normalize(_normalWS);
     float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+    <$evalMaterialRoughness(fragNormal, roughnessTex, roughness, matKey, roughness)$>;
 
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
@@ -52,7 +53,7 @@ void main(void) {
     <$evalMaterialScattering(scatteringTex, scattering, matKey, scattering)$>;
 
     packDeferredFragment(
-        normalize(_normalWS), 
+        fragNormal, 
         opacity,
         albedo,
         roughness,

--- a/libraries/render-utils/src/model_fade.slf
+++ b/libraries/render-utils/src/model_fade.slf
@@ -48,8 +48,9 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
+	vec3 fragNormal = normalize(_normalWS);
     float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+    <$evalMaterialRoughness(fragNormal, roughnessTex, roughness, matKey, roughness)$>;
 
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
@@ -60,7 +61,7 @@ void main(void) {
     float scattering = getMaterialScattering(mat);
 
     packDeferredFragment(
-        normalize(_normalWS), 
+        fragNormal, 
         opacity,
         albedo,
         roughness,

--- a/libraries/render-utils/src/model_normal_map.slf
+++ b/libraries/render-utils/src/model_normal_map.slf
@@ -40,14 +40,14 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
-    float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
-
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
     vec3 fragNormalWS;
     <$evalMaterialNormalLOD(_positionES, normalTex, _normalWS, _tangentWS, fragNormalWS)$>
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(fragNormalWS, roughnessTex, roughness, matKey, roughness)$>;
 
     float metallic = getMaterialMetallic(mat);
     <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;

--- a/libraries/render-utils/src/model_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_normal_map_fade.slf
@@ -50,14 +50,14 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
-    float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
-
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
 
     vec3 fragNormalWS;
     <$evalMaterialNormalLOD(_positionES, normalTex, _normalWS, _tangentWS, fragNormalWS)$>
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(fragNormalWS, roughnessTex, roughness, matKey, roughness)$>;
 
     float metallic = getMaterialMetallic(mat);
     <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -49,9 +49,6 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
-    float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
-
     float metallic = getMaterialMetallic(mat);
     vec3 fresnel = getFresnelF0(metallic, albedo);
 
@@ -62,6 +59,9 @@ void main(void) {
     vec3 fragPositionWS = _positionWS.xyz;
     // Lighting is done in world space
     vec3 fragNormalWS = normalize(_normalWS);
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(fragNormalWS, roughnessTex, roughness, matKey, roughness)$>;
 
     TransformCamera cam = getTransformCamera();
     vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;

--- a/libraries/render-utils/src/model_translucent_fade.slf
+++ b/libraries/render-utils/src/model_translucent_fade.slf
@@ -51,9 +51,6 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
-    float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
-
     float metallic = getMaterialMetallic(mat);
     vec3 fresnel = getFresnelF0(metallic, albedo);
 
@@ -64,6 +61,9 @@ void main(void) {
     vec3 fragPositionWS = _positionWS.xyz;
     // Lighting is done in world space
     vec3 fragNormalWS = normalize(_normalWS);
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(fragNormalWS, roughnessTex, roughness, matKey, roughness)$>;
 
     TransformCamera cam = getTransformCamera();
     vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;

--- a/libraries/render-utils/src/model_translucent_normal_map.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map.slf
@@ -50,9 +50,6 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
-    float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
-
     float metallic = getMaterialMetallic(mat);
     vec3 fresnel = getFresnelF0(metallic, albedo);
 
@@ -64,6 +61,9 @@ void main(void) {
     // Lighting is done in world space
     vec3 fragNormalWS;
     <$evalMaterialNormalLOD(_positionES, normalTex, _normalWS, _tangentWS, fragNormalWS)$>
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(fragNormalWS, roughnessTex, roughness, matKey, roughness)$>;
 
     TransformCamera cam = getTransformCamera();
     vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;

--- a/libraries/render-utils/src/model_translucent_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map_fade.slf
@@ -59,9 +59,6 @@ void main(void) {
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
     albedo *= _color;
 
-    float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
-
     float metallic = getMaterialMetallic(mat);
     vec3 fresnel = getFresnelF0(metallic, albedo);
 
@@ -73,6 +70,9 @@ void main(void) {
     // Lighting is done in world space
     vec3 fragNormalWS;
     <$evalMaterialNormalLOD(_positionES, normalTex, _normalWS, _tangentWS, fragNormalWS)$>
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(fragNormalWS, roughnessTex, roughness, matKey, roughness)$>;
 
     TransformCamera cam = getTransformCamera();
     vec3 fragToEyeWS = cam._viewInverse[3].xyz - fragPositionWS;

--- a/libraries/render-utils/src/overlay3D_model.slf
+++ b/libraries/render-utils/src/overlay3D_model.slf
@@ -48,8 +48,9 @@ void main(void) {
     float metallic = getMaterialMetallic(mat);
     vec3 fresnel = getFresnelF0(metallic, albedo);
 
+	vec3 fragNormal = normalize(_normalWS);
     float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+    <$evalMaterialRoughness(fragNormal, roughnessTex, roughness, matKey, roughness)$>;
 
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
@@ -64,7 +65,7 @@ void main(void) {
         1.0,
         occlusionTex,
         fragPosition,
-        normalize(_normalWS),
+        fragNormal,
         albedo,
         fresnel,
         metallic,

--- a/libraries/render-utils/src/overlay3D_model_translucent.slf
+++ b/libraries/render-utils/src/overlay3D_model_translucent.slf
@@ -45,8 +45,9 @@ void main(void) {
     float metallic = getMaterialMetallic(mat);
     vec3 fresnel = getFresnelF0(metallic, albedo);
 
+	vec3 fragNormal = normalize(_normalWS);
     float roughness = getMaterialRoughness(mat);
-    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+    <$evalMaterialRoughness(fragNormal, roughnessTex, roughness, matKey, roughness)$>;
 
     vec3 emissive = getMaterialEmissive(mat);
     <$evalMaterialEmissive(emissiveTex, emissive, matKey, emissive)$>;
@@ -59,7 +60,7 @@ void main(void) {
         1.0,
         occlusionTex,
         fragPosition,
-        normalize(_normalWS),
+        fragNormal,
         albedo,
         fresnel,
         metallic,

--- a/libraries/render-utils/src/taa.slf
+++ b/libraries/render-utils/src/taa.slf
@@ -35,16 +35,19 @@ void main() {
     vec2 prevFragUV = taa_fetchSourceAndHistory(fragUV, fragVel, sourceColor, historyColor);
 
     vec3 nextColor = sourceColor;
+	float blend = params.blend;
  
     if (taa_constrainColor()) {
         // clamp history to neighbourhood of current sample
-        historyColor = taa_evalConstrainColor(sourceColor, fragUV, fragVel, historyColor);
+		vec4 historyColorAndBlend = taa_evalConstrainColor(sourceColor, fragUV, fragVel, historyColor);
+		historyColor.rgb = historyColorAndBlend.rgb;
+		blend = clamp(blend * historyColorAndBlend.a, 0.0, 1.0);
     }
-    
+
     if (taa_feedbackColor()) {
-        nextColor = taa_evalFeedbackColor(sourceColor, historyColor, params.blend);
+        nextColor = taa_evalFeedbackColor(sourceColor, historyColor, blend);
     } else {
-        nextColor = mix(historyColor, sourceColor, params.blend);
+        nextColor = mix(historyColor, sourceColor, blend);
     }
 
     outFragColor = vec4(taa_resolveColor(nextColor), 1.0);

--- a/libraries/render-utils/src/taa.slh
+++ b/libraries/render-utils/src/taa.slh
@@ -46,6 +46,10 @@ bool taa_showDebugCursor() {
     return GET_BIT(params.flags.x, 1);
 }
 
+bool taa_isAntiFlickeringEnabled() {
+    return GET_BIT(params.flags.x, 2);
+}
+
 bool taa_showClosestFragment() {
     return GET_BIT(params.flags.x, 3);
 }
@@ -410,13 +414,22 @@ vec3 taa_clampColor(vec3 colorMin, vec3 colorMax, vec3 colorSource, vec3 color) 
 		return q;// point inside aabb		
 }
 
-vec3 taa_evalConstrainColor(vec3 sourceColor, vec2 sourceUV, vec2 sourceVel, vec3 candidateColor) {
+vec4 taa_evalConstrainColor(vec3 sourceColor, vec2 sourceUV, vec2 sourceVel, vec3 candidateColor) {
     mat3 colorMinMaxAvg;
 
     colorMinMaxAvg = taa_evalNeighbourColorVariance(sourceColor, sourceUV, sourceVel);
-     
-	// clamp history to neighbourhood of current sample
-    return taa_clampColor(colorMinMaxAvg[0], colorMinMaxAvg[1], sourceColor, candidateColor);
+    
+    float blendAdjust = 1.0;
+    if (taa_isAntiFlickeringEnabled()) {
+        // Anti-flickering, based on Brian Karis talk @Siggraph 2014
+        // https://de45xmedrsdbp.cloudfront.net/Resources/files/TemporalAA_small-59732822.pdf
+        // Reduce blend factor when history is near clamping
+        float distToClamp = min(abs(colorMinMaxAvg[0].x - candidateColor.x), abs(colorMinMaxAvg[1].x - candidateColor.x));
+        blendAdjust = distToClamp / (distToClamp + colorMinMaxAvg[1].x - colorMinMaxAvg[0].x);
+    }
+
+    candidateColor = taa_clampColor(colorMinMaxAvg[0], colorMinMaxAvg[1], sourceColor, candidateColor);
+    return vec4(candidateColor, blendAdjust);
 }
 
 vec3 taa_evalFeedbackColor(vec3 sourceColor, vec3 historyColor, float blendFactor) {

--- a/scripts/developer/utilities/render/antialiasing.qml
+++ b/scripts/developer/utilities/render/antialiasing.qml
@@ -103,6 +103,13 @@ Rectangle {
             Separator {}          
             HifiControls.CheckBox {
                 boxSize: 20
+                text: "Anti-Flickering"
+                checked: Render.getConfig("RenderMainView.Antialiasing")["antiFlickering"]
+                onCheckedChanged: { Render.getConfig("RenderMainView.Antialiasing")["antiFlickering"] = checked }
+            }
+            Separator {}          
+            HifiControls.CheckBox {
+                boxSize: 20
                 text: "Feedback history color"
                 checked: Render.getConfig("RenderMainView.Antialiasing")["feedbackColor"]
                 onCheckedChanged: { Render.getConfig("RenderMainView.Antialiasing")["feedbackColor"] = checked }


### PR DESCRIPTION
This PR adds two small fixes to reduce the distracting flickering that can happen when using TAA, especially on reduced resolution devices like HMD.

1. Adds a modification to the shader, as proposed by Unreal 4 talk, to adapt TAA strength based on difference between previous pixel and new pixel color (basically...)
2. Adjusts roughness per pixel based on rate of change of normal between pixels, to limit bright specular highlight flickering.

# TEST PLAN
Material and Anti-Aliasing tests should be used, respectively in _hifi_tests/tests/engine/render/material_ and _hifi_tests/tests/engine/render/antialiasing_. A hifi_test PR has been proposed with updated screenshots.

This PR should also be checked "manually" on various domains with HMD.
