### PR TITLE
Don't mark backups from domains with no asset server corrupted

### DIFF
--- a/domain-server/src/AssetsBackupHandler.h
+++ b/domain-server/src/AssetsBackupHandler.h
@@ -30,7 +30,7 @@ class AssetsBackupHandler : public QObject, public BackupHandlerInterface {
     Q_OBJECT
 
 public:
-    AssetsBackupHandler(const QString& backupDirectory);
+    AssetsBackupHandler(const QString& backupDirectory, bool assetServerEnabled);
 
     std::pair<bool, float> isAvailable(const QString& backupName) override;
     std::pair<bool, float> getRecoveryStatus() override;
@@ -65,6 +65,7 @@ private:
     void updateMappings();
 
     QString _assetsDirectory;
+    bool _assetServerEnabled { false };
 
     QTimer _mappingsRefreshTimer;
     p_high_resolution_clock::time_point _lastMappingsRefresh;

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -72,6 +72,8 @@ public:
 
     static const QString REPLACEMENT_FILE_EXTENSION;
 
+    bool isAssetServerEnabled();
+
 public slots:
     /// Called by NodeList to inform us a node has been added
     void nodeAdded(SharedNodePointer node);


### PR DESCRIPTION
If the DS doesn't choose to run an Asset Server, add an empty mappings file to the archive so they don't show as corrupted.