### PR TITLE
Fix particle entity shader

### DIFF
--- a/libraries/entities-renderer/src/textured_particle.slv
+++ b/libraries/entities-renderer/src/textured_particle.slv
@@ -37,8 +37,8 @@ layout(std140) uniform particleBuffer {
     ParticleUniforms particle;
 };
 
-in vec3 inPosition;
-in vec2 inColor; // This is actual Lifetime + Seed
+layout(location=0) in vec3 inPosition;
+layout(location=2) in vec2 inColor; // This is actual Lifetime + Seed
 
 out vec4 varColor;
 out vec2 varTexcoord;


### PR DESCRIPTION
Fixes [15725](https://highfidelity.manuscript.com/f/cases/15725)

A recent [change](https://github.com/highfidelity/hifi/commit/3beb77694f206dcff8ee18f7ae6845aad78a5663#diff-b307f4639e5ecc2e4192fb89af399c7dL528) to the backend shader compilation code caused particle shaders to break.  Apparently the particle vertex shader uses standard names for some inputs (`inPosition` & `inColor`) but not via the standard input header because the types are `vec3` and `vec2` respectively.  

Because the backend shader code now absolutely relies on the vertex shader inputs having explicit layouts, the particle shader broke, due to _not_ having explicit layouts.  This fixes the problem by adding them.  

## Testing

* Go to a domain and create a particle entity item

On master, the particle effect will not render any particles in the default just-created configuration.  In this PR build, the particle effect should emit small puffs of smoke vertically, similar to how it did in RC 67 and earlier.  
