### PR TITLE
fix copy delete cut paste commands and menus (RC68)

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -103,16 +103,32 @@ Menu::Menu() {
     editMenu->addSeparator();
 
     // Edit > Cut
-    addActionToQMenuAndActionHash(editMenu, "Cut", Qt::CTRL | Qt::Key_X);
+    auto cutAction = addActionToQMenuAndActionHash(editMenu, "Cut", QKeySequence::Cut);
+    connect(cutAction, &QAction::triggered, [] {
+            QKeyEvent* keyEvent = new QKeyEvent(QEvent::KeyPress, Qt::Key_X, Qt::ControlModifier);
+            QCoreApplication::postEvent(QCoreApplication::instance(), keyEvent);
+    });
 
     // Edit > Copy
-    addActionToQMenuAndActionHash(editMenu, "Copy", Qt::CTRL | Qt::Key_C);
+    auto copyAction = addActionToQMenuAndActionHash(editMenu, "Copy", QKeySequence::Copy);
+    connect(copyAction, &QAction::triggered, [] {
+            QKeyEvent* keyEvent = new QKeyEvent(QEvent::KeyPress, Qt::Key_C, Qt::ControlModifier);
+            QCoreApplication::postEvent(QCoreApplication::instance(), keyEvent);
+    });
 
     // Edit > Paste
-    addActionToQMenuAndActionHash(editMenu, "Paste", Qt::CTRL | Qt::Key_V);
+    auto pasteAction = addActionToQMenuAndActionHash(editMenu, "Paste", QKeySequence::Paste);
+    connect(pasteAction, &QAction::triggered, [] {
+            QKeyEvent* keyEvent = new QKeyEvent(QEvent::KeyPress, Qt::Key_V, Qt::ControlModifier);
+            QCoreApplication::postEvent(QCoreApplication::instance(), keyEvent);
+    });
 
     // Edit > Delete
-    addActionToQMenuAndActionHash(editMenu, "Delete", Qt::Key_Delete);
+    auto deleteAction =addActionToQMenuAndActionHash(editMenu, "Delete", QKeySequence::Delete);
+    connect(deleteAction, &QAction::triggered, [] {
+            QKeyEvent* keyEvent = new QKeyEvent(QEvent::KeyPress, Qt::Key_Delete, Qt::ControlModifier);
+            QCoreApplication::postEvent(QCoreApplication::instance(), keyEvent);
+    });
 
     editMenu->addSeparator();
 

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -124,7 +124,7 @@ Menu::Menu() {
     });
 
     // Edit > Delete
-    auto deleteAction =addActionToQMenuAndActionHash(editMenu, "Delete", QKeySequence::Delete);
+    auto deleteAction = addActionToQMenuAndActionHash(editMenu, "Delete", QKeySequence::Delete);
     connect(deleteAction, &QAction::triggered, [] {
             QKeyEvent* keyEvent = new QKeyEvent(QEvent::KeyPress, Qt::Key_Delete, Qt::ControlModifier);
             QCoreApplication::postEvent(QCoreApplication::instance(), keyEvent);


### PR DESCRIPTION
In  the menu reorg we added menu shortcuts for delete. copy, cut and paste  commands. These short cuts prevented these commands from being used on  websurfaces. Also the shortcuts never worked in general. This PR fixes these two issues 
ticket - https://highfidelity.manuscript.com/f/cases/15384/HMD-No-Copy-Paste


