### PR TITLE
Move down OctreeQueryNode::_viewMutex to OctreeQuery

### DIFF
--- a/libraries/octree/src/OctreeQuery.h
+++ b/libraries/octree/src/OctreeQuery.h
@@ -60,6 +60,7 @@ public slots:
     void setBoundaryLevelAdjust(int boundaryLevelAdjust) { _boundaryLevelAdjust = boundaryLevelAdjust; }
 
 protected:
+    QMutex _conicalViewsLock;
     ConicalViewFrustums _conicalViews;
 
     // octree server sending items

--- a/libraries/octree/src/OctreeQuery.h
+++ b/libraries/octree/src/OctreeQuery.h
@@ -33,9 +33,10 @@ public:
     int getBroadcastData(unsigned char* destinationBuffer);
     int parseData(ReceivedMessage& message) override;
 
-    bool hasConicalViews() const { return !_conicalViews.empty(); }
-    void setConicalViews(ConicalViewFrustums views) { _conicalViews = views; }
-    void clearConicalViews() { _conicalViews.clear(); }
+    bool hasConicalViews() const { QMutexLocker lock(&_conicalViewsLock); return !_conicalViews.empty(); }
+    void setConicalViews(ConicalViewFrustums views)
+        { QMutexLocker lock(&_conicalViewsLock); _conicalViews = views; }
+    void clearConicalViews() { QMutexLocker lock(&_conicalViewsLock); _conicalViews.clear(); }
 
     // getters/setters for JSON filter
     QJsonObject getJSONParameters() { QReadLocker locker { &_jsonParametersLock }; return _jsonParameters; }
@@ -60,7 +61,7 @@ public slots:
     void setBoundaryLevelAdjust(int boundaryLevelAdjust) { _boundaryLevelAdjust = boundaryLevelAdjust; }
 
 protected:
-    QMutex _conicalViewsLock;
+    mutable QMutex _conicalViewsLock;
     ConicalViewFrustums _conicalViews;
 
     // octree server sending items

--- a/libraries/octree/src/OctreeQueryNode.cpp
+++ b/libraries/octree/src/OctreeQueryNode.cpp
@@ -153,7 +153,7 @@ bool OctreeQueryNode::updateCurrentViewFrustum() {
     bool currentViewFrustumChanged = false;
 
     { // if there has been a change, then recalculate
-        QMutexLocker viewLocker(&_viewMutex);
+        QMutexLocker lock(&_conicalViewsLock);
 
         if (_conicalViews.size() == _currentConicalViews.size()) {
             for (size_t i = 0; i < _conicalViews.size(); ++i) {

--- a/libraries/octree/src/OctreeQueryNode.h
+++ b/libraries/octree/src/OctreeQueryNode.h
@@ -95,7 +95,6 @@ private:
     int _duplicatePacketCount { 0 };
     quint64 _firstSuppressedPacket { usecTimestampNow() };
 
-    mutable QMutex _viewMutex { QMutex::Recursive };
     ConicalViewFrustums _currentConicalViews;
     bool _viewFrustumChanging { false };
     bool _viewFrustumJustStoppedChanging { true };


### PR DESCRIPTION
I was getting what looked very much like a race collision on the _conicalViews vector, with it being cleared while in-use. I moved down the lock in OctreeQueryNode to the base OctreeQuery and used it for _conicalViews also. I could just use a second lock instead if that's preferable. This may be related to issue #14165:
https://highfidelity.manuscript.com/f/cases/14165/entity-server-doesn-t-always-relay-added-entities-to-clients

I set up a second machine to observe my local domain.  I was able to import the 64 cubes file in my local Interface and observe them on the remote interface. I was not able to find any obvious problem with the entity distributing logic.
