### PR TITLE
possible fix for pal missing info

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -472,7 +472,7 @@ Rectangle {
                     visible: !isCheckBox && !isButton && !isAvgAudio;
                     uuid: model ? model.sessionId : "";
                     selected: styleData.selected;
-                    isReplicated: model.isReplicated;
+                    isReplicated: model && model.isReplicated;
                     isAdmin: model && model.admin;
                     isPresent: model && model.isPresent;
                     // Size


### PR DESCRIPTION
I don't know if this fixes https://highfidelity.manuscript.com/f/cases/15500 (e.g., this change is on the "nearby" tab, and the reported bug is on the "connection tab", but all the more reason that model might be null), _and_ PAL is being rewritten for this release anyway, but:

1. There's a chance that the PAL rewrite won't make this release,
2. This change is both safe and it absolutely does address the error logging reported by Thoys on the ticket.
3. If it does fix the problem, it would be nice to have the option of hotfixing R67 with just the narrow fix instead of all the other changes being worked on for PAL.