### PR TITLE
Fix Oculus touch controller button handling when remote is paired (RC69)

### DIFF
--- a/plugins/oculus/src/OculusControllerManager.h
+++ b/plugins/oculus/src/OculusControllerManager.h
@@ -103,7 +103,8 @@ private:
 
     void checkForConnectedDevices();
 
-    ovrInputState _inputState {};
+    ovrInputState _remoteInputState {};
+    ovrInputState _touchInputState {};
     RemoteDevice::Pointer _remote;
     TouchDevice::Pointer _touch;
     static const char* NAME;


### PR DESCRIPTION
Fix for https://highfidelity.fogbugz.com/f/cases/15958

The PR #13314 broke the control handling for buttons, triggers, sticks etc on the Touch controller _if_ the Oculus remote was paired and active.  This has to do with the way the session management code re-ordered the fetching of the input data from the remote and touch devices respectively and the updating of the device abstraction based on the input state.  Previously it was 

* fetch touch
* update touch
* fetch remote
* update remote

but the changes to the session management required that it be changed to

* fetch touch
* fetch remote
* update touch
* update remote

The problem is that fetching the remote data overwrites the fetch touch input states.  The solution is to use separate ovrInputState instances for the touch and remote.


## Testing

On a system with an Oculus HMD *and* touch controllers *and* an active paired Oculus remote...

* run Interface 
* Verify that the remote is active by using the Oculus button to toggle the Oculus desktop on an off
* Use the touch controls to bring up the tablet and interact with it using the touch laser / trigger

On master builds the touch control interaction will fail because the buttons and triggers are ignored.  In this PR the touch control will be able to bring up and interact with the tablet

