### PR TITLE
Include shapeID in RayPick results

### DIFF
--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -185,6 +185,7 @@ public:
     /// Dimensions in meters (0.0 - TREE_SCALE)
     glm::vec3 getScaledDimensions() const;
     virtual void setScaledDimensions(const glm::vec3& value);
+    virtual glm::vec3 getRaycastDimensions() const { return getScaledDimensions(); }
 
     inline const glm::vec3 getUnscaledDimensions() const { return _unscaledDimensions; }
     virtual void setUnscaledDimensions(const glm::vec3& value);
@@ -239,7 +240,7 @@ public:
     // position, size, and bounds related helpers
     virtual AACube getMaximumAACube(bool& success) const override;
     AACube getMinimumAACube(bool& success) const;
-    AABox getAABox(bool& success) const; /// axis aligned bounding box in world-frame (meters)
+    virtual AABox getAABox(bool& success) const; /// axis aligned bounding box in world-frame (meters)
 
     using SpatiallyNestable::getQueryAACube;
     virtual AACube getQueryAACube(bool& success) const override;

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -214,7 +214,7 @@ EntityItemID EntityTreeElement::findDetailedRayIntersection(const glm::vec3& ori
         glm::mat4 entityToWorldMatrix = translation * rotation;
         glm::mat4 worldToEntityMatrix = glm::inverse(entityToWorldMatrix);
 
-        glm::vec3 dimensions = entity->getScaledDimensions();
+        glm::vec3 dimensions = entity->getRaycastDimensions();
         glm::vec3 registrationPoint = entity->getRegistrationPoint();
         glm::vec3 corner = -(dimensions * registrationPoint);
 
@@ -312,7 +312,7 @@ void EntityTreeElement::getEntities(const glm::vec3& searchPosition, float searc
         glm::vec3 penetration;
         if (!success || entityBox.findSpherePenetration(searchPosition, searchRadius, penetration)) {
 
-            glm::vec3 dimensions = entity->getScaledDimensions();
+            glm::vec3 dimensions = entity->getRaycastDimensions();
 
             // FIXME - consider allowing the entity to determine penetration so that
             //         entities could presumably dull actuall hull testing if they wanted to

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -423,8 +423,7 @@ protected:
     bool _overrideModelTransform { false };
     bool _triangleSetsValid { false };
     void calculateTriangleSets(const FBXGeometry& geometry);
-    QVector<TriangleSet> _modelSpaceMeshTriangleSets; // model space triangles for all sub meshes
-
+    std::vector<std::vector<TriangleSet>> _modelSpaceMeshTriangleSets; // model space triangles for all sub meshes
 
     virtual void createRenderItemSet();
 

--- a/libraries/shared/src/TriangleSet.h
+++ b/libraries/shared/src/TriangleSet.h
@@ -9,6 +9,8 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#pragma once
+
 #include <vector>
 
 #include "AABox.h"

--- a/scripts/developer/tests/raypickTester.js
+++ b/scripts/developer/tests/raypickTester.js
@@ -1,0 +1,73 @@
+// raypickTester.js
+//
+// display intersection details (including material) when hovering over entities/avatars/overlays
+//
+
+/* eslint-disable comma-dangle, no-empty, no-magic-numbers */
+
+var PICK_FILTERS = Picks.PICK_ENTITIES | Picks.PICK_OVERLAYS | Picks.PICK_AVATARS | Picks.PICK_INCLUDE_NONCOLLIDABLE;
+var HAND_JOINT = '_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND'.replace('RIGHT', MyAvatar.getDominantHand().toUpperCase());
+var JOINT_NAME = HMD.active ? HAND_JOINT : 'Mouse';
+var UPDATE_MS = 1000/30;
+
+// create tect3d overlay to display hover results
+var overlayID = Overlays.addOverlay('text3d', {
+    text: 'hover',
+    visible: false,
+    backgroundAlpha: 0,
+    isFacingAvatar: true,
+    lineHeight: 0.05,
+    dimensions: Vec3.HALF,
+});
+Script.scriptEnding.connect(function() {
+    Overlays.deleteOverlay(overlayID);
+});
+
+// create raycast picker
+var pickID = Picks.createPick(PickType.Ray, {
+    joint: JOINT_NAME,
+    filter: PICK_FILTERS,
+    enabled: true,
+});
+var blacklist = [ overlayID ]; // exclude hover text from ray pick results
+Picks.setIgnoreItems(pickID, blacklist);
+Script.scriptEnding.connect(function() {
+    RayPick.removeRayPick(pickID);
+});
+
+// query object materials (using the Graphics.* API)
+function getSubmeshMaterial(objectID, shapeID) {
+    try {
+        var materialLayers = Graphics.getModel(objectID).materialLayers;
+        var shapeMaterialLayers = materialLayers[shapeID];
+        return shapeMaterialLayers[0].material;
+    } catch (e) {
+        return { name: '<unknown>' };
+    }
+}
+
+// refresh hover overlay text based on intersection results
+function updateOverlay(overlayID, result) {
+    var material = this.getSubmeshMaterial(result.objectID, result.extraInfo.shapeID);
+    var position = Vec3.mix(result.searchRay.origin, result.intersection, 0.5);
+    var extraInfo = result.extraInfo;
+    var text = [
+        'mesh: ' + extraInfo.subMeshName,
+        'materialName: ' + material.name,
+        'type: ' + Entities.getNestableType(result.objectID),
+        'distance: ' + result.distance.toFixed(2)+'m',
+        ['submesh: ' + extraInfo.subMeshIndex, 'part: '+extraInfo.partIndex, 'shape: '+extraInfo.shapeID].join(' | '),
+    ].filter(Boolean).join('\n');
+
+    Overlays.editOverlay(overlayID, {
+        text: text,
+        position: position,
+        visible: result.intersects,
+    });
+}
+
+// monitor for enw results at 30fps
+Script.setInterval(function() {
+    var result = RayPick.getPrevRayPickResult(pickID);
+    updateOverlay(overlayID, result);
+}, UPDATE_MS);


### PR DESCRIPTION
This PR adds support for referencing `extraInfo.shapeID` as part of scripted RayPick results.

Given `extraInfo.shapeID` and the intersected `objectID`, it is then possible to identify the corresponding Material layer using the existing `Graphics.getModel(objectID)` APIs.

The PR also includes low-level plumbing for overriding the bounding box used for preflight intersection tests -- see virtual `EntityItem::getRaycastDimensions()` (dynamic mesh PRs will depend on being able to override this method later).

Test Plan pending -- current dev script available at [scripts/developer/tests/raypickTester.js](https://raw.githubusercontent.com/humbletim/hifi/add-raypick-shapeID/scripts/developer/tests/raypickTester.js)

(note: this PR is standalone subset of Leopoly_011)