### PR TITLE
Desktop equip: fix unequipping with capital U

### DIFF
--- a/scripts/system/controllers/controllerModules/equipEntity.js
+++ b/scripts/system/controllers/controllerModules/equipEntity.js
@@ -828,7 +828,7 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
     };
     
     var onKeyPress = function(event) {
-        if (event.text === UNEQUIP_KEY) {
+        if (event.text.toLowerCase() === UNEQUIP_KEY) {
             if (rightEquipEntity.targetEntityID) {
                 rightEquipEntity.endEquipEntity();
             }


### PR DESCRIPTION
Test Plan:
-In desktop mode rez an equippable entity and left-click after exiting Create menu to equip it
-Press U to unequip
-Turn on Caps Lock and left-click the entity to equip it again
-Press U to unequip still works as expected