### PR TITLE
RC68 version of Personal space bubble is defaulted off for now.

### DIFF
--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -180,7 +180,7 @@ private:
 #if defined(Q_OS_ANDROID)
     Setting::Handle<bool> _ignoreRadiusEnabled { "IgnoreRadiusEnabled", false };
 #else
-    Setting::Handle<bool> _ignoreRadiusEnabled { "IgnoreRadiusEnabled", true };
+    Setting::Handle<bool> _ignoreRadiusEnabled { "IgnoreRadiusEnabled", false }; // False, until such time as it is made to work better.
 #endif
 
 #if (PR_BUILD || DEV_BUILD)


### PR DESCRIPTION
See https://github.com/highfidelity/hifi/pull/13305 for test plan.