### PR TITLE
Protect against null resource

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -636,7 +636,10 @@ void Resource::attemptRequest() {
             << "- retrying asset load - attempt" << _attempts << " of " << MAX_ATTEMPTS;
     }
 
-    ResourceCache::attemptRequest(_self);
+    auto self = _self.lock();
+    if (self) {
+        ResourceCache::attemptRequest(self);
+    }
 }
 
 void Resource::finishedLoading(bool success) {


### PR DESCRIPTION
We caught this crash on android, but it seems to happen every so often on desktop too: https://highfidelity.sp.backtrace.io/dashboard/highfidelity/project/Interface/group/dc635228cc76e79bbbb0b9524b14885fa01d9de7f433c18b3f64f68f8f8b0c5d

Test plan:
- I don't know what triggers the crash.  Walk around a few domains with lots of models and textures.  You shouldn't crash.