### PR TITLE
Fix Mac dev crash caused by assert in Frame destructor

### DIFF
--- a/libraries/gpu/src/gpu/Frame.cpp
+++ b/libraries/gpu/src/gpu/Frame.cpp
@@ -21,10 +21,7 @@ Frame::~Frame() {
         framebuffer.reset();
     }
 
-    assert(bufferUpdates.empty());
-    if (!bufferUpdates.empty()) {
-        qFatal("Buffer sync error... frame destroyed without buffer updates being applied");
-    }
+    bufferUpdates.clear();
 }
 
 void Frame::finish() {


### PR DESCRIPTION
With https://github.com/highfidelity/hifi/pull/13419 and https://github.com/highfidelity/hifi/pull/13482 in place, there was still a frequent (70% repro) shutdown crash in gpu::Frame::~Frame() while in a development environment on a mac. The crash was caused by an assert which assumed Frame objects were only destroyed at runtime. The crash could have hidden other shutdown crashes in need of fixing.

Please do not volunteer to mark this as QA ready until https://github.com/highfidelity/hifi/pull/13482 is merged and this PR has been rebased on top of it. This will ensure that earlier shutdown crashes do not hide the effects of this crash fix.

## TEST PLAN
* In a dev build, on a Mac (Product > Build For > Testing, in Xcode, or the equivalent), ensure that the program with this PR has fewer shutdown crashes than without this PR.