### PR TITLE
terminate thread if it didn't complete during MAX_SCRIPT_QUITTING_TIME

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -419,7 +419,7 @@ void ScriptEngine::waitTillDoneRunning() {
                 // Wait for the scripting thread to stop running, as
                 // flooding it with aborts/exceptions will persist it longer
                 static const auto MAX_SCRIPT_QUITTING_TIME = 0.5 * MSECS_PER_SECOND;
-                if (workerThread->wait(MAX_SCRIPT_QUITTING_TIME)) {
+                if (!workerThread->wait(MAX_SCRIPT_QUITTING_TIME)) {
                     workerThread->terminate();
                 }
             }


### PR DESCRIPTION
Potential fix for https://highfidelity.fogbugz.com/f/cases/14390/crash-on-shutdown-in-processEvents-probably-delete-later-related