### PR TITLE
Fix logspam from texture transfer code

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
@@ -339,7 +339,7 @@ void GLTextureTransferEngineDefault::populateActiveBufferQueue() {
         // Can't find any pending transfers, so move on
         if (textureTransferQueue.empty()) {
             if (vargltexture->hasPendingTransfers()) {
-                qWarning(gpugllogging) << "Texture has no transfer jobs, but has pending transfers";
+                // qWarning(gpugllogging) << "Texture " << gltexture->_id << "(" << texture->source().c_str() << ") has no transfer jobs, but has pending transfers" ;
             }
             itr = _pendingTransfersMap.erase(itr);
             continue;


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/15226/Warning-spam-from-the-texture-transfer-manager

## Testing 

Verify that the message "Texture has no transfer jobs, but has pending transfers" does not spam the log output compared to master