### PR TITLE
Adding fix for enabling saved front/back advanced controls. (RC68)

### DIFF
--- a/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
+++ b/scripts/system/controllers/toggleAdvancedMovementForHandControllers.js
@@ -171,4 +171,24 @@
     Messages.subscribe(HIFI_ADVANCED_MOVEMENT_DISABLER_CHANNEL);
     Messages.messageReceived.connect(handleMessage);
 
+    function initializeControls() {
+        if(HMD.active) {
+            if (Controller.Hardware.Vive !== undefined || Controller.Hardware.OculusTouch !== undefined) {
+                if (MyAvatar.useAdvancedMovementControls) {
+                    Controller.disableMapping(DRIVING_MAPPING_NAME);
+                } else {
+                    Controller.enableMapping(DRIVING_MAPPING_NAME);
+                }
+
+                if (MyAvatar.getFlyingEnabled()) {
+                    Controller.disableMapping(FLYING_MAPPING_NAME);
+                } else {
+                    Controller.enableMapping(FLYING_MAPPING_NAME);
+                }
+			});
+
+		}
+	}
+
+	initializeControls();
 }()); // END LOCAL_SCOPE


### PR DESCRIPTION
- Fixing forward and backward HMD controls to work after restarting interface

https://highfidelity.manuscript.com/f/cases/15324