### PR TITLE
Rc67.2 Provide a toggle switch for TAA in the menu developer/render to opt-out

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -391,10 +391,10 @@ Menu::Menu() {
             if (mainViewJitterCamConfig && mainViewAntialiasingConfig) {
                 if (action->isChecked()) {
                     mainViewJitterCamConfig->play();
-                    mainViewAntialiasingConfig->debugFXAAX = 1.0;
+                    mainViewAntialiasingConfig->setDebugFXAA(false);
                 } else {
                     mainViewJitterCamConfig->none();
-                    mainViewAntialiasingConfig->debugFXAAX = 0.0;
+                    mainViewAntialiasingConfig->setDebugFXAA(true);
                 }
             }
         }

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -47,6 +47,7 @@
 
 #include "AmbientOcclusionEffect.h"
 #include "RenderShadowTask.h"
+#include "AntialiasingEffect.h"
 
 #if defined(Q_OS_MAC) || defined(Q_OS_WIN)
 #include "SpeechRecognizer.h"
@@ -380,6 +381,25 @@ Menu::Menu() {
 
     // Developer > Render >>>
     MenuWrapper* renderOptionsMenu = developerMenu->addMenu("Render");
+
+    action = addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::AntiAliasing, 0, true);
+    connect(action, &QAction::triggered, [action] {
+        auto renderConfig = qApp->getRenderEngine()->getConfiguration();
+        if (renderConfig) {
+            auto mainViewJitterCamConfig = renderConfig->getConfig<JitterSample>("RenderMainView.JitterCam");
+            auto mainViewAntialiasingConfig = renderConfig->getConfig<Antialiasing>("RenderMainView.Antialiasing");
+            if (mainViewJitterCamConfig && mainViewAntialiasingConfig) {
+                if (action->isChecked()) {
+                    mainViewJitterCamConfig->play();
+                    mainViewAntialiasingConfig->debugFXAAX = 1.0;
+                } else {
+                    mainViewJitterCamConfig->none();
+                    mainViewAntialiasingConfig->debugFXAAX = 0.0;
+                }
+            }
+        }
+    });
+
     action = addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::Shadows, 0, true);
     connect(action, &QAction::triggered, [action] {
         auto renderConfig = qApp->getRenderEngine()->getConfiguration();

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -210,6 +210,7 @@ namespace MenuOption {
     const QString DesktopTabletToToolbar = "Desktop Tablet Becomes Toolbar";
     const QString HMDTabletToToolbar = "HMD Tablet Becomes Toolbar";
     const QString Shadows = "Shadows";
+    const QString AntiAliasing = "Temporal Antialiasing (FXAA if disabled)";
     const QString AmbientOcclusion = "Ambient Occlusion";
 }
 

--- a/libraries/render-utils/src/AntialiasingEffect.h
+++ b/libraries/render-utils/src/AntialiasingEffect.h
@@ -62,7 +62,7 @@ public:
     };
 
     using Config = JitterSampleConfig;
-	using Output = glm::vec2;
+    using Output = glm::vec2;
     using JobModel = render::Job::ModelO<JitterSample, Output, Config>;
 
     void configure(const Config& config);
@@ -95,7 +95,7 @@ class AntialiasingConfig : public render::Job::Config {
 
     Q_PROPERTY(bool debug MEMBER debug NOTIFY dirty)
     Q_PROPERTY(float debugX MEMBER debugX NOTIFY dirty)
-    Q_PROPERTY(float debugFXAAX MEMBER debugFXAAX NOTIFY dirty)
+    Q_PROPERTY(bool fxaaOnOff READ debugFXAA WRITE setDebugFXAA NOTIFY dirty)
     Q_PROPERTY(float debugShowVelocityThreshold MEMBER debugShowVelocityThreshold NOTIFY dirty)
     Q_PROPERTY(bool showCursorPixel MEMBER showCursorPixel NOTIFY dirty)
     Q_PROPERTY(glm::vec2 debugCursorTexcoord MEMBER debugCursorTexcoord NOTIFY dirty)
@@ -105,6 +105,10 @@ class AntialiasingConfig : public render::Job::Config {
 
 public:
     AntialiasingConfig() : render::Job::Config(true) {}
+
+    void setDebugFXAA(bool debug) { debugFXAAX = (debug ? 0.0f : 1.0f); emit dirty();}
+    bool debugFXAA() const { return (debugFXAAX == 0.0f ? true : false); }
+
 
     float blend{ 0.25f };
     float sharpen{ 0.05f };

--- a/scripts/developer/utilities/render/antialiasing.qml
+++ b/scripts/developer/utilities/render/antialiasing.qml
@@ -38,21 +38,22 @@ Rectangle {
                 id: fxaaOnOff
                 property bool debugFXAA: false
                 HifiControls.Button {
-                    text: {
-                        if (fxaaOnOff.debugFXAA) {
-                            return "FXAA"
-                        } else {
-                            return "TAA"
+                    function getTheText() {
+                            if (Render.getConfig("RenderMainView.Antialiasing").fxaaOnOff) {
+                                return "FXAA"
+                            } else {
+                                return "TAA"
+                            }
                         }
-                        }
+                    text: getTheText()
                     onClicked: {
-                        fxaaOnOff.debugFXAA = !fxaaOnOff.debugFXAA
-                         if (fxaaOnOff.debugFXAA) {
+                        var onOff = !Render.getConfig("RenderMainView.Antialiasing").fxaaOnOff;
+                         if (onOff) {
                             Render.getConfig("RenderMainView.JitterCam").none();
-                            Render.getConfig("RenderMainView.Antialiasing").debugFXAAX = 0;
+                            Render.getConfig("RenderMainView.Antialiasing").fxaaOnOff = true;
                          } else {
                             Render.getConfig("RenderMainView.JitterCam").play();
-                            Render.getConfig("RenderMainView.Antialiasing").debugFXAAX = 1.0;
+                            Render.getConfig("RenderMainView.Antialiasing").fxaaOnOff = false;
                          }
                          
                     }


### PR DESCRIPTION
Adding  toggle switch for TAA in the menu developer/render to opt-out and go back to FXAA (before TAA was introduced)
TAA is ON by default.
![image](https://user-images.githubusercontent.com/2230265/40148097-282e442e-5921-11e8-8223-34c349d97599.png)

TEST PLAN
- verify that the new menu item (in developer/render)appears and behave as expected between re runs
  - ON by default after fresh install
  - Only accessible after enabling the developer ui
  - If toggled on / off during a session, quit, restart and it should still be in the same state as when quit
 
- Verify that the Antialiasing used in the main view used to render the image reflects the menu item value
   - Run the application in desktop mode fullscreen in a HD display (1k x 2k)
   - Going into "asimov" and facing the palm tree, observing them moving 
       - It should be obvious that with TAA ON, they look smooth, eventually a bit blurry as they move
       - With TAA OFF, they look very much Aliased

    - Repeat the same observation with HMD

