### PR TITLE
DNM: Add a simple (dangerous) Quantity field to Marketplace Checkout

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -596,6 +596,26 @@ Rectangle {
                 }
             }
 
+            Timer {
+                id: buyTimer;
+                property int currentPurchaseCount: 0;
+                property int totalPurchases: 1;
+                interval: 500;
+                running: false;
+                repeat: false;
+                onTriggered: {
+                    if (buyTimer.currentPurchaseCount !== buyTimer.totalPurchases) {
+                        Commerce.buy(root.itemId, root.itemPrice);
+                        buyTimer.currentPurchaseCount++;
+                        buyTimer.start();
+                    } else {
+                        quantityField.text = 1;
+                        buyTimer.currentPurchaseCount = 0;
+                        buyTimer.totalPurchases = 1;
+                    }
+                }
+            }
+
             // "Buy" button
             HifiControlsUit.Button {
                 id: buyButton;
@@ -608,7 +628,7 @@ Rectangle {
                 anchors.topMargin: 10;
                 height: 50;
                 anchors.left: parent.left;
-                anchors.right: parent.right;
+                width: parent.width - 100;
                 text: (root.isUpdating && root.itemEdition > 0) ? "CONFIRM UPDATE" : (((root.isCertified) ? ((ownershipStatusReceived && balanceReceived && availableUpdatesReceived) ?
                     ((viewInMyPurchasesButton.visible && !root.isUpdating) ? "Buy It Again" : "Confirm Purchase") : "--") : "Get Item"));
                 onClicked: {
@@ -633,7 +653,8 @@ Rectangle {
                                 }
                                 lightboxPopup.button2text = "CONFIRM";
                                 lightboxPopup.button2method = function() {
-                                    Commerce.buy(root.itemId, root.itemPrice);
+                                    buyTimer.totalPurchases = parseInt(quantityField.text);
+                                    buyTimer.start();
                                     lightboxPopup.visible = false;
                                     buyButton.enabled = false;
                                     loading.visible = true;
@@ -642,7 +663,8 @@ Rectangle {
                             } else {
                                 buyButton.enabled = false;
                                 loading.visible = true;
-                                Commerce.buy(root.itemId, root.itemPrice);
+                                buyTimer.totalPurchases = parseInt(quantityField.text);
+                                buyTimer.start();
                             }
                         } else {
                             buyButton.enabled = false;
@@ -655,6 +677,20 @@ Rectangle {
                         }
                     }
                 }
+            }
+
+            HifiControlsUit.TextField {
+                id: quantityField;
+                visible: buyButton.visible;
+                text: "1";
+                anchors.top: buyButton.top;
+                anchors.bottom: buyButton.bottom;
+                anchors.left: buyButton.right;
+                anchors.leftMargin: 8;
+                anchors.right: parent.right;
+                placeholderText: "qty";
+                activeFocusOnPress: true;
+                activeFocusOnTab: true;
             }
 
             // "Cancel" button


### PR DESCRIPTION
DNM because this shouldn't go into any release in its current state; it's simply to help out Greeters in a pinch 😄 

**WARNING WARNING WARNING:**
This is a _debug_ tool for convenience. Be careful with what you input in the new Quantity field during checkout - if you accidentally input "1000" when buying a flare gun and press Purchase, you'll buy 1000 flare guns unless you quit Interface really fast!

**ANOTHER IMPORTANT NOTE:** This works by buying 1 item every 500ms until you've purchased the number of items you input in the Quantity field. You'll see the "Checkout Confirmation" screen before all items are purchased. Wait a while after pressing Buy if you've bought a large number of items. For example, if you buy 150 items, it'll take 1 minute 15 seconds for all of your purchases to go through.

Here's what the screen looks like (this is for an item I've already purchased; same concept for newly-purchased items):
![image](https://user-images.githubusercontent.com/3409031/40814283-30779642-64f4-11e8-93af-531658b12d2f.png)
