### PR TITLE
fixing invisible cursor when coming from HMD mode

### DIFF
--- a/scripts/system/controllers/controllerModules/mouseHMD.js
+++ b/scripts/system/controllers/controllerModules/mouseHMD.js
@@ -101,12 +101,15 @@
         this.isReady = function(controllerData, deltaTime) {
             var now = Date.now();
             this.triggersPressed(controllerData, now);
-            if ((HMD.active && !this.mouseActivity.expired(now)) && _this.handControllerActivity.expired()) {
-                Reticle.visible = true;
-                return ControllerDispatcherUtils.makeRunningValues(true, [], []);
-            }
             if (HMD.active) {
-                Reticle.visible = false;
+                if (!this.mouseActivity.expired(now) && _this.handControllerActivity.expired()) {
+                    Reticle.visible = true;
+                    return ControllerDispatcherUtils.makeRunningValues(true, [], []);
+                } else {
+                    Reticle.visible = false;
+                }
+            } else if (!Reticle.visible) {
+                Reticle.visible = true;
             }
 
             return ControllerDispatcherUtils.makeRunningValues(false, [], []);


### PR DESCRIPTION
When you are in HMD mode and you have a window over interface, when you switch back to desktop mode the mouseHMD will not fix the the visible. This Pr addresses this issue.

ticket - https://highfidelity.manuscript.com/f/cases/11782/HMD-Mouse-cursor-disappears-when-going-from-VR-to-desktop