### PR TITLE
undo rayTest() optimization to prevent crash

### DIFF
--- a/libraries/physics/src/CharacterGhostObject.cpp
+++ b/libraries/physics/src/CharacterGhostObject.cpp
@@ -69,7 +69,7 @@ bool CharacterGhostObject::rayTest(const btVector3& start,
         const btVector3& end,
         CharacterRayResult& result) const {
     if (_world && _inWorld) {
-        btGhostObject::rayTest(start, end, result);
+        _world->rayTest(start, end, result);
     }
     return result.hasHit();
 }


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/16045/crash-on-strafing