### PR TITLE
Don't hide jump button while moving

### DIFF
--- a/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.cpp
@@ -151,11 +151,9 @@ void Basic2DWindowOpenGLDisplayPlugin::compositeExtra() {
             batch.setModelTransform(stickTransform);
             batch.draw(gpu::TRIANGLE_STRIP, 4);
 
-            if (!virtualPadManager.getLeftVirtualPad()->isBeingTouched()) {
-                batch.setResourceTexture(0, _virtualPadJumpBtnTexture);
-                batch.setModelTransform(jumpTransform);
-                batch.draw(gpu::TRIANGLE_STRIP, 4);
-            }
+            batch.setResourceTexture(0, _virtualPadJumpBtnTexture);
+            batch.setModelTransform(jumpTransform);
+            batch.draw(gpu::TRIANGLE_STRIP, 4);
         });
     }
 #endif


### PR DESCRIPTION
Restore back the jump button when user is moving with the left touchpad.

Testing plan:
- In android the jump button (a.k.a. fly button) must be visible while the user is walking or rotating using the left touchpad.
- The user must be able to jump while walking