### PR TITLE
MS15501: Fix keyboard in Create -> Model in HMD

### DIFF
--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -24,6 +24,7 @@ Rectangle {
     color: hifi.colors.baseGray;
     signal sendToScript(var message);
     property bool keyboardEnabled: false
+    property bool keyboardRaised: false
     property bool punctuationMode: false
     property bool keyboardRasied: false
 
@@ -235,10 +236,11 @@ Rectangle {
 
     Keyboard {
         id: keyboard
-        raised: parent.keyboardEnabled
+        raised: parent.keyboardEnabled && parent.keyboardRaised
         numeric: parent.punctuationMode
         anchors {
             bottom: parent.bottom
+            bottomMargin: 40
             left: parent.left
             right: parent.right
         }


### PR DESCRIPTION
Fixes [MS15501](https://highfidelity.manuscript.com/f/cases/15501/HMD-keyboard-missing-bottom-row). Also fixes a bug where the virtual keyboard in the Create -> Model screen wouldn't lower when pressing the Lower button.