### PR TITLE
Check for null material pointer in CauterizedModel

### DIFF
--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -87,7 +87,8 @@ void CauterizedModel::createVisibleRenderItemSet() {
             for (int partIndex = 0; partIndex < numParts; partIndex++) {
                 auto ptr = std::make_shared<CauterizedMeshPartPayload>(shared_from_this(), i, partIndex, shapeID, transform, offset);
                 _modelMeshRenderItems << std::static_pointer_cast<ModelMeshPartPayload>(ptr);
-                _modelMeshMaterialNames.push_back(getGeometry()->getShapeMaterial(shapeID)->getName());
+                auto material = getGeometry()->getShapeMaterial(shapeID);
+                _modelMeshMaterialNames.push_back(material ? material->getName() : "");
                 _modelMeshRenderItemShapes.emplace_back(ShapeInfo{ (int)i });
                 shapeID++;
             }


### PR DESCRIPTION
This PR fix the error that occurs when loading an avatar without materials. 
https://highfidelity.manuscript.com/f/cases/15315/Crash-in-MyAvatar-postUpdate-and-CauterizedModel-createVisibleRenderItemSet