### PR TITLE
MS14398: Make teleporter zones not grabbable

### DIFF
--- a/cmake/externals/serverless-content/CMakeLists.txt
+++ b/cmake/externals/serverless-content/CMakeLists.txt
@@ -4,8 +4,8 @@ set(EXTERNAL_NAME serverless-content)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC68-v2.zip
-  URL_MD5 f7d290471baf7f5694c147217b8fc548
+  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC69.zip
+  URL_MD5 e2467b08de069da7e22ec8e032435592
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""


### PR DESCRIPTION
Test the serverless tutorial and confirm that the teleporter zones are locked and cannot be grabbed with hand controllers