### PR TITLE
Fixing populated / allocated tracking for textures

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLTexture.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTexture.h
@@ -70,14 +70,16 @@ private:
     Texture::PixelsPointer _mipData;
     size_t _transferOffset{ 0 };
     size_t _transferSize{ 0 };
+    uint16_t _sourceMip{ 0 };
     bool _bufferingRequired{ true };
     Lambda _transferLambda{ [](const TexturePointer&) {} };
     Lambda _bufferingLambda{ [](const TexturePointer&) {} };
 public:
     TransferJob(const TransferJob& other) = delete;
-    TransferJob(const std::function<void()>& transferLambda);
+    TransferJob(uint16_t sourceMip, const std::function<void()>& transferLambda);
     TransferJob(const Texture& texture, uint16_t sourceMip, uint16_t targetMip, uint8_t face, uint32_t lines = 0, uint32_t lineOffset = 0);
     ~TransferJob();
+    const uint16_t& sourceMip() const { return _sourceMip; }
     const size_t& size() const { return _transferSize; }
     bool bufferingRequired() const { return _bufferingRequired; }
     void buffer(const TexturePointer& texture) { _bufferingLambda(texture); }
@@ -96,6 +98,7 @@ public:
     virtual void populateTransferQueue(TransferQueue& pendingTransfers) = 0;
 
     void sanityCheck() const;
+    uint16 populatedMip() const { return _populatedMip; }
     bool canPromote() const { return _allocatedMip > _minAllocatedMip; }
     bool canDemote() const { return _allocatedMip < _maxAllocatedMip; }
     bool hasPendingTransfers() const { return _populatedMip > _allocatedMip; }
@@ -109,7 +112,6 @@ public:
     static const size_t MAX_BUFFER_SIZE;
 
 protected:
-
     // THe amount of memory currently allocated
     Size _size { 0 };
 

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
@@ -279,8 +279,6 @@ using GL41VariableAllocationTexture = GL41Backend::GL41VariableAllocationTexture
 GL41VariableAllocationTexture::GL41VariableAllocationTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture) :
      GL41Texture(backend, texture)
 {
-    Backend::textureResourceCount.increment();
-
     auto mipLevels = texture.getNumMips();
     _allocatedMip = mipLevels;
     _maxAllocatedMip = _populatedMip = mipLevels;
@@ -303,9 +301,6 @@ GL41VariableAllocationTexture::GL41VariableAllocationTexture(const std::weak_ptr
 }
 
 GL41VariableAllocationTexture::~GL41VariableAllocationTexture() {
-    Backend::textureResourceCount.decrement();
-    Backend::textureResourceGPUMemSize.update(_size, 0);
-    Backend::textureResourcePopulatedGPUMemSize.update(_populatedSize, 0);
 }
 
 void GL41VariableAllocationTexture::allocateStorage(uint16 allocatedMip) {
@@ -605,7 +600,7 @@ void GL41VariableAllocationTexture::populateTransferQueue(TransferQueue& pending
         }
 
         // queue up the sampler and populated mip change for after the transfer has completed
-        pendingTransfers.emplace(new TransferJob([=] {
+        pendingTransfers.emplace(new TransferJob(sourceMip, [=] {
             _populatedMip = sourceMip;
             incrementPopulatedSize(_gpuObject.evalMipSize(sourceMip));
             sanityCheck();

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendVariableTexture.cpp
@@ -31,13 +31,9 @@ using GL45Texture = GL45Backend::GL45Texture;
 using GL45VariableAllocationTexture = GL45Backend::GL45VariableAllocationTexture;
 
 GL45VariableAllocationTexture::GL45VariableAllocationTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture) : GL45Texture(backend, texture) {
-    Backend::textureResourceCount.increment();
 }
 
 GL45VariableAllocationTexture::~GL45VariableAllocationTexture() {
-    Backend::textureResourceCount.decrement();
-    Backend::textureResourceGPUMemSize.update(_size, 0);
-    Backend::textureResourcePopulatedGPUMemSize.update(_populatedSize, 0);
 }
 
 #if GPU_BINDLESS_TEXTURES
@@ -286,7 +282,7 @@ void GL45ResourceTexture::populateTransferQueue(TransferQueue& pendingTransfers)
         }
 
         // queue up the sampler and populated mip change for after the transfer has completed
-        pendingTransfers.emplace(new TransferJob([=] {
+        pendingTransfers.emplace(new TransferJob(sourceMip, [=] {
             _populatedMip = sourceMip;
             incrementPopulatedSize(_gpuObject.evalMipSize(sourceMip));
             sanityCheck();

--- a/libraries/gpu-gles/src/gpu/gles/GLESBackendTexture.cpp
+++ b/libraries/gpu-gles/src/gpu/gles/GLESBackendTexture.cpp
@@ -341,8 +341,6 @@ using GLESVariableAllocationTexture = GLESBackend::GLESVariableAllocationTexture
 GLESVariableAllocationTexture::GLESVariableAllocationTexture(const std::weak_ptr<GLBackend>& backend, const Texture& texture) :
      GLESTexture(backend, texture)
 {
-    Backend::textureResourceCount.increment();
-
     auto mipLevels = texture.getNumMips();
     _allocatedMip = mipLevels;
     _maxAllocatedMip = _populatedMip = mipLevels;
@@ -366,9 +364,6 @@ GLESVariableAllocationTexture::GLESVariableAllocationTexture(const std::weak_ptr
 }
 
 GLESVariableAllocationTexture::~GLESVariableAllocationTexture() {
-    Backend::textureResourceCount.decrement();
-    Backend::textureResourceGPUMemSize.update(_size, 0);
-    Backend::textureResourcePopulatedGPUMemSize.update(_populatedSize, 0);
 }
 
 void GLESVariableAllocationTexture::allocateStorage(uint16 allocatedMip) {
@@ -669,7 +664,7 @@ void GLESVariableAllocationTexture::populateTransferQueue(TransferJob::Queue& qu
         }
 
         // queue up the sampler and populated mip change for after the transfer has completed
-        queue.emplace(new TransferJob([=] {
+        queue.emplace(new TransferJob(sourceMip, [=] {
             _populatedMip = sourceMip;
             incrementPopulatedSize(_gpuObject.evalMipSize(sourceMip));
             sanityCheck();


### PR DESCRIPTION
This PR fixes a race condition where the population of a given mip can be counted more than once, thus throwing off the populated size metric.

## Testing

In master build, going into a domain with many textures, such as `dev-avatarisland` will often show a higher populated size than is allocated.  With this PR, the populated size should never exceed the allocated size.  
