### PR TITLE
[RC69] fix cloneDynamic

### DIFF
--- a/scripts/system/libraries/controllerDispatcherUtils.js
+++ b/scripts/system/libraries/controllerDispatcherUtils.js
@@ -129,7 +129,8 @@ DISPATCHER_PROPERTIES = [
     "userData",
     "type",
     "href",
-    "cloneable"
+    "cloneable",
+    "cloneDynamic"
 ];
 
 // priority -- a lower priority means the module will be asked sooner than one with a higher priority in a given update step


### PR DESCRIPTION
Fixes https://highfidelity.manuscript.com/f/cases/6662/Cloned-dynamic-items-do-not-start-dynamic-when-first-grabbed

# QA Test
1. Create a Box entity that is:
    - Grabbable
    - Cloneable
    - Clone dynamic
![image](https://user-images.githubusercontent.com/607735/41427223-8939c01c-7006-11e8-897c-6e8548244998.png)
2. go into HMD mode
3. Grab the Box entity to clone it and throw it right away. (Don't re-grab it) 
4. The cloned entity should have a velocity. (it should not stay in the position that you released it)

5. Create a Box entity that is:  (could use desktop mode for this if desired)
    - Grabbable
    - Cloneable
![image](https://user-images.githubusercontent.com/607735/41427389-0cfe5354-7007-11e8-9a7a-5251b44978ba.png)
6. Grab the Box entity to clone it and throw it right away. (Don't re-grab it) 
7. The cloned entity should stay stationary in the position that you released it in. (The entity should not have velocity)



    