### PR TITLE
Fix MS15673: Ensure offscreenUI exists before updating SecurityImageProvider

### DIFF
--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -610,7 +610,11 @@ void Wallet::updateImageProvider() {
     SecurityImageProvider* securityImageProvider;
 
     // inform offscreenUI security image provider
-    QQmlEngine* engine = DependencyManager::get<OffscreenUi>()->getSurfaceContext()->engine();
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
+    if (!offscreenUI) {
+        return;
+    }
+    QQmlEngine* engine = offscreenUI->getSurfaceContext()->engine();
     securityImageProvider = reinterpret_cast<SecurityImageProvider*>(engine->imageProvider(SecurityImageProvider::PROVIDER_NAME));
     securityImageProvider->setSecurityImage(_securityImage);
 


### PR DESCRIPTION
Fixes [MS15681](https://highfidelity.fogbugz.com/f/cases/15681/Interface-crashes-when-quitting-after-opening-Wallet).

This is a check that probably should have been in there in the first place.

For some reason, our QML tries to update the wallet security image provider while quitting the app if you've opened the Wallet QML during your session. Since we're quitting, there's no guarantee that the `OffscreenUi` will be present, which might cause a crash in `Wallet.cpp`. This guard protects against that crash.