### PR TITLE
RC68: Android signing and remove audiobar

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,10 +29,10 @@ android {
         }
         signingConfigs {
             release {
-                storeFile file(HIFI_ANDROID_KEYSTORE)
-                storePassword HIFI_ANDROID_KEYSTORE_PASSWORD
-                keyAlias HIFI_ANDROID_KEY_ALIAS
-                keyPassword HIFI_ANDROID_KEY_PASSWORD
+                storeFile project.hasProperty("HIFI_ANDROID_KEYSTORE") ? file(HIFI_ANDROID_KEYSTORE) : null
+                storePassword project.hasProperty("HIFI_ANDROID_KEYSTORE_PASSWORD") ? HIFI_ANDROID_KEYSTORE_PASSWORD : ''
+                keyAlias project.hasProperty("HIFI_ANDROID_KEY_ALIAS") ? HIFI_ANDROID_KEY_ALIAS : ''
+                keyPassword project.hasProperty("HIFI_ANDROID_KEY_PASSWORD") ? HIFI_ANDROID_KEY_PASSWORD : ''
             }
         }
     }
@@ -46,7 +46,10 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
+            signingConfig project.hasProperty("HIFI_ANDROID_KEYSTORE") &&
+                    project.hasProperty("HIFI_ANDROID_KEYSTORE_PASSWORD") &&
+                    project.hasProperty("HIFI_ANDROID_KEY_ALIAS") &&
+                    project.hasProperty("HIFI_ANDROID_KEY_PASSWORD")? signingConfigs.release : null
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,6 +27,14 @@ android {
                     '-DDISABLE_KTX_CACHE=OFF'
             }
         }
+        signingConfigs {
+            release {
+                storeFile file(HIFI_ANDROID_KEYSTORE)
+                storePassword HIFI_ANDROID_KEYSTORE_PASSWORD
+                keyAlias HIFI_ANDROID_KEY_ALIAS
+                keyPassword HIFI_ANDROID_KEY_PASSWORD
+            }
+        }
     }
 
     compileOptions {
@@ -38,6 +46,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
         }
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -49,12 +49,6 @@
             android:label="@string/app_name"
             android:launchMode="singleTop"
             >
-
-            <intent-filter>
-                <category android:name="com.google.intent.category.DAYDREAM"/>
-                <action android:name="android.intent.action.MAIN" />
-            </intent-filter>
-
             <meta-data android:name="android.app.lib_name" android:value="native-lib"/>
             <meta-data android:name="android.app.qt_libs_resource_id" android:resource="@array/qt_libs"/>
             <meta-data android:name="android.app.bundled_in_lib_resource_id" android:resource="@array/bundled_in_lib"/>

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3011,9 +3011,11 @@ void Application::onDesktopRootItemCreated(QQuickItem* rootItem) {
     auto surfaceContext = DependencyManager::get<OffscreenUi>()->getSurfaceContext();
     surfaceContext->setContextProperty("Stats", Stats::getInstance());
 
+#if !defined(Q_OS_ANDROID)
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     auto qml = PathUtils::qmlUrl("AvatarInputsBar.qml");
     offscreenUi->show(qml, "AvatarInputsBar");
+#endif
 }
 
 void Application::updateCamera(RenderArgs& renderArgs, float deltaTime) {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -237,6 +237,14 @@ QString ScriptEngine::getContext() const {
     return "unknown";
 }
 
+bool ScriptEngine::isDebugMode() const { 
+#if defined(DEBUG)
+    return true;
+#else
+    return false;
+#endif
+}
+
 ScriptEngine::~ScriptEngine() {
     auto scriptEngines = DependencyManager::get<ScriptEngines>();
     if (scriptEngines) {

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -233,6 +233,12 @@ public:
     Q_INVOKABLE bool isClientScript() const { return _context == CLIENT_SCRIPT; }
 
     /**jsdoc
+     * @function Script.isDebugMode
+     * @returns {boolean}
+     */
+    Q_INVOKABLE bool isDebugMode() const;
+
+    /**jsdoc
      * @function Script.isEntityClientScript
      * @returns {boolean}
      */

--- a/scripts/+android/defaultScripts.js
+++ b/scripts/+android/defaultScripts.js
@@ -16,8 +16,7 @@ var DEFAULT_SCRIPTS_COMBINED = [
     "system/+android/touchscreenvirtualpad.js",
     "system/+android/actionbar.js",
     "system/+android/audio.js" ,
-    "system/+android/modes.js",
-    "system/+android/stats.js"/*,
+    "system/+android/modes.js"/*,
     "system/away.js",
     "system/controllers/controllerDisplayManager.js",
     "system/controllers/handControllerGrabAndroid.js",
@@ -31,6 +30,10 @@ var DEFAULT_SCRIPTS_COMBINED = [
     "system/bubble.js",
     "system/android.js",
     "developer/debugging/debugAndroidMouse.js"*/
+];
+
+var DEBUG_SCRIPTS = [
+    "system/+android/stats.js"
 ];
 
 var DEFAULT_SCRIPTS_SEPARATE = [ ];
@@ -70,12 +73,22 @@ function runDefaultsTogether() {
     for (var i in DEFAULT_SCRIPTS_COMBINED) {
         Script.include(DEFAULT_SCRIPTS_COMBINED[i]);
     }
+    if (Script.isDebugMode()) {
+        for (var i in DEBUG_SCRIPTS) {
+            Script.include(DEBUG_SCRIPTS[i]);
+        }
+    }
     loadSeparateDefaults();
 }
 
 function runDefaultsSeparately() {
     for (var i in DEFAULT_SCRIPTS_COMBINED) {
         Script.load(DEFAULT_SCRIPTS_COMBINED[i]);
+    }
+    if (Script.isDebugMode()) {
+        for (var i in DEBUG_SCRIPTS) {
+            Script.load(DEBUG_SCRIPTS[i]);
+        }
     }
     loadSeparateDefaults();
 }

--- a/scripts/system/+android/stats.js
+++ b/scripts/system/+android/stats.js
@@ -30,7 +30,7 @@ function init() {
         text: "STATS"
     });
     statsButton.clicked.connect(function() {
-        Menu.triggerOption("Stats");
+        Menu.triggerOption("Show Statistics");
     });
 }
 


### PR DESCRIPTION
Rebuild these PRs against RC68

[Sign release apk. Remove daydream intent from manifest #13242](https://github.com/highfidelity/hifi/pull/13242)
[Android: Update Application.cpp #13249](https://github.com/highfidelity/hifi/pull/13249)

Test plan:
- The bar that shows the mic intensity should not appear anymore in android (was in the top-left corner of the screen). Test muting/unmuting
- The same bar should remain in desktop
- The stats button should work on android.