### PR TITLE
Initialize Qt's use of openssl lib before calling RSA code

### DIFF
--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -729,6 +729,9 @@ void AccountManager::generateNewKeypair(bool isUserKeypair, const QUuid& domainI
         return;
     }
 
+    // Ensure openssl/Qt config is set up.
+    QSslConfiguration::defaultConfiguration();
+
     // make sure we don't already have an outbound keypair generation request
     if (!_isWaitingForKeypairResponse) {
         _isWaitingForKeypairResponse = true;

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -94,9 +94,6 @@ AccountManager::AccountManager(UserAgentGetter userAgentGetter) :
 const QString DOUBLE_SLASH_SUBSTITUTE = "slashslash";
 const QString ACCOUNT_MANAGER_REQUESTED_SCOPE = "owner";
 
-AccountManager::~AccountManager() {
-}
-
 void AccountManager::logout() {
     // a logout means we want to delete the DataServerAccountInfo we currently have for this URL, in-memory and in file
     _accountInfo = DataServerAccountInfo();

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -761,6 +761,7 @@ void AccountManager::generateNewKeypair(bool isUserKeypair, const QUuid& domainI
                 this, &AccountManager::handleKeypairGenerationError);
 
         connect(keypairGenerator, &QObject::destroyed, generateThread, &QThread::quit);
+        connect(this, &QObject::destroyed, generateThread, &QThread::quit);
         connect(generateThread, &QThread::finished, generateThread, &QThread::deleteLater);
 
         keypairGenerator->moveToThread(generateThread);

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -63,7 +63,6 @@ class AccountManager : public QObject, public Dependency {
     Q_OBJECT
 public:
     AccountManager(UserAgentGetter userAgentGetter = DEFAULT_USER_AGENT_GETTER);
-    ~AccountManager();
 
     Q_INVOKABLE void sendRequest(const QString& path,
                                  AccountManagerAuth::Type authType,

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -15,6 +15,8 @@
 #include <QtCore/QByteArray>
 #include <QtCore/QObject>
 #include <QtCore/QUrl>
+#include <QtCore/QMutex>
+#include <QtCore/QWaitCondition>
 #include <QtNetwork/QNetworkReply>
 #include <QUrlQuery>
 
@@ -63,6 +65,7 @@ class AccountManager : public QObject, public Dependency {
     Q_OBJECT
 public:
     AccountManager(UserAgentGetter userAgentGetter = DEFAULT_USER_AGENT_GETTER);
+    ~AccountManager();
 
     Q_INVOKABLE void sendRequest(const QString& path,
                                  AccountManagerAuth::Type authType,
@@ -131,6 +134,7 @@ private slots:
     void publicKeyUploadSucceeded(QNetworkReply& reply);
     void publicKeyUploadFailed(QNetworkReply& reply);
     void generateNewKeypair(bool isUserKeypair = true, const QUuid& domainID = QUuid());
+    void rsaKeygenThreadFinished();
 
 private:
     AccountManager(AccountManager const& other) = delete;
@@ -156,6 +160,9 @@ private:
     QByteArray _pendingPrivateKey;
 
     QUuid _sessionID { QUuid::createUuid() };
+    QMutex _rsaKeygenLock;
+    QWaitCondition _rsaKeygenWait;
+    QThread* _rsaKeygenThread { nullptr };
 };
 
 #endif // hifi_AccountManager_h

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -15,8 +15,6 @@
 #include <QtCore/QByteArray>
 #include <QtCore/QObject>
 #include <QtCore/QUrl>
-#include <QtCore/QMutex>
-#include <QtCore/QWaitCondition>
 #include <QtNetwork/QNetworkReply>
 #include <QUrlQuery>
 
@@ -130,11 +128,10 @@ signals:
 private slots:
     void processReply();
     void handleKeypairGenerationError();
-    void processGeneratedKeypair();
+    void processGeneratedKeypair(QByteArray publicKey, QByteArray privateKey);
     void publicKeyUploadSucceeded(QNetworkReply& reply);
     void publicKeyUploadFailed(QNetworkReply& reply);
     void generateNewKeypair(bool isUserKeypair = true, const QUuid& domainID = QUuid());
-    void rsaKeygenThreadFinished();
 
 private:
     AccountManager(AccountManager const& other) = delete;
@@ -160,9 +157,6 @@ private:
     QByteArray _pendingPrivateKey;
 
     QUuid _sessionID { QUuid::createUuid() };
-    QMutex _rsaKeygenLock;
-    QWaitCondition _rsaKeygenWait;
-    QThread* _rsaKeygenThread { nullptr };
 };
 
 #endif // hifi_AccountManager_h

--- a/libraries/networking/src/RSAKeypairGenerator.cpp
+++ b/libraries/networking/src/RSAKeypairGenerator.cpp
@@ -15,7 +15,6 @@
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
 
-#include <QSslConfiguration>
 #include <qdebug.h>
 
 #include "NetworkLogging.h"
@@ -26,8 +25,7 @@
 RSAKeypairGenerator::RSAKeypairGenerator(QObject* parent) :
     QObject(parent)
 {
-    // Ensure openssl/Qt config is set up.
-    QSslConfiguration::defaultConfiguration();
+
 }
 
 void RSAKeypairGenerator::generateKeypair() {

--- a/libraries/networking/src/RSAKeypairGenerator.cpp
+++ b/libraries/networking/src/RSAKeypairGenerator.cpp
@@ -15,6 +15,7 @@
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
 
+#include <QSslConfiguration>
 #include <qdebug.h>
 
 #include "NetworkLogging.h"
@@ -25,7 +26,8 @@
 RSAKeypairGenerator::RSAKeypairGenerator(QObject* parent) :
     QObject(parent)
 {
-    
+    // Ensure openssl/Qt config is set up.
+    QSslConfiguration::defaultConfiguration();
 }
 
 void RSAKeypairGenerator::generateKeypair() {

--- a/libraries/networking/src/RSAKeypairGenerator.cpp
+++ b/libraries/networking/src/RSAKeypairGenerator.cpp
@@ -25,7 +25,10 @@
 RSAKeypairGenerator::RSAKeypairGenerator(QObject* parent) :
     QObject(parent)
 {
+}
 
+void RSAKeypairGenerator::run() {
+    generateKeypair();
 }
 
 void RSAKeypairGenerator::generateKeypair() {
@@ -92,5 +95,5 @@ void RSAKeypairGenerator::generateKeypair() {
     OPENSSL_free(publicKeyDER);
     OPENSSL_free(privateKeyDER);
     
-    emit generatedKeypair();
+    emit generatedKeypair(_publicKey, _privateKey);
 }

--- a/libraries/networking/src/RSAKeypairGenerator.h
+++ b/libraries/networking/src/RSAKeypairGenerator.h
@@ -13,25 +13,20 @@
 #define hifi_RSAKeypairGenerator_h
 
 #include <QtCore/QObject>
+#include <QtCore/QRunnable>
 #include <QtCore/QUuid>
 
-class RSAKeypairGenerator : public QObject {
+class RSAKeypairGenerator : public QObject, public QRunnable {
     Q_OBJECT
 public:
-    RSAKeypairGenerator(QObject* parent = 0);
+    RSAKeypairGenerator(QObject* parent = nullptr);
 
-    void setDomainID(const QUuid& domainID) { _domainID = domainID; }
-    const QUuid& getDomainID() const { return _domainID; }
-
-    const QByteArray& getPublicKey() const { return _publicKey; }
-    const QByteArray& getPrivateKey() const { return _privateKey; }
-    
-public slots:
+    virtual void run() override;
     void generateKeypair();
 
 signals:
     void errorGeneratingKeypair();
-    void generatedKeypair();
+    void generatedKeypair(QByteArray publicKey, QByteArray privateKey);
 
 private:
     QUuid _domainID;


### PR DESCRIPTION
Qt installs its own callbacks into the openssl lib for mutexes. I was getting a repeatable thread collision in which Qt installed the callback during our code's use of openssl for RSA key generation. This resulted in an unlock call without a matching lock and, in debug builds, a crash.
 