### PR TITLE
Fix MS14925: Don't double-emit signal for display plugin change

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -8041,7 +8041,6 @@ void Application::switchDisplayMode() {
             setActiveDisplayPlugin(DESKTOP_DISPLAY_PLUGIN_NAME);
             startHMDStandBySession();
         }
-        emit activeDisplayPluginChanged();
     }
     _previousHMDWornStatus = currentHMDWornStatus;
 }


### PR DESCRIPTION
Fixes [MS14925](https://highfidelity.fogbugz.com/f/cases/14925/When-Rift-automatically-exits-and-enters-VR-grabbable-object-highlighting-may-break).

The `activeDisplayPluginChanged()` signal gets emitted inside `setActiveDisplayPlugin()` already - double-emitting that signal causes this bug to occur.