### PR TITLE
Fix Hifi-Grab-Hand message for equipping

### DIFF
--- a/scripts/system/controllers/controllerModules/equipEntity.js
+++ b/scripts/system/controllers/controllerModules/equipEntity.js
@@ -273,8 +273,6 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
         this.shouldSendStart = false;
         this.equipedWithSecondary = false;
         this.handHasBeenRightsideUp = false;
-        this.mouseEquip = false;
-        this.messageEquip = false;
 
         this.parameters = makeDispatcherModuleParameters(
             300,
@@ -584,8 +582,6 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
             this.targetEntityID = null;
             this.messageGrabEntity = false;
             this.grabEntityProps = null;
-            this.mouseEquip = false;
-            this.messageEquip = false;
         };
 
         this.updateInputs = function (controllerData) {
@@ -631,14 +627,12 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
 
             // if the potentialHotspot is cloneable, clone it and return it
             // if the potentialHotspot os not cloneable and locked return null
-
             if (potentialEquipHotspot &&
                 (((this.triggerSmoothedSqueezed() || this.secondarySmoothedSqueezed()) && !this.waitForTriggerRelease) ||
                  this.messageGrabEntity)) {
                 this.grabbedHotspot = potentialEquipHotspot;
                 this.targetEntityID = this.grabbedHotspot.entityID;
                 this.startEquipEntity(controllerData);
-                this.messageGrabEntity = false;
                 this.equipedWithSecondary = this.secondarySmoothedSqueezed();
                 return makeRunningValues(true, [potentialEquipHotspot.entityID], []);
             } else {
@@ -662,7 +656,7 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
             var timestamp = Date.now();
             this.updateInputs(controllerData);
 
-            if (!this.mouseEquip && !this.messageEquip && !this.isTargetIDValid(controllerData)) {
+            if (!this.messageGrabEntity && !this.isTargetIDValid(controllerData)) {
                 this.endEquipEntity();
                 return makeRunningValues(false, [], []);
             }
@@ -763,7 +757,6 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
                     var equipModule = (data.hand === "left") ? leftEquipEntity : rightEquipEntity;
                     var entityProperties = Entities.getEntityProperties(data.entityID, DISPATCHER_PROPERTIES);
                     entityProperties.id = data.entityID;
-                    equipModule.messageEquip = true;
                     equipModule.setMessageGrabData(entityProperties);
                 } catch (e) {
                     print("WARNING: equipEntity.js -- error parsing Hifi-Hand-Grab message: " + message);
@@ -815,12 +808,10 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
                 if (rightHandAvailable && (distanceToRightHand < distanceToLeftHand || !leftHandAvailable)) {
                     // clear any existing grab actions on the entity now (their later removal could affect bootstrapping flags)
                     clearGrabActions(entityID);
-                    rightEquipEntity.mouseEquip = true;
                     rightEquipEntity.setMessageGrabData(entityProperties);
                 } else if (leftHandAvailable && (distanceToLeftHand < distanceToRightHand || !rightHandAvailable)) {
                     // clear any existing grab actions on the entity now (their later removal could affect bootstrapping flags)
                     clearGrabActions(entityID);
-                    leftEquipEntity.mouseEquip = true;
                     leftEquipEntity.setMessageGrabData(entityProperties);
                 }
             }

--- a/scripts/system/controllers/controllerModules/equipEntity.js
+++ b/scripts/system/controllers/controllerModules/equipEntity.js
@@ -274,7 +274,7 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
         this.equipedWithSecondary = false;
         this.handHasBeenRightsideUp = false;
         this.mouseEquip = false;
-		this.messageEquip = false;
+        this.messageEquip = false;
 
         this.parameters = makeDispatcherModuleParameters(
             300,
@@ -585,7 +585,7 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
             this.messageGrabEntity = false;
             this.grabEntityProps = null;
             this.mouseEquip = false;
-			this.messageEquip = false;
+            this.messageEquip = false;
         };
 
         this.updateInputs = function (controllerData) {
@@ -763,7 +763,7 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
                     var equipModule = (data.hand === "left") ? leftEquipEntity : rightEquipEntity;
                     var entityProperties = Entities.getEntityProperties(data.entityID, DISPATCHER_PROPERTIES);
                     entityProperties.id = data.entityID;
-					equipModule.messageEquip = true;
+                    equipModule.messageEquip = true;
                     equipModule.setMessageGrabData(entityProperties);
                 } catch (e) {
                     print("WARNING: equipEntity.js -- error parsing Hifi-Hand-Grab message: " + message);
@@ -815,12 +815,12 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
                 if (rightHandAvailable && (distanceToRightHand < distanceToLeftHand || !leftHandAvailable)) {
                     // clear any existing grab actions on the entity now (their later removal could affect bootstrapping flags)
                     clearGrabActions(entityID);
-					rightEquipEntity.mouseEquip = true;
+                    rightEquipEntity.mouseEquip = true;
                     rightEquipEntity.setMessageGrabData(entityProperties);
                 } else if (leftHandAvailable && (distanceToLeftHand < distanceToRightHand || !rightHandAvailable)) {
                     // clear any existing grab actions on the entity now (their later removal could affect bootstrapping flags)
                     clearGrabActions(entityID);
-					leftEquipEntity.mouseEquip = true;
+                    leftEquipEntity.mouseEquip = true;
                     leftEquipEntity.setMessageGrabData(entityProperties);
                 }
             }

--- a/scripts/system/controllers/controllerModules/equipEntity.js
+++ b/scripts/system/controllers/controllerModules/equipEntity.js
@@ -274,6 +274,7 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
         this.equipedWithSecondary = false;
         this.handHasBeenRightsideUp = false;
         this.mouseEquip = false;
+		this.messageEquip = false;
 
         this.parameters = makeDispatcherModuleParameters(
             300,
@@ -283,11 +284,10 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
 
         var equipHotspotBuddy = new EquipHotspotBuddy();
 
-        this.setMessageGrabData = function(entityProperties, mouseEquip) {
+        this.setMessageGrabData = function(entityProperties) {
             if (entityProperties) {
                 this.messageGrabEntity = true;
                 this.grabEntityProps = entityProperties;
-                this.mouseEquip = mouseEquip;
             }
         };
 
@@ -585,6 +585,7 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
             this.messageGrabEntity = false;
             this.grabEntityProps = null;
             this.mouseEquip = false;
+			this.messageEquip = false;
         };
 
         this.updateInputs = function (controllerData) {
@@ -661,7 +662,7 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
             var timestamp = Date.now();
             this.updateInputs(controllerData);
 
-            if (!this.mouseEquip && !this.isTargetIDValid(controllerData)) {
+            if (!this.mouseEquip && !this.messageEquip && !this.isTargetIDValid(controllerData)) {
                 this.endEquipEntity();
                 return makeRunningValues(false, [], []);
             }
@@ -762,9 +763,8 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
                     var equipModule = (data.hand === "left") ? leftEquipEntity : rightEquipEntity;
                     var entityProperties = Entities.getEntityProperties(data.entityID, DISPATCHER_PROPERTIES);
                     entityProperties.id = data.entityID;
-                    var mouseEquip = false;
-                    equipModule.setMessageGrabData(entityProperties, mouseEquip);
-
+					equipModule.messageEquip = true;
+                    equipModule.setMessageGrabData(entityProperties);
                 } catch (e) {
                     print("WARNING: equipEntity.js -- error parsing Hifi-Hand-Grab message: " + message);
                 }
@@ -812,15 +812,16 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
                 var distanceToLeftHand = Vec3.distance(entityProperties.position, leftHandPosition);
                 var leftHandAvailable = leftEquipEntity.targetEntityID === null;
                 var rightHandAvailable = rightEquipEntity.targetEntityID === null;          
-                var mouseEquip = true;
                 if (rightHandAvailable && (distanceToRightHand < distanceToLeftHand || !leftHandAvailable)) {
                     // clear any existing grab actions on the entity now (their later removal could affect bootstrapping flags)
                     clearGrabActions(entityID);
-                    rightEquipEntity.setMessageGrabData(entityProperties, mouseEquip);
+					rightEquipEntity.mouseEquip = true;
+                    rightEquipEntity.setMessageGrabData(entityProperties);
                 } else if (leftHandAvailable && (distanceToLeftHand < distanceToRightHand || !rightHandAvailable)) {
                     // clear any existing grab actions on the entity now (their later removal could affect bootstrapping flags)
                     clearGrabActions(entityID);
-                    leftEquipEntity.setMessageGrabData(entityProperties, mouseEquip);
+					leftEquipEntity.mouseEquip = true;
+                    leftEquipEntity.setMessageGrabData(entityProperties);
                 }
             }
         }


### PR DESCRIPTION
Fixes https://highfidelity.manuscript.com/f/cases/15648/Need-to-be-able-to-equip-an-object-from-a-script

Test Plan:
-Start Interface and load into your sandbox
-Rez 2 equippable entities for testing (such as https://hifi-content.s3.amazonaws.com/davidback/development/flaregun.json)
-Select each of the 2 entities rezzed above in Create and find their entity IDs in Properties
-Close Create and run each of the following lines in the Console under Developer menu:
Messages.sendLocalMessage('Hifi-Hand-Grab', JSON.stringify({hand: 'left', entityID: XXX}));
Messages.sendLocalMessage('Hifi-Hand-Grab', JSON.stringify({hand: 'right', entityID: XXX}));
where XXX are the entity IDs from above pasted in
-Verify the entities equip to their respective hands
-Press U on the keyboard
-Verify the entities unequip

Also run tests:
https://highfidelity.testrail.net/index.php?/cases/view/15103
https://highfidelity.testrail.net/index.php?/cases/view/73
