### PR TITLE
RC69: 16089: test wearables for wear before gifting and wearing

### DIFF
--- a/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
@@ -646,6 +646,7 @@ Item {
             height: 40;
             enabled: root.hasPermissionToRezThis &&
                 MyAvatar.skeletonModelURL !== root.itemHref &&
+                !root.wornEntityID &&
                 root.valid;
 
             onHoveredChanged: {

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -957,7 +957,7 @@ Rectangle {
     function updateCurrentlyWornWearables(wearables) {
         for (var i = 0; i < purchasesModel.count; i++) {
             for (var j = 0; j < wearables.length; j++) {
-                if (purchasesModel.get(i).itemType === "wearable" &&
+                if (purchasesModel.get(i).item_type === "wearable" &&
                     wearables[j].entityCertID === purchasesModel.get(i).certificate_id &&
                     wearables[j].entityEdition.toString() === purchasesModel.get(i).edition_number) {
                     purchasesModel.setProperty(i, 'wornEntityID', wearables[j].entityID);


### PR DESCRIPTION
Fixes https://highfidelity.fogbugz.com/f/cases/16089/Can-gift-a-wearable-without-removing-it

1. As reported in the ticket,  you can gift things you are wearing instead of first asking if you want to remove it. That started with 0.69, and is fixed here.

2. There is another, unreported problem that is fixed here: If you're already wearing something, the "wear" button should be disabled. (Just like "install" app and "wear" avatar are.)  That one may have already been a problem before 0.69.