### PR TITLE
Fix hips position when flying

### DIFF
--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -60,7 +60,7 @@ static AnimPose computeHipsInSensorFrame(MyAvatar* myAvatar, bool isFlying) {
         // rotate the hips back to match the flying animation.
 
         const float TILT_ANGLE = 0.523f;
-        const glm::quat tiltRot = glm::angleAxis(TILT_ANGLE, transformVectorFast(avatarToSensorMat, -Vectors::UNIT_X));
+        const glm::quat tiltRot = glm::angleAxis(TILT_ANGLE, transformVectorFull(avatarToSensorMat, -Vectors::UNIT_X));
 
         glm::vec3 headPos;
         int headIndex = myAvatar->getJointIndex("Head");

--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -60,7 +60,7 @@ static AnimPose computeHipsInSensorFrame(MyAvatar* myAvatar, bool isFlying) {
         // rotate the hips back to match the flying animation.
 
         const float TILT_ANGLE = 0.523f;
-        const glm::quat tiltRot = glm::angleAxis(TILT_ANGLE, transformVectorFull(avatarToSensorMat, -Vectors::UNIT_X));
+        const glm::quat tiltRot = glm::angleAxis(TILT_ANGLE, glm::normalize(transformVectorFast(avatarToSensorMat, -Vectors::UNIT_X)));
 
         glm::vec3 headPos;
         int headIndex = myAvatar->getJointIndex("Head");


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/13380/Avatar-becomes-invisible-after-shrinking-and-jumping-HMD-mode-only

This PR fix the computation of the hips' position when the avatar is flying and its scale is less than 1/3
 
