### PR TITLE
Domain-unreachable message remaining on slow connects

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletRoot.qml
+++ b/interface/resources/qml/hifi/tablet/TabletRoot.qml
@@ -65,6 +65,18 @@ Item {
         return false;
     }
 
+    function closeDialog() {
+        if (openMessage != null) {
+            openMessage.destroy();
+            openMessage = null;
+        }
+
+        if (openModal != null) {
+            openModal.destroy();
+            openModal = null;
+        }
+    }
+
     function isUrlLoaded(url) {
         if (currentApp >= 0) {
             var currentAppUrl = tabletApps.get(currentApp).appUrl;

--- a/interface/src/ui/DialogsManager.cpp
+++ b/interface/src/ui/DialogsManager.cpp
@@ -93,6 +93,7 @@ void DialogsManager::setDomainConnectionFailureVisibility(bool visible) {
         static const QUrl url("dialogs/TabletConnectionFailureDialog.qml");
         auto hmd = DependencyManager::get<HMDScriptingInterface>();
         if (visible) {
+            _dialogCreatedWhileShown = tablet->property("tabletShown").toBool();
             tablet->initialScreen(url);
             if (!hmd->getShouldShowTablet()) {
                 hmd->openTablet();
@@ -100,7 +101,10 @@ void DialogsManager::setDomainConnectionFailureVisibility(bool visible) {
         } else if (tablet->isPathLoaded(url)) {
             tablet->closeDialog();
             tablet->gotoHomeScreen();
-            hmd->closeTablet();
+            if (!_dialogCreatedWhileShown) {
+                hmd->closeTablet();
+            }
+            _dialogCreatedWhileShown = false;
         }
     }
 }

--- a/interface/src/ui/DialogsManager.cpp
+++ b/interface/src/ui/DialogsManager.cpp
@@ -97,7 +97,8 @@ void DialogsManager::setDomainConnectionFailureVisibility(bool visible) {
             if (!hmd->getShouldShowTablet()) {
                 hmd->openTablet();
             }
-        } else {
+        } else if (tablet->isPathLoaded(url)) {
+            tablet->closeDialog();
             tablet->gotoHomeScreen();
             hmd->closeTablet();
         }

--- a/interface/src/ui/DialogsManager.cpp
+++ b/interface/src/ui/DialogsManager.cpp
@@ -97,6 +97,9 @@ void DialogsManager::setDomainConnectionFailureVisibility(bool visible) {
             if (!hmd->getShouldShowTablet()) {
                 hmd->openTablet();
             }
+        } else {
+            tablet->gotoHomeScreen();
+            hmd->closeTablet();
         }
     }
 }

--- a/interface/src/ui/DialogsManager.h
+++ b/interface/src/ui/DialogsManager.h
@@ -80,6 +80,7 @@ private:
     QPointer<OctreeStatsDialog> _octreeStatsDialog;
     QPointer<TestingDialog> _testingDialog;
     QPointer<DomainConnectionDialog> _domainConnectionDialog;
+    bool _dialogCreatedWhileShown { false };
     bool _addressBarVisible { false };
 };
 

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -433,7 +433,6 @@ bool TabletProxy::isMessageDialogOpen() {
 
 void TabletProxy::closeDialog() {
     if (QThread::currentThread() != thread()) {
-        bool result = false;
         QMetaObject::invokeMethod(this, "closeDialog");
         return;
     }

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -431,6 +431,20 @@ bool TabletProxy::isMessageDialogOpen() {
     return result.toBool();
 }
 
+void TabletProxy::closeDialog() {
+    if (QThread::currentThread() != thread()) {
+        bool result = false;
+        QMetaObject::invokeMethod(this, "isMessageDialogOpen");
+        return;
+    }
+
+    if (!_qmlTabletRoot) {
+        return;
+    }
+
+    QMetaObject::invokeMethod(_qmlTabletRoot, "closeDialog");
+}
+
 void TabletProxy::emitWebEvent(const QVariant& msg) {
     if (QThread::currentThread() != thread()) {
         QMetaObject::invokeMethod(this, "emitWebEvent", Q_ARG(QVariant, msg));

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -434,7 +434,7 @@ bool TabletProxy::isMessageDialogOpen() {
 void TabletProxy::closeDialog() {
     if (QThread::currentThread() != thread()) {
         bool result = false;
-        QMetaObject::invokeMethod(this, "isMessageDialogOpen");
+        QMetaObject::invokeMethod(this, "closeDialog");
         return;
     }
 

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -309,6 +309,12 @@ public:
     Q_INVOKABLE bool isMessageDialogOpen();
 
     /**jsdoc
+    * Close any open dialogs.
+    * @function TabletProxy#closeDialog
+    */
+    Q_INVOKABLE void closeDialog();
+
+    /**jsdoc
      * Creates a new button, adds it to this and returns it.
      * @function TabletProxy#addButton
      * @param {object} properties - Button properties.


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/14417/

For the HMD case only the enable request was being handled, not the disable request (the desktop case handles both). This PR should fix that, although it is difficult to reliably test.
