### PR TITLE
Prevent connection timestamp map from growing unboundedly

### DIFF
--- a/interface/src/ui/DomainConnectionDialog.cpp
+++ b/interface/src/ui/DomainConnectionDialog.cpp
@@ -37,7 +37,7 @@ DomainConnectionDialog::DomainConnectionDialog(QWidget* parent) :
     // ask the NodeList for the current values for connection times
     LimitedNodeList::ConnectionTimesMap times = DependencyManager::get<NodeList>()->getLastConnectionTimes();
     
-    timeTable->setRowCount(times.size());
+    timeTable->setRowCount((int) times.size());
 
     timeTable->setHorizontalHeaderLabels(TABLE_HEADERS);
 

--- a/interface/src/ui/DomainConnectionDialog.cpp
+++ b/interface/src/ui/DomainConnectionDialog.cpp
@@ -35,42 +35,7 @@ DomainConnectionDialog::DomainConnectionDialog(QWidget* parent) :
     timeTable->setColumnCount(TABLE_HEADERS.size());
 
     // ask the NodeList for the current values for connection times
-    //QMap<quint64, LimitedNodeList::ConnectionStep> times = DependencyManager::get<NodeList>()->getLastConnectionTimes();
-
-    //timeTable->setRowCount(times.size());
-
-    //timeTable->setHorizontalHeaderLabels(TABLE_HEADERS);
-
-    //// setup our data with the values from the NodeList
-    //quint64 firstStepTime = times.firstKey() / USECS_PER_MSEC;
-    //quint64 lastStepTime = firstStepTime;
-
-    //int thisRow = 0;
-
-    //const QMetaObject &nodeListMeta = NodeList::staticMetaObject;
-    //QMetaEnum stepEnum = nodeListMeta.enumerator(nodeListMeta.indexOfEnumerator("ConnectionStep"));
-
-    //foreach(quint64 timestamp, times.keys()) {
-    //    // When did this step occur, how long since the last step, how long since the start?
-    //    quint64 stepTime = timestamp / USECS_PER_MSEC;
-    //    quint64 delta = (stepTime - lastStepTime);
-    //    quint64 elapsed = stepTime - firstStepTime;
-
-    //    lastStepTime = stepTime;
-
-    //    // setup the columns for this row in the table
-    //    int stepIndex = (int) times.value(timestamp);
-
-    //    timeTable->setItem(thisRow, 0, new QTableWidgetItem(stepEnum.valueToKey(stepIndex)));
-    //    timeTable->setItem(thisRow, 1, new QTableWidgetItem(QString::number(stepTime)));
-    //    timeTable->setItem(thisRow, 2, new QTableWidgetItem(QString::number(delta)));
-    //    timeTable->setItem(thisRow, 3, new QTableWidgetItem(QString::number(elapsed)));
-
-    //    ++thisRow;
-    //}
-
-    // ask the NodeList for the current values for connection times
-    QMap<LimitedNodeList::ConnectionStep, quint64> times = DependencyManager::get<NodeList>()->getLastConnectionTimes();
+    LimitedNodeList::ConnectionTimesMap times = DependencyManager::get<NodeList>()->getLastConnectionTimes();
     
     timeTable->setRowCount(times.size());
 
@@ -80,8 +45,9 @@ DomainConnectionDialog::DomainConnectionDialog(QWidget* parent) :
     Steps steps;
     steps.reserve(times.size());
 
-    steps.insert(steps.begin(), times.constKeyValueBegin(), times.constKeyValueEnd());
-    std::sort(steps.begin(), steps.end(), [](Steps::value_type& s1, Steps::value_type& s2) { return s1.second < s2.second; });
+    steps.insert(steps.begin(), times.cbegin(), times.cend());
+    std::sort(steps.begin(), steps.end(),
+        [](Steps::value_type& s1, Steps::value_type& s2) { return s1.second < s2.second; });
 
     // setup our data with the values from the NodeList
     quint64 firstStepTime = steps.empty() ? 0L : steps[0].second / USECS_PER_MSEC;

--- a/interface/src/ui/DomainConnectionDialog.cpp
+++ b/interface/src/ui/DomainConnectionDialog.cpp
@@ -35,14 +35,56 @@ DomainConnectionDialog::DomainConnectionDialog(QWidget* parent) :
     timeTable->setColumnCount(TABLE_HEADERS.size());
 
     // ask the NodeList for the current values for connection times
-    QMap<quint64, LimitedNodeList::ConnectionStep> times = DependencyManager::get<NodeList>()->getLastConnectionTimes();
+    //QMap<quint64, LimitedNodeList::ConnectionStep> times = DependencyManager::get<NodeList>()->getLastConnectionTimes();
 
+    //timeTable->setRowCount(times.size());
+
+    //timeTable->setHorizontalHeaderLabels(TABLE_HEADERS);
+
+    //// setup our data with the values from the NodeList
+    //quint64 firstStepTime = times.firstKey() / USECS_PER_MSEC;
+    //quint64 lastStepTime = firstStepTime;
+
+    //int thisRow = 0;
+
+    //const QMetaObject &nodeListMeta = NodeList::staticMetaObject;
+    //QMetaEnum stepEnum = nodeListMeta.enumerator(nodeListMeta.indexOfEnumerator("ConnectionStep"));
+
+    //foreach(quint64 timestamp, times.keys()) {
+    //    // When did this step occur, how long since the last step, how long since the start?
+    //    quint64 stepTime = timestamp / USECS_PER_MSEC;
+    //    quint64 delta = (stepTime - lastStepTime);
+    //    quint64 elapsed = stepTime - firstStepTime;
+
+    //    lastStepTime = stepTime;
+
+    //    // setup the columns for this row in the table
+    //    int stepIndex = (int) times.value(timestamp);
+
+    //    timeTable->setItem(thisRow, 0, new QTableWidgetItem(stepEnum.valueToKey(stepIndex)));
+    //    timeTable->setItem(thisRow, 1, new QTableWidgetItem(QString::number(stepTime)));
+    //    timeTable->setItem(thisRow, 2, new QTableWidgetItem(QString::number(delta)));
+    //    timeTable->setItem(thisRow, 3, new QTableWidgetItem(QString::number(elapsed)));
+
+    //    ++thisRow;
+    //}
+
+    // ask the NodeList for the current values for connection times
+    QMap<LimitedNodeList::ConnectionStep, quint64> times = DependencyManager::get<NodeList>()->getLastConnectionTimes();
+    
     timeTable->setRowCount(times.size());
 
     timeTable->setHorizontalHeaderLabels(TABLE_HEADERS);
 
+    using Steps = std::vector<std::pair<LimitedNodeList::ConnectionStep, quint64>>;
+    Steps steps;
+    steps.reserve(times.size());
+
+    steps.insert(steps.begin(), times.constKeyValueBegin(), times.constKeyValueEnd());
+    std::sort(steps.begin(), steps.end(), [](Steps::value_type& s1, Steps::value_type& s2) { return s1.second < s2.second; });
+
     // setup our data with the values from the NodeList
-    quint64 firstStepTime = times.firstKey() / USECS_PER_MSEC;
+    quint64 firstStepTime = steps.empty() ? 0L : steps[0].second / USECS_PER_MSEC;
     quint64 lastStepTime = firstStepTime;
 
     int thisRow = 0;
@@ -50,18 +92,15 @@ DomainConnectionDialog::DomainConnectionDialog(QWidget* parent) :
     const QMetaObject &nodeListMeta = NodeList::staticMetaObject;
     QMetaEnum stepEnum = nodeListMeta.enumerator(nodeListMeta.indexOfEnumerator("ConnectionStep"));
 
-    foreach(quint64 timestamp, times.keys()) {
-        // When did this step occur, how long since the last step, how long since the start?
-        quint64 stepTime = timestamp / USECS_PER_MSEC;
-        quint64 delta = (stepTime - lastStepTime);
+    for (auto step: steps) {
+        quint64 stepTime = step.second / USECS_PER_MSEC;
+        quint64 delta = stepTime - lastStepTime;
         quint64 elapsed = stepTime - firstStepTime;
 
         lastStepTime = stepTime;
 
         // setup the columns for this row in the table
-        int stepIndex = (int) times.value(timestamp);
-
-        timeTable->setItem(thisRow, 0, new QTableWidgetItem(stepEnum.valueToKey(stepIndex)));
+        timeTable->setItem(thisRow, 0, new QTableWidgetItem(stepEnum.valueToKey(step.first)));
         timeTable->setItem(thisRow, 1, new QTableWidgetItem(QString::number(stepTime)));
         timeTable->setItem(thisRow, 2, new QTableWidgetItem(QString::number(delta)));
         timeTable->setItem(thisRow, 3, new QTableWidgetItem(QString::number(elapsed)));

--- a/interface/src/ui/DomainConnectionModel.cpp
+++ b/interface/src/ui/DomainConnectionModel.cpp
@@ -29,7 +29,7 @@ QVariant DomainConnectionModel::data(const QModelIndex& index, int role) const {
     const LimitedNodeList::ConnectionTimesMap& times =
               DependencyManager::get<NodeList>()->getLastConnectionTimes();
 
-    if (!index.isValid() || index.row() >= times.size())
+    if (!index.isValid() || index.row() >= (int) times.size())
         return QVariant();
 
     

--- a/interface/src/ui/DomainConnectionModel.cpp
+++ b/interface/src/ui/DomainConnectionModel.cpp
@@ -26,7 +26,7 @@ DomainConnectionModel::~DomainConnectionModel() {
 QVariant DomainConnectionModel::data(const QModelIndex& index, int role) const {
     //sanity
 
-    const QMap<LimitedNodeList::ConnectionStep, quint64> &times =
+    const LimitedNodeList::ConnectionTimesMap& times =
               DependencyManager::get<NodeList>()->getLastConnectionTimes();
 
     if (!index.isValid() || index.row() >= times.size())
@@ -37,8 +37,9 @@ QVariant DomainConnectionModel::data(const QModelIndex& index, int role) const {
     Steps steps;
     steps.reserve(times.size());
 
-    steps.insert(steps.begin(), times.constKeyValueBegin(), times.constKeyValueEnd());
-    std::sort(steps.begin(), steps.end(), [](Steps::value_type& s1, Steps::value_type& s2) { return s1.second < s2.second; });
+    steps.insert(steps.begin(), times.cbegin(), times.cend());
+    std::sort(steps.begin(), steps.end(),
+        [](Steps::value_type& s1, Steps::value_type& s2) { return s1.second < s2.second; });
     
     /// setup our data with the values from the NodeList
     quint64 firstStepTime = steps[0].second / USECS_PER_MSEC;
@@ -71,9 +72,9 @@ QVariant DomainConnectionModel::data(const QModelIndex& index, int role) const {
 
 int DomainConnectionModel::rowCount(const QModelIndex& parent) const {
     Q_UNUSED(parent)
-    const QMap<LimitedNodeList::ConnectionStep, quint64> &times =
+    const LimitedNodeList::ConnectionTimesMap& times =
             DependencyManager::get<NodeList>()->getLastConnectionTimes();
-    return times.size();
+    return (int) times.size();
 }
 
 QHash<int, QByteArray> DomainConnectionModel::roleNames() const {

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -1241,35 +1241,6 @@ void LimitedNodeList::flagTimeForConnectionStep(ConnectionStep connectionStep) {
 }
 
 void LimitedNodeList::flagTimeForConnectionStep(ConnectionStep connectionStep, quint64 timestamp) {
-    //if (connectionStep == ConnectionStep::LookupAddress) {
-    //    QWriteLocker writeLock(&_connectionTimeLock);
-
-    //    // we clear the current times if the user just fired off a lookup
-    //    _lastConnectionTimes.clear();
-    //    _areConnectionTimesComplete = false;
-
-    //    _lastConnectionTimes[timestamp] = connectionStep;
-    //} else if (!_areConnectionTimesComplete) {
-    //    QWriteLocker writeLock(&_connectionTimeLock);
-
-
-    //    // anything > than sending the first DS check should not come before the DS check in, so we drop those
-    //    // this handles the case where you lookup an address and get packets in the existing domain before changing domains
-    //    if (connectionStep > LimitedNodeList::ConnectionStep::SendDSCheckIn
-    //        && (_lastConnectionTimes.key(ConnectionStep::SendDSCheckIn) == 0
-    //            || timestamp <= _lastConnectionTimes.key(ConnectionStep::SendDSCheckIn))) {
-    //        return;
-    //    }
-
-    //    // if there is no time for existing step add a timestamp on the first call for each ConnectionStep
-    //    _lastConnectionTimes[timestamp] = connectionStep;
-
-    //    // if this is a received audio packet we consider our connection times complete
-    //    if (connectionStep == ConnectionStep::ReceiveFirstAudioPacket) {
-    //        _areConnectionTimesComplete = true;
-    //    }
-    //}
-
     if (connectionStep == ConnectionStep::LookupAddress) {
         QWriteLocker writeLock(&_connectionTimeLock);
 

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -1251,12 +1251,12 @@ void LimitedNodeList::flagTimeForConnectionStep(ConnectionStep connectionStep, q
     if (!_areConnectionTimesComplete) {
         QWriteLocker writeLock(&_connectionTimeLock);
 
-        if (!_lastConnectionTimes.contains(connectionStep)) {
+        if (_lastConnectionTimes.count(connectionStep) == 0) {
 
             // anything > than sending the first DS check should not come before the DS check in, so we drop those
             // this handles the case where you lookup an address and get packets in the existing domain before changing domains
             if (connectionStep > LimitedNodeList::ConnectionStep::SendDSCheckIn
-                && !_lastConnectionTimes.contains(ConnectionStep::SendDSCheckIn)) {
+                && _lastConnectionTimes.count(ConnectionStep::SendDSCheckIn) == 0) {
                 return;
             }
             _lastConnectionTimes[connectionStep] = timestamp;

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -1241,32 +1241,59 @@ void LimitedNodeList::flagTimeForConnectionStep(ConnectionStep connectionStep) {
 }
 
 void LimitedNodeList::flagTimeForConnectionStep(ConnectionStep connectionStep, quint64 timestamp) {
+    //if (connectionStep == ConnectionStep::LookupAddress) {
+    //    QWriteLocker writeLock(&_connectionTimeLock);
+
+    //    // we clear the current times if the user just fired off a lookup
+    //    _lastConnectionTimes.clear();
+    //    _areConnectionTimesComplete = false;
+
+    //    _lastConnectionTimes[timestamp] = connectionStep;
+    //} else if (!_areConnectionTimesComplete) {
+    //    QWriteLocker writeLock(&_connectionTimeLock);
+
+
+    //    // anything > than sending the first DS check should not come before the DS check in, so we drop those
+    //    // this handles the case where you lookup an address and get packets in the existing domain before changing domains
+    //    if (connectionStep > LimitedNodeList::ConnectionStep::SendDSCheckIn
+    //        && (_lastConnectionTimes.key(ConnectionStep::SendDSCheckIn) == 0
+    //            || timestamp <= _lastConnectionTimes.key(ConnectionStep::SendDSCheckIn))) {
+    //        return;
+    //    }
+
+    //    // if there is no time for existing step add a timestamp on the first call for each ConnectionStep
+    //    _lastConnectionTimes[timestamp] = connectionStep;
+
+    //    // if this is a received audio packet we consider our connection times complete
+    //    if (connectionStep == ConnectionStep::ReceiveFirstAudioPacket) {
+    //        _areConnectionTimesComplete = true;
+    //    }
+    //}
+
     if (connectionStep == ConnectionStep::LookupAddress) {
         QWriteLocker writeLock(&_connectionTimeLock);
 
         // we clear the current times if the user just fired off a lookup
         _lastConnectionTimes.clear();
         _areConnectionTimesComplete = false;
-
-        _lastConnectionTimes[timestamp] = connectionStep;
-    } else if (!_areConnectionTimesComplete) {
+    }
+    if (!_areConnectionTimesComplete) {
         QWriteLocker writeLock(&_connectionTimeLock);
 
+        if (!_lastConnectionTimes.contains(connectionStep)) {
 
-        // anything > than sending the first DS check should not come before the DS check in, so we drop those
-        // this handles the case where you lookup an address and get packets in the existing domain before changing domains
-        if (connectionStep > LimitedNodeList::ConnectionStep::SendDSCheckIn
-            && (_lastConnectionTimes.key(ConnectionStep::SendDSCheckIn) == 0
-                || timestamp <= _lastConnectionTimes.key(ConnectionStep::SendDSCheckIn))) {
-            return;
-        }
+            // anything > than sending the first DS check should not come before the DS check in, so we drop those
+            // this handles the case where you lookup an address and get packets in the existing domain before changing domains
+            if (connectionStep > LimitedNodeList::ConnectionStep::SendDSCheckIn
+                && !_lastConnectionTimes.contains(ConnectionStep::SendDSCheckIn)) {
+                return;
+            }
+            _lastConnectionTimes[connectionStep] = timestamp;
 
-        // if there is no time for existing step add a timestamp on the first call for each ConnectionStep
-        _lastConnectionTimes[timestamp] = connectionStep;
-
-        // if this is a received audio packet we consider our connection times complete
-        if (connectionStep == ConnectionStep::ReceiveFirstAudioPacket) {
-            _areConnectionTimesComplete = true;
+            // if this is a received audio packet we consider our connection times complete
+            if (connectionStep == ConnectionStep::ReceiveFirstAudioPacket) {
+                _areConnectionTimesComplete = true;
+            }
         }
     }
 }

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -17,6 +17,7 @@
 #include <iterator>
 #include <memory>
 #include <set>
+#include <map>
 #include <unordered_map>
 
 #ifndef _WIN32
@@ -294,7 +295,8 @@ public:
     void putLocalPortIntoSharedMemory(const QString key, QObject* parent, quint16 localPort);
     bool getLocalServerPortFromSharedMemory(const QString key, quint16& localPort);
 
-    const QMap<ConnectionStep, quint64> getLastConnectionTimes() const
+    using ConnectionTimesMap = std::map<ConnectionStep, quint64>;
+    const ConnectionTimesMap getLastConnectionTimes() const
         { QReadLocker readLock(&_connectionTimeLock); return _lastConnectionTimes; }
     void flagTimeForConnectionStep(ConnectionStep connectionStep);
 
@@ -411,7 +413,7 @@ protected:
     quint64 _publicSocketUpdateTime = 0;
 
     mutable QReadWriteLock _connectionTimeLock { };
-    QMap<ConnectionStep, quint64> _lastConnectionTimes;
+    ConnectionTimesMap _lastConnectionTimes;
     bool _areConnectionTimesComplete = false;
 
     template<typename IteratorLambda>

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -294,7 +294,7 @@ public:
     void putLocalPortIntoSharedMemory(const QString key, QObject* parent, quint16 localPort);
     bool getLocalServerPortFromSharedMemory(const QString key, quint16& localPort);
 
-    const QMap<quint64, ConnectionStep> getLastConnectionTimes() const
+    const QMap<ConnectionStep, quint64> getLastConnectionTimes() const
         { QReadLocker readLock(&_connectionTimeLock); return _lastConnectionTimes; }
     void flagTimeForConnectionStep(ConnectionStep connectionStep);
 
@@ -411,7 +411,7 @@ protected:
     quint64 _publicSocketUpdateTime = 0;
 
     mutable QReadWriteLock _connectionTimeLock { };
-    QMap<quint64, ConnectionStep> _lastConnectionTimes;
+    QMap<ConnectionStep, quint64> _lastConnectionTimes;
     bool _areConnectionTimesComplete = false;
 
     template<typename IteratorLambda>


### PR DESCRIPTION
This PR converts the _lastConnectionTimes from time->event to event->time. On ACs the map can grow forever as the connection times are not considered complete.

It also changes the DomainConnectionDialog to use this format. I changed the DomainConnectionModel also but nothing appears to use it currently.

https://highfidelity.manuscript.com/f/cases/16232/
