### PR TITLE
Fix image and text overlay drifting

### DIFF
--- a/interface/src/ui/overlays/Billboard3DOverlay.cpp
+++ b/interface/src/ui/overlays/Billboard3DOverlay.cpp
@@ -46,6 +46,13 @@ bool Billboard3DOverlay::applyTransformTo(Transform& transform, bool force) {
     return transformChanged;
 }
 
+void Billboard3DOverlay::update(float duration) {
+    if (isFacingAvatar()) {
+        _renderVariableDirty = true;
+    }
+    Parent::update(duration);
+}
+
 Transform Billboard3DOverlay::evalRenderTransform() {
     Transform transform = getTransform();
     bool transformChanged = applyTransformTo(transform, true);

--- a/interface/src/ui/overlays/Billboard3DOverlay.h
+++ b/interface/src/ui/overlays/Billboard3DOverlay.h
@@ -18,6 +18,7 @@
 
 class Billboard3DOverlay : public Planar3DOverlay, public PanelAttachable, public Billboardable {
     Q_OBJECT
+    using Parent = Planar3DOverlay;
 
 public:
     Billboard3DOverlay() {}
@@ -25,6 +26,8 @@ public:
 
     void setProperties(const QVariantMap& properties) override;
     QVariant getProperty(const QString& property) override;
+
+    void update(float duration) override;
 
 protected:
     virtual bool applyTransformTo(Transform& transform, bool force = false) override;

--- a/interface/src/ui/overlays/Image3DOverlay.cpp
+++ b/interface/src/ui/overlays/Image3DOverlay.cpp
@@ -51,11 +51,6 @@ void Image3DOverlay::update(float deltatime) {
         _texture = DependencyManager::get<TextureCache>()->getTexture(_url);
         _textureIsLoaded = false;
     }
-    if (usecTimestampNow() > _transformExpiry) {
-        Transform transform = getTransform();
-        applyTransformTo(transform);
-        setTransform(transform);
-    }
     Parent::update(deltatime);
 }
 

--- a/interface/src/ui/overlays/Text3DOverlay.cpp
+++ b/interface/src/ui/overlays/Text3DOverlay.cpp
@@ -83,15 +83,6 @@ xColor Text3DOverlay::getBackgroundColor() {
     return result;
 }
 
-void Text3DOverlay::update(float deltatime) {
-    if (usecTimestampNow() > _transformExpiry) {
-        Transform transform = getTransform();
-        applyTransformTo(transform);
-        setTransform(transform);
-    }
-    Parent::update(deltatime);
-}
-
 void Text3DOverlay::render(RenderArgs* args) {
     if (!_renderVisible || !getParentVisible()) {
         return; // do nothing if we're not visible
@@ -307,12 +298,3 @@ QSizeF Text3DOverlay::textSize(const QString& text) const {
 
     return QSizeF(extents.x, extents.y) * pointToWorldScale;
 }
-
-bool Text3DOverlay::findRayIntersection(const glm::vec3 &origin, const glm::vec3 &direction, float &distance,
-                                            BoxFace &face, glm::vec3& surfaceNormal) {
-    Transform transform = getTransform();
-    applyTransformTo(transform, true);
-    setTransform(transform);
-    return Billboard3DOverlay::findRayIntersection(origin, direction, distance, face, surfaceNormal);
-}
-

--- a/interface/src/ui/overlays/Text3DOverlay.h
+++ b/interface/src/ui/overlays/Text3DOverlay.h
@@ -30,8 +30,6 @@ public:
     ~Text3DOverlay();
     virtual void render(RenderArgs* args) override;
 
-    virtual void update(float deltatime) override;
-
     virtual const render::ShapeKey getShapeKey() override;
 
     // getters
@@ -59,9 +57,6 @@ public:
     QVariant getProperty(const QString& property) override;
 
     QSizeF textSize(const QString& test) const;  // Meters
-
-    virtual bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
-                                        BoxFace& face, glm::vec3& surfaceNormal) override;
 
     virtual Text3DOverlay* createClone() const override;
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/13917/

Test plan:
- Find a mirror (dev-mobile, blue, etc.).  Stand in front of it for a while (5-10 minutes).  It shouldn't rotate slowly over time or clip into the mirror model behind it.
- Run [this](https://gist.githubusercontent.com/SamGondelman/5e5037a33c175434b12136ab97326ced/raw/c4800d395e9d4986e91cacdfa651541e91848456/Drift.js).  Stand in front of the things for a while (5-10 minutes).  None of the entities or overlays should rotate slowly or clip into their backdrops.
- Run [this](https://gist.githubusercontent.com/SamGondelman/ea8abaaf4504e314f6afa13acd112ae5/raw/5e92a5e601b55385e705fcbfe839d8812fc4bb01/AATest2.js).  Move around.  The text overlays should rotate to follow you.