### PR TITLE
fix focus issues when mouse is offscreen

### DIFF
--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -177,6 +177,10 @@ function goActive() {
 
     UserActivityLogger.toggledAway(false);
     MyAvatar.isAway = false;
+
+    if (!Window.hasFocus()) {
+        Window.setFocus();
+    }
 }
 
 MyAvatar.wentAway.connect(setAwayProperties);


### PR DESCRIPTION
At time you are able to use interface in HMD without having window focus. This causes issue when trying to use text boxes.  This PR addresses this issue.

Ticket - https://highfidelity.manuscript.com/f/cases/15029/When-Interface-loses-window-focus-while-using-Vive-the-tablet-keyboard-will-either-not-appear-or-not-type-in-selected-field