### PR TITLE
Fix for black text rendering white in web elements

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2614,10 +2614,55 @@ void Application::initializeGL() {
         _isGLInitialized = true;
     }
 
-    _glWidget->makeCurrent();
-    glClearColor(0.2f, 0.2f, 0.2f, 1);
-    glClear(GL_COLOR_BUFFER_BIT);
-    _glWidget->swapBuffers();
+    if (!_glWidget->makeCurrent()) {
+        qCWarning(interfaceapp, "Unable to make window context current");
+    }
+
+#if !defined(DISABLE_QML)
+    // Build a shared canvas / context for the Chromium processes
+    {
+        // Disable signed distance field font rendering on ATI/AMD GPUs, due to
+        // https://highfidelity.manuscript.com/f/cases/13677/Text-showing-up-white-on-Marketplace-app
+        std::string vendor{ (const char*)glGetString(GL_VENDOR) };
+        if ((vendor.find("AMD") != std::string::npos) || (vendor.find("ATI") != std::string::npos)) {
+            qputenv("QTWEBENGINE_CHROMIUM_FLAGS", QByteArray("--disable-distance-field-text"));
+        }
+
+        // Chromium rendering uses some GL functions that prevent nSight from capturing
+        // frames, so we only create the shared context if nsight is NOT active.
+        if (!nsightActive()) {
+            _chromiumShareContext = new OffscreenGLCanvas();
+            _chromiumShareContext->setObjectName("ChromiumShareContext");
+            _chromiumShareContext->create(_glWidget->qglContext());
+            if (!_chromiumShareContext->makeCurrent()) {
+                qCWarning(interfaceapp, "Unable to make chromium shared context current");
+            }
+            qt_gl_set_global_share_context(_chromiumShareContext->getContext());
+            _chromiumShareContext->doneCurrent();
+            // Restore the GL widget context
+            if (!_glWidget->makeCurrent()) {
+                qCWarning(interfaceapp, "Unable to make window context current");
+            }
+        } else {
+            qCWarning(interfaceapp) << "nSight detected, disabling chrome rendering";
+        }
+    }
+#endif
+
+    // Build a shared canvas / context for the QML rendering
+    {
+        _qmlShareContext = new OffscreenGLCanvas();
+        _qmlShareContext->setObjectName("QmlShareContext");
+        _qmlShareContext->create(_glWidget->qglContext());
+        if (!_qmlShareContext->makeCurrent()) {
+            qCWarning(interfaceapp, "Unable to make QML shared context current");
+        }
+        OffscreenQmlSurface::setSharedContext(_qmlShareContext->getContext());
+        _qmlShareContext->doneCurrent();
+        if (!_glWidget->makeCurrent()) {
+            qCWarning(interfaceapp, "Unable to make window context current");
+        }
+    }
 
     // Build an offscreen GL context for the main thread.
     _offscreenContext = new OffscreenGLCanvas();
@@ -2628,6 +2673,11 @@ void Application::initializeGL() {
     }
     _offscreenContext->doneCurrent();
     _offscreenContext->setThreadContext();
+
+    _glWidget->makeCurrent();
+    glClearColor(0.2f, 0.2f, 0.2f, 1);
+    glClear(GL_COLOR_BUFFER_BIT);
+    _glWidget->swapBuffers();
 
     // Move the GL widget context to the render event handler thread
     _renderEventHandler = new RenderEventHandler(_glWidget->qglContext());
@@ -2751,40 +2801,6 @@ extern void setupPreferences();
 static void addDisplayPluginToMenu(const DisplayPluginPointer& displayPlugin, int index, bool active = false);
 
 void Application::initializeUi() {
-    // Build a shared canvas / context for the Chromium processes
-#if !defined(DISABLE_QML)
-    // Chromium rendering uses some GL functions that prevent nSight from capturing
-    // frames, so we only create the shared context if nsight is NOT active.
-    if (!nsightActive()) {
-        _chromiumShareContext = new OffscreenGLCanvas();
-        _chromiumShareContext->setObjectName("ChromiumShareContext");
-        _chromiumShareContext->create(_offscreenContext->getContext());
-        if (!_chromiumShareContext->makeCurrent()) {
-            qCWarning(interfaceapp, "Unable to make chromium shared context current");
-        }
-        qt_gl_set_global_share_context(_chromiumShareContext->getContext());
-        _chromiumShareContext->doneCurrent();
-        // Restore the GL widget context
-        _offscreenContext->makeCurrent();
-    } else {
-        qCWarning(interfaceapp) << "nSIGHT detected, disabling chrome rendering";
-    }
-#endif
-
-    // Build a shared canvas / context for the QML rendering
-    _qmlShareContext = new OffscreenGLCanvas();
-    _qmlShareContext->setObjectName("QmlShareContext");
-    _qmlShareContext->create(_offscreenContext->getContext());
-    if (!_qmlShareContext->makeCurrent()) {
-        qCWarning(interfaceapp, "Unable to make QML shared context current");
-    }
-    OffscreenQmlSurface::setSharedContext(_qmlShareContext->getContext());
-    _qmlShareContext->doneCurrent();
-    // Restore the GL widget context
-    _offscreenContext->makeCurrent();
-    // Make sure all QML surfaces share the main thread GL context
-    OffscreenQmlSurface::setSharedContext(_offscreenContext->getContext());
-
     AddressBarDialog::registerType();
     ErrorDialog::registerType();
     LoginDialog::registerType();


### PR DESCRIPTION
[The bug](https://highfidelity.manuscript.com/f/cases/13677/Text-showing-up-white-on-Marketplace-app)

Currently on master since build 8014 on AMD based GPUs all HTML elements (marketplace, browser windows, web entities, etc) have been rendering text incorrectly, showing black text as white, with a white background making the text effectively invisible.  This apparently was triggered by the migration to Qt 5.10.1.  Investigation has not determined the exact cause, and smaller test apps intended to reproduce the bug for easier diagnosis don't in fact reproduce the bug.  However, experimentation while trying to reproduce the issue did demonstrate that certain chromium flags (of which there are roughly a [bazlliion](https://peter.sh/experiments/chromium-command-line-switches/)) appear to work around the issue.  This PR changes the startup code to detect AMD based GPUs and apply a flag that appears to stop the problem but which hopefully should not have a significant effect on web rendering performance.

## Testing

Testing requires an AMD based GPU

* Open interface
* Open the marketplace (either in tablet or toolbar mode, doesn't matter) 
  * You can also open a browser window or examine a web entity and navigate to a text heave website like Wikipedia or Slashdot
* Scroll down the marketplace window.
  * In the master build, notice that there is no text description or title for items in the marketplace.  If you drag your mouse in some of the areas you will be able to see the text as a result of highlighting, but without highlighting the text is invisible as it's white on white
  * In the PR build, text should be properly visible, rendering black on white

