### PR TITLE
Fix MS13202: Don't save incomplete list of scripts to Settings while reloading scripts

### DIFF
--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -594,7 +594,7 @@ void ScriptEngines::onScriptFinished(const QString& rawScriptURL, ScriptEnginePo
         }
     }
 
-    if (removed) {
+    if (removed && !_isReloading) {
         // Update settings with removed script
         saveScripts();
         emit scriptCountChanged();


### PR DESCRIPTION
Fixes [MS13202](https://highfidelity.manuscript.com/f/cases/13202/Crashing-while-reloading-scripts-will-not-restore-all-scripts-upon-restart).