### PR TITLE
fix crash setting model texture

### DIFF
--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -457,7 +457,7 @@ protected:
     bool _needsFixupInScene { true }; // needs to be removed/re-added to scene
     bool _needsReload { true };
     bool _needsUpdateClusterMatrices { true };
-    mutable bool _needsUpdateTextures { true };
+    QVariantMap _pendingTextures { };
 
     friend class ModelMeshPartPayload;
     Rig _rig;


### PR DESCRIPTION
If Model::setTexture is called before the model is loaded, a dynamic signal handler was assigned (and never removed) that could cause a crash within  Geometry::setTextures.  This was intermittently happening the first time time a user opened the PAL in a session (which causes a model overlay to be created, and then sets the texture on it).  This PR fixes that by restructuring how texture-setting is deferred when the model isn't loaded.

https://highfidelity.fogbugz.com/f/cases/11185/Crash-Tablet-people

However, there is more to it than that. While I was able to occasionally trigger the bug on older code, I now find (on current master) that the model overlay NEVER loads the first time it is used, and thus never triggers the crash.  For example, if you start a session and open the PAL, none of setTextures, setUrl, and loadUrlFinished are called.  If you close the PAL and open it again, these are called and the code in this PR then works correctly, and will stay working throughout the session. I think that there must be a _second_ bug about initial loading: when that bug is fixed, we are likely to then once more run into the bug fixed by this PR.