### PR TITLE
Use version from JSON on domain restore

### DIFF
--- a/libraries/octree/src/OctreeDataUtils.cpp
+++ b/libraries/octree/src/OctreeDataUtils.cpp
@@ -40,9 +40,10 @@ bool readOctreeFile(QString path, QJsonDocument* doc) {
 }
 
 bool OctreeUtils::RawOctreeData::readOctreeDataInfoFromJSON(QJsonObject root) {
-    if (root.contains("Id") && root.contains("DataVersion")) {
+    if (root.contains("Id") && root.contains("DataVersion") && root.contains("Version")) {
         id = root["Id"].toVariant().toUuid();
-        version = root["DataVersion"].toInt();
+        dataVersion = root["DataVersion"].toInt();
+        version = root["Version"].toInt();
     }
     readSubclassData(root);
     return true;
@@ -76,11 +77,10 @@ bool OctreeUtils::RawOctreeData::readOctreeDataInfoFromFile(QString path) {
 }
 
 QByteArray OctreeUtils::RawOctreeData::toByteArray() {
-    const auto protocolVersion = (int)versionForPacketType((PacketTypeEnum::Value)dataPacketType());
     QJsonObject obj {
-        { "DataVersion", QJsonValue((qint64)version) },
+        { "DataVersion", QJsonValue((qint64)dataVersion) },
         { "Id", QJsonValue(id.toString()) },
-        { "Version", protocolVersion },
+        { "Version", QJsonValue((qint64)version) },
     };
 
     writeSubclassData(obj);
@@ -111,8 +111,8 @@ PacketType OctreeUtils::RawOctreeData::dataPacketType() const {
 
 void OctreeUtils::RawOctreeData::resetIdAndVersion() {
     id = QUuid::createUuid();
-    version = OctreeUtils::INITIAL_VERSION;
-    qDebug() << "Reset octree data to: " << id << version;
+    dataVersion = OctreeUtils::INITIAL_VERSION;
+    qDebug() << "Reset octree data to: " << id << dataVersion;
 }
 
 void OctreeUtils::RawEntityData::readSubclassData(const QJsonObject& root) {

--- a/libraries/octree/src/OctreeDataUtils.h
+++ b/libraries/octree/src/OctreeDataUtils.h
@@ -28,6 +28,7 @@ constexpr Version INITIAL_VERSION = 0;
 class RawOctreeData {
 public:
     QUuid id { QUuid() };
+    Version dataVersion { -1 };
     Version version { -1 };
 
     virtual PacketType dataPacketType() const;

--- a/libraries/octree/src/OctreePersistThread.cpp
+++ b/libraries/octree/src/OctreePersistThread.cpp
@@ -179,8 +179,8 @@ bool OctreePersistThread::process() {
 
         OctreeUtils::RawOctreeData data;
         if (data.readOctreeDataInfoFromFile(_filename)) {
-            qDebug() << "Setting entity version info to: " << data.id << data.version;
-            _tree->setOctreeVersionInfo(data.id, data.version);
+            qDebug() << "Setting entity version info to: " << data.id << data.dataVersion;
+            _tree->setOctreeVersionInfo(data.id, data.dataVersion);
         }
 
         bool persistentFileRead;


### PR DESCRIPTION
Separate Version in RawOctreeData to Version and DataVersion (which was previously Version).

Update Version from JSON via readOctreeDataInfoFromJSON, and use that Version in toByteArray instead of latest Version for packet type.

This fixes domain restores using latest Version at the time instead of using the Version from the JSON being restored.

Test Plan:
-Launch into your sandbox
-Open this zip file and copy models.json.gz out of it: https://hifi-content.s3.amazonaws.com/davidback/development/autobackup-weekly_rolling-2018-05-15_19-46-46.zip
-Browse http://localhost:40100/content/#upload_content_group and under Upload Content choose the models.json.gz from above and then click Upload Content button
-Go to localhost/98.2,1.5,78 in world and find the table with the guns and bow on it
-Open Create, select the raygun and flaregun on the table, and verify under Properties that they are set as Cloneable with a Clone Lifetime of 86000, a Clone Limit of 10, and set as Clone Dynamic
-Enter HMD and verify the raygun and the flaregun can be cloned

Also test the following:
https://highfidelity.testrail.net/index.php?/cases/view/11884
https://highfidelity.testrail.net/index.php?/cases/view/11444
