### PR TITLE
Bug fix for Manuscript issue 15019 : "Translucent Model over Procedural SHader is broken"

### DIFF
--- a/libraries/graphics/src/graphics/skybox.slf
+++ b/libraries/graphics/src/graphics/skybox.slf
@@ -35,8 +35,11 @@ void main(void) {
 #ifdef PROCEDURAL
 
     vec3 color = getSkyboxColor();
-     // Procedural Shaders are expected to be Gamma corrected so let's bring back the RGB in linear space for the rest of the pipeline
-     color = pow(color, vec3(2.2));
+    // Protect from NaNs and negative values
+    color = mix(color, vec3(0), isnan(color));
+    color = max(color, vec3(0));
+    // Procedural Shaders are expected to be Gamma corrected so let's bring back the RGB in linear space for the rest of the pipeline
+    color = pow(color, vec3(2.2));
     _fragColor = vec4(color, 0.0);
 
     // FIXME: scribe does not yet scrub out else statements

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -270,18 +270,24 @@ void Procedural::prepare(gpu::Batch& batch, const glm::vec3& position, const glm
         // Leave this here for debugging
         // qCDebug(procedural) << "FragmentShader:\n" << fragmentShaderSource.c_str();
 
+		gpu::Shader::BindingSet slotBindings;
+		slotBindings.insert(gpu::Shader::Binding(std::string("iChannel0"), 0));
+		slotBindings.insert(gpu::Shader::Binding(std::string("iChannel1"), 1));
+		slotBindings.insert(gpu::Shader::Binding(std::string("iChannel2"), 2));
+		slotBindings.insert(gpu::Shader::Binding(std::string("iChannel3"), 3));
+
         _opaqueFragmentShader = gpu::Shader::createPixel(opaqueShaderSource);
         _opaqueShader = gpu::Shader::createProgram(_vertexShader, _opaqueFragmentShader);
-        _transparentFragmentShader = gpu::Shader::createPixel(transparentShaderSource);
-        _transparentShader = gpu::Shader::createProgram(_vertexShader, _transparentFragmentShader);
+		gpu::Shader::makeProgram(*_opaqueShader, slotBindings);
 
-        gpu::Shader::BindingSet slotBindings;
-        slotBindings.insert(gpu::Shader::Binding(std::string("iChannel0"), 0));
-        slotBindings.insert(gpu::Shader::Binding(std::string("iChannel1"), 1));
-        slotBindings.insert(gpu::Shader::Binding(std::string("iChannel2"), 2));
-        slotBindings.insert(gpu::Shader::Binding(std::string("iChannel3"), 3));
-        gpu::Shader::makeProgram(*_opaqueShader, slotBindings);
-        gpu::Shader::makeProgram(*_transparentShader, slotBindings);
+		if (!transparentShaderSource.empty() && transparentShaderSource != opaqueShaderSource) {
+			_transparentFragmentShader = gpu::Shader::createPixel(transparentShaderSource);
+			_transparentShader = gpu::Shader::createProgram(_vertexShader, _transparentFragmentShader);
+			gpu::Shader::makeProgram(*_transparentShader, slotBindings);
+		} else {
+			_transparentFragmentShader = _opaqueFragmentShader;
+			_transparentShader = _opaqueShader;
+		}
 
         _opaquePipeline = gpu::Pipeline::create(_opaqueShader, _opaqueState);
         _transparentPipeline = gpu::Pipeline::create(_transparentShader, _transparentState);


### PR DESCRIPTION
[Reference manuscript bug link](https://highfidelity.fogbugz.com/f/cases/15019/Translucent-Model-over-Procedural-SHader-is-broken).
Issue was with procedural sky shader producing negative color values, which once transformed to linear color space for further processing produced NaN values which completely broke the blend with the transparent object.

Current (maybe temporary) fix is to clamp negative values and NaNs coming from procedural shader to 0.

There was also a shader compilation error when procedurals do not produce a transparent shader. Now, if this is the case, the transparent shader is assumed to be the same as the opaque one.

# QUESTIONS
Should we protect in a similar manner other types of procedural shaders? 
Should we let the user break the shading with negative values and NaNs?
Or maybe produce weird but valid colors (magenta, cyan, etc..) when this happens so that it pops out but without breaking the following rendering passes?

# TEST PLAN
Should test with as many procedural skys as possible with transparent objects in front.

Follow the repro steps of the bug referenced above

for example in Asimov i now see the correct result expected with this pr:
![image](https://user-images.githubusercontent.com/2230265/39930272-1f37693a-54ef-11e8-9b45-d01caa3375f9.png)

ANd in porange same issue fixed too:
![image](https://user-images.githubusercontent.com/2230265/39930411-82af3416-54ef-11e8-9847-6d825ec82eb5.png)

