### PR TITLE
TAA fix for highlight

### DIFF
--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -482,16 +482,14 @@ JitterSample::SampleSequence::SampleSequence(){
 }
 
 void JitterSample::configure(const Config& config) {
-    _freeze = config.freeze;
-    if (config.stop || _freeze) {
+    _freeze = config.stop || config.freeze;
+    if (config.freeze) {
         auto pausedIndex = config.getIndex();
         if (_sampleSequence.currentIndex != pausedIndex) {
             _sampleSequence.currentIndex = pausedIndex;
         }
-    } else {
-        if (_sampleSequence.currentIndex < 0) {
-            _sampleSequence.currentIndex = config.getIndex();
-        }
+    } else if (config.stop) {
+        _sampleSequence.currentIndex = -1;
     }
     _scale = config.scale;
 }
@@ -505,7 +503,12 @@ void JitterSample::run(const render::RenderContextPointer& renderContext, Output
             current = -1;
         }
     }
-    jitter = _sampleSequence.offsets[(current < 0 ? SEQUENCE_LENGTH : current)];
+
+    jitter.x = 0.0f;
+    jitter.y = 0.0f;
+    if (current >= 0) {
+        jitter = _sampleSequence.offsets[current];
+    }
 }
 
 

--- a/libraries/render-utils/src/HighlightEffect.h
+++ b/libraries/render-utils/src/HighlightEffect.h
@@ -113,7 +113,7 @@ private:
 class DrawHighlightMask {
 public:
 
-    using Inputs = render::VaryingSet2<render::ShapeBounds, HighlightRessourcesPointer>;
+    using Inputs = render::VaryingSet3<render::ShapeBounds, HighlightRessourcesPointer, glm::vec2>;
     using Outputs = glm::ivec4;
     using JobModel = render::Job::ModelIO<DrawHighlightMask, Inputs, Outputs>;
 
@@ -182,7 +182,7 @@ signals:
 
 class DebugHighlight {
 public:
-    using Inputs = render::VaryingSet2<HighlightRessourcesPointer, glm::ivec4>;
+    using Inputs = render::VaryingSet3<HighlightRessourcesPointer, glm::ivec4, glm::vec2>;
     using Config = DebugHighlightConfig;
     using JobModel = render::Job::ModelI<DebugHighlight, Inputs, Config>;
 
@@ -205,7 +205,7 @@ private:
 class DrawHighlightTask {
 public:
 
-    using Inputs = render::VaryingSet4<RenderFetchCullSortTask::BucketList, DeferredFramebufferPointer, gpu::FramebufferPointer, DeferredFrameTransformPointer>;
+    using Inputs = render::VaryingSet5<RenderFetchCullSortTask::BucketList, DeferredFramebufferPointer, gpu::FramebufferPointer, DeferredFrameTransformPointer, glm::vec2>;
     using Config = render::Task::Config;
     using JobModel = render::Task::ModelI<DrawHighlightTask, Inputs, Config>;
 

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -41,7 +41,7 @@ protected:
 
 class DrawDeferred {
 public:
-    using Inputs = render::VaryingSet3 <render::ItemBounds, LightingModelPointer, LightClustersPointer>;
+    using Inputs = render::VaryingSet4<render::ItemBounds, LightingModelPointer, LightClustersPointer, glm::vec2>;
     using Config = DrawDeferredConfig;
     using JobModel = render::Job::ModelI<DrawDeferred, Inputs, Config>;
 

--- a/libraries/render/src/render/DrawStatus.cpp
+++ b/libraries/render/src/render/DrawStatus.cpp
@@ -104,13 +104,16 @@ void DrawStatus::configure(const Config& config) {
     _showNetwork = config.showNetwork;
 }
 
-void DrawStatus::run(const RenderContextPointer& renderContext, const ItemBounds& inItems) {
+void DrawStatus::run(const RenderContextPointer& renderContext, const Input& input) {
     assert(renderContext->args);
     assert(renderContext->args->hasViewFrustum());
     RenderArgs* args = renderContext->args;
     auto& scene = renderContext->_scene;
     const int NUM_STATUS_VEC4_PER_ITEM = 2;
     const int VEC4_LENGTH = 4;
+
+    const auto& inItems = input.get0();
+    const auto jitter = input.get1();
 
     // FIrst thing, we collect the bound and the status for all the items we want to render
     int nbItems = 0;
@@ -171,6 +174,7 @@ void DrawStatus::run(const RenderContextPointer& renderContext, const ItemBounds
         batch.setViewportTransform(args->_viewport);
 
         batch.setProjectionTransform(projMat);
+        batch.setProjectionJitter(jitter.x, jitter.y);
         batch.setViewTransform(viewMat, true);
         batch.setModelTransform(Transform());
 

--- a/libraries/render/src/render/DrawStatus.h
+++ b/libraries/render/src/render/DrawStatus.h
@@ -39,13 +39,14 @@ namespace render {
     class DrawStatus {
     public:
         using Config = DrawStatusConfig;
-        using JobModel = Job::ModelI<DrawStatus, ItemBounds, Config>;
+        using Input = VaryingSet2<ItemBounds, glm::vec2>;
+        using JobModel = Job::ModelI<DrawStatus, Input, Config>;
 
         DrawStatus() {}
         DrawStatus(const gpu::TexturePointer statusIconMap) { setStatusIconMap(statusIconMap); }
 
         void configure(const Config& config);
-        void run(const RenderContextPointer& renderContext, const ItemBounds& inItems);
+        void run(const RenderContextPointer& renderContext, const Input& input);
 
         const gpu::PipelinePointer getDrawItemBoundsPipeline();
         const gpu::PipelinePointer getDrawItemStatusPipeline();


### PR DESCRIPTION
This PR fixes a bug with the Highlight effect when TAA was enabled which could display a highly distracting flickering bug on objects highlighted with a fill color.

This fixes one of the bugs identified by _jyoum_ in [issue 15110](https://highfidelity.fogbugz.com/f/cases/15110/Users-reporting-blurring-issues-with-the-new-TAA-feature-desktop-and-HMD).

Bug 15122

# TEST PLAN
Use _hifi_tests\tests\engine\render\effect\highlight_. Filled highlights should be stable and shouldn't display any z-fighting type effect. This should also be checked on HMD.