### PR TITLE
RC69: Fix audio device sometimes being on the wrong thread

### DIFF
--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -129,12 +129,10 @@ Rectangle {
                     id: stereoMic
                     spacing: muteMic.spacing;
                     text: qsTr("Enable stereo input");
-                    checked: AudioScriptingInterface.isStereoInput();
+                    checked: AudioScriptingInterface.isStereoInput;
                     onClicked: {
-                        var success = AudioScriptingInterface.setStereoInput(checked);
-                        if (!success) {
-                            checked = !checked;
-                        }
+                        AudioScriptingInterface.isStereoInput = checked;
+                        checked = Qt.binding(function() { return AudioScriptingInterface.isStereoInput; }); // restore binding
                     }
                 }
             }

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1426,6 +1426,8 @@ bool AudioClient::setIsStereoInput(bool isStereoInput) {
 
         // restart the input device
         switchInputToAudioDevice(_inputDeviceInfo);
+
+        emit isStereoInputChanged(_isStereoInput);
     }
 
     return stereoInputChanged;

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1463,6 +1463,8 @@ void AudioClient::outputFormatChanged() {
 }
 
 bool AudioClient::switchInputToAudioDevice(const QAudioDeviceInfo inputDeviceInfo, bool isShutdownRequest) {
+    Q_ASSERT_X(QThread::currentThread() == thread(), Q_FUNC_INFO, "Function invoked on wrong thread");
+
     qCDebug(audioclient) << __FUNCTION__ << "inputDeviceInfo: [" << inputDeviceInfo.deviceName() << "]";
     bool supportedFormat = false;
 
@@ -1663,6 +1665,8 @@ void AudioClient::outputNotify() {
 }
 
 bool AudioClient::switchOutputToAudioDevice(const QAudioDeviceInfo outputDeviceInfo, bool isShutdownRequest) {
+    Q_ASSERT_X(QThread::currentThread() == thread(), Q_FUNC_INFO, "Function invoked on wrong thread");
+
     qCDebug(audioclient) << "AudioClient::switchOutputToAudioDevice() outputDeviceInfo: [" << outputDeviceInfo.deviceName() << "]";
     bool supportedFormat = false;
 
@@ -2021,7 +2025,7 @@ void AudioClient::setAvatarBoundingBoxParameters(glm::vec3 corner, glm::vec3 sca
 
 
 void AudioClient::startThread() {
-    moveToNewNamedThread(this, "Audio Thread", [this] { start(); });
+    moveToNewNamedThread(this, "Audio Thread", [this] { start(); }, QThread::TimeCriticalPriority);
 }
 
 void AudioClient::setInputVolume(float volume, bool emitSignal) {

--- a/libraries/audio/src/AbstractAudioInterface.h
+++ b/libraries/audio/src/AbstractAudioInterface.h
@@ -44,6 +44,9 @@ public slots:
     virtual bool setIsStereoInput(bool stereo) = 0;
 
     virtual bool isStereoInput() = 0;
+
+signals:
+    void isStereoInputChanged(bool isStereo);
 };
 
 Q_DECLARE_METATYPE(AbstractAudioInterface*)

--- a/libraries/script-engine/src/AudioScriptingInterface.cpp
+++ b/libraries/script-engine/src/AudioScriptingInterface.cpp
@@ -63,8 +63,15 @@ ScriptAudioInjector* AudioScriptingInterface::playSound(SharedSoundPointer sound
 bool AudioScriptingInterface::setStereoInput(bool stereo) {
     bool stereoInputChanged = false;
     if (_localAudioInterface) {
-        stereoInputChanged = _localAudioInterface->setIsStereoInput(stereo);
+        if (QThread::currentThread() != _localAudioInterface->thread()) {
+            // TODO: This can block the main thread which is not ideal, make this function and the UI calling it async
+            BLOCKING_INVOKE_METHOD(_localAudioInterface, "setIsStereoInput", Q_RETURN_ARG(bool, stereoInputChanged),
+                                   Q_ARG(bool, stereo));
+        } else {
+            stereoInputChanged = _localAudioInterface->setIsStereoInput(stereo);
+        }
     }
+    
     return stereoInputChanged;
 }
 

--- a/libraries/script-engine/src/AudioScriptingInterface.h
+++ b/libraries/script-engine/src/AudioScriptingInterface.h
@@ -23,9 +23,11 @@ class AudioScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
     SINGLETON_DEPENDENCY
 
+    Q_PROPERTY(bool isStereoInput READ isStereoInput WRITE setStereoInput NOTIFY isStereoInputChanged)
+
 public:
     virtual ~AudioScriptingInterface() {}
-    void setLocalAudioInterface(AbstractAudioInterface* audioInterface) { _localAudioInterface = audioInterface; }
+    void setLocalAudioInterface(AbstractAudioInterface* audioInterface);
 
 protected:
     AudioScriptingInterface() {}
@@ -52,9 +54,8 @@ protected:
     /**jsdoc
      * @function Audio.setStereoInput
      * @param {boolean} stereo
-     * @returns {boolean} 
      */
-    Q_INVOKABLE bool setStereoInput(bool stereo);
+    Q_INVOKABLE void setStereoInput(bool stereo);
 
     /**jsdoc
      * @function Audio.isStereoInput
@@ -113,6 +114,13 @@ signals:
      * @returns {Signal} 
      */
     void inputReceived(const QByteArray& inputSamples);
+
+    /**jsdoc
+    * @function Audio.isStereoInputChanged
+    * @param {boolean} isStereo
+    * @returns {Signal}
+    */
+    void isStereoInputChanged(bool isStereo);
 
 private:
     AbstractAudioInterface* _localAudioInterface { nullptr };


### PR DESCRIPTION
The JS/QML audio interface was calling setIsStereoInput on the wrong thread, which in turn was causing the audio device to live on the wrong thread (Main thread).
Being on the main thread means that the sample delivery was sometimes delayed when the main thread was under heavy load and the event loop was very busy.

This was causing unnecessary audio starves on the server because the samples were getting there too late.