### PR TITLE
Mac: render unsupported BPTC textures as uncompressed

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendTexture.cpp
@@ -31,6 +31,10 @@ bool GL41Backend::supportedTextureFormat(const gpu::Element& format) {
         case gpu::Semantic::COMPRESSED_EAC_RED_SIGNED:
         case gpu::Semantic::COMPRESSED_EAC_XY:
         case gpu::Semantic::COMPRESSED_EAC_XY_SIGNED:
+        // The ARB_texture_compression_bptc extension is not supported on 4.1
+        // See https://www.g-truc.net/doc/OpenGL%204%20Hardware%20Matrix.pdf
+        case gpu::Semantic::COMPRESSED_BC6_RGB:
+        case gpu::Semantic::COMPRESSED_BC7_SRGBA:
             return false;
         default:
             return true;

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendTexture.cpp
@@ -33,6 +33,8 @@ using namespace gpu::gl45;
 
 bool GL45Backend::supportedTextureFormat(const gpu::Element& format) {
     switch (format.getSemantic()) {
+        // ETC textures are actually required by the OpenGL spec as of 4.3, but aren't always supported by hardware
+        // They'll be recompressed by OpenGL, which will be slow or have poor quality, so disable them for now
         case gpu::Semantic::COMPRESSED_ETC2_RGB:
         case gpu::Semantic::COMPRESSED_ETC2_SRGB:
         case gpu::Semantic::COMPRESSED_ETC2_RGB_PUNCHTHROUGH_ALPHA:


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/9494

Use the new client texture negotiation feature to disable unsupported formats on Mac.

Test plan (Windows, Mac, Android):
- Make sure to clear your KTX cache (Developer -> Render -> Clear KTX Cache) and delete all your Android data (uninstall, or find the option in Settings) before testing.
- Create a skybox with this URL (skybox and ambient): `https://hifi-content.s3.amazonaws.com/samuel/Daylight%20Box_0.texmeta.json`
- Go to that location on Windows, Mac, and Android.  On all systems, the skybox should show up.