### PR TITLE
Fix for landing on the roof of some domains.

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -279,18 +279,16 @@ EntityItemProperties RenderableModelEntityItem::getProperties(EntityPropertyFlag
 }
 
 bool RenderableModelEntityItem::supportsDetailedRayIntersection() const {
-    return isModelLoaded();
+    return true;
 }
 
 bool RenderableModelEntityItem::findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
                          OctreeElementPointer& element, float& distance, BoxFace& face,
                          glm::vec3& surfaceNormal, QVariantMap& extraInfo, bool precisionPicking) const {
     auto model = getModel();
-    if (!model) {
-        return true;
+    if (!model || !isModelLoaded()) {
+        return false;
     }
-    // qCDebug(entitiesrenderer) << "RenderableModelEntityItem::findDetailedRayIntersection() precisionPicking:"
-    //                           << precisionPicking;
 
     return model->findRayIntersectionAgainstSubMeshes(origin, direction, distance,
                face, surfaceNormal, extraInfo, precisionPicking, false);


### PR DESCRIPTION
Prevent ray-picks against Model Entity bounding boxes when loading the model has not yet completed.

This should help prevent issues where an avatar ends up high in the air or on the roof on entry to a domain via the GOTO app.  This is not a comprehensive fix, but it should help reduce the instances where this occurs.  There is technical work on going to address this issue in a more holistic manner.