### PR TITLE
Send repeated check-in requests for greater resilience

### DIFF
--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -483,8 +483,8 @@ bool DomainHandler::checkInPacketTimeout() {
         // so emit our signal that says that
         qCDebug(networking) << "Limit of silent domain checkins reached";
         emit limitOfSilentDomainCheckInsReached();
-        return false;
-    } else {
         return true;
+    } else {
+        return false;
     }
 }

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -475,13 +475,16 @@ void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<Rec
     }
 }
 
-void DomainHandler::sentCheckInPacket() {
+bool DomainHandler::checkInPacketTimeout() {
     ++_checkInPacketsSinceLastReply;
 
-    if (_checkInPacketsSinceLastReply >= MAX_SILENT_DOMAIN_SERVER_CHECK_INS) {
+    if (_checkInPacketsSinceLastReply > MAX_SILENT_DOMAIN_SERVER_CHECK_INS) {
         // we haven't heard back from DS in MAX_SILENT_DOMAIN_SERVER_CHECK_INS
         // so emit our signal that says that
         qCDebug(networking) << "Limit of silent domain checkins reached";
         emit limitOfSilentDomainCheckInsReached();
+        return false;
+    } else {
+        return true;
     }
 }

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -96,7 +96,7 @@ public:
     void softReset();
 
     int getCheckInPacketsSinceLastReply() const { return _checkInPacketsSinceLastReply; }
-    void sentCheckInPacket();
+    bool checkInPacketTimeout();
     void clearPendingCheckins() { _checkInPacketsSinceLastReply = 0; }
 
     /**jsdoc

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -419,6 +419,12 @@ void NodeList::sendDomainServerCheckIn() {
 
         flagTimeForConnectionStep(LimitedNodeList::ConnectionStep::SendDSCheckIn);
 
+        int outstandingCheckins = _domainHandler.getCheckInPacketsSinceLastReply();
+        int checkinCount = outstandingCheckins > 1 ? std::pow(2, outstandingCheckins - 1) : 1;
+        for (int i = 1; i < checkinCount; ++i) {
+            auto packetCopy = domainPacket->createCopy(*domainPacket);
+            sendPacket(std::move(packetCopy), _domainHandler.getSockAddr());
+        }
         sendPacket(std::move(domainPacket), _domainHandler.getSockAddr());
 
         // let the domain handler know we sent another check in or connect packet

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -306,7 +306,7 @@ void NodeList::sendDomainServerCheckIn() {
         qCDebug(networking) << "Waiting for ICE discovered domain-server socket. Will not send domain-server check in.";
         handleICEConnectionToDomainServer();
         // let the domain handler know we are due to send a checkin packet
-    } else if (!_domainHandler.getIP().isNull() && _domainHandler.checkInPacketTimeout()) {
+    } else if (!_domainHandler.getIP().isNull() && !_domainHandler.checkInPacketTimeout()) {
 
         PacketType domainPacketType = !_domainHandler.isConnected()
             ? PacketType::DomainConnectRequest : PacketType::DomainListRequest;


### PR DESCRIPTION
When clients send domain check-ins (usually due to a 1 s timeout) and there are still outstanding check-ins send duplicates in a binary-exponential pattern.

The check for the limit before detaching from the domain is moved to before check-in transmission, so as to not uselessly send packets when already committed to a disconnect.

https://highfidelity.manuscript.com/f/cases/16152/
