### PR TITLE
Fix models starting as green boxes

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -206,7 +206,7 @@ private:
 
     render::ItemKey _itemKey { render::ItemKey::Builder().withTypeMeta() };
 
-    bool _didLastVisualGeometryRequestSucceed { false };
+    bool _didLastVisualGeometryRequestSucceed { true };
 
     void processMaterials();
 };


### PR DESCRIPTION
Test plan:
- Go to a domain with lots of models (dev-welcome is good).
- In master, green boxes show up everywhere until the models load.  In this PR, models won't show up until they actually load.
- Create a model with a junk url.  It should show up as a green box after a few seconds.