### PR TITLE
Fix Avatar > Attachments joint and spinboxes

### DIFF
--- a/interface/resources/qml/controls-uit/SpinBox.qml
+++ b/interface/resources/qml/controls-uit/SpinBox.qml
@@ -31,8 +31,8 @@ SpinBox {
     property real maximumValue: 0.0
 
     property real realValue: 0.0
-    property real realFrom: 0.0
-    property real realTo: 100.0
+    property real realFrom: minimumValue
+    property real realTo: maximumValue
     property real realStepSize: 1.0
 
     signal editingFinished()

--- a/interface/resources/qml/controls-uit/SpinBox.qml
+++ b/interface/resources/qml/controls-uit/SpinBox.qml
@@ -81,6 +81,7 @@ SpinBox {
     }
 
     valueFromText: function(text, locale) {
+        spinBox.value = 0; // Force valueChanged signal to be emitted so that validator fires.
         return Number.fromLocaleString(locale, text)*factor;
     }
 

--- a/interface/resources/qml/hifi/dialogs/attachments/Attachment.qml
+++ b/interface/resources/qml/hifi/dialogs/attachments/Attachment.qml
@@ -119,8 +119,8 @@ Item {
                 colorScheme: hifi.colorSchemes.dark
                 currentIndex: attachment ? model.indexOf(attachment.jointName) : -1
                 onCurrentIndexChanged: {
-                    if (completed && attachment && currentIndex != -1 && currentText && currentText !== attachment.jointName) {
-                        attachment.jointName = currentText;
+                    if (completed && attachment && currentIndex != -1 && attachment.jointName !== model[currentIndex]) {
+                        attachment.jointName = model[currentIndex];
                         updateAttachment();
                     }
                 }


### PR DESCRIPTION
- Fix setting attachment joint in Avatar > Attachments dialog.
- Fix QML spinbox min/max values.
- Fix QML spinbox not validating second time you enter invalid value.
