### PR TITLE
RC67.1: Fixed procedural shaders

### DIFF
--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -251,7 +251,7 @@ void ZoneEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scen
         updateAmbientLightFromEntity(entity);
     }
 
-    if (skyboxChanged) {
+    if (skyboxChanged || _proceduralUserData != entity->getUserData()) {
         updateKeyBackgroundFromEntity(entity);
     }
 
@@ -292,6 +292,10 @@ bool ZoneEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPoint
         return true;
     }
     if (entity->getWorldOrientation() != _lastRotation) {
+        return true;
+    }
+
+    if (entity->getUserData() != _proceduralUserData) {
         return true;
     }
 

--- a/libraries/render-utils/src/forward_simple.slf
+++ b/libraries/render-utils/src/forward_simple.slf
@@ -16,10 +16,20 @@
 <@include ForwardGlobalLight.slh@>
 <$declareEvalSkyboxGlobalColor()$>
 
+
 // the interpolated normal
 in vec3 _normalWS;
+in vec3 _normalMS;
 in vec4 _color;
+in vec2 _texCoord0;
+in vec4 _positionMS;
 in vec4 _positionES;
+
+// For retro-compatibility
+#define _normal      _normalWS
+#define _modelNormal _normalMS
+#define _position    _positionMS
+#define _eyePosition _positionES
 
 layout(location = 0) out vec4 _fragColor0;
 

--- a/libraries/render-utils/src/forward_simple_transparent.slf
+++ b/libraries/render-utils/src/forward_simple_transparent.slf
@@ -18,8 +18,17 @@
 
 // the interpolated normal
 in vec3 _normalWS;
+in vec3 _normalMS;
 in vec4 _color;
+in vec2 _texCoord0;
+in vec4 _positionMS;
 in vec4 _positionES;
+
+// For retro-compatibility
+#define _normal      _normalWS
+#define _modelNormal _normalMS
+#define _position    _positionMS
+#define _eyePosition _positionES
 
 layout(location = 0) out vec4 _fragColor0;
 

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -16,7 +16,17 @@
 
 // the interpolated normal
 in vec3 _normalWS;
+in vec3 _normalMS;
 in vec4 _color;
+in vec2 _texCoord0;
+in vec4 _positionMS;
+in vec4 _positionES;
+
+// For retro-compatibility
+#define _normal			_normalWS
+#define _modelNormal	_normalMS
+#define _position		_positionMS
+#define _eyePosition	_positionES
 
 //PROCEDURAL_COMMON_BLOCK
 

--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -23,10 +23,10 @@ in vec4 _positionMS;
 in vec4 _positionES;
 
 // For retro-compatibility
-#define _normal			_normalWS
-#define _modelNormal	_normalMS
-#define _position		_positionMS
-#define _eyePosition	_positionES
+#define _normal      _normalWS
+#define _modelNormal _normalMS
+#define _position    _positionMS
+#define _eyePosition _positionES
 
 //PROCEDURAL_COMMON_BLOCK
 

--- a/libraries/render-utils/src/simple_fade.slf
+++ b/libraries/render-utils/src/simple_fade.slf
@@ -27,10 +27,10 @@ in vec4 _positionES;
 in vec4 _positionWS;
 
 // For retro-compatibility
-#define _normal			_normalWS
-#define _modelNormal	_normalMS
-#define _position		_positionMS
-#define _eyePosition	_positionES
+#define _normal      _normalWS
+#define _modelNormal _normalMS
+#define _position    _positionMS
+#define _eyePosition _positionES
 
 //PROCEDURAL_COMMON_BLOCK
 

--- a/libraries/render-utils/src/simple_fade.slf
+++ b/libraries/render-utils/src/simple_fade.slf
@@ -19,8 +19,18 @@
 
 // the interpolated normal
 in vec3 _normalWS;
+in vec3 _normalMS;
 in vec4 _color;
+in vec2 _texCoord0;
+in vec4 _positionMS;
+in vec4 _positionES;
 in vec4 _positionWS;
+
+// For retro-compatibility
+#define _normal			_normalWS
+#define _modelNormal	_normalMS
+#define _position		_positionMS
+#define _eyePosition	_positionES
 
 //PROCEDURAL_COMMON_BLOCK
 

--- a/libraries/render-utils/src/simple_transparent.slf
+++ b/libraries/render-utils/src/simple_transparent.slf
@@ -16,7 +16,17 @@
 
 // the interpolated normal
 in vec3 _normalWS;
+in vec3 _normalMS;
 in vec4 _color;
+in vec2 _texCoord0;
+in vec4 _positionMS;
+in vec4 _positionES;
+
+// For retro-compatibility
+#define _normal      _normalWS
+#define _modelNormal _normalMS
+#define _position    _positionMS
+#define _eyePosition _positionES
 
 //PROCEDURAL_COMMON_BLOCK
 


### PR DESCRIPTION
Same fix as PR12992 but in rc67 branch, fb14812

This PR fixes procedural shaders when they are referencing position and normal attributes comming out of vertex shader.

TEST PLAN
visit hifi://windwaker/-5557.91,-4986.3,-5055.39/0,0.951511,0,-0.307615 and see that the floor represent a light blue ocean look:
![image](https://user-images.githubusercontent.com/2230265/39909506-ff4341c2-54a7-11e8-9560-fcab0d39014a.png)
IN current stable i see this:
![image](https://user-images.githubusercontent.com/2230265/39908937-49bb2740-54a5-11e8-8a47-2d61da9355e0.png)


visit hifi://azooz/-0.66171,30.2853,2.64812/0,-0.0625808,0,0.99804 and see the lava floor should look like so:
![image](https://user-images.githubusercontent.com/2230265/39909777-1730841a-54a9-11e8-9793-4402eefe3eaf.png)
In current stable i see this instead:
![image](https://user-images.githubusercontent.com/2230265/39909819-4b5d202c-54a9-11e8-8c63-e77c49e89b0f.png)

visit hifi://porange/5130.68,-5471.28,-4918.68/0,0.998192,0,0.0601041 and see the vertical sign that represent the test "porange":
![image](https://user-images.githubusercontent.com/2230265/39910042-41f3f5b4-54aa-11e8-830f-75699be93cef.png)

In Current stable i see this:
![image](https://user-images.githubusercontent.com/2230265/39909976-f2dc33ec-54a9-11e8-904a-8bb34f22c6fb.png)

https://highfidelity.fogbugz.com/f/cases/14812/shaders-that-use-_position-are-broken