### PR TITLE
Remove functionality for rendering collision models directly in the Model class

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2250,9 +2250,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     DependencyManager::get<EntityTreeRenderer>()->setSetPrecisionPickingOperator([&](unsigned int rayPickID, bool value) {
         DependencyManager::get<PickManager>()->setPrecisionPicking(rayPickID, value);
     });
-    EntityTreeRenderer::setRenderDebugHullsOperator([] {
-        return Menu::getInstance()->isOptionChecked(MenuOption::PhysicsShowHulls);
-    });
 
     // Preload Tablet sounds
     DependencyManager::get<TabletScriptingInterface>()->preloadSounds();

--- a/interface/src/Application_render.cpp
+++ b/interface/src/Application_render.cpp
@@ -205,10 +205,6 @@ void Application::runRenderFrame(RenderArgs* renderArgs) {
 
         RenderArgs::DebugFlags renderDebugFlags = RenderArgs::RENDER_DEBUG_NONE;
 
-        if (Menu::getInstance()->isOptionChecked(MenuOption::PhysicsShowHulls)) {
-            renderDebugFlags = static_cast<RenderArgs::DebugFlags>(renderDebugFlags |
-                static_cast<int>(RenderArgs::RENDER_DEBUG_HULLS));
-        }
         renderArgs->_debugFlags = renderDebugFlags;
     }
 

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -725,7 +725,6 @@ Menu::Menu() {
         addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowOwned,
             0, false, drawStatusConfig, SLOT(setShowNetwork(bool)));
     }
-    addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowHulls, 0, false, qApp->getEntities().data(), SIGNAL(setRenderDebugHulls()));
 
     addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowBulletWireframe, 0, false, qApp, SLOT(setShowBulletWireframe(bool)));
     addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowBulletAABBs, 0, false, qApp, SLOT(setShowBulletAABBs(bool)));

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -141,7 +141,6 @@ namespace MenuOption {
     const QString Overlays = "Show Overlays";
     const QString PackageModel = "Package Model as .fst...";
     const QString Pair = "Pair";
-    const QString PhysicsShowHulls = "Draw Collision Shapes";
     const QString PhysicsShowOwned = "Highlight Simulation Ownership";
     const QString VerboseLogging = "Verbose Logging";
     const QString PhysicsShowBulletWireframe = "Show Bullet Collision";

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -42,7 +42,6 @@
 
 size_t std::hash<EntityItemID>::operator()(const EntityItemID& id) const { return qHash(id); }
 std::function<bool()> EntityTreeRenderer::_entitiesShouldFadeFunction;
-std::function<bool()> EntityTreeRenderer::_renderDebugHullsOperator = [] { return false; };
 
 EntityTreeRenderer::EntityTreeRenderer(bool wantScripts, AbstractViewStateInterface* viewState,
                                             AbstractScriptingServicesInterface* scriptingServices) :

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -116,14 +116,10 @@ public:
     EntityItemPointer getEntity(const EntityItemID& id);
     void onEntityChanged(const EntityItemID& id);
 
-    static void setRenderDebugHullsOperator(std::function<bool()> renderDebugHullsOperator) { _renderDebugHullsOperator = renderDebugHullsOperator; }
-    static bool shouldRenderDebugHulls() { return _renderDebugHullsOperator(); }
-
 signals:
     void enterEntity(const EntityItemID& entityItemID);
     void leaveEntity(const EntityItemID& entityItemID);
     void collisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
-    void setRenderDebugHulls();
 
 public slots:
     void addingEntity(const EntityItemID& entityID);
@@ -259,8 +255,6 @@ private:
     static int _entitiesScriptEngineCount;
     static CalculateEntityLoadingPriority _calculateEntityLoadingPriorityFunc;
     static std::function<bool()> _entitiesShouldFadeFunction;
-
-    static std::function<bool()> _renderDebugHullsOperator;
 };
 
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1416,19 +1416,18 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
         setCollisionMeshKey(entity->getCollisionMeshKey());
         _needsCollisionGeometryUpdate = false;
         ShapeType type = entity->getShapeType();
-        if (DependencyManager::get<EntityTreeRenderer>()->shouldRenderDebugHulls() && type != SHAPE_TYPE_STATIC_MESH && type != SHAPE_TYPE_NONE) {
+        if (DependencyManager::get<EntityTreeRenderer>()->shouldRenderDebugHulls() && type != SHAPE_TYPE_NONE) {
             // NOTE: it is OK if _collisionMeshKey is nullptr
             graphics::MeshPointer mesh = collisionMeshCache.getMesh(_collisionMeshKey);
-            // NOTE: the model will render the collisionGeometry if it has one
-            _model->setCollisionMesh(mesh);
+            // TODO: Start displaying collision model
+
         } else {
             if (_collisionMeshKey) {
                 // release mesh
                 collisionMeshCache.releaseMesh(_collisionMeshKey);
             }
-            // clear model's collision geometry
-            graphics::MeshPointer mesh = nullptr;
-            _model->setCollisionMesh(mesh);
+            // TODO: Stop displaying collision model
+
         }
     }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1052,6 +1052,7 @@ using namespace render;
 using namespace render::entities;
 
 ModelEntityRenderer::ModelEntityRenderer(const EntityItemPointer& entity) : Parent(entity) {
+    // TODO: Re-add menu item in Menu.ccp/Menu.h when collision model updates in doRenderUpdateSynchronousTyped(...) are re-implemented
     connect(DependencyManager::get<EntityTreeRenderer>().data(), &EntityTreeRenderer::setRenderDebugHulls, this, [&] {
         _needsCollisionGeometryUpdate = true;
         emit requestRenderUpdate();

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -161,7 +161,6 @@ protected:
     virtual bool needsRenderUpdate() const override;
     virtual void doRender(RenderArgs* args) override;
     virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
-    void flagForCollisionGeometryUpdate();
     void setCollisionMeshKey(const void* key);
 
     render::hifi::Tag getTagMask() const override;
@@ -189,7 +188,6 @@ private:
 #endif
 
     bool _needsJointSimulation { false };
-    bool _needsCollisionGeometryUpdate { false };
     const void* _collisionMeshKey { nullptr };
 
     // used on client side

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -47,7 +47,7 @@ bool CauterizedModel::updateGeometry() {
     return needsFullUpdate;
 }
 
-void CauterizedModel::createVisibleRenderItemSet() {
+void CauterizedModel::createRenderItemSet() {
     if (_isCauterized) {
         assert(isLoaded());
         const auto& meshes = _renderGeometry->getMeshes();
@@ -94,7 +94,7 @@ void CauterizedModel::createVisibleRenderItemSet() {
             }
         }
     } else {
-        Model::createVisibleRenderItemSet();
+        Model::createRenderItemSet();
     }
 }
 

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -98,11 +98,6 @@ void CauterizedModel::createVisibleRenderItemSet() {
     }
 }
 
-void CauterizedModel::createCollisionRenderItemSet() {
-    // Temporary HACK: use base class method for now
-    Model::createCollisionRenderItemSet();
-}
-
 void CauterizedModel::updateClusterMatrices() {
     PerformanceTimer perfTimer("CauterizedModel::updateClusterMatrices");
 
@@ -185,12 +180,6 @@ void CauterizedModel::updateRenderItems() {
     if (_isCauterized) {
         if (!_addedToScene) {
             return;
-        }
-
-        glm::vec3 scale = getScale();
-        if (_collisionGeometry) {
-            // _collisionGeometry is already scaled
-            scale = glm::vec3(1.0f);
         }
         _needsUpdateClusterMatrices = true;
         _renderItemsNeedUpdate = false;

--- a/libraries/render-utils/src/CauterizedModel.h
+++ b/libraries/render-utils/src/CauterizedModel.h
@@ -32,8 +32,7 @@ public:
     bool updateGeometry() override;
 
     void createVisibleRenderItemSet() override;
-    void createCollisionRenderItemSet() override;
-
+    
     virtual void updateClusterMatrices() override;
     void updateRenderItems() override;
 

--- a/libraries/render-utils/src/CauterizedModel.h
+++ b/libraries/render-utils/src/CauterizedModel.h
@@ -31,7 +31,7 @@ public:
     void deleteGeometry() override;
     bool updateGeometry() override;
 
-    void createVisibleRenderItemSet() override;
+    void createRenderItemSet() override;
     
     virtual void updateClusterMatrices() override;
     void updateRenderItems() override;

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -725,14 +725,6 @@ void Model::updateRenderItemsKey(const render::ScenePointer& scene) {
             data.updateKey(renderItemsKey);
         });
     }
-    //TODO: Remove
-#ifdef RENDER_MODEL_BOUNDING_BOXES
-    foreach(auto item, _collisionRenderItemsMap.keys()) {
-        transaction.updateItem<ModelMeshPartPayload>(item, [renderItemsKey](ModelMeshPartPayload& data) {
-            data.updateKey(renderItemsKey);
-        });
-    }
-#endif
     scene->enqueueTransaction(transaction);
 }
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -808,7 +808,7 @@ bool Model::addToScene(const render::ScenePointer& scene,
     if (!_addedToScene && isLoaded()) {
         updateClusterMatrices();
         if (_modelMeshRenderItems.empty()) {
-            createVisibleRenderItemSet();
+            createRenderItemSet();
         }
     }
 
@@ -1458,7 +1458,7 @@ const render::ItemIDs& Model::fetchRenderItemIDs() const {
     return _modelMeshRenderItemIDs;
 }
 
-void Model::createVisibleRenderItemSet() {
+void Model::createRenderItemSet() {
     assert(isLoaded());
     const auto& meshes = _renderGeometry->getMeshes();
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -47,8 +47,6 @@ int vec3VectorTypeId = qRegisterMetaType<QVector<glm::vec3> >();
 float Model::FAKE_DIMENSION_PLACEHOLDER = -1.0f;
 #define HTTP_INVALID_COM "http://invalid.com"
 
-const int NUM_COLLISION_HULL_COLORS = 24;
-
 Model::Model(QObject* parent, SpatiallyNestable* spatiallyNestableOverride) :
     QObject(parent),
     _renderGeometry(),

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -48,50 +48,10 @@ float Model::FAKE_DIMENSION_PLACEHOLDER = -1.0f;
 #define HTTP_INVALID_COM "http://invalid.com"
 
 const int NUM_COLLISION_HULL_COLORS = 24;
-std::vector<graphics::MaterialPointer> _collisionMaterials;
-
-void initCollisionMaterials() {
-    // generates bright colors in red, green, blue, yellow, magenta, and cyan spectrums
-    // (no browns, greys, or dark shades)
-    float component[NUM_COLLISION_HULL_COLORS] = {
-        0.0f, 0.0f, 0.0f, 0.0f,
-        0.0f, 0.0f, 0.0f, 0.0f,
-        0.2f, 0.4f, 0.6f, 0.8f,
-        1.0f, 1.0f, 1.0f, 1.0f,
-        1.0f, 1.0f, 1.0f, 1.0f,
-        0.8f, 0.6f, 0.4f, 0.2f
-    };
-    _collisionMaterials.reserve(NUM_COLLISION_HULL_COLORS);
-
-    // each component gets the same cuve
-    // but offset by a multiple of one third the full width
-    int numComponents = 3;
-    int sectionWidth = NUM_COLLISION_HULL_COLORS / numComponents;
-    int greenPhase = sectionWidth;
-    int bluePhase = 2 * sectionWidth;
-
-    // we stride through the colors to scatter adjacent shades
-    // so they don't tend to group together for large models
-    for (int i = 0; i < sectionWidth; ++i) {
-        for (int j = 0; j < numComponents; ++j) {
-            graphics::MaterialPointer material;
-            material = std::make_shared<graphics::Material>();
-            int index = j * sectionWidth + i;
-            float red = component[index % NUM_COLLISION_HULL_COLORS];
-            float green = component[(index + greenPhase) % NUM_COLLISION_HULL_COLORS];
-            float blue = component[(index + bluePhase) % NUM_COLLISION_HULL_COLORS];
-            material->setAlbedo(glm::vec3(red, green, blue));
-            material->setMetallic(0.02f);
-            material->setRoughness(0.5f);
-            _collisionMaterials.push_back(material);
-        }
-    }
-}
 
 Model::Model(QObject* parent, SpatiallyNestable* spatiallyNestableOverride) :
     QObject(parent),
     _renderGeometry(),
-    _collisionGeometry(),
     _renderWatcher(_renderGeometry),
     _spatiallyNestableOverride(spatiallyNestableOverride),
     _translation(0.0f),
@@ -307,16 +267,6 @@ void Model::updateRenderItems() {
 
                 data.updateKey(renderItemKeyGlobalFlags);
                 data.setShapeKey(invalidatePayloadShapeKey, isWireframe, useDualQuaternionSkinning);
-            });
-        }
-
-        Transform collisionMeshOffset;
-        collisionMeshOffset.setIdentity();
-        foreach(auto itemID, self->_collisionRenderItemsMap.keys()) {
-            transaction.updateItem<MeshPartPayload>(itemID, [renderItemKeyGlobalFlags, modelTransform, collisionMeshOffset](MeshPartPayload& data) {
-                // update the model transform for this render item.
-                data.updateKey(renderItemKeyGlobalFlags);
-                data.updateTransform(modelTransform, collisionMeshOffset);
             });
         }
 
@@ -777,11 +727,14 @@ void Model::updateRenderItemsKey(const render::ScenePointer& scene) {
             data.updateKey(renderItemsKey);
         });
     }
+    //TODO: Remove
+#ifdef RENDER_MODEL_BOUNDING_BOXES
     foreach(auto item, _collisionRenderItemsMap.keys()) {
         transaction.updateItem<ModelMeshPartPayload>(item, [renderItemsKey](ModelMeshPartPayload& data) {
             data.updateKey(renderItemsKey);
         });
     }
+#endif
     scene->enqueueTransaction(transaction);
 }
 
@@ -862,49 +815,37 @@ const render::ItemKey Model::getRenderItemKeyGlobalFlags() const {
 bool Model::addToScene(const render::ScenePointer& scene,
                        render::Transaction& transaction,
                        render::Item::Status::Getters& statusGetters) {
-    bool readyToRender = _collisionGeometry || isLoaded();
-    if (!_addedToScene && readyToRender) {
-        createRenderItemSet();
+    if (!_addedToScene && isLoaded()) {
+        updateClusterMatrices();
+        if (_modelMeshRenderItems.empty()) {
+            createVisibleRenderItemSet();
+        }
     }
 
     bool somethingAdded = false;
-    if (_collisionGeometry) {
-        if (_collisionRenderItemsMap.empty()) {
-            foreach (auto renderItem, _collisionRenderItems) {
-                auto item = scene->allocateID();
-                auto renderPayload = std::make_shared<MeshPartPayload::Payload>(renderItem);
-                if (_collisionRenderItems.empty() && statusGetters.size()) {
-                    renderPayload->addStatusGetters(statusGetters);
-                }
-                transaction.resetItem(item, renderPayload);
-                _collisionRenderItemsMap.insert(item, renderPayload);
+
+    if (_modelMeshRenderItemsMap.empty()) {
+
+        bool hasTransparent = false;
+        size_t verticesCount = 0;
+        foreach(auto renderItem, _modelMeshRenderItems) {
+            auto item = scene->allocateID();
+            auto renderPayload = std::make_shared<ModelMeshPartPayload::Payload>(renderItem);
+            if (_modelMeshRenderItemsMap.empty() && statusGetters.size()) {
+                renderPayload->addStatusGetters(statusGetters);
             }
-            somethingAdded = !_collisionRenderItemsMap.empty();
+            transaction.resetItem(item, renderPayload);
+
+            hasTransparent = hasTransparent || renderItem.get()->getShapeKey().isTranslucent();
+            verticesCount += renderItem.get()->getVerticesCount();
+            _modelMeshRenderItemsMap.insert(item, renderPayload);
+            _modelMeshRenderItemIDs.emplace_back(item);
         }
-    } else {
-        if (_modelMeshRenderItemsMap.empty()) {
+        somethingAdded = !_modelMeshRenderItemsMap.empty();
 
-            bool hasTransparent = false;
-            size_t verticesCount = 0;
-            foreach(auto renderItem, _modelMeshRenderItems) {
-                auto item = scene->allocateID();
-                auto renderPayload = std::make_shared<ModelMeshPartPayload::Payload>(renderItem);
-                if (_modelMeshRenderItemsMap.empty() && statusGetters.size()) {
-                    renderPayload->addStatusGetters(statusGetters);
-                }
-                transaction.resetItem(item, renderPayload);
-
-                hasTransparent = hasTransparent || renderItem.get()->getShapeKey().isTranslucent();
-                verticesCount += renderItem.get()->getVerticesCount();
-                _modelMeshRenderItemsMap.insert(item, renderPayload);
-                _modelMeshRenderItemIDs.emplace_back(item);
-            }
-            somethingAdded = !_modelMeshRenderItemsMap.empty();
-
-            _renderInfoVertexCount = verticesCount;
-            _renderInfoDrawCalls = _modelMeshRenderItemsMap.count();
-            _renderInfoHasTransparent = hasTransparent;
-        }
+        _renderInfoVertexCount = verticesCount;
+        _renderInfoDrawCalls = _modelMeshRenderItemsMap.count();
+        _renderInfoHasTransparent = hasTransparent;
     }
 
     if (somethingAdded) {
@@ -926,11 +867,6 @@ void Model::removeFromScene(const render::ScenePointer& scene, render::Transacti
     _modelMeshMaterialNames.clear();
     _modelMeshRenderItemShapes.clear();
 
-    foreach(auto item, _collisionRenderItemsMap.keys()) {
-        transaction.removeItem(item);
-    }
-    _collisionRenderItems.clear();
-    _collisionRenderItemsMap.clear();
     _addedToScene = false;
 
     _renderInfoVertexCount = 0;
@@ -1505,7 +1441,6 @@ void Model::deleteGeometry() {
     _rig.destroyAnimGraph();
     _blendedBlendshapeCoefficients.clear();
     _renderGeometry.reset();
-    _collisionGeometry.reset();
 }
 
 void Model::overrideModelTransformAndOffset(const Transform& transform, const glm::vec3& offset) {
@@ -1532,19 +1467,6 @@ AABox Model::getRenderableMeshBound() const {
 const render::ItemIDs& Model::fetchRenderItemIDs() const {
     return _modelMeshRenderItemIDs;
 }
-
-void Model::createRenderItemSet() {
-    updateClusterMatrices();
-    if (_collisionGeometry) {
-        if (_collisionRenderItems.empty()) {
-            createCollisionRenderItemSet();
-        }
-    } else {
-        if (_modelMeshRenderItems.empty()) {
-            createVisibleRenderItemSet();
-        }
-    }
-};
 
 void Model::createVisibleRenderItemSet() {
     assert(isLoaded());
@@ -1588,41 +1510,6 @@ void Model::createVisibleRenderItemSet() {
             _modelMeshMaterialNames.push_back(material ? material->getName() : "");
             _modelMeshRenderItemShapes.emplace_back(ShapeInfo{ (int)i });
             shapeID++;
-        }
-    }
-}
-
-void Model::createCollisionRenderItemSet() {
-    assert((bool)_collisionGeometry);
-    if (_collisionMaterials.empty()) {
-        initCollisionMaterials();
-    }
-
-    const auto& meshes = _collisionGeometry->getMeshes();
-
-    // We should not have any existing renderItems if we enter this section of code
-    Q_ASSERT(_collisionRenderItems.isEmpty());
-
-    Transform identity;
-    identity.setIdentity();
-    Transform offset;
-    offset.postTranslate(_offset);
-
-    // Run through all of the meshes, and place them into their segregated, but unsorted buckets
-    uint32_t numMeshes = (uint32_t)meshes.size();
-    for (uint32_t i = 0; i < numMeshes; i++) {
-        const auto& mesh = meshes.at(i);
-        if (!mesh) {
-            continue;
-        }
-
-        // Create the render payloads
-        int numParts = (int)mesh->getNumParts();
-        for (int partIndex = 0; partIndex < numParts; partIndex++) {
-            graphics::MaterialPointer& material = _collisionMaterials[partIndex % NUM_COLLISION_HULL_COLORS];
-            auto payload = std::make_shared<MeshPartPayload>(mesh, partIndex, material);
-            payload->updateTransform(identity, offset);
-            _collisionRenderItems << payload;
         }
     }
 }
@@ -1709,15 +1596,6 @@ public:
         _meshParts = std::shared_ptr<const GeometryMeshParts>();
     }
 };
-
-void Model::setCollisionMesh(graphics::MeshPointer mesh) {
-    if (mesh) {
-        _collisionGeometry = std::make_shared<CollisionRenderGeometry>(mesh);
-    } else {
-        _collisionGeometry.reset();
-    }
-    _needsFixupInScene = true;
-}
 
 ModelBlender::ModelBlender() :
     _pendingBlenders(0) {

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -426,7 +426,7 @@ protected:
     QVector<TriangleSet> _modelSpaceMeshTriangleSets; // model space triangles for all sub meshes
 
 
-    virtual void createVisibleRenderItemSet();
+    virtual void createRenderItemSet();
 
     bool _isWireframe;
     bool _useDualQuaternionSkinning { false };

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -153,8 +153,6 @@ public:
 
     /// Returns a reference to the shared geometry.
     const Geometry::Pointer& getGeometry() const { return _renderGeometry; }
-    /// Returns a reference to the shared collision geometry.
-    const Geometry::Pointer& getCollisionGeometry() const { return _collisionGeometry; }
 
     const QVariantMap getTextures() const { assert(isLoaded()); return _renderGeometry->getTextures(); }
     Q_INVOKABLE virtual void setTextures(const QVariantMap& textures);
@@ -260,7 +258,6 @@ public:
 
     // returns 'true' if needs fullUpdate after geometry change
     virtual bool updateGeometry();
-    void setCollisionMesh(graphics::MeshPointer mesh);
 
     void setLoadingPriority(float priority) { _loadingPriority = priority; }
 
@@ -362,7 +359,6 @@ protected:
     bool getJointPosition(int jointIndex, glm::vec3& position) const;
 
     Geometry::Pointer _renderGeometry; // only ever set by its watcher
-    Geometry::Pointer _collisionGeometry;
 
     GeometryResourceWatcher _renderWatcher;
 
@@ -430,9 +426,7 @@ protected:
     QVector<TriangleSet> _modelSpaceMeshTriangleSets; // model space triangles for all sub meshes
 
 
-    void createRenderItemSet();
     virtual void createVisibleRenderItemSet();
-    virtual void createCollisionRenderItemSet();
 
     bool _isWireframe;
     bool _useDualQuaternionSkinning { false };
@@ -442,9 +436,6 @@ protected:
 
 
     static AbstractViewStateInterface* _viewState;
-
-    QVector<std::shared_ptr<MeshPartPayload>> _collisionRenderItems;
-    QMap<render::ItemID, render::PayloadPointer> _collisionRenderItemsMap;
 
     QVector<std::shared_ptr<ModelMeshPartPayload>> _modelMeshRenderItems;
     QMap<render::ItemID, render::PayloadPointer> _modelMeshRenderItemsMap;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/12114/Draw-Collision-Shapes-causes-affected-entities-to-simply-disappear
From the end-user's standpoint, this PR results in the menu option "Draw Collision Shapes" being removed from the Physics section of the developer menu.

Behind the scenes, the Model class no longer serves the dual purpose of rendering aesthetic models and physics models. The physics model rendering functionality will later be re-implemented elsewhere. Some of the generic logic for switching between these two types of models is still present in RenderableModelEntityItem, for later implementation.

## TEST PLAN
- In this PR, check that the "Draw Collision Shapes" option in the Physics section of the developer menu is not present.