### PR TITLE
Remove unneeded reticle checks in edit handles

### DIFF
--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -667,9 +667,6 @@ SelectionDisplay = (function() {
                     activeHand = (activeHand === Controller.Standard.RightHand) ?
                         Controller.Standard.LeftHand : Controller.Standard.RightHand;
                 }
-                if (Reticle.pointingAtSystemOverlay || Overlays.getOverlayAtPoint(Reticle.position)) {
-                    return;
-                }
                 that.mousePressEvent({});
             } else if (that.triggered && (value < that.TRIGGER_OFF_VALUE)) {
                 that.triggered = false;


### PR DESCRIPTION
The reticle checks in makeTriggerHandler function are no longer needed/useful as this function is only used for simulating mousePressEvents/mouseReleaseEvents for the laser triggers. Reticle.pointingAtSystemOverlay does not give accurate results when using the laser which is a separate issue, however it is not really needed here because you can't point at the windows in question while in edit mode because hudOverlayPointer won't be running. Overlays.getOverlayAtPoint(Reticle.position) is not a valid check here because Reticle.position is always constant when using the lasers so this was always false anyway. Either way the mousePressEvent function would not find a matching hit edit handle overlay if we aren't pointing at one.

Fixes: https://highfidelity.manuscript.com/f/cases/15198/