### PR TITLE
Fix MS7224: Add dimensions to printed Snapshot entity

### DIFF
--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -295,6 +295,7 @@ function printToPolaroid(image_url) {
         "description": "Printed from Snaps",                               
         "modelURL": POLAROID_MODEL_URL,
 
+        "dimensions": { "x": 0.5667, "y": 0.0212, "z": 0.4176 },
         "position": model_pos,
         "rotation": model_rot,
 


### PR DESCRIPTION
Fixes [MS7224](https://highfidelity.fogbugz.com/f/cases/7224/My-snapshots-are-cubes-OR-invisible-to-users).