### PR TITLE
Fix MS16012: Correct the criteria used to determine empty txn history

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
@@ -253,8 +253,12 @@ Item {
             anchors.left: parent.left;
             anchors.right: parent.right;
 
-            Item {  // On empty history. We don't want to flash and then replace, so don't show until we know we're zero.
-                visible: transactionHistoryModel.count === 0 && transactionHistoryModel.currentPageToRetrieve < 0;
+            Item {
+                // On empty history. We don't want to flash and then replace, so don't show until we know we should.
+                // The history is empty when it contains 1 item (the pending item count) AND there are no pending items.
+                visible: transactionHistoryModel.count === 1 &&
+                    transactionHistoryModel.retrievedAtLeastOnePage &&
+                    transactionHistoryModel.get(0).count === 0;
                 anchors.centerIn: parent;
                 width: parent.width - 12;
                 height: parent.height;


### PR DESCRIPTION
Fixes [MS16012](https://highfidelity.manuscript.com/f/cases/16012/Missing-message-on-Wallet-Home-about-Hifi-Bank).