### PR TITLE
Fix MS15721: Delete app.json if installed script isn't running

### DIFF
--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -227,10 +227,13 @@ QString QmlCommerce::getInstalledApps() {
             QString scriptURL = appFileJsonObject["scriptURL"].toString();
 
             // If the script .app.json is on the user's local disk but the associated script isn't running
-            // for some reason, start that script again.
+            // for some reason (i.e. the user stopped it from Running Scripts),
+            // delete the .app.json from the user's local disk.
             if (!runningScripts.contains(scriptURL)) {
-                if ((DependencyManager::get<ScriptEngines>()->loadScript(scriptURL.trimmed())).isNull()) {
-                    qCDebug(commerce) << "Couldn't start script while checking installed apps.";
+                if (!appFile.remove()) {
+                    qCWarning(commerce)
+                        << "Couldn't delete local .app.json file (app's script isn't running). App filename is:"
+                        << appFileName;
                 }
             }
         } else {


### PR DESCRIPTION
Implements [MS15721](https://highfidelity.fogbugz.com/f/cases/15721/Installed-tablet-apps-automatically-re-install-themselves-when-visiting-My-Purchases).