### PR TITLE
Rc67.2 : Fixing translucents objects in ambient lighting

### DIFF
--- a/libraries/render-utils/src/DeferredBufferWrite.slh
+++ b/libraries/render-utils/src/DeferredBufferWrite.slh
@@ -27,6 +27,7 @@ float evalOpaqueFinalAlpha(float alpha, float mapAlpha) {
 }
 
 <@include DefaultMaterials.slh@>
+<@include LightingModel.slh@>
 
 void packDeferredFragment(vec3 normal, float alpha, vec3 albedo, float roughness, float metallic, vec3 emissive, float occlusion, float scattering) {
     if (alpha != 1.0) {
@@ -36,7 +37,7 @@ void packDeferredFragment(vec3 normal, float alpha, vec3 albedo, float roughness
     _fragColor1 = vec4(packNormal(normal), clamp(roughness, 0.0, 1.0));
     _fragColor2 = vec4(((scattering > 0.0) ? vec3(scattering) : emissive), occlusion);
     
-    _fragColor3 = vec4(emissive, 1.0);
+    _fragColor3 = vec4(isEmissiveEnabled() * emissive, 1.0);
 }
 
 void packDeferredFragmentLightmap(vec3 normal, float alpha, vec3 albedo, float roughness, float metallic, vec3 fresnel, vec3 lightmap) {
@@ -46,9 +47,9 @@ void packDeferredFragmentLightmap(vec3 normal, float alpha, vec3 albedo, float r
 
     _fragColor0 = vec4(albedo, packLightmappedMetallic(metallic));
     _fragColor1 = vec4(packNormal(normal), clamp(roughness, 0.0, 1.0));
-    _fragColor2 = vec4(lightmap, 1.0);
+    _fragColor2 = vec4(isLightmapEnabled() * lightmap, 1.0);
 
-    _fragColor3 = vec4(lightmap * albedo, 1.0);
+    _fragColor3 = vec4(isLightmapEnabled() * lightmap * albedo, 1.0);
 }
 
 void packDeferredFragmentUnlit(vec3 normal, float alpha, vec3 color) {

--- a/libraries/render-utils/src/DeferredGlobalLight.slh
+++ b/libraries/render-utils/src/DeferredGlobalLight.slh
@@ -140,7 +140,7 @@ vec3 evalSkyboxGlobalColor(mat4 invViewMat, float shadowAttenuation, float obscu
     color += directionalSpecular;
 
     // Attenuate the light if haze effect selected
-    if ((hazeParams.hazeMode & HAZE_MODE_IS_KEYLIGHT_ATTENUATED) == HAZE_MODE_IS_KEYLIGHT_ATTENUATED) {
+    if ((isHazeEnabled() > 0) && (hazeParams.hazeMode & HAZE_MODE_IS_KEYLIGHT_ATTENUATED) == HAZE_MODE_IS_KEYLIGHT_ATTENUATED) {
         color = computeHazeColorKeyLightAttenuation(color, lightDirection, fragPositionWS);    
     }
 
@@ -234,7 +234,7 @@ vec3 evalGlobalLightingAlphaBlendedWithHaze(
     color += (ambientSpecular + directionalSpecular) / opacity;
 
     // Haze
-    if ((hazeParams.hazeMode & HAZE_MODE_IS_ACTIVE) == HAZE_MODE_IS_ACTIVE) {
+    if ((isHazeEnabled() > 0) && (hazeParams.hazeMode & HAZE_MODE_IS_ACTIVE) == HAZE_MODE_IS_ACTIVE) {
         vec4 colorV4 = computeHazeColor(
             vec4(color, 1.0),               // fragment original color
             positionES,                     // fragment position in eye   coordinates
@@ -272,7 +272,7 @@ vec3 evalGlobalLightingAlphaBlendedWithHaze(
     color += (ambientSpecular + directionalSpecular) / opacity;
 
     // Haze
-    if ((hazeParams.hazeMode & HAZE_MODE_IS_ACTIVE) == HAZE_MODE_IS_ACTIVE) {
+    if ((isHazeEnabled() > 0) && (hazeParams.hazeMode & HAZE_MODE_IS_ACTIVE) == HAZE_MODE_IS_ACTIVE) {
         vec4 colorV4 = computeHazeColor(
             vec4(color, 1.0),               // fragment original color
             positionES,                     // fragment position in eye   coordinates

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -61,20 +61,22 @@ enum DeferredShader_MapSlot {
     DEFERRED_BUFFER_EMISSIVE_UNIT = 2,
     DEFERRED_BUFFER_DEPTH_UNIT = 3,
     DEFERRED_BUFFER_OBSCURANCE_UNIT = 4,
-    SHADOW_MAP_UNIT = 5,
-    SKYBOX_MAP_UNIT = SHADOW_MAP_UNIT + SHADOW_CASCADE_MAX_COUNT,
-    DEFERRED_BUFFER_LINEAR_DEPTH_UNIT,
-    DEFERRED_BUFFER_CURVATURE_UNIT,
-    DEFERRED_BUFFER_DIFFUSED_CURVATURE_UNIT,
-    SCATTERING_LUT_UNIT,
-    SCATTERING_SPECULAR_UNIT,
+    DEFERRED_BUFFER_LINEAR_DEPTH_UNIT = 5,
+    DEFERRED_BUFFER_CURVATURE_UNIT = 6,
+    DEFERRED_BUFFER_DIFFUSED_CURVATURE_UNIT = 7,
+    SCATTERING_LUT_UNIT = 8,
+    SCATTERING_SPECULAR_UNIT = 9,
+    SKYBOX_MAP_UNIT = render::ShapePipeline::Slot::LIGHT_AMBIENT_MAP, // unit = 10
+    SHADOW_MAP_UNIT = 11,
+    nextAvailableUnit = SHADOW_MAP_UNIT + SHADOW_CASCADE_MAX_COUNT
 };
 enum DeferredShader_BufferSlot {
     DEFERRED_FRAME_TRANSFORM_BUFFER_SLOT = 0,
     CAMERA_CORRECTION_BUFFER_SLOT,
     SCATTERING_PARAMETERS_BUFFER_SLOT,
     LIGHTING_MODEL_BUFFER_SLOT = render::ShapePipeline::Slot::LIGHTING_MODEL,
-    LIGHT_GPU_SLOT = render::ShapePipeline::Slot::LIGHT,
+    KEY_LIGHT_SLOT = render::ShapePipeline::Slot::KEY_LIGHT,
+    LIGHT_ARRAY_SLOT = render::ShapePipeline::Slot::LIGHT_ARRAY_BUFFER,
     LIGHT_AMBIENT_SLOT = render::ShapePipeline::Slot::LIGHT_AMBIENT_BUFFER,
     HAZE_MODEL_BUFFER_SLOT = render::ShapePipeline::Slot::HAZE_MODEL,
     LIGHT_INDEX_GPU_SLOT,
@@ -149,17 +151,20 @@ void DeferredLightingEffect::unsetKeyLightBatch(gpu::Batch& batch, int lightBuff
 }
 
 void DeferredLightingEffect::setupLocalLightsBatch(gpu::Batch& batch,
-                                                   int clusterGridBufferUnit, int clusterContentBufferUnit, int frustumGridBufferUnit,
+                                                   int lightArrayBufferUnit, int clusterGridBufferUnit, int clusterContentBufferUnit, int frustumGridBufferUnit,
                                                    const LightClustersPointer& lightClusters) {
     // Bind the global list of lights and the visible lights this frame
-    batch.setUniformBuffer(_localLightLocations->lightBufferUnit, lightClusters->_lightStage->getLightArrayBuffer());
+    batch.setUniformBuffer(lightArrayBufferUnit, lightClusters->_lightStage->getLightArrayBuffer());
 
     batch.setUniformBuffer(frustumGridBufferUnit, lightClusters->_frustumGridBuffer);
     batch.setUniformBuffer(clusterGridBufferUnit, lightClusters->_clusterGridBuffer);
     batch.setUniformBuffer(clusterContentBufferUnit, lightClusters->_clusterContentBuffer);
 }
 
-void DeferredLightingEffect::unsetLocalLightsBatch(gpu::Batch& batch, int clusterGridBufferUnit, int clusterContentBufferUnit, int frustumGridBufferUnit) {
+void DeferredLightingEffect::unsetLocalLightsBatch(gpu::Batch& batch, int lightArrayBufferUnit, int clusterGridBufferUnit, int clusterContentBufferUnit, int frustumGridBufferUnit) {
+    if (lightArrayBufferUnit >= 0) {
+        batch.setUniformBuffer(lightArrayBufferUnit, nullptr);
+    }
     if (clusterGridBufferUnit >= 0) {
         batch.setUniformBuffer(clusterGridBufferUnit, nullptr);
     }
@@ -194,7 +199,8 @@ static gpu::ShaderPointer makeLightProgram(const gpu::ShaderPointer& vertShader,
     slotBindings.insert(gpu::Shader::Binding(std::string("lightingModelBuffer"), LIGHTING_MODEL_BUFFER_SLOT));
     slotBindings.insert(gpu::Shader::Binding(std::string("hazeBuffer"), HAZE_MODEL_BUFFER_SLOT));
     slotBindings.insert(gpu::Shader::Binding(std::string("subsurfaceScatteringParametersBuffer"), SCATTERING_PARAMETERS_BUFFER_SLOT));
-    slotBindings.insert(gpu::Shader::Binding(std::string("lightBuffer"), LIGHT_GPU_SLOT));
+    slotBindings.insert(gpu::Shader::Binding(std::string("keyLightBuffer"), KEY_LIGHT_SLOT));
+    slotBindings.insert(gpu::Shader::Binding(std::string("lightBuffer"), LIGHT_ARRAY_SLOT));
     slotBindings.insert(gpu::Shader::Binding(std::string("lightAmbientBuffer"), LIGHT_AMBIENT_SLOT));
     slotBindings.insert(gpu::Shader::Binding(std::string("lightIndexBuffer"), LIGHT_INDEX_GPU_SLOT));
 
@@ -592,7 +598,7 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
         batch._glUniform4fv(locations->texcoordFrameTransform, 1, reinterpret_cast< const float* >(&textureFrameTransform));
 
         // Setup the global lighting
-        deferredLightingEffect->setupKeyLightBatch(args, batch, locations->keyLightBufferUnit, locations->ambientBufferUnit, SKYBOX_MAP_UNIT);
+        deferredLightingEffect->setupKeyLightBatch(args, batch, KEY_LIGHT_SLOT, LIGHT_AMBIENT_SLOT, SKYBOX_MAP_UNIT);
 
         // Haze
         if (haze) {
@@ -601,7 +607,7 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
         
         batch.draw(gpu::TRIANGLE_STRIP, 4);
 
-        deferredLightingEffect->unsetKeyLightBatch(batch, locations->keyLightBufferUnit, locations->ambientBufferUnit, SKYBOX_MAP_UNIT);
+        deferredLightingEffect->unsetKeyLightBatch(batch, KEY_LIGHT_SLOT, LIGHT_AMBIENT_SLOT, SKYBOX_MAP_UNIT);
 
         for (auto i = 0; i < SHADOW_CASCADE_MAX_COUNT; i++) {
             batch.setResourceTexture(SHADOW_MAP_UNIT+i, nullptr);
@@ -656,8 +662,9 @@ void RenderDeferredLocals::run(const render::RenderContextPointer& renderContext
 
         auto& lightIndices = lightClusters->_visibleLightIndices;
         if (!lightIndices.empty() && lightIndices[0] > 0) {
-            deferredLightingEffect->setupLocalLightsBatch(batch, LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT, LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT, LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT,
-                                                          lightClusters);
+            deferredLightingEffect->setupLocalLightsBatch(batch,
+                LIGHT_ARRAY_SLOT, LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT, LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT, LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT,
+                lightClusters);
 
             // Local light pipeline
             batch.setPipeline(deferredLightingEffect->_localLight);

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -51,8 +51,8 @@ public:
     void setupKeyLightBatch(const RenderArgs* args, gpu::Batch& batch, int lightBufferUnit, int ambientBufferUnit, int skyboxCubemapUnit);
     void unsetKeyLightBatch(gpu::Batch& batch, int lightBufferUnit, int ambientBufferUnit, int skyboxCubemapUnit);
 
-    void setupLocalLightsBatch(gpu::Batch& batch, int clusterGridBufferUnit, int clusterContentBufferUnit, int frustumGridBufferUnit, const LightClustersPointer& lightClusters);
-    void unsetLocalLightsBatch(gpu::Batch& batch, int clusterGridBufferUnit, int clusterContentBufferUnit, int frustumGridBufferUnit);
+    void setupLocalLightsBatch(gpu::Batch& batch, int lightArrayBufferUnit, int clusterGridBufferUnit, int clusterContentBufferUnit, int frustumGridBufferUnit, const LightClustersPointer& lightClusters);
+    void unsetLocalLightsBatch(gpu::Batch& batch, int lightArrayBufferUnit, int clusterGridBufferUnit, int clusterContentBufferUnit, int frustumGridBufferUnit);
 
     void setShadowMapEnabled(bool enable) { _shadowMapEnabled = enable; };
     void setAmbientOcclusionEnabled(bool enable) { _ambientOcclusionEnabled = enable; }

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -2264,7 +2264,7 @@ gpu::PipelinePointer GeometryCache::getSimplePipeline(bool textured, bool transp
             slotBindings.insert(gpu::Shader::Binding(std::string("lightingModelBuffer"), render::ShapePipeline::Slot::LIGHTING_MODEL));
             slotBindings.insert(gpu::Shader::Binding(std::string("keyLightBuffer"), render::ShapePipeline::Slot::KEY_LIGHT));
             slotBindings.insert(gpu::Shader::Binding(std::string("lightAmbientBuffer"), render::ShapePipeline::Slot::LIGHT_AMBIENT_BUFFER));
-            slotBindings.insert(gpu::Shader::Binding(std::string("skyboxMap"), render::ShapePipeline::Slot::MAP::LIGHT_AMBIENT));
+            slotBindings.insert(gpu::Shader::Binding(std::string("skyboxMap"), render::ShapePipeline::Slot::MAP::LIGHT_AMBIENT_MAP));
             gpu::Shader::makeProgram(*_simpleShader, slotBindings);
             gpu::Shader::makeProgram(*_transparentShader, slotBindings);
             gpu::Shader::makeProgram(*_unlitShader, slotBindings);
@@ -2284,7 +2284,7 @@ gpu::PipelinePointer GeometryCache::getSimplePipeline(bool textured, bool transp
             slotBindings.insert(gpu::Shader::Binding(std::string("lightingModelBuffer"), render::ShapePipeline::Slot::LIGHTING_MODEL));
             slotBindings.insert(gpu::Shader::Binding(std::string("keyLightBuffer"), render::ShapePipeline::Slot::KEY_LIGHT));
             slotBindings.insert(gpu::Shader::Binding(std::string("lightAmbientBuffer"), render::ShapePipeline::Slot::LIGHT_AMBIENT_BUFFER));
-            slotBindings.insert(gpu::Shader::Binding(std::string("skyboxMap"), render::ShapePipeline::Slot::MAP::LIGHT_AMBIENT));
+            slotBindings.insert(gpu::Shader::Binding(std::string("skyboxMap"), render::ShapePipeline::Slot::MAP::LIGHT_AMBIENT_MAP));
             slotBindings.insert(gpu::Shader::Binding(std::string("fadeMaskMap"), render::ShapePipeline::Slot::MAP::FADE_MASK));
             gpu::Shader::makeProgram(*_simpleFadeShader, slotBindings);
             gpu::Shader::makeProgram(*_unlitFadeShader, slotBindings);

--- a/libraries/render-utils/src/Haze.slf
+++ b/libraries/render-utils/src/Haze.slf
@@ -42,7 +42,7 @@ in vec2 varTexCoord0;
 out vec4 outFragColor;
 
 void main(void) {
-    if ((hazeParams.hazeMode & HAZE_MODE_IS_ACTIVE) != HAZE_MODE_IS_ACTIVE) {
+    if ((isHazeEnabled() == 0) || (hazeParams.hazeMode & HAZE_MODE_IS_ACTIVE) != HAZE_MODE_IS_ACTIVE) {
         discard;
     }
 

--- a/libraries/render-utils/src/LightClusters.cpp
+++ b/libraries/render-utils/src/LightClusters.cpp
@@ -39,7 +39,7 @@ enum LightClusterGridShader_MapSlot {
 enum LightClusterGridShader_BufferSlot {
     DEFERRED_FRAME_TRANSFORM_BUFFER_SLOT = 0,
     CAMERA_CORRECTION_BUFFER_SLOT = 1,
-    LIGHT_GPU_SLOT = render::ShapePipeline::Slot::LIGHT,
+    LIGHT_GPU_SLOT = render::ShapePipeline::Slot::LIGHT_ARRAY_BUFFER,
     LIGHT_INDEX_GPU_SLOT = 7,
     LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT = 8,
     LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT = 9,

--- a/libraries/render-utils/src/LightingModel.cpp
+++ b/libraries/render-utils/src/LightingModel.cpp
@@ -49,6 +49,14 @@ void LightingModel::setBackground(bool enable) {
 bool LightingModel::isBackgroundEnabled() const {
     return (bool)_parametersBuffer.get<Parameters>().enableBackground;
 }
+void LightingModel::setHaze(bool enable) {
+    if (enable != isHazeEnabled()) {
+        _parametersBuffer.edit<Parameters>().enableHaze = (float)enable;
+    }
+}
+bool LightingModel::isHazeEnabled() const {
+    return (bool)_parametersBuffer.get<Parameters>().enableHaze;
+}
 void LightingModel::setObscurance(bool enable) {
     if (enable != isObscuranceEnabled()) {
         _parametersBuffer.edit<Parameters>().enableObscurance = (float)enable;
@@ -160,6 +168,7 @@ void MakeLightingModel::configure(const Config& config) {
     _lightingModel->setEmissive(config.enableEmissive);
     _lightingModel->setLightmap(config.enableLightmap);
     _lightingModel->setBackground(config.enableBackground);
+    _lightingModel->setHaze(config.enableHaze);
 
     _lightingModel->setObscurance(config.enableObscurance);
 

--- a/libraries/render-utils/src/LightingModel.h
+++ b/libraries/render-utils/src/LightingModel.h
@@ -36,6 +36,9 @@ public:
     void setBackground(bool enable);
     bool isBackgroundEnabled() const;
 
+    void setHaze(bool enable);
+    bool isHazeEnabled() const;
+
     void setObscurance(bool enable);
     bool isObscuranceEnabled() const;
 
@@ -86,7 +89,6 @@ protected:
         float enableSpecular{ 1.0f };
         float enableAlbedo{ 1.0f };
 
-
         float enableAmbientLight{ 1.0f };
         float enableDirectionalLight{ 1.0f };
         float enablePointLight{ 1.0f };
@@ -98,6 +100,11 @@ protected:
 
         float enableMaterialTexturing { 1.0f };
         float enableWireframe { 0.0f }; // false by default
+
+        float enableHaze{ 1.0f };
+        float spare1;  // Needed for having the LightingModel class aligned on a 4 scalar boundary for gpu 
+        float spare2;
+        float spare3;
 
         Parameters() {}
     };
@@ -116,6 +123,7 @@ class MakeLightingModelConfig : public render::Job::Config {
     Q_PROPERTY(bool enableEmissive MEMBER enableEmissive NOTIFY dirty)
     Q_PROPERTY(bool enableLightmap MEMBER enableLightmap NOTIFY dirty)
     Q_PROPERTY(bool enableBackground MEMBER enableBackground NOTIFY dirty)
+    Q_PROPERTY(bool enableHaze MEMBER enableHaze NOTIFY dirty)
 
     Q_PROPERTY(bool enableObscurance MEMBER enableObscurance NOTIFY dirty)
 
@@ -158,6 +166,7 @@ public:
     bool showLightContour { false }; // false by default
 
     bool enableWireframe { false }; // false by default
+    bool enableHaze{ true };
 
 signals:
     void dirty();

--- a/libraries/render-utils/src/LightingModel.slh
+++ b/libraries/render-utils/src/LightingModel.slh
@@ -18,6 +18,7 @@ struct LightingModel {
     PRECISIONQ vec4 _ScatteringDiffuseSpecularAlbedo;
     PRECISIONQ vec4 _AmbientDirectionalPointSpot;
     PRECISIONQ vec4 _ShowContourObscuranceWireframe;
+    PRECISIONQ vec4 _Haze_spareyzw;
 };
 
 uniform lightingModelBuffer{
@@ -72,6 +73,10 @@ float isShowLightContour() {
 
 float isWireframeEnabled() {
     return lightingModel._ShowContourObscuranceWireframe.z;
+}
+
+float isHazeEnabled() {
+    return lightingModel._Haze_spareyzw.x;
 }
 
 <@endfunc@>

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -340,11 +340,18 @@ void DrawDeferred::run(const RenderContextPointer& renderContext, const Inputs& 
         // Setup lighting model for all items;
         batch.setUniformBuffer(render::ShapePipeline::Slot::LIGHTING_MODEL, lightingModel->getParametersBuffer());
 
-        deferredLightingEffect->setupLocalLightsBatch(batch, 
-                                                      render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT,
-                                                      render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT,
-                                                      render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT,
-                                                      lightClusters);
+        // Set the light
+        deferredLightingEffect->setupKeyLightBatch(args, batch,
+            render::ShapePipeline::Slot::KEY_LIGHT,
+            render::ShapePipeline::Slot::LIGHT_AMBIENT_BUFFER,
+            render::ShapePipeline::Slot::LIGHT_AMBIENT_MAP);
+
+        deferredLightingEffect->setupLocalLightsBatch(batch,
+            render::ShapePipeline::Slot::LIGHT_ARRAY_BUFFER,
+            render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT,
+            render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT,
+            render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT,
+            lightClusters);
 
         // Setup haze if current zone has haze
         auto hazeStage = args->_scene->getStage<HazeStage>();
@@ -370,9 +377,15 @@ void DrawDeferred::run(const RenderContextPointer& renderContext, const Inputs& 
         args->_globalShapeKey = 0;
 
         deferredLightingEffect->unsetLocalLightsBatch(batch,
-                                                      render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT,
-                                                      render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT,
-                                                      render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT);
+            render::ShapePipeline::Slot::LIGHT_ARRAY_BUFFER,
+            render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT,
+            render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT,
+            render::ShapePipeline::Slot::LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT);
+
+        deferredLightingEffect->unsetKeyLightBatch(batch,
+            render::ShapePipeline::Slot::KEY_LIGHT,
+            render::ShapePipeline::Slot::LIGHT_AMBIENT_BUFFER,
+            render::ShapePipeline::Slot::LIGHT_AMBIENT_MAP);
     });
 
     config->setNumDrawn((int)inItems.size());

--- a/libraries/render-utils/src/RenderForwardTask.cpp
+++ b/libraries/render-utils/src/RenderForwardTask.cpp
@@ -175,7 +175,7 @@ void PrepareForward::run(const RenderContextPointer& renderContext, const Inputs
             batch.setUniformBuffer(render::ShapePipeline::Slot::LIGHT_AMBIENT_BUFFER, keyAmbiLight->getAmbientSchemaBuffer());
 
             if (keyAmbiLight->getAmbientMap()) {
-                batch.setResourceTexture(render::ShapePipeline::Slot::LIGHT_AMBIENT, keyAmbiLight->getAmbientMap());
+                batch.setResourceTexture(render::ShapePipeline::Slot::LIGHT_AMBIENT_MAP, keyAmbiLight->getAmbientMap());
             }
         }
     });

--- a/libraries/render/src/render/ShapePipeline.cpp
+++ b/libraries/render/src/render/ShapePipeline.cpp
@@ -89,9 +89,9 @@ void ShapePlumber::addPipeline(const Filter& filter, const gpu::ShaderPointer& p
         slotBindings.insert(gpu::Shader::Binding(std::string("occlusionMap"), Slot::MAP::OCCLUSION));
         slotBindings.insert(gpu::Shader::Binding(std::string("scatteringMap"), Slot::MAP::SCATTERING));
         slotBindings.insert(gpu::Shader::Binding(std::string("keyLightBuffer"), Slot::BUFFER::KEY_LIGHT));
-        slotBindings.insert(gpu::Shader::Binding(std::string("lightBuffer"), Slot::BUFFER::LIGHT));
+        slotBindings.insert(gpu::Shader::Binding(std::string("lightBuffer"), Slot::BUFFER::LIGHT_ARRAY_BUFFER));
         slotBindings.insert(gpu::Shader::Binding(std::string("lightAmbientBuffer"), Slot::BUFFER::LIGHT_AMBIENT_BUFFER));
-        slotBindings.insert(gpu::Shader::Binding(std::string("skyboxMap"), Slot::MAP::LIGHT_AMBIENT));
+        slotBindings.insert(gpu::Shader::Binding(std::string("skyboxMap"), Slot::MAP::LIGHT_AMBIENT_MAP));
         slotBindings.insert(gpu::Shader::Binding(std::string("fadeMaskMap"), Slot::MAP::FADE_MASK));
         slotBindings.insert(gpu::Shader::Binding(std::string("fadeParametersBuffer"), Slot::BUFFER::FADE_PARAMETERS));
         slotBindings.insert(gpu::Shader::Binding(std::string("hazeBuffer"), Slot::BUFFER::HAZE_MODEL));
@@ -123,7 +123,7 @@ void ShapePlumber::addPipeline(const Filter& filter, const gpu::ShaderPointer& p
     locations->lightAmbientMapUnit = program->getTextures().findLocation("skyboxMap");
     locations->fadeMaskTextureUnit = program->getTextures().findLocation("fadeMaskMap");
     locations->fadeParameterBufferUnit = program->getUniformBuffers().findLocation("fadeParametersBuffer");
-    locations->hazeParameterBufferUnit = program->getUniformBuffers().findLocation("hazeParametersBuffer");
+    locations->hazeParameterBufferUnit = program->getUniformBuffers().findLocation("hazeBuffer");
     if (key.isTranslucent()) {
         locations->lightClusterGridBufferUnit = program->getUniformBuffers().findLocation("clusterGridBuffer");
         locations->lightClusterContentBufferUnit = program->getUniformBuffers().findLocation("clusterContentBuffer");

--- a/libraries/render/src/render/ShapePipeline.h
+++ b/libraries/render/src/render/ShapePipeline.h
@@ -236,7 +236,7 @@ public:
             TEXMAPARRAY,
             LIGHTING_MODEL,
             KEY_LIGHT,
-            LIGHT,
+            LIGHT_ARRAY_BUFFER,
             LIGHT_AMBIENT_BUFFER,
             HAZE_MODEL,
             FADE_PARAMETERS,
@@ -254,8 +254,9 @@ public:
             ROUGHNESS,
             OCCLUSION,
             SCATTERING,
-            LIGHT_AMBIENT,
             FADE_MASK,
+
+            LIGHT_AMBIENT_MAP = 10,
         };
     };
 

--- a/scripts/developer/utilities/render/deferredLighting.qml
+++ b/scripts/developer/utilities/render/deferredLighting.qml
@@ -45,7 +45,8 @@ Rectangle {
                          "Unlit:LightingModel:enableUnlit", 
                          "Emissive:LightingModel:enableEmissive", 
                          "Lightmap:LightingModel:enableLightmap",
-                         "Background:LightingModel:enableBackground",                      
+                         "Background:LightingModel:enableBackground",      
+                         "Haze:LightingModel:enableHaze",                
                          "ssao:AmbientOcclusion:enabled",                      
                          "Textures:LightingModel:enableMaterialTexturing"                     
                     ]


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/edit/15104/Materials-with-transparency-don-t-receive-reflections-from-the-ambient-map-in-RC67

This PR fixes this bug ^.
the problem was that the ambient map & buffer wasn't bound correctly during the rendering of the transparent objects.
The ambient lighting on transparent objects wasn't displayed correctly.
To address this, we made sure the place where the shader slots are defined for the global lighting & shading resources are unique accross the different pass of the shaders.

While doing this work and in order to help with debugging, we added support for disabling enabling the Haze effect and the Emissive effect from the Lighting Model and from the deferredREndering.qml ui tool for Luci.js

TEST PLAN
Run the tests in this folder:
https://github.com/highfidelity/hifi_tests/tree/master/tests/engine/render/material

Going into domain with translucent cmaterials such as avatarisland validate that the ambient lighting is properly applied to the transparent objects
You can do so by running the Luci app and checking the lighting with AMbient only checking the "Specular" aka the reflection of the environment is visible