### PR TITLE
Fix MS15154: Remove focused button color

### DIFF
--- a/interface/resources/qml/controls-uit/Button.qml
+++ b/interface/resources/qml/controls-uit/Button.qml
@@ -62,8 +62,6 @@ Original.Button {
                         hifi.buttons.pressedColor[control.color]
                     } else if (control.hovered) {
                         hifi.buttons.hoveredColor[control.color]
-                        }  else if (!control.hovered && control.focus) {
-                            hifi.buttons.focusedColor[control.color]
                     } else {
                         hifi.buttons.colorStart[control.color]
                     }
@@ -78,8 +76,6 @@ Original.Button {
                         hifi.buttons.pressedColor[control.color]
                     } else if (control.hovered) {
                         hifi.buttons.hoveredColor[control.color]
-                        } else if (!control.hovered && control.focus) {
-                            hifi.buttons.focusedColor[control.color]
                     } else {
                         hifi.buttons.colorFinish[control.color]
                     }


### PR DESCRIPTION
Fixes [MS15154](https://highfidelity.manuscript.com/f/cases/15154/).

It appears as though the `focused` button color was added without Design input. In almost all cases, the `focused` button color looks the same as the `hovered` color, which is confusing to users.

Per @mukulHF, we should remove the `focused` button color right now until we overhaul the UIT.