### PR TITLE
Android: Update Application.cpp

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3011,9 +3011,11 @@ void Application::onDesktopRootItemCreated(QQuickItem* rootItem) {
     auto surfaceContext = DependencyManager::get<OffscreenUi>()->getSurfaceContext();
     surfaceContext->setContextProperty("Stats", Stats::getInstance());
 
+#if !defined(Q_OS_ANDROID)
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     auto qml = PathUtils::qmlUrl("AvatarInputsBar.qml");
     offscreenUi->show(qml, "AvatarInputsBar");
+#endif
 }
 
 void Application::updateCamera(RenderArgs& renderArgs, float deltaTime) {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -237,6 +237,14 @@ QString ScriptEngine::getContext() const {
     return "unknown";
 }
 
+bool ScriptEngine::isDebugMode() const { 
+#if defined(DEBUG)
+    return true;
+#else
+    return false;
+#endif
+}
+
 ScriptEngine::~ScriptEngine() {
     auto scriptEngines = DependencyManager::get<ScriptEngines>();
     if (scriptEngines) {

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -233,6 +233,12 @@ public:
     Q_INVOKABLE bool isClientScript() const { return _context == CLIENT_SCRIPT; }
 
     /**jsdoc
+     * @function Script.isDebugMode
+     * @returns {boolean}
+     */
+    Q_INVOKABLE bool isDebugMode() const;
+
+    /**jsdoc
      * @function Script.isEntityClientScript
      * @returns {boolean}
      */

--- a/scripts/+android/defaultScripts.js
+++ b/scripts/+android/defaultScripts.js
@@ -16,8 +16,7 @@ var DEFAULT_SCRIPTS_COMBINED = [
     "system/+android/touchscreenvirtualpad.js",
     "system/+android/actionbar.js",
     "system/+android/audio.js" ,
-    "system/+android/modes.js",
-    "system/+android/stats.js"/*,
+    "system/+android/modes.js"/*,
     "system/away.js",
     "system/controllers/controllerDisplayManager.js",
     "system/controllers/handControllerGrabAndroid.js",
@@ -31,6 +30,10 @@ var DEFAULT_SCRIPTS_COMBINED = [
     "system/bubble.js",
     "system/android.js",
     "developer/debugging/debugAndroidMouse.js"*/
+];
+
+var DEBUG_SCRIPTS = [
+    "system/+android/stats.js"
 ];
 
 var DEFAULT_SCRIPTS_SEPARATE = [ ];
@@ -70,12 +73,22 @@ function runDefaultsTogether() {
     for (var i in DEFAULT_SCRIPTS_COMBINED) {
         Script.include(DEFAULT_SCRIPTS_COMBINED[i]);
     }
+    if (Script.isDebugMode()) {
+        for (var i in DEBUG_SCRIPTS) {
+            Script.include(DEBUG_SCRIPTS[i]);
+        }
+    }
     loadSeparateDefaults();
 }
 
 function runDefaultsSeparately() {
     for (var i in DEFAULT_SCRIPTS_COMBINED) {
         Script.load(DEFAULT_SCRIPTS_COMBINED[i]);
+    }
+    if (Script.isDebugMode()) {
+        for (var i in DEBUG_SCRIPTS) {
+            Script.load(DEBUG_SCRIPTS[i]);
+        }
     }
     loadSeparateDefaults();
 }

--- a/scripts/system/+android/stats.js
+++ b/scripts/system/+android/stats.js
@@ -30,7 +30,7 @@ function init() {
         text: "STATS"
     });
     statsButton.clicked.connect(function() {
-        Menu.triggerOption("Stats");
+        Menu.triggerOption("Show Statistics");
     });
 }
 


### PR DESCRIPTION
Remove the mic bar for android

Testing plan
1. The bar that shows the mic intensity should not appear anymore in android (was in the top-left corner of the screen). Test muting/unmuting 
2. The same bar should remain in desktop
3. The stats button should work on android.
