### PR TITLE
Fix scaling avatar points twice

### DIFF
--- a/libraries/fbx/src/FBXReader.cpp
+++ b/libraries/fbx/src/FBXReader.cpp
@@ -1816,7 +1816,6 @@ FBXGeometry* FBXReader::extractFBXGeometry(const QVariantHash& mapping, const QS
                     }
                 }
 
-                float clusterScale = extractUniformScale(fbxCluster.inverseBindMatrix);
                 glm::mat4 meshToJoint = glm::inverse(joint.bindTransform) * modelTransform;
                 ShapeVertices& points = shapeVertices.at(jointIndex);
 
@@ -1832,7 +1831,7 @@ FBXGeometry* FBXReader::extractFBXGeometry(const QVariantHash& mapping, const QS
                         if (weight >= EXPANSION_WEIGHT_THRESHOLD) {
                             // transform to joint-frame and save for later
                             const glm::mat4 vertexTransform = meshToJoint * glm::translate(extracted.mesh.vertices.at(newIndex));
-                            points.push_back(extractTranslation(vertexTransform) * clusterScale);
+                            points.push_back(extractTranslation(vertexTransform));
                         }
 
                         // look for an unused slot in the weights vector
@@ -1886,12 +1885,11 @@ FBXGeometry* FBXReader::extractFBXGeometry(const QVariantHash& mapping, const QS
             FBXJoint& joint = geometry.joints[jointIndex];
 
             // transform cluster vertices to joint-frame and save for later
-            float clusterScale = extractUniformScale(firstFBXCluster.inverseBindMatrix);
             glm::mat4 meshToJoint = glm::inverse(joint.bindTransform) * modelTransform;
             ShapeVertices& points = shapeVertices.at(jointIndex);
             foreach (const glm::vec3& vertex, extracted.mesh.vertices) {
                 const glm::mat4 vertexTransform = meshToJoint * glm::translate(vertex);
-                points.push_back(extractTranslation(vertexTransform) * clusterScale);
+                points.push_back(extractTranslation(vertexTransform));
             }
 
             // Apply geometric offset, if present, by transforming the vertices directly


### PR DESCRIPTION
This PR fixes the bug that occurs when trying to load an avatar model when its main body scale is different than 1.
The points that are used to calculate the collision hulls are being scaled twice. This resulted on bigger collision hulls when the body scale is > 1.
https://highfidelity.manuscript.com/f/cases/14114/Normal-sized-avatars-can-have-a-huge-collision-hull-push-everyone-away
The points are being computed by
`point = extractTranslation(vertexTransform) * clusterScale`
where 
`vertexTransform = meshToJoint * glm::translate(vertex)`
but 
`meshToJoint = glm::inverse(joint.bindTransform) * modelTransform`
that is already taking into account the scale component on modelTransform. Multiplying by clusterScale will apply the scale twice.