### PR TITLE
FB15569 - Debug default scripts no longer on developer menu (for RC68)

### DIFF
--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -57,7 +57,6 @@ if (Menu.menuExists(MENU_CATEGORY) && !Menu.menuItemExists(MENU_CATEGORY, MENU_I
         menuItemName: MENU_ITEM,
         isCheckable: true,
         isChecked: previousSetting,
-        grouping: "Advanced"
     });
 }
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/15569/Debug-default-scripts-no-longer-on-developer-menu

*** Test plan ***

Ensure 'Developer' menu has menu item 'Debug defaultScripts.js'