### PR TITLE
Fix crash when deleting objects in serverless mode

### DIFF
--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -347,7 +347,7 @@ bool EntityMotionState::remoteSimulationOutOfSync(uint32_t simulationStep) {
 
     if (_numInactiveUpdates > 0) {
         const uint8_t MAX_NUM_INACTIVE_UPDATES = 20;
-        if (_numInactiveUpdates > MAX_NUM_INACTIVE_UPDATES || isServerlessMode()) {
+        if (_numInactiveUpdates > MAX_NUM_INACTIVE_UPDATES) {
             // clear local ownership (stop sending updates) and let the server clear itself
             _entity->clearSimulationOwnership();
             return false;
@@ -828,10 +828,4 @@ void EntityMotionState::clearObjectVelocities() const {
         }
     }
     _entity->setAcceleration(glm::vec3(0.0f));
-}
-
-bool EntityMotionState::isServerlessMode() {
-    EntityTreeElementPointer element = _entity->getElement();
-    EntityTreePointer tree = element ? element->getTree() : nullptr;
-    return tree ? tree->isServerlessMode() : false;
 }

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -277,7 +277,7 @@ void PhysicalEntitySimulation::getObjectsToChange(VectorOfMotionStates& result) 
 }
 
 void PhysicalEntitySimulation::handleDeactivatedMotionStates(const VectorOfMotionStates& motionStates) {
-    boolean serverlessMode = getEntityTree()->isServerlessMode();
+    bool serverlessMode = getEntityTree()->isServerlessMode();
     for (auto stateItr : motionStates) {
         ObjectMotionState* state = &(*stateItr);
         assert(state);
@@ -382,7 +382,7 @@ void PhysicalEntitySimulation::sendOwnershipBids(uint32_t numSubsteps) {
 }
 
 void PhysicalEntitySimulation::sendOwnedUpdates(uint32_t numSubsteps) {
-    boolean serverlessMode = getEntityTree()->isServerlessMode();
+    bool serverlessMode = getEntityTree()->isServerlessMode();
     PROFILE_RANGE_EX(simulation_physics, "Update", 0x00000000, (uint64_t)_owned.size());
     uint32_t i = 0;
     while (i < _owned.size()) {

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -328,13 +328,7 @@ void PhysicalEntitySimulation::handleChangedMotionStates(const VectorOfMotionSta
 }
 
 void PhysicalEntitySimulation::addOwnershipBid(EntityMotionState* motionState) {
-    if (getEntityTree()->isServerlessMode()) {
-        EntityItemPointer entity = motionState->getEntity();
-        auto nodeList = DependencyManager::get<NodeList>();
-        auto sessionID = nodeList->getSessionUUID();
-        entity->setSimulationOwner(SimulationOwner(sessionID, SCRIPT_GRAB_SIMULATION_PRIORITY));
-        _owned.push_back(motionState);
-    } else {
+    if (!getEntityTree()->isServerlessMode()) {
         motionState->initForBid();
         motionState->sendBid(_entityPacketSender, _physicsEngine->getNumSubsteps());
         _bids.push_back(motionState);
@@ -343,8 +337,10 @@ void PhysicalEntitySimulation::addOwnershipBid(EntityMotionState* motionState) {
 }
 
 void PhysicalEntitySimulation::addOwnership(EntityMotionState* motionState) {
-    motionState->initForOwned();
-    _owned.push_back(motionState);
+    if (!getEntityTree()->isServerlessMode()) {
+        motionState->initForOwned();
+        _owned.push_back(motionState);
+    }
 }
 
 void PhysicalEntitySimulation::sendOwnershipBids(uint32_t numSubsteps) {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/15806/Crash-on-Delete-Cube
This PR fixes a crash where deleting an object, such as a cube, would cause the interface the crash. The crash was caused by an unresolved invalid state in the physics engine. The resolution in this PR is to simplify the physics simulation ownership state in serverless mode. The state being simplified away is used for networking when a user is connected to a server.

Serverless mode is the mode that a user ends up in when they click on the "GOTO" button or press Ctrl+L (in desktop mode) and click on the home button, or are otherwise not logged into a server. You can see that the Interface is in serverless mode when the title bar contains "serverless".

## TEST PLAN
* In master, in serverless mode, wait for the avatar to stop floating directly above the ground. Then, create a cube and make simple changes to it such as moving it around and resizing it. After doing this, delete the cube. The program should crash.
* In this PR, in serverless mode, do the same. The program should not crash.
* In this PR, create a cube, set Dynamic to enabled in the Properties menu, and set the y value of gravity to some negative value. The cube should fall, and not snap back to a previous position.
* In this PR, create a cube, and set Dynamic to enabled in the Properties menu of the Create window. Then close the window, and have the avatar collide with the cube. The cube should bounce away as normal.