### PR TITLE
Minor fix allows import glTF from Substance Painter

### DIFF
--- a/libraries/fbx/src/GLTFReader.cpp
+++ b/libraries/fbx/src/GLTFReader.cpp
@@ -1174,7 +1174,7 @@ bool GLTFReader::addArrayOfType(const QByteArray& bin, int byteOffset, int byteL
         break;
     }
     case GLTFAccessorComponentType::UNSIGNED_INT: {
-        readArray<quint8>(bin, byteOffset, byteLength, outarray, accessorType);
+        readArray<quint32>(bin, byteOffset, byteLength, outarray, accessorType);
         break;
     }
     case GLTFAccessorComponentType::UNSIGNED_SHORT: {

--- a/libraries/fbx/src/GLTFReader.h
+++ b/libraries/fbx/src/GLTFReader.h
@@ -190,7 +190,7 @@ namespace GLTFBufferViewTarget {
 struct GLTFBufferView {
     int buffer; //required
     int byteLength; //required
-    int byteOffset;
+    int byteOffset { 0 };
     int target;
     QMap<QString, bool> defined;
     void dump() {
@@ -470,7 +470,7 @@ namespace GLTFAccessorComponentType {
 }
 struct GLTFAccessor {
     int bufferView;
-    int byteOffset;
+    int byteOffset { 0 };
     int componentType; //required
     int count; //required
     int type; //required


### PR DESCRIPTION
This PR fixes the glTF importer to support Substance Painter .gltf files.

