### PR TITLE
Fix for Avatar Lean in Direction of Movement: Bug 16075 (for RC70) 

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -3318,7 +3318,7 @@ void MyAvatar::FollowHelper::prePhysicsUpdate(MyAvatar& myAvatar, const glm::mat
         if (!isActive(Rotation) && (shouldActivateRotation(myAvatar, desiredBodyMatrix, currentBodyMatrix) || hasDriveInput)) {
             activate(Rotation);
         }
-        if (!isActive(Horizontal) && shouldActivateHorizontal(myAvatar, desiredBodyMatrix, currentBodyMatrix)) {
+        if (!isActive(Horizontal) && (shouldActivateHorizontal(myAvatar, desiredBodyMatrix, currentBodyMatrix) || hasDriveInput)) {
             activate(Horizontal);
         }
         if (!isActive(Vertical) && (shouldActivateVertical(myAvatar, desiredBodyMatrix, currentBodyMatrix) || hasDriveInput)) {

--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -46,7 +46,7 @@ static AnimPose computeHipsInSensorFrame(MyAvatar* myAvatar, bool isFlying) {
     }
 
     glm::mat4 hipsMat;
-    if (myAvatar->getCenterOfGravityModelEnabled()) {
+    if (myAvatar->getCenterOfGravityModelEnabled() && !isFlying) {
         // then we use center of gravity model
         hipsMat = myAvatar->deriveBodyUsingCgModel();
     } else {


### PR DESCRIPTION
Fixed the lurch caused by the new CG code by using meat hook method for flying and enabling horizontal recentering when we have drive input.

This is a P1 bug.
The associated task in Fogbugz is https://highfidelity.fogbugz.com/f/cases/16075/VR-users-avatars-lean-and-lurch-in-the-direction-of-movement

### TEST PLAN
1.Enter interface with an HMD
2.Find an observer and/or switch to third person view
3.Turn on advanced movement with hand controllers
4.Walk forward or strafe sideways
5.Verify that the Avatar does not lean and lurch as if the body is trying to catch up to the head
6.Fly at high speed in different directions
7.Verify that the rear of the avatar does not raise up and that the head does not stretch away from the body

[edit, jcII: repeat above on both Rift and Vive]