### PR TITLE
 Adding showHidden properties to file dialogs to allow for showing hidden files/folders

### DIFF
--- a/interface/resources/qml/dialogs/+android/FileDialog.qml
+++ b/interface/resources/qml/dialogs/+android/FileDialog.qml
@@ -57,7 +57,7 @@ ModalWindow {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property bool showHidden: folderListModel.showHidden
+    property alias showHidden: folderListModel.showHidden
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;

--- a/interface/resources/qml/dialogs/+android/FileDialog.qml
+++ b/interface/resources/qml/dialogs/+android/FileDialog.qml
@@ -57,7 +57,7 @@ ModalWindow {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property bool showHidden: false;
+    property bool showHidden: folderListModel.showHidden
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;

--- a/interface/resources/qml/dialogs/+android/FileDialog.qml
+++ b/interface/resources/qml/dialogs/+android/FileDialog.qml
@@ -57,7 +57,7 @@ ModalWindow {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property alias showHidden: folderListModel.showHidden
+    property bool showHidden: true;
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;
@@ -324,8 +324,10 @@ ModalWindow {
             showDirsFirst: true
             showDotAndDotDot: false
             showFiles: !root.selectDirectory
+            showHidden: root.showHidden
             Component.onCompleted: {
                 showFiles = !root.selectDirectory
+                showHidden = root.showHidden
             }
 
             onFolderChanged: {

--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -58,7 +58,7 @@ ModalWindow {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property bool showHidden: false;
+    property bool showHidden: folderListModel.showHidden
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;

--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -58,7 +58,7 @@ ModalWindow {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property bool showHidden: folderListModel.showHidden
+    property alias showHidden: folderListModel.showHidden
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;

--- a/interface/resources/qml/dialogs/FileDialog.qml
+++ b/interface/resources/qml/dialogs/FileDialog.qml
@@ -58,7 +58,7 @@ ModalWindow {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property alias showHidden: folderListModel.showHidden
+    property bool showHidden: true;
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;
@@ -325,8 +325,10 @@ ModalWindow {
             showDirsFirst: true
             showDotAndDotDot: false
             showFiles: !root.selectDirectory
+            showHidden: root.showHidden
             Component.onCompleted: {
                 showFiles = !root.selectDirectory
+                showHidden = root.showHidden
             }
 
             onFolderChanged: {

--- a/interface/resources/qml/dialogs/TabletFileDialog.qml
+++ b/interface/resources/qml/dialogs/TabletFileDialog.qml
@@ -55,7 +55,7 @@ TabletModalWindow {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property bool showHidden: false;
+    property bool showHidden: folderListModel.showHidden
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;

--- a/interface/resources/qml/dialogs/TabletFileDialog.qml
+++ b/interface/resources/qml/dialogs/TabletFileDialog.qml
@@ -55,7 +55,7 @@ TabletModalWindow {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property bool showHidden: folderListModel.showHidden
+    property alias showHidden: folderListModel.showHidden
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;

--- a/interface/resources/qml/dialogs/TabletFileDialog.qml
+++ b/interface/resources/qml/dialogs/TabletFileDialog.qml
@@ -55,7 +55,7 @@ TabletModalWindow {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property alias showHidden: folderListModel.showHidden
+    property bool showHidden: true;
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;
@@ -288,8 +288,10 @@ TabletModalWindow {
             showDirsFirst: true
             showDotAndDotDot: false
             showFiles: !root.selectDirectory
+            showHidden: root.showHidden
             Component.onCompleted: {
                 showFiles = !root.selectDirectory
+                showHidden = root.showHidden
             }
 
             onFolderChanged: {

--- a/interface/resources/qml/hifi/tablet/tabletWindows/TabletFileDialog.qml
+++ b/interface/resources/qml/hifi/tablet/tabletWindows/TabletFileDialog.qml
@@ -52,7 +52,7 @@ Rectangle {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property alias showHidden: folderListModel.showHidden
+    property bool showHidden: true;
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;
@@ -280,8 +280,10 @@ Rectangle {
             showDirsFirst: true
             showDotAndDotDot: false
             showFiles: !root.selectDirectory
+            showHidden: root.showHidden
             Component.onCompleted: {
                 showFiles = !root.selectDirectory
+                showHidden = root.showHidden
             }
 
             onFolderChanged: {

--- a/interface/resources/qml/hifi/tablet/tabletWindows/TabletFileDialog.qml
+++ b/interface/resources/qml/hifi/tablet/tabletWindows/TabletFileDialog.qml
@@ -52,7 +52,7 @@ Rectangle {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property bool showHidden: false;
+    property bool showHidden: folderListModel.showHidden
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;

--- a/interface/resources/qml/hifi/tablet/tabletWindows/TabletFileDialog.qml
+++ b/interface/resources/qml/hifi/tablet/tabletWindows/TabletFileDialog.qml
@@ -52,7 +52,7 @@ Rectangle {
     property int iconSize: 40
 
     property bool selectDirectory: false;
-    property bool showHidden: folderListModel.showHidden
+    property alias showHidden: folderListModel.showHidden
     // FIXME implement
     property bool multiSelect: false;
     property bool saveDialog: false;


### PR DESCRIPTION
Fixing file dialog in QML to allow for displaying hidden files/folders.
https://highfidelity.manuscript.com/f/cases/14515/#