### PR TITLE
Use optimized Bullet raytest function in CharacterGhostObject::rayTest()

### DIFF
--- a/libraries/physics/src/CharacterGhostObject.cpp
+++ b/libraries/physics/src/CharacterGhostObject.cpp
@@ -69,7 +69,7 @@ bool CharacterGhostObject::rayTest(const btVector3& start,
         const btVector3& end,
         CharacterRayResult& result) const {
     if (_world && _inWorld) {
-        _world->rayTest(start, end, result);
+        this->btGhostObject::rayTest(start, end, result);
     }
     return result.hasHit();
 }

--- a/libraries/physics/src/CharacterGhostObject.cpp
+++ b/libraries/physics/src/CharacterGhostObject.cpp
@@ -69,7 +69,7 @@ bool CharacterGhostObject::rayTest(const btVector3& start,
         const btVector3& end,
         CharacterRayResult& result) const {
     if (_world && _inWorld) {
-        this->btGhostObject::rayTest(start, end, result);
+        btGhostObject::rayTest(start, end, result);
     }
     return result.hasHit();
 }

--- a/libraries/physics/src/CharacterGhostObject.h
+++ b/libraries/physics/src/CharacterGhostObject.h
@@ -23,7 +23,7 @@
 
 class CharacterGhostShape;
 
-class CharacterGhostObject : public btPairCachingGhostObject {
+class CharacterGhostObject : public btGhostObject {
 public:
     CharacterGhostObject() { }
     ~CharacterGhostObject();


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/15596/Should-use-btGhostObject-rayTest-in-CharacterGhostObject-rayTest-for-optimization
This PR makes a small change to the code responsible for avatar collision checking in order to improve performance. The change should not affect program behavior.

## TEST PLAN

* Make sure that when an avatar is hovering above an object, that the height at which they transition to falling is the same
* Make sure that when an avatar walks or flies into an object, that the height relative to the avatar height at which movement is blocked remains the same, and detects thin objects (such as fences) with the same level of reliability
* Make sure that when an avatar walks into an object that does not block motion, the avatar is able to ascend on top of the object
* Make sure that when an avatar flies into an object that does not block motion, the avatar is able to ascend on top of the object, and continues flying as before (ie does not transition to walking)
* Make sure that the avatar is only able to walk up slopes below the same level of steepness