### PR TITLE
guard startDynamicDomainVerification against missing entity

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -504,6 +504,11 @@ void EntityServer::startDynamicDomainVerification() {
                         QString thisDomainID = DependencyManager::get<AddressManager>()->getDomainID().remove(QRegExp("\\{|\\}"));
                         if (jsonObject["domain_id"].toString() != thisDomainID) {
                             EntityItemPointer entity = tree->findEntityByEntityItemID(entityID);
+                            if (!entity) {
+                                qCDebug(entities) << "Entity undergoing dynamic domain verification is no longer available:" << entityID;
+                                networkReply->deleteLater();
+                                return;
+                            }
                             if (entity->getAge() > (_MAXIMUM_DYNAMIC_DOMAIN_VERIFICATION_TIMER_MS/MSECS_PER_SECOND)) {
                                 qCDebug(entities) << "Entity's cert's domain ID" << jsonObject["domain_id"].toString()
                                                 << "doesn't match the current Domain ID" << thisDomainID << "; deleting entity" << entityID;


### PR DESCRIPTION
possible fix for https://highfidelity.fogbugz.com/f/cases/16150/Entity-server-crash-in-startDynamicVerification-only-on-hifiqa-pr-metaverse-staging