### PR TITLE
Enable gamepad by default

### DIFF
--- a/plugins/hifiSdl2/src/SDL2Manager.cpp
+++ b/plugins/hifiSdl2/src/SDL2Manager.cpp
@@ -47,7 +47,7 @@ static_assert(
 const char* SDL2Manager::NAME = "SDL2";
 const char* SDL2Manager::SDL2_ID_STRING = "SDL2";
 
-const bool DEFAULT_ENABLED = false;
+const bool DEFAULT_ENABLED = true;
 
 SDL_JoystickID SDL2Manager::getInstanceId(SDL_GameController* controller) {
     SDL_Joystick* joystick = SDL_GameControllerGetJoystick(controller);


### PR DESCRIPTION
For https://highfidelity.fogbugz.com/f/cases/13950/ so that when a gamepad is plugged in it will be immediately usable without the user having to find an option to enable it.