### PR TITLE
RC69: crash fixes

### DIFF
--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -105,8 +105,10 @@ QStringList Animation::getJointNames() const {
         return result;
     }
     QStringList names;
-    foreach (const FBXJoint& joint, _geometry->joints) {
-        names.append(joint.name);
+    if (_geometry) {
+        foreach (const FBXJoint& joint, _geometry->joints) {
+            names.append(joint.name);
+        }
     }
     return names;
 }
@@ -114,11 +116,15 @@ QStringList Animation::getJointNames() const {
 QVector<FBXAnimationFrame> Animation::getFrames() const {
     if (QThread::currentThread() != thread()) {
         QVector<FBXAnimationFrame> result;
-        BLOCKING_INVOKE_METHOD(const_cast<Animation*>(this), "getFrames", 
+        BLOCKING_INVOKE_METHOD(const_cast<Animation*>(this), "getFrames",
             Q_RETURN_ARG(QVector<FBXAnimationFrame>, result));
         return result;
     }
-    return _geometry->animationFrames;
+    if (_geometry) {
+        return _geometry->animationFrames;
+    } else {
+        return QVector<FBXAnimationFrame>();
+    }
 }
 
 const QVector<FBXAnimationFrame>& Animation::getFramesReference() const {

--- a/libraries/gpu/src/gpu/Sysmem.cpp
+++ b/libraries/gpu/src/gpu/Sysmem.cpp
@@ -124,7 +124,7 @@ Size Sysmem::setData( Size size, const Byte* bytes ) {
 }
 
 Size Sysmem::setSubData( Size offset, Size size, const Byte* bytes) {
-    if (size && ((offset + size) <= getSize()) && bytes) {
+    if (_data && size && ((offset + size) <= getSize()) && bytes) {
         memcpy( _data + offset, bytes, size );
         return size;
     }

--- a/libraries/physics/src/ObjectMotionState.cpp
+++ b/libraries/physics/src/ObjectMotionState.cpp
@@ -92,7 +92,7 @@ void ObjectMotionState::setMass(float mass) {
 }
 
 float ObjectMotionState::getMass() const {
-    if (_shape) {
+    if (_shape && _shape->getShapeType() != TRIANGLE_MESH_SHAPE_PROXYTYPE) {
         // scale the density by the current Aabb volume to get mass
         btTransform transform;
         transform.setIdentity();
@@ -348,8 +348,10 @@ void ObjectMotionState::updateLastKinematicStep() {
 
 void ObjectMotionState::updateBodyMassProperties() {
     float mass = getMass();
-    btVector3 inertia(0.0f, 0.0f, 0.0f);
-    _body->getCollisionShape()->calculateLocalInertia(mass, inertia);
+    btVector3 inertia(1.0f, 1.0f, 1.0f);
+    if (mass > 0.0f) {
+        _body->getCollisionShape()->calculateLocalInertia(mass, inertia);
+    }
     _body->setMassProps(mass, inertia);
     _body->updateInertiaTensor();
 }

--- a/libraries/ui/src/ui/Menu.cpp
+++ b/libraries/ui/src/ui/Menu.cpp
@@ -402,8 +402,10 @@ MenuWrapper* Menu::addMenu(const QString& menuName, const QString& grouping) {
 
     // hook our show/hide for popup menus, so we can keep track of whether or not one
     // of our submenus is currently showing.
-    connect(menu->_realMenu, &QMenu::aboutToShow, []() { _isSomeSubmenuShown = true; });
-    connect(menu->_realMenu, &QMenu::aboutToHide, []() { _isSomeSubmenuShown = false; });
+    if (menu && menu->_realMenu) {
+        connect(menu->_realMenu, &QMenu::aboutToShow, []() { _isSomeSubmenuShown = true; });
+        connect(menu->_realMenu, &QMenu::aboutToHide, []() { _isSomeSubmenuShown = false; });
+    }
 
     return menu;
 }


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/15968/crash-when-accessing-an-Animation-via-JS-before-it-has-loaded

* fix a crash when accessing an Animation from JS before it was loaded
* fix a crash when computing inertia tensor on RigidBody with triangle-mesh shape
* add protection against a few theoretical crash modes