### PR TITLE
Fix MS15663/15664: Don't set Wallet Status to 'ready' too early

### DIFF
--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -531,7 +531,6 @@ bool Wallet::walletIsAuthenticatedWithPassphrase() {
 
             // be sure to add the public key so we don't do this over and over
             _publicKeys.push_back(publicKey.toBase64());
-            DependencyManager::get<WalletScriptingInterface>()->setWalletStatus((uint)WalletStatus::WALLET_STATUS_READY);
             return true;
         }
     }


### PR DESCRIPTION
Fixes both [MS15663](https://highfidelity.manuscript.com/f/cases/15663/Wallet-prompts-for-new-wallet-after-selecting-Continue-With-These-Keys) and [MS15664](https://highfidelity.manuscript.com/f/cases/15664/Wallet-requires-reopening-before-prompt-of-different-keys-will-appear).

This one-line change prevents the Wallet Status from being incorrectly reported as "Ready" before the system has had a chance to make a backend round-trip to check to see if the newly selected Wallet is a "preexisting" wallet, or a "conflicting" wallet.