### PR TITLE
Fix MS16088: Prevent long usernames from overlapping HFC logo in Wallet Home

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
@@ -76,7 +76,7 @@ Item {
         anchors.top: parent.top;
         anchors.left: parent.left;
         anchors.leftMargin: 20;
-        width: parent.width/2;
+        width: parent.width/2 - anchors.leftMargin;
         height: 80;
     }
 


### PR DESCRIPTION
Fixes [MS16088](https://highfidelity.fogbugz.com/f/cases/16088).