### PR TITLE
Fix shutdown crash on Mac in Application::onPresent

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -269,9 +269,6 @@ public:
         }
         _renderContext->doneCurrent();
 
-        // Deleting the object with automatically shutdown the thread
-        connect(qApp, &QCoreApplication::aboutToQuit, this, &QObject::deleteLater);
-
         // Transfer to a new thread
         moveToNewNamedThread(this, "RenderThread", [this](QThread* renderThread) {
             hifi::qt::addBlockingForbiddenThread("Render", renderThread);
@@ -2590,6 +2587,8 @@ Application::~Application() {
 
     // Can't log to file passed this point, FileLogger about to be deleted
     qInstallMessageHandler(LogHandler::verboseMessageHandler);
+    
+    _renderEventHandler->deleteLater();
 }
 
 void Application::initializeGL() {


### PR DESCRIPTION
On a 2017 Macbook Pro, a crash on shutdown in Application::onPresent would get 50-70% repro. It was caused by the present thread still being busy and attempting to access a no-longer-existent _renderEventHandler. This PR delays when _renderEventHandler is destroyed, to prevent the invalid access.

Please do not volunteer to mark this as QA ready until https://github.com/highfidelity/hifi/pull/13419 is merged and this PR has been rebased on top of it. This will ensure that earlier shutdown crashes do not hide the effects of this crash fix.

## TEST PLAN
* In a release build, on a Mac, ensure that the program with this PR has fewer shutdown crashes than without this PR.