### PR TITLE
Use binary resources on OSX

### DIFF
--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -133,13 +133,7 @@ if (APPLE)
   # set where in the bundle to put the resources file
   set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/icon/${INTERFACE_ICON_FILENAME} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
-  set(DISCOVERED_RESOURCES "")
-
-  # use the add_resources_to_os_x_bundle macro to recurse into resources
-  add_resources_to_os_x_bundle("${CMAKE_CURRENT_SOURCE_DIR}/resources")
-
   # append the discovered resources to our list of interface sources
-  list(APPEND INTERFACE_SRCS ${DISCOVERED_RESOURCES})
   list(APPEND INTERFACE_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/icon/${INTERFACE_ICON_FILENAME})
 endif()
 
@@ -316,18 +310,27 @@ if (APPLE)
   set(SCRIPTS_INSTALL_DIR "${INTERFACE_INSTALL_APP_PATH}/Contents/Resources")
   set(RESOURCES_DEV_DIR "$<TARGET_FILE_DIR:${TARGET_NAME}>/../Resources")
 
-  # copy script files beside the executable
   add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+    # copy script files beside the executable
     COMMAND "${CMAKE_COMMAND}" -E copy_directory
-    "${CMAKE_SOURCE_DIR}/scripts"
-    "${RESOURCES_DEV_DIR}/scripts"
-  )
-
-  # copy JSDoc files beside the executable
-  add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+      "${CMAKE_SOURCE_DIR}/scripts"
+      "${RESOURCES_DEV_DIR}/scripts"
+    # copy JSDoc files beside the executable
     COMMAND "${CMAKE_COMMAND}" -E copy_directory
-    "${CMAKE_SOURCE_DIR}/tools/jsdoc/out"
-    "${RESOURCES_DEV_DIR}/jsdoc"
+      "${CMAKE_SOURCE_DIR}/tools/jsdoc/out"
+      "${RESOURCES_DEV_DIR}/jsdoc"
+    # copy the resources files beside the executable
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+      "${RESOURCES_RCC}"
+      "${RESOURCES_DEV_DIR}"
+    # FIXME, the edit script code loads HTML from the scripts folder
+    # which in turn relies on CSS that refers to the fonts.  In theory
+    # we should be able to modify the CSS to reference the QRC path to
+    # the ttf files, but doing so generates a CORS policy violation,
+    # so we have to retain a copy of the fonts outside of the resources binary
+    COMMAND "${CMAKE_COMMAND}" -E copy_directory
+      "${PROJECT_SOURCE_DIR}/resources/fonts"
+      "${RESOURCES_DEV_DIR}/fonts"
   )
 
   # call the fixup_interface macro to add required bundling commands for installation
@@ -356,13 +359,10 @@ else()
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different
       "${PROJECT_SOURCE_DIR}/resources/serverless/tutorial.json"
       "${RESOURCES_DEV_DIR}/serverless/tutorial.json"
-  )
-
-  # copy JSDoc files beside the executable
-  add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+    # copy JSDoc files beside the executable
     COMMAND "${CMAKE_COMMAND}" -E copy_directory
-    "${CMAKE_SOURCE_DIR}/tools/jsdoc/out"
-    "${INTERFACE_EXEC_DIR}/jsdoc"
+      "${CMAKE_SOURCE_DIR}/tools/jsdoc/out"
+      "${INTERFACE_EXEC_DIR}/jsdoc"
   )
 
   # link target to external libraries

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -802,15 +802,8 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
         qApp->setProperty(hifi::properties::APP_LOCAL_DATA_PATH, cacheDir);
     }
 
-    // FIXME fix the OSX installer to install the resources.rcc binary instead of resource files and remove
-    // this conditional exclusion
-#if !defined(Q_OS_OSX)
     {
-#if defined(Q_OS_ANDROID)
-        const QString resourcesBinaryFile = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/resources.rcc";
-#else
-        const QString resourcesBinaryFile = QCoreApplication::applicationDirPath() + "/resources.rcc";
-#endif
+        const QString resourcesBinaryFile = PathUtils::getRccPath();
         if (!QFile::exists(resourcesBinaryFile)) {
             throw std::runtime_error("Unable to find primary resources");
         }
@@ -818,7 +811,6 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
             throw std::runtime_error("Unable to load primary resources");
         }
     }
-#endif
 
     // Tell the plugin manager about our statically linked plugins
     auto pluginManager = PluginManager::getInstance();

--- a/libraries/shared/src/PathUtils.h
+++ b/libraries/shared/src/PathUtils.h
@@ -37,6 +37,7 @@ class PathUtils : public QObject, public Dependency {
     Q_PROPERTY(QString resources READ resourcesPath CONSTANT)
     Q_PROPERTY(QUrl defaultScripts READ defaultScriptsLocation CONSTANT)
 public:
+    static const QString& getRccPath();
     static const QString& resourcesUrl();
     static QUrl resourcesUrl(const QString& relative);
     static const QString& resourcesPath();


### PR DESCRIPTION
Switch Mac builds to using binary resources (like all other platforms)

## Testing

OSX & Windows smoke test 
* Verify UI elements load and render
