### PR TITLE
prevent having more than one instance of a script running after reloading the script

### DIFF
--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -432,10 +432,13 @@ bool ScriptEngines::stopScript(const QString& rawScriptURL, bool restart) {
                 ScriptEngine::Type type = scriptEngine->getType();
                 auto scriptCache = DependencyManager::get<ScriptCache>();
                 scriptCache->deleteScript(scriptURL);
-                connect(scriptEngine.data(), &ScriptEngine::finished,
-                        this, [this, isUserLoaded, type](QString scriptName, ScriptEnginePointer engine) {
-                    reloadScript(scriptName, isUserLoaded)->setType(type);
-                });
+
+                if (!scriptEngine->isStopping()) {
+                    connect(scriptEngine.data(), &ScriptEngine::finished,
+                            this, [this, isUserLoaded, type](QString scriptName, ScriptEnginePointer engine) {
+                            reloadScript(scriptName, isUserLoaded)->setType(type);
+                    });
+                }
             }
             scriptEngine->stop();
             stoppedScript = true;


### PR DESCRIPTION
At times when you spam the reload script button, you may end up with multiple instances of that script running.

ticket - https://highfidelity.manuscript.com/f/cases/15834/Script-refresh-can-duplicate-script