### PR TITLE
Android - Allow search among protocol compatible user stories and not only tagged ones

### DIFF
--- a/android/app/src/main/java/io/highfidelity/hifiinterface/provider/UserStoryDomainProvider.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/provider/UserStoryDomainProvider.java
@@ -1,10 +1,11 @@
 package io.highfidelity.hifiinterface.provider;
 
 import android.util.Log;
-import android.util.MutableInt;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import io.highfidelity.hifiinterface.HifiUtils;
 import io.highfidelity.hifiinterface.view.DomainAdapter;
@@ -47,24 +48,42 @@ public class UserStoryDomainProvider implements DomainProvider {
         suggestions = new ArrayList<>();
     }
 
+    @Override
+    public synchronized void retrieve(String filterText, DomainCallback domainCallback) {
+        if (!startedToGetFromAPI) {
+            startedToGetFromAPI = true;
+            fillDestinations(filterText, domainCallback);
+        } else {
+            filterChoicesByText(filterText, domainCallback);
+        }
+    }
+
     private void fillDestinations(String filterText, DomainCallback domainCallback) {
         StoriesFilter filter = new StoriesFilter(filterText);
-        final MutableInt counter = new MutableInt(0);
-        allStories.clear();
-        getUserStoryPage(1,
+
+        List<UserStory> taggedStories = new ArrayList<>();
+        Set<String> taggedStoriesIds = new HashSet<>();
+        getUserStoryPage(1, taggedStories, TAGS_TO_SEARCH,
                 e -> {
-                    allStories.subList(counter.value, allStories.size()).forEach(userStory -> {
-                        filter.filterOrAdd(userStory);
+                    taggedStories.forEach(userStory -> {
+                        taggedStoriesIds.add(userStory.id);
                     });
-                    if (domainCallback != null) {
-                        domainCallback.retrieveOk(suggestions); //ended
-                    }
-                },
-                a -> {
-                    allStories.forEach(userStory -> {
-                        counter.value++;
-                        filter.filterOrAdd(userStory);
-                    });
+
+                    allStories.clear();
+                    getUserStoryPage(1, allStories, null,
+                            ex -> {
+                                allStories.forEach(userStory -> {
+                                    if (taggedStoriesIds.contains(userStory.id)) {
+                                        userStory.tagFound = true;
+                                    }
+                                    filter.filterOrAdd(userStory);
+                                });
+                                if (domainCallback != null) {
+                                    domainCallback.retrieveOk(suggestions); //ended
+                                }
+                            }
+                    );
+
                 }
         );
     }
@@ -73,25 +92,22 @@ public class UserStoryDomainProvider implements DomainProvider {
         restOfPagesCallback.callback(new Exception("Error accessing url [" + url + "]", t));
     }
 
-    private void getUserStoryPage(int pageNumber, Callback<Exception> restOfPagesCallback, Callback<Void> firstPageCallback) {
+    private void getUserStoryPage(int pageNumber, List<UserStory> userStoriesList, String tagsFilter, Callback<Exception> restOfPagesCallback) {
         Call<UserStories> userStories = mUserStoryDomainProviderService.getUserStories(
                 INCLUDE_ACTIONS_FOR_PLACES,
                 "open",
                 true,
                 mProtocol,
-                TAGS_TO_SEARCH,
+                tagsFilter,
                 pageNumber);
         Log.d("API-USER-STORY-DOMAINS", "Protocol [" + mProtocol + "] include_actions [" + INCLUDE_ACTIONS_FOR_PLACES + "]");
         userStories.enqueue(new retrofit2.Callback<UserStories>() {
             @Override
             public void onResponse(Call<UserStories> call, Response<UserStories> response) {
                 UserStories data = response.body();
-                allStories.addAll(data.user_stories);
+                userStoriesList.addAll(data.user_stories);
                 if (data.current_page < data.total_pages && data.current_page <= MAX_PAGES_TO_GET) {
-                    if (pageNumber == 1 && firstPageCallback != null) {
-                        firstPageCallback.callback(null);
-                    }
-                    getUserStoryPage(pageNumber + 1, restOfPagesCallback, null);
+                    getUserStoryPage(pageNumber + 1, userStoriesList, tagsFilter, restOfPagesCallback);
                     return;
                 }
                 restOfPagesCallback.callback(null);
@@ -107,12 +123,16 @@ public class UserStoryDomainProvider implements DomainProvider {
     private class StoriesFilter {
         String[] mWords = new String[]{};
         public StoriesFilter(String filterText) {
-            mWords = filterText.toUpperCase().split("\\s+");
+            mWords = filterText.trim().toUpperCase().split("\\s+");
+            if (mWords.length == 1 && (mWords[0] == null || mWords[0].length() <= 0 ) ) {
+                mWords = null;
+            }
         }
 
         private boolean matches(UserStory story) {
-            if (mWords.length <= 0) {
-                return true;
+            if (mWords == null || mWords.length <= 0) {
+                // No text filter? So filter by tag
+                return story.tagFound;
             }
 
             for (String word : mWords) {
@@ -128,6 +148,9 @@ public class UserStoryDomainProvider implements DomainProvider {
             suggestions.add(story.toDomain());
         }
 
+        /**
+         * if the story matches this filter criteria it's added into suggestions
+         * */
         public void filterOrAdd(UserStory story) {
             if (matches(story)) {
                 addToSuggestions(story);
@@ -144,16 +167,6 @@ public class UserStoryDomainProvider implements DomainProvider {
         domainCallback.retrieveOk(suggestions);
     }
 
-    @Override
-    public synchronized void retrieve(String filterText, DomainCallback domainCallback) {
-        if (!startedToGetFromAPI) {
-            startedToGetFromAPI = true;
-            fillDestinations(filterText, domainCallback);
-        } else {
-            filterChoicesByText(filterText, domainCallback);
-        }
-    }
-
     public interface UserStoryDomainProviderService {
         @GET("api/v1/user_stories")
         Call<UserStories> getUserStories(@Query("include_actions") String includeActions,
@@ -166,12 +179,14 @@ public class UserStoryDomainProvider implements DomainProvider {
 
     class UserStory {
         public UserStory() {}
+        String id;
         String place_name;
         String path;
         String thumbnail_url;
         String place_id;
         String domain_id;
         private String searchText;
+        private boolean tagFound; // Locally used
 
         // New fields? tags, description
 

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/view/DomainAdapter.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/view/DomainAdapter.java
@@ -54,27 +54,10 @@ public class DomainAdapter extends RecyclerView.Adapter<DomainAdapter.ViewHolder
             @Override
             public void retrieveOk(List<Domain> domain) {
                 if (filterText.length() == 0) {
-                    Domain lastVisitedDomain = new Domain(mContext.getString(R.string.your_last_location), mLastLocation, DEFAULT_THUMBNAIL_PLACE);
-                    if (!mLastLocation.isEmpty() && mLastLocation.contains("://")) {
-                        int startIndex = mLastLocation.indexOf("://");
-                        int endIndex = mLastLocation.indexOf("/", startIndex + 3);
-                        String toSearch = mLastLocation.substring(0, endIndex + 1).toLowerCase();
-                        for (Domain d : domain) {
-                            if (d.url.toLowerCase().startsWith(toSearch)) {
-                                lastVisitedDomain.thumbnail = d.thumbnail;
-                            }
-                        }
-                    }
-                    domain.add(0, lastVisitedDomain);
+                    addLastLocation(domain);
                 }
 
-                for (Domain d : domain) {
-                    // we override the default picture added in the server by an android specific version
-                    if (d.thumbnail != null &&
-                            d.thumbnail.endsWith("assets/places/thumbnail-default-place-e5a3f33e773ab699495774990a562f9f7693dc48ef90d8be6985c645a0280f75.png")) {
-                        d.thumbnail = DEFAULT_THUMBNAIL_PLACE;
-                    }
-                }
+                overrideDefaultThumbnails(domain);
 
                 mDomains = new Domain[domain.size()];
                 mDomains = domain.toArray(mDomains);
@@ -94,6 +77,31 @@ public class DomainAdapter extends RecyclerView.Adapter<DomainAdapter.ViewHolder
                 if (mAdapterListener != null) mAdapterListener.onError(e, message);
             }
         });
+    }
+
+    private void overrideDefaultThumbnails(List<Domain> domain) {
+        for (Domain d : domain) {
+            // we override the default picture added in the server by an android specific version
+            if (d.thumbnail != null &&
+                    d.thumbnail.endsWith("assets/places/thumbnail-default-place-e5a3f33e773ab699495774990a562f9f7693dc48ef90d8be6985c645a0280f75.png")) {
+                d.thumbnail = DEFAULT_THUMBNAIL_PLACE;
+            }
+        }
+    }
+
+    private void addLastLocation(List<Domain> domain) {
+        Domain lastVisitedDomain = new Domain(mContext.getString(R.string.your_last_location), mLastLocation, DEFAULT_THUMBNAIL_PLACE);
+        if (!mLastLocation.isEmpty() && mLastLocation.contains("://")) {
+            int startIndex = mLastLocation.indexOf("://");
+            int endIndex = mLastLocation.indexOf("/", startIndex + 3);
+            String toSearch = mLastLocation.substring(0, endIndex + 1).toLowerCase();
+            for (Domain d : domain) {
+                if (d.url.toLowerCase().startsWith(toSearch)) {
+                    lastVisitedDomain.thumbnail = d.thumbnail;
+                }
+            }
+        }
+        domain.add(0, lastVisitedDomain);
     }
 
     @Override


### PR DESCRIPTION
Domains with the mobile tag will appear when no text filter is searched. But, when filtering by text, other domains also will be included if they protocol matches the client version.

Test plan:
- On Android, when you open the app, you should only see domains tagged as mobile compatible.
- Start typing in the search bar for a known protocol-compatible domain (like Eschatology).  It should appear in the search results.
- Clear the search text.  You should only see mobile-compatible domains again.