### PR TITLE
Try to fix ModelOverlay texture loading

### DIFF
--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -123,6 +123,9 @@ void ModelOverlay::update(float deltatime) {
 
     if (!_texturesLoaded && _model->getGeometry() && _model->getGeometry()->areTexturesLoaded()) {
         _texturesLoaded = true;
+        if (!_modelTextures.isEmpty()) {
+            _model->setTextures(_modelTextures);
+        }
         _model->updateRenderItems();
     }
 }
@@ -221,8 +224,7 @@ void ModelOverlay::setProperties(const QVariantMap& properties) {
     if (texturesValue.isValid() && texturesValue.canConvert(QVariant::Map)) {
         _texturesLoaded = false;
         QVariantMap textureMap = texturesValue.toMap();
-        QMetaObject::invokeMethod(_model.get(), "setTextures", Qt::AutoConnection,
-                                  Q_ARG(const QVariantMap&, textureMap));
+        _modelTextures = textureMap;
     }
 
     auto groupCulledValue = properties["isGroupCulled"];

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -457,7 +457,7 @@ protected:
     bool _needsFixupInScene { true }; // needs to be removed/re-added to scene
     bool _needsReload { true };
     bool _needsUpdateClusterMatrices { true };
-    mutable bool _needsUpdateTextures { true };
+    QVariantMap _pendingTextures { };
 
     friend class ModelMeshPartPayload;
     Rig _rig;

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -40,7 +40,6 @@ var HOVER_TEXTURES = {
 var UNSELECTED_COLOR = { red: 0x1F, green: 0xC6, blue: 0xA6};
 var SELECTED_COLOR = {red: 0xF3, green: 0x91, blue: 0x29};
 var HOVER_COLOR = {red: 0xD0, green: 0xD0, blue: 0xD0}; // almost white for now
-var conserveResources = true;
 
 Script.include("/~/system/libraries/controllers.js");
 
@@ -429,7 +428,7 @@ function addAvatarNode(id) {
         alpha: 0.8,
         color: color(selected, false, 0.0),
         ignoreRayIntersection: false
-    }, selected, !conserveResources);
+    }, selected, true);
 }
 // Each open/refresh will capture a stable set of avatarsOfInterest, within the specified filter.
 var avatarsOfInterest = {};
@@ -494,7 +493,6 @@ function populateNearbyUserList(selectData, oldAudioData) {
         print('PAL data:', JSON.stringify(avatarPalDatum));
     });
     getConnectionData(false, location.domainID); // Even admins don't get relationship data in requestUsernameFromID (which is still needed for admin status, which comes from domain).
-    conserveResources = Object.keys(avatarsOfInterest).length > 20;
     sendToQml({ method: 'nearbyUsers', params: data });
     if (selectData) {
         selectData[2] = true;
@@ -717,7 +715,7 @@ function onTabletScreenChanged(type, url) {
         ContextOverlay.enabled = false;
         Users.requestsDomainListData = true;
 
-        audioTimer = createAudioInterval(conserveResources ? AUDIO_LEVEL_CONSERVED_UPDATE_INTERVAL_MS : AUDIO_LEVEL_UPDATE_INTERVAL_MS);
+        audioTimer = createAudioInterval(AUDIO_LEVEL_UPDATE_INTERVAL_MS);
 
         tablet.tabletShownChanged.connect(tabletVisibilityChanged);
         Script.update.connect(updateOverlays);
@@ -872,7 +870,6 @@ startup();
 var isWired = false;
 var audioTimer;
 var AUDIO_LEVEL_UPDATE_INTERVAL_MS = 100; // 10hz for now (change this and change the AVERAGING_RATIO too)
-var AUDIO_LEVEL_CONSERVED_UPDATE_INTERVAL_MS = 300;
 function off() {
     if (isWired) {
         Script.update.disconnect(updateOverlays);


### PR DESCRIPTION
Includes Howard's change from https://github.com/highfidelity/hifi/pull/13324

https://highfidelity.fogbugz.com/f/cases/11185/Crash-Tablet-people

Test Plan:
- Go to a domain with multiple avatars.
- While looking at the avatars, open the People app.  Spheres with a transparent "halo" like effect around them should appear over each avatar.
- Click on one of the spheres.  Both it and the halo should change color.
- Repeatedly open and close the People app.  You shouldn't crash.
- Run [this](https://gist.githubusercontent.com/SamGondelman/598039055c2ba58744c0bc3aa94cdb62/raw/0060ce9c563b388db1602171817bbef467e03285/ModelOverlayTextures.js).  You should see a yellow rectangle.  Press "u" and it should become lime green.  Press "u" again and it should go back to yellow.