### PR TITLE
fix case sensitive comparison in AddressManager::setHost

### DIFF
--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -767,10 +767,10 @@ bool AddressManager::handleUsername(const QString& lookupString) {
 }
 
 bool AddressManager::setHost(const QString& host, LookupTrigger trigger, quint16 port) {
-    if (host != _domainURL.host() || port != _domainURL.port()) {
+    int hostComparisonResult = QString::compare(host, _domainURL.host(), Qt::CaseInsensitive);
+    if (hostComparisonResult != 0 || port != _domainURL.port()) {
         addCurrentAddressToHistory(trigger);
 
-        bool emitHostChanged = host != _domainURL.host();
         _domainURL = QUrl();
         _domainURL.setScheme(URL_SCHEME_HIFI);
         _domainURL.setHost(host);
@@ -781,7 +781,7 @@ bool AddressManager::setHost(const QString& host, LookupTrigger trigger, quint16
         // any host change should clear the shareable place name
         _shareablePlaceName.clear();
 
-        if (emitHostChanged) {
+        if (hostComparisonResult != 0) {
             emit hostChanged(host);
         }
 

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -767,8 +767,8 @@ bool AddressManager::handleUsername(const QString& lookupString) {
 }
 
 bool AddressManager::setHost(const QString& host, LookupTrigger trigger, quint16 port) {
-    int hostComparisonResult = QString::compare(host, _domainURL.host(), Qt::CaseInsensitive);
-    if (hostComparisonResult != 0 || port != _domainURL.port()) {
+    bool hostHasChanged = QString::compare(host, _domainURL.host(), Qt::CaseInsensitive);
+    if (hostHasChanged || port != _domainURL.port()) {
         addCurrentAddressToHistory(trigger);
 
         _domainURL = QUrl();
@@ -781,7 +781,7 @@ bool AddressManager::setHost(const QString& host, LookupTrigger trigger, quint16
         // any host change should clear the shareable place name
         _shareablePlaceName.clear();
 
-        if (hostComparisonResult != 0) {
+        if (hostHasChanged) {
             emit hostChanged(host);
         }
 


### PR DESCRIPTION
In the function `AddressManager::setHost` we do a comparison to see if the host have changes
i.e `host != _domainURL.host()`. If the host names are the same but cased differently the test will fail.
Ticket - https://highfidelity.manuscript.com/f/cases/15126/Goto-Tab-Closes-By-Itself-If-You-Cannot-Connect-To-A-Domain