### PR TITLE
Highest loading priorities for avatars and attachments

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -121,6 +121,7 @@ MyAvatar::MyAvatar(QThread* thread) :
     _headData = new MyHead(this);
 
     _skeletonModel = std::make_shared<MySkeletonModel>(this, nullptr);
+    _skeletonModel->setLoadingPriority(MYAVATAR_LOADING_PRIORITY);
     connect(_skeletonModel.get(), &Model::setURLFinished, this, &Avatar::setModelURLFinished);
     connect(_skeletonModel.get(), &Model::setURLFinished, this, [this](bool success) {
         if (success) {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -49,6 +49,9 @@ const float DISPLAYNAME_FADE_FACTOR = pow(0.01f, 1.0f / DISPLAYNAME_FADE_TIME);
 const float DISPLAYNAME_ALPHA = 1.0f;
 const float DISPLAYNAME_BACKGROUND_ALPHA = 0.4f;
 const glm::vec3 HAND_TO_PALM_OFFSET(0.0f, 0.12f, 0.08f);
+const float Avatar::MYAVATAR_LOADING_PRIORITY = (float)M_PI; // Entity priority is computed as atan2(maxDim, distance) which is <= PI / 2
+const float Avatar::OTHERAVATAR_LOADING_PRIORITY = MYAVATAR_LOADING_PRIORITY - EPSILON;
+const float Avatar::ATTACHMENT_LOADING_PRIORITY = OTHERAVATAR_LOADING_PRIORITY - EPSILON;
 
 namespace render {
     template <> const ItemKey payloadGetKey(const AvatarSharedPointer& avatar) {
@@ -1418,6 +1421,7 @@ void Avatar::setAttachmentData(const QVector<AttachmentData>& attachmentData) {
         if (_attachmentModels[i]->getURL() != attachmentData[i].modelURL) {
             _attachmentModelsTexturesLoaded[i] = false;
         }
+        _attachmentModels[i]->setLoadingPriority(ATTACHMENT_LOADING_PRIORITY);
         _attachmentModels[i]->setURL(attachmentData[i].modelURL);
     }
 }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -540,6 +540,10 @@ protected:
     AABox _renderBound;
     bool _isMeshVisible{ true };
     bool _needMeshVisibleSwitch{ true };
+
+    static const float MYAVATAR_LOADING_PRIORITY;
+    static const float OTHERAVATAR_LOADING_PRIORITY;
+    static const float ATTACHMENT_LOADING_PRIORITY;
 };
 
 #endif // hifi_Avatar_h

--- a/libraries/avatars-renderer/src/avatars-renderer/OtherAvatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/OtherAvatar.cpp
@@ -12,6 +12,7 @@ OtherAvatar::OtherAvatar(QThread* thread) : Avatar(thread) {
     // give the pointer to our head to inherited _headData variable from AvatarData
     _headData = new Head(this);
     _skeletonModel = std::make_shared<SkeletonModel>(this, nullptr);
+    _skeletonModel->setLoadingPriority(OTHERAVATAR_LOADING_PRIORITY);
     connect(_skeletonModel.get(), &Model::setURLFinished, this, &Avatar::setModelURLFinished);
     connect(_skeletonModel.get(), &Model::rigReady, this, &Avatar::rigReady);
     connect(_skeletonModel.get(), &Model::rigReset, this, &Avatar::rigReset);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/16004/Set-Avatar-loading-priority

Test plan.
- First, confirm that you can reliably reproduce the issue in master:
- Go to a domain that doesn't exist (type in whatever to goto).  Reload resources from the Edit menu.
- Have someone else wear some attachments and go to a domain with lots of models and stand in a known location.
- Go to that domain so that right when you load, their avatar and lots of models are in view.  Watch your download stats in the middle column of the expanded stats.  Their avatar and attachments will only load once all the other downloads are finished.
- Repeat with this PR.  Their avatar and attachments should load faster, and should appear before all the downloads finish.
(dev-avatarisland is a good domain to use for this, there are thousands of models and textures)

It's possible that due to the order that we get packets from the entity and avatar mixers, they won't always appear all the way at the end or all the way at the beginning now, but it should be faster with this PR.