### PR TITLE
MS15788: drillDownToPlace and isStacked based on server data.

### DIFF
--- a/interface/resources/qml/hifi/Feed.qml
+++ b/interface/resources/qml/hifi/Feed.qml
@@ -86,7 +86,9 @@ Column {
             tags: tags,
             description: description,
             online_users: data.details.connections || data.details.concurrency || 0,
-            drillDownToPlace: false
+            // Server currently doesn't give isStacked (undefined). Could give bool.
+            drillDownToPlace: (data.isStacked === undefined) ? (data.action !== 'concurrency') : data.isStacked,
+            isStacked: !!data.isStacked
         };
     }
 
@@ -124,6 +126,7 @@ Column {
             onlineUsers: model.online_users;
             storyId: model.metaverseId;
             drillDownToPlace: model.drillDownToPlace;
+            isStacked: model.isStacked;
 
             textPadding: root.textPadding;
             smallMargin: root.smallMargin;


### PR DESCRIPTION
For now, when one clicks for more info on GOTO announcements and snapshots, it shows you the place card (which in turn, lists the announcements and snapshots).

When the back end also specifies the "isStacked" boolean property (back end change), the client will obey that, and also only drill down to place when stacked.

This PR is compatible with current (staging) metaverse, compatible with the next data-web change (to group announcements and snapshots by place), and compatible with the next data-web after that (if it gets done) in which isStacked will be explicitly specified as a boolean.