### PR TITLE
Interface Fix for MS14314: Make use of original image filename when sharing

### DIFF
--- a/interface/src/ui/SnapshotUploader.cpp
+++ b/interface/src/ui/SnapshotUploader.cpp
@@ -35,6 +35,7 @@ void SnapshotUploader::uploadSuccess(QNetworkReply& reply) {
         QString thumbnailUrl = dataObject.value("thumbnail_url").toString();
         QString imageUrl = dataObject.value("image_url").toString();
         QString snapshotID = dataObject.value("id").toString();
+        QString originalImageFileName = dataObject.value("original_image_file_name").toString();
         auto addressManager = DependencyManager::get<AddressManager>();
         QString placeName = _inWorldLocation.authority(); // We currently only upload shareable places, in which case this is just host.
         QString currentPath = _inWorldLocation.path();
@@ -48,6 +49,7 @@ void SnapshotUploader::uploadSuccess(QNetworkReply& reply) {
             detailsObject.insert("shareable_url", dataObject.value("shareable_url").toString());
         }
         detailsObject.insert("snapshot_id", snapshotID);
+        detailsObject.insert("original_image_file_name", originalImageFileName);
         QString pickledDetails = QJsonDocument(detailsObject).toJson();
         userStoryObject.insert("details", pickledDetails);
         userStoryObject.insert("thumbnail_url", thumbnailUrl);

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -387,7 +387,6 @@ function snapshotUploaded(isError, reply) {
             isGif = fileExtensionMatches(imageURL, "gif"),
             ignoreGifSnapshotData = false,
             ignoreStillSnapshotData = false;
-        console.log("ZRF " + JSON.stringify(replyJson));
         storyIDsToMaybeDelete.push(storyID);
         if (isGif) {
             if (mostRecentGifSnapshotFilename !== replyJson.user_story.details.original_image_file_name) {


### PR DESCRIPTION
This is the clientside fix for [MS14314](https://highfidelity.fogbugz.com/f/cases/14314/Taking-two-GIF-snapshots-and-sharing-the-second-one-to-the-feed-may-share-the-first-GIF-new-GIF-gets-no-story-ID). The full fix requires the merge of a corresponding data-web PR, found here.

Not QA ready until the data-web PR is merged to Staging.