### PR TITLE
Workaround for android buffer corruption issue

### DIFF
--- a/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
@@ -170,25 +170,29 @@ public class InterfaceActivity extends QtActivity {
 
     private void surfacesWorkaround() {
         FrameLayout fl = findViewById(android.R.id.content);
-        QtLayout qtLayout = (QtLayout) fl.getChildAt(0);
-        QtSurface s1 = (QtSurface) qtLayout.getChildAt(0);
-        QtSurface s2 = (QtSurface) qtLayout.getChildAt(1);
-        Integer subLayer1 = 0;
-        Integer subLayer2 = 0;
-        try {
-            Field f = s1.getClass().getSuperclass().getDeclaredField("mSubLayer");
-            f.setAccessible(true);
-            subLayer1 = (Integer) f.get(s1);
-            subLayer2 = (Integer) f.get(s2);
-            if (subLayer1 < subLayer2) {
-                s1.setVisibility(View.VISIBLE);
-                s2.setVisibility(View.INVISIBLE);
-            } else {
-                s1.setVisibility(View.INVISIBLE);
-                s2.setVisibility(View.VISIBLE);
+        if (fl.getChildCount() > 0) {
+            QtLayout qtLayout = (QtLayout) fl.getChildAt(0);
+            if (qtLayout.getChildCount() > 1) {
+                QtSurface s1 = (QtSurface) qtLayout.getChildAt(0);
+                QtSurface s2 = (QtSurface) qtLayout.getChildAt(1);
+                Integer subLayer1 = 0;
+                Integer subLayer2 = 0;
+                try {
+                    Field f = s1.getClass().getSuperclass().getDeclaredField("mSubLayer");
+                    f.setAccessible(true);
+                    subLayer1 = (Integer) f.get(s1);
+                    subLayer2 = (Integer) f.get(s2);
+                    if (subLayer1 < subLayer2) {
+                        s1.setVisibility(View.VISIBLE);
+                        s2.setVisibility(View.INVISIBLE);
+                    } else {
+                        s1.setVisibility(View.INVISIBLE);
+                        s2.setVisibility(View.VISIBLE);
+                    }
+                } catch (ReflectiveOperationException e) {
+                    Log.e(TAG, "Workaround failed");
+                }
             }
-        } catch (ReflectiveOperationException e) {
-            Log.e(TAG, "Workaround failed");
         }
     }
 

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
@@ -14,6 +14,7 @@ package io.highfidelity.hifiinterface;
 import android.content.Intent;
 import android.content.res.AssetManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Vibrator;
@@ -178,7 +179,13 @@ public class InterfaceActivity extends QtActivity {
                 Integer subLayer1 = 0;
                 Integer subLayer2 = 0;
                 try {
-                    Field f = s1.getClass().getSuperclass().getDeclaredField("mSubLayer");
+                    String field;
+                    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        field = "mSubLayer";
+                    } else {
+                        field = "mWindowType";
+                    }
+                    Field f = s1.getClass().getSuperclass().getDeclaredField(field);
                     f.setAccessible(true);
                     subLayer1 = (Integer) f.get(s1);
                     subLayer2 = (Integer) f.get(s2);


### PR DESCRIPTION
Workaround for buffer corruption issue (only affects Android)

Test plan:
- On multiple phones, switch back and forth between the Home screen and a few domains multiple times.  At no point should the screen become "corrupted" with a tv-static-like effect.
- Test in the different supported versions of android (7 and 8)