### PR TITLE
Fix MS15858: Prevent Interface deadlock during 360 Snap capture

### DIFF
--- a/unpublishedScripts/marketplace/spectator-camera/SpectatorCamera.qml
+++ b/unpublishedScripts/marketplace/spectator-camera/SpectatorCamera.qml
@@ -205,7 +205,7 @@ Rectangle {
             // Spectator Camera Preview
             Hifi.ResourceImageItem {
                 id: spectatorCameraPreview;
-                visible: masterSwitch.checked;
+                visible: masterSwitch.checked && !root.processing360Snapshot;
                 url: showCameraView.checked || !HMD.active ? "resource://spectatorCameraFrame" : "resource://hmdPreviewFrame";
                 ready: masterSwitch.checked;
                 mirrorVertically: true;


### PR DESCRIPTION
Fixes [MS15858](https://highfidelity.manuscript.com/f/cases/15858/Spectator-camera-crashes-taking-360-snapshot-in-desktop-mode-while-processing).

No engine changes here, just an app change.

No milestone here because the app will be updated separately from the engine; this is only to keep the repo updated.