### PR TITLE
Fix crash in image baking due to undefined mip format

### DIFF
--- a/libraries/image/src/image/Image.cpp
+++ b/libraries/image/src/image/Image.cpp
@@ -835,6 +835,7 @@ gpu::TexturePointer TextureUsage::process2DTextureColorFromImage(QImage&& srcIma
             } else {
                 formatGPU = gpu::Element::COLOR_COMPRESSED_BCX_SRGB;
             }
+            formatMip = formatGPU;
         } else {
 #ifdef USE_GLES
             // GLES does not support GL_BGRA


### PR DESCRIPTION
A recent change caused formatMip to no longer be specified. This causes
an issue deeper in the code when generating mips, causing a
Q_UNREACHABLE to be hit.