### PR TITLE
Fix Flickery Procedural Shader

### DIFF
--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -272,24 +272,29 @@ void Procedural::prepare(gpu::Batch& batch, const glm::vec3& position, const glm
         // Leave this here for debugging
         // qCDebug(procedural) << "FragmentShader:\n" << fragmentShaderSource.c_str();
 
-		gpu::Shader::BindingSet slotBindings;
-		slotBindings.insert(gpu::Shader::Binding(std::string("iChannel0"), 0));
-		slotBindings.insert(gpu::Shader::Binding(std::string("iChannel1"), 1));
-		slotBindings.insert(gpu::Shader::Binding(std::string("iChannel2"), 2));
-		slotBindings.insert(gpu::Shader::Binding(std::string("iChannel3"), 3));
+        gpu::Shader::BindingSet slotBindings;
+
+        slotBindings.insert(gpu::Shader::Binding(std::string("iChannel0"), 0));
+        slotBindings.insert(gpu::Shader::Binding(std::string("iChannel1"), 1));
+        slotBindings.insert(gpu::Shader::Binding(std::string("iChannel2"), 2));
+        slotBindings.insert(gpu::Shader::Binding(std::string("iChannel3"), 3));
+
+        // TODO: THis is a simple fix, we need a cleaner way to provide the "hosting" program for procedural custom shaders to be defined together with the required bindings.
+        const int PROCEDURAL_PROGRAM_LIGHTING_MODEL_SLOT = 3;
+        slotBindings.insert(gpu::Shader::Binding(std::string("lightingModelBuffer"), PROCEDURAL_PROGRAM_LIGHTING_MODEL_SLOT));
 
         _opaqueFragmentShader = gpu::Shader::createPixel(opaqueShaderSource);
         _opaqueShader = gpu::Shader::createProgram(_vertexShader, _opaqueFragmentShader);
-		gpu::Shader::makeProgram(*_opaqueShader, slotBindings);
+        gpu::Shader::makeProgram(*_opaqueShader, slotBindings);
 
-		if (!transparentShaderSource.empty() && transparentShaderSource != opaqueShaderSource) {
-			_transparentFragmentShader = gpu::Shader::createPixel(transparentShaderSource);
-			_transparentShader = gpu::Shader::createProgram(_vertexShader, _transparentFragmentShader);
-			gpu::Shader::makeProgram(*_transparentShader, slotBindings);
-		} else {
-			_transparentFragmentShader = _opaqueFragmentShader;
-			_transparentShader = _opaqueShader;
-		}
+        if (!transparentShaderSource.empty() && transparentShaderSource != opaqueShaderSource) {
+            _transparentFragmentShader = gpu::Shader::createPixel(transparentShaderSource);
+            _transparentShader = gpu::Shader::createProgram(_vertexShader, _transparentFragmentShader);
+            gpu::Shader::makeProgram(*_transparentShader, slotBindings);
+        } else {
+            _transparentFragmentShader = _opaqueFragmentShader;
+            _transparentShader = _opaqueShader;
+        }
 
         _opaquePipeline = gpu::Pipeline::create(_opaqueShader, _opaqueState);
         _transparentPipeline = gpu::Pipeline::create(_transparentShader, _transparentState);


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/15199/Some-shaders-have-become-dark
Fixing the procedural shader flickering key lighting, this is due to the LightingModel binding slot not assigned

TEST PLAN
In the domain named blue at this location:
hifi://blue/17.0528,-9.80423,-2.09991/0,-0.609638,0,0.79268

THere are 2 boxes displaying 2 procedural shaders (lava and ocean):
![image](https://user-images.githubusercontent.com/2230265/40258963-5aa6ad3c-5aa8-11e8-848f-25dd3c1a7d1d.png)

- In this pr, while turning around the boxes it should always be displayed properly (same as on the picture)
- Using the app Luci, you can enable disable the sprocedural shading displayed on these boxes by checking on off the checkbox "lightmap":
![image](https://user-images.githubusercontent.com/2230265/40259056-e71fe5d0-5aa8-11e8-9edd-24eb818cd159.png)

In current master, these materials are Flickering going dark/correct depending on your viewpoint on them:
![image](https://user-images.githubusercontent.com/2230265/40259103-6d664d32-5aa9-11e8-8b7d-7f9418563dec.png)

And the luci app "Lightmap" checkbox has NO effect
![image](https://user-images.githubusercontent.com/2230265/40259115-96ff167e-5aa9-11e8-9452-d7db50651433.png)
![image](https://user-images.githubusercontent.com/2230265/40259122-a796ccc0-5aa9-11e8-83e1-acbdc3475564.png)



