### PR TITLE
Protect against null hudTexture

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -586,7 +586,7 @@ void OpenGLDisplayPlugin::updateFrameData() {
 
 std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> OpenGLDisplayPlugin::getHUDOperator() {
     return [this](gpu::Batch& batch, const gpu::TexturePointer& hudTexture, bool mirror) {
-        if (_hudPipeline) {
+        if (_hudPipeline && hudTexture) {
             batch.enableStereo(false);
             batch.setPipeline(mirror ? _mirrorHUDPipeline : _hudPipeline);
             batch.setResourceTexture(0, hudTexture);

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -428,7 +428,7 @@ void HmdDisplayPlugin::HUDRenderer::updatePipeline() {
 std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> HmdDisplayPlugin::HUDRenderer::render(HmdDisplayPlugin& plugin) {
     updatePipeline();
     return [this](gpu::Batch& batch, const gpu::TexturePointer& hudTexture, bool mirror) {
-        if (pipeline) {
+        if (pipeline && hudTexture) {
             batch.setPipeline(pipeline);
 
             batch.setInputFormat(format);


### PR DESCRIPTION
I saw this crash on Android:
```
05-18 14:48:33.561 24639-24639/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
    Build fingerprint: 'samsung/star2qlteue/star2qlteue:8.0.0/R16NW/G965U1UEU1ARBG:user/release-keys'
    Revision: '14'
    ABI: 'arm64'
    pid: 24222, tid: 24352, name: RenderThread  >>> io.highfidelity.hifiinterface <<<
    signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
    Cause: null pointer dereference
        x0   0000000000000000  x1   0000007e397d5840  x2   0000007e36800000  x3   0000000000000005
        x4   00000000000000db  x5   0000007e34d018f0  x6   ff71646565746164  x7   7f7f7f7f7f7f7f7f
        x8   0000007e34d010e0  x9   0000007e397d5840  x10  0000000000000000  x11  0000000000000000
        x12  0000000000000000  x13  0000007e48792d04  x14  0000000000000008  x15  0000000000000000
        x16  0000007e442c0098  x17  0000007e43bcc6e8  x18  0000007e36a0c2f0  x19  0000007e2840f5a0
        x20  0000007e3619efe0  x21  0000007e4876a800  x22  0000007e38e8ab80  x23  0000007e57e153e0
        x24  0000007e474b6d50  x25  0000000000000001  x26  0000007e34d02588  x27  0000000000000000
        x28  0000007e2840f5a0  x29  0000007e34d010b0  x30  0000007e43bf002c
        sp   0000007e34d01090  pc   0000007e43bf003c  pstate 0000000060000000
05-18 14:48:33.563 24639-24639/? A/DEBUG: backtrace:
        #00 pc 000000000072e03c  /data/app/io.highfidelity.hifiinterface-51uwG3pjxoMN7jCUTqfVPw==/lib/arm64/libinterface.so (_ZNSt6__ndk18functionIFvRN3gpu5BatchERKNS_10shared_ptrINS1_7TextureEEEbEEC2ERKSA_+104)
        #01 pc 000000000072aa78  /data/app/io.highfidelity.hifiinterface-51uwG3pjxoMN7jCUTqfVPw==/lib/arm64/libinterface.so (_ZNSt6__ndk18functionIFvRN3gpu5BatchERKNS_10shared_ptrINS1_7TextureEEEbEEaSERKSA_+52)
        #02 pc 0000000000019c2c  /data/app/io.highfidelity.hifiinterface-51uwG3pjxoMN7jCUTqfVPw==/lib/arm64/libplugins.so (_ZN13DisplayPlugin14getHUDOperatorEv+88)
        #03 pc 000000000072839c  /data/app/io.highfidelity.hifiinterface-51uwG3pjxoMN7jCUTqfVPw==/lib/arm64/libinterface.so (_ZN11Application7paintGLEv+3872)
        #04 pc 000000000065c1a4  /data/app/io.highfidelity.hifiinterface-51uwG3pjxoMN7jCUTqfVPw==/lib/arm64/libinterface.so (_ZN18RenderEventHandler6renderEv+32)
        #05 pc 000000000064b3d8  /data/app/io.highfidelity.hifiinterface-51uwG3pjxoMN7jCUTqfVPw==/lib/arm64/libinterface.so (_ZN18RenderEventHandler5eventEP6QEvent+60)
        #06 pc 000000000018e3fc  /data/app/io.highfidelity.hifiinterface-51uwG3pjxoMN7jCUTqfVPw==/lib/arm64/libQt5Widgets.so (_ZN19QApplicationPrivate13notify_helperEP7QObjectP6QEvent+304)
```

This should protect against it, although I don't know what causes it to happen.

Test plan:
- Android and desktop smoke.  Verify that the UI shows up.  You shouldn't crash on Android (or, if you do, please attach logs to verify that it's not a different crash).