### PR TITLE
RC69 Fix for the point light test flashing in HMD

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.h
@@ -278,6 +278,7 @@ protected:
 
     struct InputStageState {
         bool _invalidFormat { true };
+        bool _lastUpdateStereoState{ false };
         bool _hadColorAttribute{ true };
         Stream::FormatPointer _format;
         std::string _formatKey;

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendInput.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendInput.cpp
@@ -226,7 +226,6 @@ void GLBackend::updateInput() {
                 glVertexBindingDivisor(bufferChannelNum, frequency);
 #endif
             }
-            _input._lastUpdateStereoState = isStereoNow;
 
             if (_input._hadColorAttribute && !hasColorAttribute) {
                 // The previous input stage had a color attribute but this one doesn't so reset

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendInput.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendInput.cpp
@@ -156,6 +156,14 @@ void GLBackend::do_setIndirectBuffer(const Batch& batch, size_t paramOffset) {
 }
 
 void GLBackend::updateInput() {
+    bool isStereoNow = isStereo();
+    // track stereo state change potentially happening wihtout changing the input format
+    // this is a rare case requesting to invalid the format
+#ifdef GPU_STEREO_DRAWCALL_INSTANCED
+    _input._invalidFormat |= (isStereoNow != _input._lastUpdateStereoState);
+#endif
+    _input._lastUpdateStereoState = isStereoNow;
+
     if (_input._invalidFormat) {
         InputStageState::ActivationCache newActivation;
 
@@ -213,11 +221,12 @@ void GLBackend::updateInput() {
                     (void)CHECK_GL_ERROR();
                 }
 #ifdef GPU_STEREO_DRAWCALL_INSTANCED
-                glVertexBindingDivisor(bufferChannelNum, frequency * (isStereo() ? 2 : 1));
+                glVertexBindingDivisor(bufferChannelNum, frequency * (isStereoNow ? 2 : 1));
 #else
                 glVertexBindingDivisor(bufferChannelNum, frequency);
 #endif
             }
+            _input._lastUpdateStereoState = isStereoNow;
 
             if (_input._hadColorAttribute && !hasColorAttribute) {
                 // The previous input stage had a color attribute but this one doesn't so reset

--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendInput.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendInput.cpp
@@ -25,6 +25,14 @@ void GL41Backend::resetInputStage() {
 }
 
 void GL41Backend::updateInput() {
+    bool isStereoNow = isStereo();
+    // track stereo state change potentially happening wihtout changing the input format
+    // this is a rare case requesting to invalid the format
+#ifdef GPU_STEREO_DRAWCALL_INSTANCED
+    _input._invalidFormat |= (isStereoNow != _input._lastUpdateStereoState);
+#endif
+    _input._lastUpdateStereoState = isStereoNow;
+
     if (_input._invalidFormat || _input._invalidBuffers.any()) {
 
         if (_input._invalidFormat) {
@@ -111,7 +119,7 @@ void GL41Backend::updateInput() {
                                         reinterpret_cast<GLvoid*>(pointer + perLocationStride * (GLuint)locNum));
                                 }
 #ifdef GPU_STEREO_DRAWCALL_INSTANCED
-                                glVertexAttribDivisor(slot + (GLuint)locNum, attrib._frequency * (isStereo() ? 2 : 1));
+                                glVertexAttribDivisor(slot + (GLuint)locNum, attrib._frequency * (isStereoNow ? 2 : 1));
 #else
                                 glVertexAttribDivisor(slot + (GLuint)locNum, attrib._frequency);
 #endif

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendInput.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendInput.cpp
@@ -27,6 +27,14 @@ void GL45Backend::resetInputStage() {
 }
 
 void GL45Backend::updateInput() {
+    bool isStereoNow = isStereo();
+    // track stereo state change potentially happening wihtout changing the input format
+    // this is a rare case requesting to invalid the format
+#ifdef GPU_STEREO_DRAWCALL_INSTANCED
+    _input._invalidFormat |= (isStereoNow != _input._lastUpdateStereoState);
+#endif
+    _input._lastUpdateStereoState = isStereoNow;
+
     if (_input._invalidFormat) {
         InputStageState::ActivationCache newActivation;
 
@@ -84,7 +92,7 @@ void GL45Backend::updateInput() {
                     (void)CHECK_GL_ERROR();
                 }
 #ifdef GPU_STEREO_DRAWCALL_INSTANCED
-                glVertexBindingDivisor(bufferChannelNum, frequency * (isStereo() ? 2 : 1));
+                glVertexBindingDivisor(bufferChannelNum, frequency * (isStereoNow ? 2 : 1));
 #else
                 glVertexBindingDivisor(bufferChannelNum, frequency);
 #endif


### PR DESCRIPTION
Fixing the input format not being updated correctly in case of a stereo state change and instanced attributes

This is adressing this bug:
https://highfidelity.fogbugz.com/f/cases/15999/HMD-Rendering-Test-Error-rapid-flashing-colors-Point-Light

The same repo doesn't trigger the problem in this pr
Since the problem only happens in HMD/stereo, it s only worth testing on WIndows with HMD
