### PR TITLE
MS15090: Fix gifting when running marketplaces.js separately

### DIFF
--- a/scripts/system/marketplaces/marketplaces.js
+++ b/scripts/system/marketplaces/marketplaces.js
@@ -19,6 +19,7 @@ var selectionDisplay = null; // for gridTool.js to ignore
 
     Script.include("/~/system/libraries/WebTablet.js");
     Script.include("/~/system/libraries/gridTool.js");
+    Script.include("/~/system/libraries/connectionUtils.js");
 
     var METAVERSE_SERVER_URL = Account.metaverseServerURL;
     var MARKETPLACE_URL = METAVERSE_SERVER_URL + "/marketplace";


### PR DESCRIPTION
Fixes [MS15090](https://highfidelity.manuscript.com/f/cases/15090/Gifting-to-recipients-fails-when-running-marketplace-script-separately#BugEvent.94659).