### PR TITLE
[DNM][Case 7734] Asset Browser: Drag & Drop Export Functionality

### DIFF
--- a/interface/resources/qml/hifi/AssetServer.qml
+++ b/interface/resources/qml/hifi/AssetServer.qml
@@ -761,9 +761,19 @@ Windows.ScrollingWindow {
             MouseArea {
                 id: treeViewMousePad
 
+                property var wantDebug: false
+
                 propagateComposedEvents: true
                 anchors.fill: parent
                 acceptedButtons: Qt.RightButton
+
+                function printLog(msg) {
+                    if (!wantDebug) {
+                        return;
+                    }
+
+                    console.log( msg );
+                }
 
                 onClicked: {
                     if (treeView.selection.hasSelection && !HMD.active) {  // Popup only displays properly on desktop
@@ -782,30 +792,30 @@ Windows.ScrollingWindow {
                 }// End_OF( treeViewMousePad::onClicked )
 
                 onPressAndHold: {
-                    console.log("AssetServer.qml - treeViewMousePad::onPressAndHold - Triggered");
+                    printLog("AssetServer.qml - treeViewMousePad::onPressAndHold - Triggered");
                     if (drag.target == null) {
                         var index = treeView.indexAt(mouse.x, mouse.y);
                         if ( index !== treeView.currentIndex ) {
-                            console.log("AssetServer.qml - treeViewMousePad::onPressAndHold - Hold not triggered on current index.");
+                            printLog("AssetServer.qml - treeViewMousePad::onPressAndHold - Hold not triggered on current index.");
                             treeView.selection.setCurrentIndex(index, ItemSelectionModel.ClearAndSelect);
                         }
-                        console.log("AssetServer.qml - treeViewMousePad::onPressAndHold - Attempting to mark held selection.");
+                        printLog("AssetServer.qml - treeViewMousePad::onPressAndHold - Attempting to mark held selection.");
                         treeView.markIndexForDrag(index);
                     }
                 }// End_OF( treeViewMousePad::onPressAndHold )
 
                 onEntered: {
-                    console.log("AssetServer.qml - treeViewMousePad::onEntered");
+                    printLog("AssetServer.qml - treeViewMousePad::onEntered");
                 }// End_OF( treeViewMousePad::onEntered )
 
                 onExited: {
-                    console.log("AssetServer.qml - treeViewMousePad::onExited");
+                    printLog("AssetServer.qml - treeViewMousePad::onExited");
                 }// End_OF( treeViewMousePad::onExited )
 
                 onReleased: {
-                    console.log("AssetServer.qml - treeViewMousePad::onRelease - Triggered");
-                    console.log("AssetServer.qml - assetExportArea.state is: " + assetExportArea.state);
-                    console.log("AssetServer.qml - assetBrowseArea.state is: " + assetBrowseArea.state);
+                    printLog("AssetServer.qml - treeViewMousePad::onRelease - Triggered");
+                    printLog("AssetServer.qml - assetExportArea.state is: " + assetExportArea.state);
+                    printLog("AssetServer.qml - assetBrowseArea.state is: " + assetBrowseArea.state);
                     if (!mouse.wasHeld) {
                         //--EARLY EXIT--( no need to go farther )
                         return;
@@ -813,7 +823,7 @@ Windows.ScrollingWindow {
 
                     if ((drag.target !== null)) {
                         if (assetExportArea.state === "inExportArea") {
-                            console.log("AssetServer.qml - treeViewMousePad::onRelease - Attempting to trigger drop action.");
+                            printLog("AssetServer.qml - treeViewMousePad::onRelease - Attempting to trigger drop action.");
                             drag.target.Drag.drop();
                         }
 

--- a/interface/resources/qml/js/Utils_AssetServerQml.js
+++ b/interface/resources/qml/js/Utils_AssetServerQml.js
@@ -1,0 +1,69 @@
+.pragma library //< Should only ever have a single instance of this script when imported with QML file
+
+
+// @note: Entity Export Section
+var SHAPE_TYPE_NONE = 0;
+var SHAPE_TYPE_SIMPLE_HULL = 1;
+var SHAPE_TYPE_SIMPLE_COMPOUND = 2;
+var SHAPE_TYPE_STATIC_MESH = 3;
+var SHAPE_TYPE_BOX = 4;
+var SHAPE_TYPE_SPHERE = 5;
+
+var SHAPE_TYPE_DEFAULT = SHAPE_TYPE_SIMPLE_COMPOUND;
+var DYNAMIC_DEFAULT = false;
+
+var SHAPE_TYPES = [];
+SHAPE_TYPES[SHAPE_TYPE_NONE] = "none";
+SHAPE_TYPES[SHAPE_TYPE_SIMPLE_HULL] = "simple-hull";
+SHAPE_TYPES[SHAPE_TYPE_SIMPLE_COMPOUND] = "simple-compound";
+SHAPE_TYPES[SHAPE_TYPE_STATIC_MESH] = "static-mesh";
+SHAPE_TYPES[SHAPE_TYPE_BOX] = "box";
+SHAPE_TYPES[SHAPE_TYPE_SPHERE] = "sphere";
+
+var COLLISION_TYPES = [];
+COLLISION_TYPES[SHAPE_TYPE_NONE] = "No Collision";
+COLLISION_TYPES[SHAPE_TYPE_SIMPLE_HULL] = "Basic - Whole model";
+COLLISION_TYPES[SHAPE_TYPE_SIMPLE_COMPOUND] = "Good - Sub-meshes";
+COLLISION_TYPES[SHAPE_TYPE_STATIC_MESH] = "Exact - All polygons";
+COLLISION_TYPES[SHAPE_TYPE_BOX] = "Box";
+COLLISION_TYPES[SHAPE_TYPE_SPHERE] = "Sphere";
+
+function getDefaultShape() {
+    return SHAPE_TYPES[SHAPE_TYPE_DEFAULT];
+}
+
+function getDefaultCollision() {
+    return COLLISION_TYPES[SHAPE_TYPE_DEFAULT];
+}
+
+function getShapeType(shapeType) {
+    if (shapeType === null || shapeType === undefined || typeof(shapeType) !== "number"){
+        print("ERROR: AssetServerQMLUtils::getShapeType - Invalid arg specified for shapeType: " + shapeType);
+        //--EARLY EXIT--
+        return SHAPE_TYPES[SHAPE_TYPE_NONE];
+    }
+
+    if ((shapeType < 0) || (shapeType >= SHAPE_TYPES.length)) {
+        print("ERROR: AssetServerQMLUtils::getShapeType - Specified invalid/unknown type: " + shapeType);
+        //--EARLY EXIT--
+        return SHAPE_TYPES[SHAPE_TYPE_NONE];
+    }
+
+    return SHAPE_TYPES[shapeType];
+}
+
+function getCollisionType(shapeType) {
+    if (shapeType === null || shapeType === undefined || typeof(shapeType) !== "number"){
+        print("ERROR: AssetServerQMLUtils::getCollisionType - Invalid arg specified for shapeType: " + shapeType);
+        //--EARLY EXIT--
+        return COLLISION_TYPES[SHAPE_TYPE_NONE];
+    }
+
+    if ((shapeType < 0) || (shapeType >= COLLISION_TYPES.length)) {
+        print("ERROR: AssetServerQMLUtils::getCollisionType - Specified invalid/unknown type: " + shapeType);
+        //--EARLY EXIT--
+        return COLLISION_TYPES[SHAPE_TYPE_NONE];
+    }
+
+    return COLLISION_TYPES[shapeType];
+}


### PR DESCRIPTION
Case Link: https://highfidelity.manuscript.com/f/cases/7734

* Drag & Drop world export is currently triggered by the Right Mouse Button pressAndHold as opposed to the expected Left Mouse Button pressAndHold event.
    * If the currently selected item is a viable type (obj, fbx, png, jpg) then the drag event is initiated.
    * If the user right click pressAndHolds on an unselected item, the selection will be changed to the item under the cursor _if_and_only_if_ the item is a viable type after which the drag event is initiated.
    * If the user releases the drag event anywhere within the AssetBrowser window the drag event is canceled without triggering any export functionality.
    * If the user releases the drag event anywhere outside the AssetBrowser window the drag event transitions to a drop event, triggering the export functionality of the dragged asset.
* Objects exported via this method utilize the default settings previously exclusive to addToWorld within the Asset Browser.
* Verified by that [Case 10865] Make Asset Browser multi-select work with Ctrl/Cmd/Shift+Click is still fixed with the changes within this commit.

* Known Issue(s):
    * Left Button pressAndHold control is the desired functionality; however, is currently
      hindered by what appears to be a bug in the interaction of mouse areas/cursor handling
      within Qt.
        * When enabling LeftButton events for treeViewMousePad the treeView rows no longer highlight when clicked.  The treeViewMousePad has propagateComposedEvents: true, which should mean that the events aren't eaten by the mouseArea if things beneath it accept mouse clicks/events.
            * A secondary issue, that seemed to be tied enabling LeftButton events for treeViewMousePad, was what appeared to hovering/tooltip type behavior triggering on the top 2 rows in the browser; however, none of the other rows exhibited this behavior when testing.  This didn't occur when LeftButton events weren't enabled for treeViewMousePad.
        * Looking through the Qt BugReports for open, re-opened, or in progress items related to MouseArea, there appear to be several that may be related at least somewhat to the observed behavior, but aren't an exact match.  See the Related Qt Bugs section below.
    * The icon snippet when dragging doesn't draw outside the AssetBrowser.
        * This could be solved by figuring out how to trigger a re-parenting event along with a position conversion for the drag object when it leaves the bounds of the AssetBrowser/assetBrowseArea to the assetExportArea.
    * pressAndHold interval, though the default interval, seems a bit long, this should
      be tweak-able; however, is lower priority than the Left Button control.

* Related Qt Bugs:
    * Potential Influencer(s) Issue(s)
        * Items under MouseArea don't catch press event if it's not accepted
            * https://bugreports.qt.io/browse/QTBUG-63271
        * MouseArea falsely reports hover when it is a root item or receives a right click
            * https://bugreports.qt.io/browse/QTBUG-36442
        * Hover events can't be propagated from a MouseArea to a QQuickItem
            * https://bugreports.qt.io/browse/QTBUG-34354

    * Bypassed or Circumvented Issue(s)
      _Note_: Implementation Details section within  Commit 40df4b7 may contain more info.
        * DropAreas work weirdly when they intersect
            * https://bugreports.qt.io/browse/QTBUG-30305