### PR TITLE
Fix crash when walking sideways

### DIFF
--- a/interface/src/avatar/MyCharacterController.cpp
+++ b/interface/src/avatar/MyCharacterController.cpp
@@ -109,7 +109,7 @@ bool MyCharacterController::testRayShotgun(const glm::vec3& position, const glm:
     if (lengthAxis > FLT_EPSILON) {
         // we're walking sideways
         btScalar cosAngle = lengthAxis / adjustedDirection.length();
-        if (cosAngle < 1) {
+        if (cosAngle < 1.0f) {
             btScalar angle = acosf(cosAngle);
             if (rayDirection.dot(forward) < 0.0f) {
                 angle = PI - angle;

--- a/interface/src/avatar/MyCharacterController.cpp
+++ b/interface/src/avatar/MyCharacterController.cpp
@@ -108,12 +108,15 @@ bool MyCharacterController::testRayShotgun(const glm::vec3& position, const glm:
     btScalar lengthAxis = axis.length();
     if (lengthAxis > FLT_EPSILON) {
         // we're walking sideways
-        btScalar angle = acosf(lengthAxis / adjustedDirection.length());
-        if (rayDirection.dot(forward) < 0.0f) {
-            angle = PI - angle;
+        btScalar cosAngle = lengthAxis / adjustedDirection.length();
+        if (cosAngle < 1) {
+            btScalar angle = acosf(cosAngle);
+            if (rayDirection.dot(forward) < 0.0f) {
+                angle = PI - angle;
+            }
+            axis /= lengthAxis;
+            rotation = btMatrix3x3(btQuaternion(axis, angle)) * rotation;
         }
-        axis /= lengthAxis;
-        rotation = btMatrix3x3(btQuaternion(axis, angle)) * rotation;
     } else if (rayDirection.dot(forward) < 0.0f) {
         // we're walking backwards
         rotation = btMatrix3x3(btQuaternion(_currentUp, PI)) * rotation;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/16045/crash-on-strafing
The bug described above showed up after this PR: https://github.com/highfidelity/hifi/pull/13304
The bug occurred because there was some code being used that was never used before, causing some NaNs to show up that were previously ignored.
The solution, given in this PR, is to get rid of the NaNs.
This is a proper fix to take the place of this PR: https://github.com/highfidelity/hifi/pull/13420

## TEST PLAN
* In master, verify program crashes when strafing with the avatar for a while.
* In this PR, verify crash goes away.
* In this PR, verify that avatar forward/sideways/diagonal/backwards movement is still as expected.