### PR TITLE
Fix multi-selection color setting visible/locked to false

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -2027,12 +2027,8 @@ var PropertiesTool = function (opts) {
         } else if (data.type === "update") {
             selectionManager.saveProperties();
             if (selectionManager.selections.length > 1) {
-                properties = {
-                    locked: data.properties.locked,
-                    visible: data.properties.visible
-                };
                 for (i = 0; i < selectionManager.selections.length; i++) {
-                    Entities.editEntity(selectionManager.selections[i], properties);
+                    Entities.editEntity(selectionManager.selections[i], data.properties);
                 }
             } else if (data.properties) {
                 if (data.properties.dynamic === false) {

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -269,6 +269,9 @@ For usage and examples: colpick.com/plugin
             },
             // Show/hide the color picker
             show = function (ev) {
+				if ($(this).attr('disabled')) {
+					return;
+				}
                 // Prevent the trigger of any direct parent
                 ev.stopPropagation();
                 var cal = $('#' + $(this).data('colpickId'));

--- a/scripts/system/html/js/colpick.js
+++ b/scripts/system/html/js/colpick.js
@@ -269,9 +269,9 @@ For usage and examples: colpick.com/plugin
             },
             // Show/hide the color picker
             show = function (ev) {
-				if ($(this).attr('disabled')) {
-					return;
-				}
+                if ($(this).attr('disabled')) {
+                    return;
+                }
                 // Prevent the trigger of any direct parent
                 ev.stopPropagation();
                 var cal = $('#' + $(this).data('colpickId'));


### PR DESCRIPTION
Fix the color picker causing visible and locked entity properties to be set to false when clicking on it with multiple entities selected. This is a two part fix where first the color picker should never be triggering anything in the first place during multi-selection because it is disabled, and for that the show function for color pickers is now blocked when it's disabled. Second, there is also some code in edit.js which was causing the actual problem with the visible and locked properties when an update was received during multi-selection, and that code is removed.

Fixes: https://highfidelity.manuscript.com/f/cases/15669/

Test Plan:
-Enter Interface in desktop mode
-Open Create, create 2 or more cube or sphere entities, and select the newly created entities
-On the Properties tab and attempt to edit the Entity Color
-Verify nothing occurs when clicking on the Entity Color and the selected entities do not change or go invisible
-On the List tab, verify the selected entities can all be locked and then unlocked as well as set to invisible and then visible again
-Select 1 entity individually and on the Properties tab verify the Entity Color can be changed and works as expected