### PR TITLE
Disable shadows in secondary camera

### DIFF
--- a/interface/src/SecondaryCamera.cpp
+++ b/interface/src/SecondaryCamera.cpp
@@ -11,24 +11,15 @@
 
 #include "SecondaryCamera.h"
 
+#include <RenderDeferredTask.h>
+#include <RenderForwardTask.h>
+
 #include <glm/gtx/transform.hpp>
 #include <gpu/Context.h>
-#include <TextureCache.h>
 
 #include "Application.h"
 
 using RenderArgsPointer = std::shared_ptr<RenderArgs>;
-
-void MainRenderTask::build(JobModel& task, const render::Varying& inputs, render::Varying& outputs, render::CullFunctor cullFunctor, bool isDeferred) {    
-    task.addJob<RenderShadowTask>("RenderShadowTask", cullFunctor, render::ItemKey::TAG_BITS_1, render::ItemKey::TAG_BITS_1);
-    const auto items = task.addJob<RenderFetchCullSortTask>("FetchCullSort", cullFunctor, render::ItemKey::TAG_BITS_1, render::ItemKey::TAG_BITS_1);
-    assert(items.canCast<RenderFetchCullSortTask::Output>());
-    if (!isDeferred) {
-        task.addJob<RenderForwardTask>("Forward", items);
-    } else {
-        task.addJob<RenderDeferredTask>("RenderDeferredTask", items);
-    }
-}
 
 class SecondaryCameraJob {  // Changes renderContext for our framebuffer and view.
 public:
@@ -213,10 +204,10 @@ void SecondaryCameraRenderTask::build(JobModel& task, const render::Varying& inp
     const auto cachedArg = task.addJob<SecondaryCameraJob>("SecondaryCamera");
     const auto items = task.addJob<RenderFetchCullSortTask>("FetchCullSort", cullFunctor, render::ItemKey::TAG_BITS_1, render::ItemKey::TAG_BITS_1);
     assert(items.canCast<RenderFetchCullSortTask::Output>());
-    if (!isDeferred) {
-        task.addJob<RenderForwardTask>("Forward", items);
+    if (isDeferred) {
+        task.addJob<RenderDeferredTask>("RenderDeferredTask", items, false);
     } else {
-        task.addJob<RenderDeferredTask>("RenderDeferredTask", items);
+        task.addJob<RenderForwardTask>("Forward", items);
     }
     task.addJob<EndSecondaryCameraFrame>("EndSecondaryCamera", cachedArg);
 }

--- a/interface/src/SecondaryCamera.h
+++ b/interface/src/SecondaryCamera.h
@@ -12,22 +12,10 @@
 #pragma once
 #ifndef hifi_SecondaryCamera_h
 #define hifi_SecondaryCamera_h
-    
-#include <RenderShadowTask.h>
+
 #include <render/RenderFetchCullSortTask.h>
-#include <RenderDeferredTask.h>
-#include <RenderForwardTask.h>
 #include <TextureCache.h>
 #include <ViewFrustum.h>
-
-class MainRenderTask {
-public:
-    using JobModel = render::Task::Model<MainRenderTask>;
-
-    MainRenderTask() {}
-
-    void build(JobModel& task, const render::Varying& inputs, render::Varying& outputs, render::CullFunctor cullFunctor, bool isDeferred = true);
-};
 
 class SecondaryCameraJobConfig : public render::Task::Config { // Exposes secondary camera parameters to JavaScript.
     Q_OBJECT

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -472,7 +472,8 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
     const graphics::HazePointer& haze,
     const SurfaceGeometryFramebufferPointer& surfaceGeometryFramebuffer,
     const AmbientOcclusionFramebufferPointer& ambientOcclusionFramebuffer,
-    const SubsurfaceScatteringResourcePointer& subsurfaceScatteringResource) {
+    const SubsurfaceScatteringResourcePointer& subsurfaceScatteringResource,
+    bool renderShadows) {
 
     auto args = renderContext->args;
     auto& batch = (*args->_batch);
@@ -554,7 +555,7 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
             // Check if keylight casts shadows
             bool keyLightCastShadows { false };
 
-            if (lightStage && lightStage->_currentFrame._sunLights.size()) {
+            if (renderShadows && lightStage && lightStage->_currentFrame._sunLights.size()) {
                 graphics::LightPointer keyLight = lightStage->getLight(lightStage->_currentFrame._sunLights.front());
                 if (keyLight) {
                     keyLightCastShadows = keyLight->getCastShadows();
@@ -711,11 +712,6 @@ void RenderDeferredCleanup::run(const render::RenderContextPointer& renderContex
     }
 }
 
-RenderDeferred::RenderDeferred() {
-
-}
-
-
 void RenderDeferred::configure(const Config& config) {
 }
 
@@ -742,7 +738,7 @@ void RenderDeferred::run(const RenderContextPointer& renderContext, const Inputs
         args->_batch = &batch;
          _gpuTimer->begin(batch);
 
-        setupJob.run(renderContext, deferredTransform, deferredFramebuffer, lightingModel, haze, surfaceGeometryFramebuffer, ssaoFramebuffer, subsurfaceScatteringResource);
+        setupJob.run(renderContext, deferredTransform, deferredFramebuffer, lightingModel, haze, surfaceGeometryFramebuffer, ssaoFramebuffer, subsurfaceScatteringResource, _renderShadows);
     
         lightsJob.run(renderContext, deferredTransform, deferredFramebuffer, lightingModel, surfaceGeometryFramebuffer, lightClusters);
 

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -127,7 +127,8 @@ public:
         const graphics::HazePointer& haze,
         const SurfaceGeometryFramebufferPointer& surfaceGeometryFramebuffer,
         const AmbientOcclusionFramebufferPointer& ambientOcclusionFramebuffer,
-        const SubsurfaceScatteringResourcePointer& subsurfaceScatteringResource);
+        const SubsurfaceScatteringResourcePointer& subsurfaceScatteringResource,
+        bool renderShadows);
 };
 
 class RenderDeferredLocals {
@@ -166,7 +167,8 @@ public:
     using Config = RenderDeferredConfig;
     using JobModel = render::Job::ModelI<RenderDeferred, Inputs, Config>;
 
-    RenderDeferred();
+    RenderDeferred() {}
+    RenderDeferred(bool renderShadows) : _renderShadows(renderShadows) {}
 
     void configure(const Config& config);
 
@@ -178,6 +180,9 @@ public:
 
 protected:
     gpu::RangeTimerPointer _gpuTimer;
+
+private:
+    bool _renderShadows { false };
 };
 
 class DefaultLightingSetup {

--- a/libraries/render-utils/src/RenderCommonTask.h
+++ b/libraries/render-utils/src/RenderCommonTask.h
@@ -61,7 +61,6 @@ protected:
 class DrawOverlay3D {
 public:
     using Inputs = render::VaryingSet3<render::ItemBounds, LightingModelPointer, glm::vec2>;
-
     using Config = DrawOverlay3DConfig;
     using JobModel = render::Job::ModelI<DrawOverlay3D, Inputs, Config>;
 
@@ -73,7 +72,7 @@ public:
 protected:
     render::ShapePlumberPointer _shapePlumber;
     int _maxDrawn; // initialized by Config
-    bool _opaquePass{ true };
+    bool _opaquePass { true };
 };
 
 class CompositeHUD {

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -64,8 +64,8 @@ void RenderDeferredTask::configure(const Config& config)
 }
 
 const render::Varying RenderDeferredTask::addSelectItemJobs(JobModel& task, const char* selectionName,
-                                                            const render::Varying& metas, 
-                                                            const render::Varying& opaques, 
+                                                            const render::Varying& metas,
+                                                            const render::Varying& opaques,
                                                             const render::Varying& transparents) {
     const auto selectMetaInput = SelectItems::Inputs(metas, Varying(), std::string()).asVarying();
     const auto selectedMetas = task.addJob<SelectItems>("MetaSelection", selectMetaInput, selectionName);
@@ -75,7 +75,7 @@ const render::Varying RenderDeferredTask::addSelectItemJobs(JobModel& task, cons
     return task.addJob<SelectItems>("TransparentSelection", selectItemInput, selectionName);
 }
 
-void RenderDeferredTask::build(JobModel& task, const render::Varying& input, render::Varying& output) {
+void RenderDeferredTask::build(JobModel& task, const render::Varying& input, render::Varying& output, bool renderShadows) {
     const auto& items = input.get<Input>();
     auto fadeEffect = DependencyManager::get<FadeEffect>();
 
@@ -168,7 +168,7 @@ void RenderDeferredTask::build(JobModel& task, const render::Varying& input, ren
     const auto deferredLightingInputs = RenderDeferred::Inputs(deferredFrameTransform, deferredFramebuffer, lightingModel,
         surfaceGeometryFramebuffer, ambientOcclusionFramebuffer, scatteringResource, lightClusters, hazeModel).asVarying();
     
-    task.addJob<RenderDeferred>("RenderDeferred", deferredLightingInputs);
+    task.addJob<RenderDeferred>("RenderDeferred", deferredLightingInputs, renderShadows);
 
 
     // Similar to light stage, background stage has been filled by several potential render items and resolved for the frame in this job

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -126,7 +126,7 @@ public:
     RenderDeferredTask();
 
     void configure(const Config& config);
-    void build(JobModel& task, const render::Varying& inputs, render::Varying& outputs);
+    void build(JobModel& task, const render::Varying& inputs, render::Varying& outputs, bool renderShadows);
 
 private:
     static const render::Varying addSelectItemJobs(JobModel& task,

--- a/libraries/render-utils/src/RenderViewTask.cpp
+++ b/libraries/render-utils/src/RenderViewTask.cpp
@@ -27,7 +27,7 @@ void RenderViewTask::build(JobModel& task, const render::Varying& input, render:
     assert(items.canCast<RenderFetchCullSortTask::Output>());
 
     if (isDeferred) {
-        task.addJob<RenderDeferredTask>("RenderDeferredTask", items);
+        task.addJob<RenderDeferredTask>("RenderDeferredTask", items, true);
     } else {
         task.addJob<RenderForwardTask>("Forward", items);
     }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/15957/Shadows-don-t-render-correctly-in-the-Secondary-Camera

Test plan:
- Go somewhere with a mirror and shadows.  dev-mobile has a mirror on the cart near the starting area, and has shadows on.  You should see shadows in the main view, but not in the mirror.