### PR TITLE
Breakpad integration for android Interface (part II)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,8 +48,8 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField "String", "BACKTRACE_URL", "\"" + (System.getenv("CMAKE_BACKTRACE_URL") ? System.getenv("CMAKE_BACKTRACE_URL") : '') + "\""
-            buildConfigField "String", "BACKTRACE_TOKEN", "\"" + (System.getenv("CMAKE_BACKTRACE_TOKEN") ? System.getenv("CMAKE_BACKTRACE_TOKEN") : '') + "\""
+            buildConfigField "String", "BACKTRACE_URL", "\"https://gcalero999.sp.backtrace.io:6098\""
+            buildConfigField "String", "BACKTRACE_TOKEN", "\"4ff1f957cd6c357e6e5d5b2fe076f9ca46379a19b7d6baea1707cefb70e7ed15\""
         }
         release {
             minifyEnabled false

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,7 +28,7 @@ android {
                     '-DSTABLE_BUILD=' + STABLE_BUILD,
                     '-DDISABLE_QML=OFF',
                     '-DDISABLE_KTX_CACHE=OFF',
-                    '-DUSE_BREAKPAD=' + (project.hasProperty("BACKTRACE_URL") && project.hasProperty("BACKTRACE_TOKEN") ? 'ON' : 'OFF');
+                    '-DUSE_BREAKPAD=' + (System.getenv("BACKTRACE_URL") && System.getenv("BACKTRACE_TOKEN") ? 'ON' : 'OFF');
             }
         }
         signingConfigs {
@@ -48,8 +48,8 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField "String", "BACKTRACE_URL", "\"" + (project.hasProperty("BACKTRACE_URL") ? BACKTRACE_URL : '') + "\""
-            buildConfigField "String", "BACKTRACE_TOKEN", "\"" + (project.hasProperty("BACKTRACE_TOKEN") ? BACKTRACE_TOKEN : '') + "\""
+            buildConfigField "String", "BACKTRACE_URL", "\"" + (System.getenv("BACKTRACE_URL") ? System.getenv("BACKTRACE_URL") : '') + "\""
+            buildConfigField "String", "BACKTRACE_TOKEN", "\"" + (System.getenv("BACKTRACE_TOKEN") ? System.getenv("BACKTRACE_TOKEN") : '') + "\""
         }
         release {
             minifyEnabled false
@@ -58,8 +58,8 @@ android {
                     project.hasProperty("HIFI_ANDROID_KEYSTORE_PASSWORD") &&
                     project.hasProperty("HIFI_ANDROID_KEY_ALIAS") &&
                     project.hasProperty("HIFI_ANDROID_KEY_PASSWORD")? signingConfigs.release : null
-            buildConfigField "String", "BACKTRACE_URL", "\"" + (project.hasProperty("BACKTRACE_URL") ? BACKTRACE_URL : '') + "\""
-            buildConfigField "String", "BACKTRACE_TOKEN", "\"" + (project.hasProperty("BACKTRACE_TOKEN") ? BACKTRACE_TOKEN : '') + "\""
+            buildConfigField "String", "BACKTRACE_URL", "\"" + (System.getenv("BACKTRACE_URL") ? System.getenv("BACKTRACE_URL") : '') + "\""
+            buildConfigField "String", "BACKTRACE_TOKEN", "\"" + (System.getenv("BACKTRACE_TOKEN") ? System.getenv("BACKTRACE_TOKEN") : '') + "\""
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,7 +76,9 @@ android {
             variant.mergeResources.dependsOn(task)
             def uploadDumpSymsTask = rootProject.getTasksByName("uploadBreakpadDumpSyms${variant.name.capitalize()}", false).first()
             def runDumpSymsTask = rootProject.getTasksByName("runBreakpadDumpSyms${variant.name.capitalize()}", false).first()
+            println (runDumpSymsTask.name + " dependsOn " + task.name)
             runDumpSymsTask.dependsOn(task)
+            println (variant.assemble.name + " dependsOn " + uploadDumpSymsTask.name)
             variant.assemble.dependsOn(uploadDumpSymsTask)
         }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,7 +28,7 @@ android {
                     '-DSTABLE_BUILD=' + STABLE_BUILD,
                     '-DDISABLE_QML=OFF',
                     '-DDISABLE_KTX_CACHE=OFF',
-                    '-DUSE_BREAKPAD=' + (System.getenv("BACKTRACE_URL") && System.getenv("BACKTRACE_TOKEN") ? 'ON' : 'OFF');
+                    '-DUSE_BREAKPAD=' + (System.getenv("CMAKE_BACKTRACE_URL") && System.getenv("CMAKE_BACKTRACE_TOKEN") ? 'ON' : 'OFF');
             }
         }
         signingConfigs {
@@ -48,8 +48,8 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField "String", "BACKTRACE_URL", "\"" + (System.getenv("BACKTRACE_URL") ? System.getenv("BACKTRACE_URL") : '') + "\""
-            buildConfigField "String", "BACKTRACE_TOKEN", "\"" + (System.getenv("BACKTRACE_TOKEN") ? System.getenv("BACKTRACE_TOKEN") : '') + "\""
+            buildConfigField "String", "BACKTRACE_URL", "\"" + (System.getenv("CMAKE_BACKTRACE_URL") ? System.getenv("CMAKE_BACKTRACE_URL") : '') + "\""
+            buildConfigField "String", "BACKTRACE_TOKEN", "\"" + (System.getenv("CMAKE_BACKTRACE_TOKEN") ? System.getenv("CMAKE_BACKTRACE_TOKEN") : '') + "\""
         }
         release {
             minifyEnabled false
@@ -58,8 +58,8 @@ android {
                     project.hasProperty("HIFI_ANDROID_KEYSTORE_PASSWORD") &&
                     project.hasProperty("HIFI_ANDROID_KEY_ALIAS") &&
                     project.hasProperty("HIFI_ANDROID_KEY_PASSWORD")? signingConfigs.release : null
-            buildConfigField "String", "BACKTRACE_URL", "\"" + (System.getenv("BACKTRACE_URL") ? System.getenv("BACKTRACE_URL") : '') + "\""
-            buildConfigField "String", "BACKTRACE_TOKEN", "\"" + (System.getenv("BACKTRACE_TOKEN") ? System.getenv("BACKTRACE_TOKEN") : '') + "\""
+            buildConfigField "String", "BACKTRACE_URL", "\"" + (System.getenv("CMAKE_BACKTRACE_URL") ? System.getenv("CMAKE_BACKTRACE_URL") : '') + "\""
+            buildConfigField "String", "BACKTRACE_TOKEN", "\"" + (System.getenv("CMAKE_BACKTRACE_TOKEN") ? System.getenv("CMAKE_BACKTRACE_TOKEN") : '') + "\""
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,10 +74,10 @@ android {
         // so our merge has to depend on the external native build
         variant.externalNativeBuildTasks.each { task ->
             variant.mergeResources.dependsOn(task)
-            def dumpSymsTaskName = "uploadBreakpadDumpSyms${variant.name.capitalize()}";
-            def dumpSymsTask = rootProject.getTasksByName(dumpSymsTaskName, false).first()
-            dumpSymsTask.dependsOn(task)
-            variant.assemble.dependsOn(dumpSymsTask)
+            def uploadDumpSymsTask = rootProject.getTasksByName("uploadBreakpadDumpSyms${variant.name.capitalize()}", false).first()
+            def runDumpSymsTask = rootProject.getTasksByName("runBreakpadDumpSyms${variant.name.capitalize()}", false).first()
+            runDumpSymsTask.dependsOn(task)
+            variant.assemble.dependsOn(uploadDumpSymsTask)
         }
 
         variant.mergeAssets.doLast {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,8 +48,8 @@ android {
 
     buildTypes {
         debug {
-            buildConfigField "String", "BACKTRACE_URL", "\"https://gcalero999.sp.backtrace.io:6098\""
-            buildConfigField "String", "BACKTRACE_TOKEN", "\"4ff1f957cd6c357e6e5d5b2fe076f9ca46379a19b7d6baea1707cefb70e7ed15\""
+            buildConfigField "String", "BACKTRACE_URL", "\"" + (System.getenv("CMAKE_BACKTRACE_URL") ? System.getenv("CMAKE_BACKTRACE_URL") : '') + "\""
+            buildConfigField "String", "BACKTRACE_TOKEN", "\"" + (System.getenv("CMAKE_BACKTRACE_TOKEN") ? System.getenv("CMAKE_BACKTRACE_TOKEN") : '') + "\""
         }
         release {
             minifyEnabled false
@@ -76,9 +76,7 @@ android {
             variant.mergeResources.dependsOn(task)
             def uploadDumpSymsTask = rootProject.getTasksByName("uploadBreakpadDumpSyms${variant.name.capitalize()}", false).first()
             def runDumpSymsTask = rootProject.getTasksByName("runBreakpadDumpSyms${variant.name.capitalize()}", false).first()
-            println (runDumpSymsTask.name + " dependsOn " + task.name)
             runDumpSymsTask.dependsOn(task)
-            println (variant.assemble.name + " dependsOn " + uploadDumpSymsTask.name)
             variant.assemble.dependsOn(uploadDumpSymsTask)
         }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,6 +74,10 @@ android {
         // so our merge has to depend on the external native build
         variant.externalNativeBuildTasks.each { task ->
             variant.mergeResources.dependsOn(task)
+            def dumpSymsTaskName = "runBreakpadDumpSyms${variant.name.capitalize()}";
+            def dumpSymsTask = rootProject.getTasksByName(dumpSymsTaskName, false).first()
+            dumpSymsTask.dependsOn(task)
+            variant.assemble.dependsOn(dumpSymsTask)
         }
 
         variant.mergeAssets.doLast {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -74,7 +74,7 @@ android {
         // so our merge has to depend on the external native build
         variant.externalNativeBuildTasks.each { task ->
             variant.mergeResources.dependsOn(task)
-            def dumpSymsTaskName = "runBreakpadDumpSyms${variant.name.capitalize()}";
+            def dumpSymsTaskName = "uploadBreakpadDumpSyms${variant.name.capitalize()}";
             def dumpSymsTask = rootProject.getTasksByName(dumpSymsTaskName, false).first()
             dumpSymsTask.dependsOn(task)
             variant.assemble.dependsOn(dumpSymsTask)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -151,11 +151,11 @@ def packages = [
         checksum: '14b02795d774457a33bbc60e00a786bc'
     ],
     breakpad: [
-        file: 'breakpad.zip',
-        versionId: '2OwvCCZrF171wnte5T44AnjTYFhhJsGJ',
-        checksum: 'a46062a3167dfedd4fb4916136e204d2',
+        file: 'breakpad_dump_syms.zip',
+        versionId: 'udimLCwfB7tMbfGdE1CcLRt5p0.ehtoM',
+        checksum: '92b6ace2edb95ea82dca257cf0fe522b',
         sharedLibFolder: 'lib',
-        includeLibs: ['libbreakpad_client.a','libbreakpad.a']
+        includeLibs: ['libbreakpad_client.a']
     ]
 ]
 
@@ -547,6 +547,44 @@ task cleanDependencies(type: Delete) {
     delete 'app/src/main/jniLibs/arm64-v8a'
     delete 'app/src/main/assets/--Added-by-androiddeployqt--'
     delete 'app/src/main/res/values/libs.xml'
+}
+
+def runBreakpadDumpSyms = { buildType ->
+    def objDir = new File("${appDir}/build/intermediates/cmake/${buildType}/obj/arm64-v8a")
+    def stripDebugSymbol = "${appDir}/build/intermediates/transforms/stripDebugSymbol/${buildType}/0/lib/arm64-v8a/"
+    def outputDir = new File("${appDir}/build/tmp/breakpadDumpSyms")
+    if (!outputDir.exists()) {
+        outputDir.mkdirs()
+    }
+
+    objDir.eachFileRecurse (FileType.FILES) { file ->
+        if (file.name.endsWith('.so')) {
+            def output = file.name + ".sym"
+            def cmdArgs = [
+                    file.toString(),
+                    stripDebugSymbol
+            ]
+            exec {
+                workingDir HIFI_ANDROID_PRECOMPILED + '/breakpad/bin'
+                commandLine './dump_syms'
+                args cmdArgs
+                standardOutput = new BufferedOutputStream(new FileOutputStream(new File(outputDir, output)))
+            }
+
+        }
+    }
+}
+
+task runBreakpadDumpSymsRelease() {
+    doLast {
+        runBreakpadDumpSyms("release");
+    }
+}
+
+task runBreakpadDumpSymsDebug() {
+    doLast {
+        runBreakpadDumpSyms("debug");
+    }
 }
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,6 +21,8 @@ buildscript {
 plugins {
     id 'de.undercouch.download' version '3.3.0'
     id "cz.malohlava" version "1.0.3"
+    id "io.github.http-builder-ng.http-plugin" version "0.1.1"
+
 }
 
 allprojects {
@@ -550,9 +552,11 @@ task cleanDependencies(type: Delete) {
 }
 
 def runBreakpadDumpSyms = { buildType ->
+    gradle.startParameter.showStacktrace = ShowStacktrace.ALWAYS
+
     def objDir = new File("${appDir}/build/intermediates/cmake/${buildType}/obj/arm64-v8a")
     def stripDebugSymbol = "${appDir}/build/intermediates/transforms/stripDebugSymbol/${buildType}/0/lib/arm64-v8a/"
-    def outputDir = new File("${appDir}/build/tmp/breakpadDumpSyms")
+    def outputDir = new File("${appDir}/build/tmp/breakpadDumpSyms/${buildType}")
     if (!outputDir.exists()) {
         outputDir.mkdirs()
     }
@@ -564,18 +568,44 @@ def runBreakpadDumpSyms = { buildType ->
                     file.toString(),
                     stripDebugSymbol
             ]
-            exec {
+            println ("Executing " + HIFI_ANDROID_PRECOMPILED + '/breakpad/bin' + "/dump_syms")
+            println ("Arguments "  + cmdArgs)
+            def result = exec {
                 workingDir HIFI_ANDROID_PRECOMPILED + '/breakpad/bin'
                 commandLine './dump_syms'
                 args cmdArgs
                 standardOutput = new BufferedOutputStream(new FileOutputStream(new File(outputDir, output)))
-                errorOutput  = new ByteArrayOutputStream()
-                doLast {
-                    println ("Exec error output: " + errorOutput.toString())
-                }
+            }
+            println ("Done "  + result)
+            println ("E:[" + new File(outputDir, output+".err").text+ "]")
+        }
+    }
+}
+
+def uploadDumpSyms = { buildType ->
+    def tmpDir = "${appDir}/build/tmp/breakpadDumpSyms/${buildType}/"
+    def zipFilename = "symbols-${RELEASE_NUMBER}.zip"
+    def zipDir = "${appDir}/build/tmp/breakpadDumpSyms/"
+    zip {
+        from tmpDir
+        include '*/*'
+        archiveName zipFilename
+        destinationDir(file(zipDir))
+    }
+
+    httpTask {
+        config {
+            request.uri = 'https://gcalero998.sp.backtrace.io:6098/post?format=symbols&token=d65d0d184789ac40c121952001fd91dfba7e149899b1eeccd68ccffe91dd2fd0'
+        }
+        post {
+            request.uri.path = '/notify'
+            request.body = new File(zipDir, zipFilename).bytes
+            response.success {
+                println 'Symbols upload successful'
             }
         }
     }
+
 }
 
 task runBreakpadDumpSymsRelease() {
@@ -590,7 +620,17 @@ task runBreakpadDumpSymsDebug() {
     }
 }
 
+task uploadBreakpadDumpSymsRelease(dependsOn: runBreakpadDumpSymsRelease) {
+    doLast {
+        uploadDumpSyms("release")
+    }
+}
 
+task uploadBreakpadDumpSymsDebug(dependsOn: runBreakpadDumpSymsDebug) {
+    doLast {
+        uploadDumpSyms("debug")
+    }
+}
 
 // FIXME this code is prototyping the desired functionality for doing build time binary dependency resolution.
 // See the comment on the qtBundle task above

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -556,8 +556,9 @@ def runBreakpadDumpSyms = { buildType ->
 
     def objDir = new File("${appDir}/build/intermediates/cmake/${buildType}/obj/arm64-v8a")
     def stripDebugSymbol = "${appDir}/build/intermediates/transforms/stripDebugSymbol/${buildType}/0/lib/arm64-v8a/"
-    if (!breakpadDumpSymsDir.exists()) {
-        breakpadDumpSymsDir.mkdirs()
+    def outputDir = new File(breakpadDumpSymsDir, buildType)
+    if (!outputDir.exists()) {
+        outputDir.mkdirs()
     }
 
     objDir.eachFileRecurse (FileType.FILES) { file ->
@@ -567,21 +568,14 @@ def runBreakpadDumpSyms = { buildType ->
                     file.toString(),
                     stripDebugSymbol
             ]
-            println ("Running dump_syms with arguments " + cmdArgs)
             def result = exec {
                 workingDir HIFI_ANDROID_PRECOMPILED + '/breakpad/bin'
                 commandLine './dump_syms'
                 args cmdArgs
                 ignoreExitValue true
-                standardOutput = new BufferedOutputStream(new FileOutputStream(new File(breakpadDumpSymsDir, output)))
+                standardOutput = new BufferedOutputStream(new FileOutputStream(new File(outputDir, output)))
             }
         }
-    }
-}
-
-task runBreakpadDumpSymsRelease() {
-    doLast {
-        runBreakpadDumpSyms("release");
     }
 }
 
@@ -591,41 +585,59 @@ task runBreakpadDumpSymsDebug() {
     }
 }
 
-task zipDumpSymsDebug(type: Zip, dependsOn: runBreakpadDumpSymsDebug) {
-    doFirst {
-        println ("Zipping " + breakpadDumpSymsDir.absolutePath + " into " + breakpadDumpSymsDir)
-    }
-    from (breakpadDumpSymsDir.absolutePath)
-    archiveName "symbols-${RELEASE_NUMBER}.zip"
-    destinationDir(new File("${appDir}/build/tmp/"))
+task runBreakpadDumpSymsRelease() {
     doLast {
-        println ("Zipped " + breakpadDumpSymsDir.absolutePath + " into " + breakpadDumpSymsDir)
+        runBreakpadDumpSyms("release");
     }
 }
 
-task uploadBreakpadDumpSymsRelease(dependsOn: runBreakpadDumpSymsRelease) {
-    doLast {
-        //uploadDumpSyms("release")
-    }
+task zipDumpSymsDebug(type: Zip, dependsOn: runBreakpadDumpSymsDebug) {
+    from (new File(breakpadDumpSymsDir, "debug").absolutePath)
+    archiveName "symbols-${RELEASE_NUMBER}-debug.zip"
+    destinationDir(new File("${appDir}/build/tmp/"))
+}
+
+task zipDumpSymsRelease(type: Zip, dependsOn: runBreakpadDumpSymsRelease) {
+    from (new File(breakpadDumpSymsDir, "release").absolutePath)
+    archiveName "symbols-${RELEASE_NUMBER}-release.zip"
+    destinationDir(new File("${appDir}/build/tmp/"))
 }
 
 task uploadBreakpadDumpSymsDebug(type:io.github.httpbuilderng.http.HttpTask, dependsOn: zipDumpSymsDebug) {
+    onlyIf {
+        System.getenv("CMAKE_BACKTRACE_URL") && System.getenv("CMAKE_BACKTRACE_SYMBOLS_TOKEN")
+    }
     config {
-        request.uri = 'https://gcalero998.sp.backtrace.io:6098'
+        request.uri = System.getenv("CMAKE_BACKTRACE_URL")
     }
     post {
         request.uri.path = '/post'
-        request.uri.query = [format: 'symbols', token: 'd65d0d184789ac40c121952001fd91dfba7e149899b1eeccd68ccffe91dd2fd0']
-        request.body = new File("${appDir}/build/tmp/", "symbols-${RELEASE_NUMBER}.zip").bytes
+        request.uri.query = [format: 'symbols', token: System.getenv("CMAKE_BACKTRACE_SYMBOLS_TOKEN")]
+        request.body = new File("${appDir}/build/tmp/", "symbols-${RELEASE_NUMBER}-debug.zip").bytes
         request.contentType = 'application/octet-stream'
         response.success {
-            println ("${appDir}/build/tmp/symbols-${RELEASE_NUMBER}.zip uploaded")
+            println ("${appDir}/build/tmp/symbols-${RELEASE_NUMBER}-debug.zip uploaded")
         }
-
     }
 }
 
-
+task uploadBreakpadDumpSymsRelease(type:io.github.httpbuilderng.http.HttpTask, dependsOn: zipDumpSymsRelease) {
+    onlyIf {
+        System.getenv("CMAKE_BACKTRACE_URL") && System.getenv("CMAKE_BACKTRACE_SYMBOLS_TOKEN")
+    }
+    config {
+        request.uri = System.getenv("CMAKE_BACKTRACE_URL")
+    }
+    post {
+        request.uri.path = '/post'
+        request.uri.query = [format: 'symbols', token: System.getenv("CMAKE_BACKTRACE_SYMBOLS_TOKEN")]
+        request.body = new File("${appDir}/build/tmp/", "symbols-${RELEASE_NUMBER}-release.zip").bytes
+        request.contentType = 'application/octet-stream'
+        response.success {
+            println ("${appDir}/build/tmp/symbols-${RELEASE_NUMBER}-release.zip uploaded")
+        }
+    }
+}
 
 // FIXME this code is prototyping the desired functionality for doing build time binary dependency resolution.
 // See the comment on the qtBundle task above

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -572,6 +572,7 @@ def runBreakpadDumpSyms = { buildType ->
                 workingDir HIFI_ANDROID_PRECOMPILED + '/breakpad/bin'
                 commandLine './dump_syms'
                 args cmdArgs
+                ignoreExitValue true
                 standardOutput = new BufferedOutputStream(new FileOutputStream(new File(outputDir, output)))
             }
         }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -569,8 +569,11 @@ def runBreakpadDumpSyms = { buildType ->
                 commandLine './dump_syms'
                 args cmdArgs
                 standardOutput = new BufferedOutputStream(new FileOutputStream(new File(outputDir, output)))
+                errorOutput  = new ByteArrayOutputStream()
+                doLast {
+                    println ("Exec error output: " + errorOutput.toString())
+                }
             }
-
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -610,7 +610,15 @@ task uploadBreakpadDumpSymsRelease(dependsOn: runBreakpadDumpSymsRelease) {
 
 
 task uploadBreakpadDumpSymsDebug(dependsOn: zipDumpSymsDebug) {
-    def p = ['curl', '--data-binary', "@"+new File("${appDir}/build/tmp/", "symbols-${RELEASE_NUMBER}.zip").absolutePath, "\"https://gcalero998.sp.backtrace.io:6098/post?format=symbols&token=d65d0d184789ac40c121952001fd91dfba7e149899b1eeccd68ccffe91dd2fd0\""].execute()
+    doLast {
+        def p = ['curl', '--data-binary', "@"+new File("${appDir}/build/tmp/", "symbols-${RELEASE_NUMBER}.zip").absolutePath, "\"https://gcalero998.sp.backtrace.io:6098/post?format=symbols&token=d65d0d184789ac40c121952001fd91dfba7e149899b1eeccd68ccffe91dd2fd0\""].execute()
+        p.waitFor()
+        if (p.exitValue() != 0) {
+            println "Upload breakpad symbols: curl exited with status " + p.exitValue()
+            println p.getErrorStream().text
+        }
+
+    }
 }
 
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,6 +21,7 @@ buildscript {
 plugins {
     id 'de.undercouch.download' version '3.3.0'
     id "cz.malohlava" version "1.0.3"
+    id "io.github.http-builder-ng.http-plugin" version "0.1.1"
 }
 
 allprojects {
@@ -608,14 +609,17 @@ task uploadBreakpadDumpSymsRelease(dependsOn: runBreakpadDumpSymsRelease) {
     }
 }
 
-
-task uploadBreakpadDumpSymsDebug(dependsOn: zipDumpSymsDebug) {
-    doLast {
-        def p = ['curl', '--data-binary', "@"+new File("${appDir}/build/tmp/", "symbols-${RELEASE_NUMBER}.zip").absolutePath, "\"https://gcalero998.sp.backtrace.io:6098/post?format=symbols&token=d65d0d184789ac40c121952001fd91dfba7e149899b1eeccd68ccffe91dd2fd0\""].execute()
-        p.waitFor()
-        if (p.exitValue() != 0) {
-            println "Upload breakpad symbols: curl exited with status " + p.exitValue()
-            println p.getErrorStream().text
+task uploadBreakpadDumpSymsDebug(type:io.github.httpbuilderng.http.HttpTask, dependsOn: zipDumpSymsDebug) {
+    config {
+        request.uri = 'https://gcalero998.sp.backtrace.io:6098'
+    }
+    post {
+        request.uri.path = '/post'
+        request.uri.query = [format: 'symbols', token: 'd65d0d184789ac40c121952001fd91dfba7e149899b1eeccd68ccffe91dd2fd0']
+        request.body = new File("${appDir}/build/tmp/", "symbols-${RELEASE_NUMBER}.zip").bytes
+        request.contentType = 'application/octet-stream'
+        response.success {
+            println ("${appDir}/build/tmp/symbols-${RELEASE_NUMBER}.zip uploaded")
         }
 
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -152,8 +152,8 @@ def packages = [
     ],
     breakpad: [
         file: 'breakpad_dump_syms.zip',
-        versionId: 'udimLCwfB7tMbfGdE1CcLRt5p0.ehtoM',
-        checksum: '92b6ace2edb95ea82dca257cf0fe522b',
+        versionId: 'yIIByczdMWGm.1f9DztIUoa6Sn3NM3IN',
+        checksum: '6440dbb25d0e86c8d32ad8b9fa74991c',
         sharedLibFolder: 'lib',
         includeLibs: ['libbreakpad_client.a']
     ]

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -153,9 +153,9 @@ def packages = [
         checksum: '14b02795d774457a33bbc60e00a786bc'
     ],
     breakpad: [
-        file: 'breakpad_dump_syms.zip',
-        versionId: 'yIIByczdMWGm.1f9DztIUoa6Sn3NM3IN',
-        checksum: '6440dbb25d0e86c8d32ad8b9fa74991c',
+        file: 'breakpad.tgz',
+        versionId: '8VrYXz7oyc.QBxNia0BVJOUBvrFO61jI',
+        checksum: 'ddcb23df336b08017042ba4786db1d9e',
         sharedLibFolder: 'lib',
         includeLibs: ['libbreakpad_client.a']
     ]
@@ -568,16 +568,12 @@ def runBreakpadDumpSyms = { buildType ->
                     file.toString(),
                     stripDebugSymbol
             ]
-            println ("Executing " + HIFI_ANDROID_PRECOMPILED + '/breakpad/bin' + "/dump_syms")
-            println ("Arguments "  + cmdArgs)
             def result = exec {
                 workingDir HIFI_ANDROID_PRECOMPILED + '/breakpad/bin'
                 commandLine './dump_syms'
                 args cmdArgs
                 standardOutput = new BufferedOutputStream(new FileOutputStream(new File(outputDir, output)))
             }
-            println ("Done "  + result)
-            println ("E:[" + new File(outputDir, output+".err").text+ "]")
         }
     }
 }
@@ -586,7 +582,7 @@ def uploadDumpSyms = { buildType ->
     def tmpDir = "${appDir}/build/tmp/breakpadDumpSyms/${buildType}/"
     def zipFilename = "symbols-${RELEASE_NUMBER}.zip"
     def zipDir = "${appDir}/build/tmp/breakpadDumpSyms/"
-    zip {
+    Zip {
         from tmpDir
         include '*/*'
         archiveName zipFilename

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,8 +21,6 @@ buildscript {
 plugins {
     id 'de.undercouch.download' version '3.3.0'
     id "cz.malohlava" version "1.0.3"
-    id "io.github.http-builder-ng.http-plugin" version "0.1.1"
-
 }
 
 allprojects {
@@ -69,6 +67,7 @@ def baseFolder = new File(HIFI_ANDROID_PRECOMPILED)
 def appDir = new File(projectDir, 'app')
 def jniFolder = new File(appDir, 'src/main/jniLibs/arm64-v8a')
 def baseUrl = 'https://hifi-public.s3.amazonaws.com/dependencies/android/'
+def breakpadDumpSymsDir = new File("${appDir}/build/tmp/breakpadDumpSyms")
 
 def qtFile='qt-5.9.3_linux_armv8-libcpp_openssl.tgz'
 def qtChecksum='04599670ccca84bd2b15f6915568eb2d'
@@ -556,9 +555,8 @@ def runBreakpadDumpSyms = { buildType ->
 
     def objDir = new File("${appDir}/build/intermediates/cmake/${buildType}/obj/arm64-v8a")
     def stripDebugSymbol = "${appDir}/build/intermediates/transforms/stripDebugSymbol/${buildType}/0/lib/arm64-v8a/"
-    def outputDir = new File("${appDir}/build/tmp/breakpadDumpSyms/${buildType}")
-    if (!outputDir.exists()) {
-        outputDir.mkdirs()
+    if (!breakpadDumpSymsDir.exists()) {
+        breakpadDumpSymsDir.mkdirs()
     }
 
     objDir.eachFileRecurse (FileType.FILES) { file ->
@@ -568,41 +566,16 @@ def runBreakpadDumpSyms = { buildType ->
                     file.toString(),
                     stripDebugSymbol
             ]
+            println ("Running dump_syms with arguments " + cmdArgs)
             def result = exec {
                 workingDir HIFI_ANDROID_PRECOMPILED + '/breakpad/bin'
                 commandLine './dump_syms'
                 args cmdArgs
                 ignoreExitValue true
-                standardOutput = new BufferedOutputStream(new FileOutputStream(new File(outputDir, output)))
+                standardOutput = new BufferedOutputStream(new FileOutputStream(new File(breakpadDumpSymsDir, output)))
             }
         }
     }
-}
-
-def uploadDumpSyms = { buildType ->
-    def tmpDir = "${appDir}/build/tmp/breakpadDumpSyms/${buildType}/"
-    def zipFilename = "symbols-${RELEASE_NUMBER}.zip"
-    def zipDir = "${appDir}/build/tmp/breakpadDumpSyms/"
-    Zip {
-        from tmpDir
-        include '*/*'
-        archiveName zipFilename
-        destinationDir(file(zipDir))
-    }
-
-    httpTask {
-        config {
-            request.uri = 'https://gcalero998.sp.backtrace.io:6098/post?format=symbols&token=d65d0d184789ac40c121952001fd91dfba7e149899b1eeccd68ccffe91dd2fd0'
-        }
-        post {
-            request.uri.path = '/notify'
-            request.body = new File(zipDir, zipFilename).bytes
-            response.success {
-                println 'Symbols upload successful'
-            }
-        }
-    }
-
 }
 
 task runBreakpadDumpSymsRelease() {
@@ -617,17 +590,30 @@ task runBreakpadDumpSymsDebug() {
     }
 }
 
-task uploadBreakpadDumpSymsRelease(dependsOn: runBreakpadDumpSymsRelease) {
+task zipDumpSymsDebug(type: Zip, dependsOn: runBreakpadDumpSymsDebug) {
+    doFirst {
+        println ("Zipping " + breakpadDumpSymsDir.absolutePath + " into " + breakpadDumpSymsDir)
+    }
+    from (breakpadDumpSymsDir.absolutePath)
+    archiveName "symbols-${RELEASE_NUMBER}.zip"
+    destinationDir(breakpadDumpSymsDir)
     doLast {
-        uploadDumpSyms("release")
+        println ("Zipped " + breakpadDumpSymsDir.absolutePath + " into " + breakpadDumpSymsDir)
     }
 }
 
-task uploadBreakpadDumpSymsDebug(dependsOn: runBreakpadDumpSymsDebug) {
+task uploadBreakpadDumpSymsRelease(dependsOn: runBreakpadDumpSymsRelease) {
     doLast {
-        uploadDumpSyms("debug")
+        //uploadDumpSyms("release")
     }
 }
+
+
+task uploadBreakpadDumpSymsDebug(dependsOn: zipDumpSymsDebug) {
+    def p = ['curl', '--data-binary', "@"+new File(breakpadDumpSymsDir, "symbols-${RELEASE_NUMBER}.zip").absolutePath, "\"https://gcalero998.sp.backtrace.io:6098/post?format=symbols&token=d65d0d184789ac40c121952001fd91dfba7e149899b1eeccd68ccffe91dd2fd0\""].execute()
+}
+
+
 
 // FIXME this code is prototyping the desired functionality for doing build time binary dependency resolution.
 // See the comment on the qtBundle task above

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -596,7 +596,7 @@ task zipDumpSymsDebug(type: Zip, dependsOn: runBreakpadDumpSymsDebug) {
     }
     from (breakpadDumpSymsDir.absolutePath)
     archiveName "symbols-${RELEASE_NUMBER}.zip"
-    destinationDir(breakpadDumpSymsDir)
+    destinationDir(new File("${appDir}/build/tmp/"))
     doLast {
         println ("Zipped " + breakpadDumpSymsDir.absolutePath + " into " + breakpadDumpSymsDir)
     }
@@ -610,7 +610,7 @@ task uploadBreakpadDumpSymsRelease(dependsOn: runBreakpadDumpSymsRelease) {
 
 
 task uploadBreakpadDumpSymsDebug(dependsOn: zipDumpSymsDebug) {
-    def p = ['curl', '--data-binary', "@"+new File(breakpadDumpSymsDir, "symbols-${RELEASE_NUMBER}.zip").absolutePath, "\"https://gcalero998.sp.backtrace.io:6098/post?format=symbols&token=d65d0d184789ac40c121952001fd91dfba7e149899b1eeccd68ccffe91dd2fd0\""].execute()
+    def p = ['curl', '--data-binary', "@"+new File("${appDir}/build/tmp/", "symbols-${RELEASE_NUMBER}.zip").absolutePath, "\"https://gcalero998.sp.backtrace.io:6098/post?format=symbols&token=d65d0d184789ac40c121952001fd91dfba7e149899b1eeccd68ccffe91dd2fd0\""].execute()
 }
 
 

--- a/scripts/system/+android/audio.js
+++ b/scripts/system/+android/audio.js
@@ -46,7 +46,6 @@ function init() {
 
 function onMuteClicked() {
     Audio.muted = !Audio.muted;
-    Menu.triggerOption("Out of Bounds Vector Access");
 }
 
 function onMutePressed() {


### PR DESCRIPTION
Part I: PR 13331

This pr integrates Breakpad to Android Interface.

Gradle script was adapted to use environment variables CMAKE_BACKTRACE_URL & CMAKE_BACKTRACE_TOKEN.

When the app crashes a handler must catch the error and generate a breakpad minidump that is stored in the device at /storage/emulated/0/Android/obb/io.highfidelity.hifiinterface.

Annotations added from any code calling setCrashAnnotation(,) are stored in a file in the same obb directory where dumps are created. This way we can hold the latest annotations and send them together with the dumps to the backtrace server.

One of the first things Interface does is starting an android service that runs in background, in a separated OS process. This service should run even some time after the app is closed or killed.

When the service starts it checks for dump (*.dmp) files in the obb dir and send them to backtrace according to CMAKE_BACKTRACE_URL & CMAKE_BACKTRACE_TOKEN. This is just in case something failed uploading it on real time.

The service also monitors the directory looking for new files.

In all cases, after sending a dump to the server the file is deleted

Test plan:

All builds should function normally.
Trigger a crash on desktop (Developer -> Crash) and Android (press the Audio button). Confirm that the crash appears on Backtrace.
On Android, after confirming that the crash has been uploaded, make sure there's no .dmp files in your /storage/emulated/0/Android/obb/io.highfidelity.hifiinterface directory (use adb shell ls -l <path> to check the device filesystem)
More info about breakpad: https://github.com/google/breakpad/blob/master/docs/getting_started_with_breakpad.md