### PR TITLE
Billboardable::pointTransformAtCamera div by zero asan warning

### DIFF
--- a/interface/src/ui/overlays/Billboardable.cpp
+++ b/interface/src/ui/overlays/Billboardable.cpp
@@ -41,9 +41,13 @@ bool Billboardable::pointTransformAtCamera(Transform& transform, glm::quat offse
         glm::vec3 cameraPos = qApp->getCamera().getPosition();
         // use the referencial from the avatar, y isn't always up
         glm::vec3 avatarUP = DependencyManager::get<AvatarManager>()->getMyAvatar()->getWorldOrientation()*Vectors::UP;
-        glm::vec3 zeroPos{ 0.0f, 0.0f, 0.0f };
-        if (!(glm::all(glm::equal(cameraPos, zeroPos)) || glm::all(glm::equal(billboardPos, zeroPos)) ||
-              glm::all(glm::equal(avatarUP, zeroPos)))) {
+        // check to see if glm::lookAt will work / using glm::lookAt function names
+
+		glm::highp_vec3 s(glm::cross(billboardPos - cameraPos, avatarUP));
+		glm::highp_vec3 u(glm::cross(s, billboardPos - cameraPos));
+
+        // make sure s and u are not NaN for any component
+        if(glm::length2(s) > 0.0f && glm::length2(u) > 0.0f) {
             glm::quat rotation(conjugate(toQuat(glm::lookAt(cameraPos, billboardPos, avatarUP))));
             transform.setRotation(rotation);
             transform.postRotate(offsetRotation);

--- a/interface/src/ui/overlays/Billboardable.cpp
+++ b/interface/src/ui/overlays/Billboardable.cpp
@@ -41,12 +41,14 @@ bool Billboardable::pointTransformAtCamera(Transform& transform, glm::quat offse
         glm::vec3 cameraPos = qApp->getCamera().getPosition();
         // use the referencial from the avatar, y isn't always up
         glm::vec3 avatarUP = DependencyManager::get<AvatarManager>()->getMyAvatar()->getWorldOrientation()*Vectors::UP;
-        
-        glm::quat rotation(conjugate(toQuat(glm::lookAt(cameraPos, billboardPos, avatarUP))));
-        
-        transform.setRotation(rotation);
-        transform.postRotate(offsetRotation);
-        return true;
+        glm::vec3 zeroPos{ 0.0f, 0.0f, 0.0f };
+        if (!(glm::all(glm::equal(cameraPos, zeroPos)) || glm::all(glm::equal(billboardPos, zeroPos)) ||
+              glm::all(glm::equal(avatarUP, zeroPos)))) {
+            glm::quat rotation(conjugate(toQuat(glm::lookAt(cameraPos, billboardPos, avatarUP))));
+            transform.setRotation(rotation);
+            transform.postRotate(offsetRotation);
+            return true;
+        }
     }
     return false;
 }

--- a/interface/src/ui/overlays/Billboardable.cpp
+++ b/interface/src/ui/overlays/Billboardable.cpp
@@ -41,13 +41,11 @@ bool Billboardable::pointTransformAtCamera(Transform& transform, glm::quat offse
         glm::vec3 cameraPos = qApp->getCamera().getPosition();
         // use the referencial from the avatar, y isn't always up
         glm::vec3 avatarUP = DependencyManager::get<AvatarManager>()->getMyAvatar()->getWorldOrientation()*Vectors::UP;
-        // check to see if glm::lookAt will work / using glm::lookAt function names
-
+        // check to see if glm::lookAt will work / using glm::lookAt variable name
 		glm::highp_vec3 s(glm::cross(billboardPos - cameraPos, avatarUP));
-		glm::highp_vec3 u(glm::cross(s, billboardPos - cameraPos));
 
-        // make sure s and u are not NaN for any component
-        if(glm::length2(s) > 0.0f && glm::length2(u) > 0.0f) {
+        // make sure s is not NaN for any component
+        if(glm::length2(s) > 0.0f) {
             glm::quat rotation(conjugate(toQuat(glm::lookAt(cameraPos, billboardPos, avatarUP))));
             transform.setRotation(rotation);
             transform.postRotate(offsetRotation);


### PR DESCRIPTION
- Fixing ASAN warning at [#14709](https://highfidelity.fogbugz.com/f/cases/14709/Billboardable-pointTransformAtCamera-div-by-zero-asan-warning)

To test, just launch a smoke-test for overlays.

Steps:
- Launch Interface
- All overlays should work as normal
