### PR TITLE
[RC67.1] Bug fix for Vive Tracker Calibration Settings

### DIFF
--- a/interface/resources/qml/hifi/tablet/ControllerSettings.qml
+++ b/interface/resources/qml/hifi/tablet/ControllerSettings.qml
@@ -172,7 +172,7 @@ StackView {
             source: InputConfiguration.configurationLayout(box.currentText);
             onLoaded: {
                 if (loader.item.hasOwnProperty("pluginName")) {
-                    if (box.currentText === "Vive") {
+                    if (box.currentText === "HTC Vive") {
                         loader.item.pluginName = "OpenVR";
                     } else {
                         loader.item.pluginName = box.currentText;


### PR DESCRIPTION
This issue was inadvertently introduced by the name change of the Vive display plugin.