### PR TITLE
update server-side bounding box more correctly for grabbed things

### DIFF
--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -446,17 +446,13 @@ bool EntityMotionState::shouldSendUpdate(uint32_t simulationStep) {
     // this case is prevented by setting _ownershipState to UNOWNABLE in EntityMotionState::ctor
     assert(!(_entity->getClientOnly() && _entity->getOwningAvatarID() != Physics::getSessionUUID()));
 
-    // shouldSendUpdate() sould NOT be triggering updates to maintain the queryAACube of dynamic entities.
-    // The server is supposed to predict the transform of such moving things.  The client performs a "double prediction"
-    // where it predicts what the the server is doing, and only sends updates whent the entity's true transform
-    // differs significantly.  That is what the remoteSimulationOutOfSync() logic is all about.
-    if (_entity->dynamicDataNeedsTransmit() ||
-            (!_entity->getDynamic() && _entity->queryAACubeNeedsUpdate())) {
+    if (_entity->dynamicDataNeedsTransmit()) {
         return true;
     }
-
     if (_entity->shouldSuppressLocationEdits()) {
-        return false;
+        // "shouldSuppressLocationEdits" really means: "the entity has a 'Hold' action therefore
+        // we don't need send an update unless the entity is not contained by its queryAACube"
+        return _entity->queryAACubeNeedsUpdate();
     }
 
     return remoteSimulationOutOfSync(simulationStep);


### PR DESCRIPTION
* fix bug where the server-side bounding box is not correctly updated for near-grabbed dynamic entity
* fix bug where children of near-grabbed entity do not have their server-side bounding box correctly updated