### PR TITLE
Android - Make sure we call Interface enterBackground when opening

### DIFF
--- a/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
@@ -126,7 +126,6 @@ public class InterfaceActivity extends QtActivity {
         if (super.isLoading) {
             nativeEnterBackgroundCallEnqueued = true;
         } else {
-            Log.d("[ENTERBACKGROUND]","onPause calling nativeEnterBackground");
             nativeEnterBackground();
         }
         //gvrApi.pauseTracking();
@@ -265,7 +264,6 @@ public class InterfaceActivity extends QtActivity {
     public void onAppLoadedComplete() {
         super.isLoading = false;
         if (nativeEnterBackgroundCallEnqueued) {
-            Log.d("[ENTERBACKGROUND]","onAppLoadedComplete calling nativeEnterBackground");
             nativeEnterBackground();
         }
     }

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
@@ -56,6 +56,8 @@ public class InterfaceActivity extends QtActivity {
     private AssetManager assetManager;
 
     private static boolean inVrMode;
+
+    private boolean nativeEnterBackgroundCallEnqueued = false;
 //    private GvrApi gvrApi;
     // Opaque native pointer to the Application C++ object.
     // This object is owned by the InterfaceActivity instance and passed to the native methods.
@@ -121,13 +123,19 @@ public class InterfaceActivity extends QtActivity {
     @Override
     protected void onPause() {
         super.onPause();
-        nativeEnterBackground();
+        if (super.isLoading) {
+            nativeEnterBackgroundCallEnqueued = true;
+        } else {
+            Log.d("[ENTERBACKGROUND]","onPause calling nativeEnterBackground");
+            nativeEnterBackground();
+        }
         //gvrApi.pauseTracking();
     }
 
     @Override
     protected void onStart() {
         super.onStart();
+        nativeEnterBackgroundCallEnqueued = false;
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
     }
 
@@ -256,6 +264,10 @@ public class InterfaceActivity extends QtActivity {
 
     public void onAppLoadedComplete() {
         super.isLoading = false;
+        if (nativeEnterBackgroundCallEnqueued) {
+            Log.d("[ENTERBACKGROUND]","onAppLoadedComplete calling nativeEnterBackground");
+            nativeEnterBackground();
+        }
     }
 
     public void performHapticFeedback(int duration) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -8248,12 +8248,10 @@ void Application::saveNextPhysicsStats(QString filename) {
 
 #if defined(Q_OS_ANDROID)
 void Application::enterBackground() {
-    qDebug() << "[ENTERBACKGROUND] Application::enterBackground()";
     QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(),
                               "stop", Qt::BlockingQueuedConnection);
     if (getActiveDisplayPlugin()->isActive()) {
         getActiveDisplayPlugin()->deactivate();
-        qDebug() << "[ENTERBACKGROUND] Application::enterBackground() getActiveDisplayPlugin()->deactivated";
     }
 }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -8248,10 +8248,12 @@ void Application::saveNextPhysicsStats(QString filename) {
 
 #if defined(Q_OS_ANDROID)
 void Application::enterBackground() {
+    qDebug() << "[ENTERBACKGROUND] Application::enterBackground()";
     QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(),
                               "stop", Qt::BlockingQueuedConnection);
     if (getActiveDisplayPlugin()->isActive()) {
         getActiveDisplayPlugin()->deactivate();
+        qDebug() << "[ENTERBACKGROUND] Application::enterBackground() getActiveDisplayPlugin()->deactivated";
     }
 }
 


### PR DESCRIPTION
Test plan:
- Open Interface.  You should be brought to the Home screen.
- Go to a domain.  The UI (joystick, etc.) should render properly.
- Go back to Home and click on a different domain.  The UI should still render properly.
- Repeat a few times.