### PR TITLE
Implement MS16257: Remove 'clear overlay when moving' setting and code

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1068,7 +1068,6 @@ void MyAvatar::saveData() {
     settings.setValue("displayName", _displayName);
     settings.setValue("collisionSoundURL", _collisionSoundURL);
     settings.setValue("useSnapTurn", _useSnapTurn);
-    settings.setValue("clearOverlayWhenMoving", _clearOverlayWhenMoving);
     settings.setValue("userHeight", getUserHeight());
 
     settings.endGroup();
@@ -1223,7 +1222,6 @@ void MyAvatar::loadData() {
     setDisplayName(settings.value("displayName").toString());
     setCollisionSoundURL(settings.value("collisionSoundURL", DEFAULT_AVATAR_COLLISION_SOUND_URL).toString());
     setSnapTurn(settings.value("useSnapTurn", _useSnapTurn).toBool());
-    setClearOverlayWhenMoving(settings.value("clearOverlayWhenMoving", _clearOverlayWhenMoving).toBool());
     setDominantHand(settings.value("dominantHand", _dominantHand).toString().toLower());
     setUserHeight(settings.value("userHeight", DEFAULT_AVATAR_HEIGHT).toDouble());
     settings.endGroup();

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -469,16 +469,6 @@ public:
      * @param {boolean} on
      */
     Q_INVOKABLE void setSnapTurn(bool on) { _useSnapTurn = on; }
-    /**jsdoc
-     * @function MyAvatar.getClearOverlayWhenMoving
-     * @returns {boolean} 
-     */
-    Q_INVOKABLE bool getClearOverlayWhenMoving() const { return _clearOverlayWhenMoving; }
-    /**jsdoc
-     * @function MyAvatar.setClearOverlayWhenMoving
-     * @param {boolean} on
-     */
-    Q_INVOKABLE void setClearOverlayWhenMoving(bool on) { _clearOverlayWhenMoving = on; }
 
 
     /**jsdoc
@@ -1495,7 +1485,6 @@ private:
     ThreadSafeValueCache<QUrl> _prefOverrideAnimGraphUrl;
     QUrl _fstAnimGraphOverrideUrl;
     bool _useSnapTurn { true };
-    bool _clearOverlayWhenMoving { true };
     QString _dominantHand { DOMINANT_RIGHT_HAND };
 
     const float ROLL_CONTROL_DEAD_ZONE_DEFAULT = 8.0f; // degrees

--- a/interface/src/ui/OverlayConductor.cpp
+++ b/interface/src/ui/OverlayConductor.cpp
@@ -88,13 +88,10 @@ void OverlayConductor::update(float dt) {
         _hmdMode = false;
     }
 
-    bool isAtRest = updateAvatarIsAtRest();
-    bool isMoving = !isAtRest;
-
     bool shouldRecenter = false;
 
     if (_suppressedByHead) {
-        if (isAtRest) {
+        if (updateAvatarIsAtRest()) {
             _suppressedByHead = false;
             shouldRecenter = true;
         }

--- a/interface/src/ui/OverlayConductor.cpp
+++ b/interface/src/ui/OverlayConductor.cpp
@@ -93,17 +93,6 @@ void OverlayConductor::update(float dt) {
 
     bool shouldRecenter = false;
 
-    if (_flags & SuppressedByMove) {
-        if (!isMoving) {
-            _flags &= ~SuppressedByMove;
-            shouldRecenter = true;
-        }
-    } else {
-        if (myAvatar->getClearOverlayWhenMoving() && isMoving) {
-            _flags |= SuppressedByMove;
-        }
-    }
-
     if (_flags & SuppressedByHead) {
         if (isAtRest) {
             _flags &= ~SuppressedByHead;

--- a/interface/src/ui/OverlayConductor.cpp
+++ b/interface/src/ui/OverlayConductor.cpp
@@ -104,7 +104,7 @@ void OverlayConductor::update(float dt) {
         }
     }
 
-    bool targetVisible = Menu::getInstance()->isOptionChecked(MenuOption::Overlays) && (0 == (_flags & SuppressMask));
+    bool targetVisible = Menu::getInstance()->isOptionChecked(MenuOption::Overlays) && (0 == (_flags & SuppressedByHead));
     if (targetVisible != currentVisible) {
         offscreenUi->setPinned(!targetVisible);
     }

--- a/interface/src/ui/OverlayConductor.cpp
+++ b/interface/src/ui/OverlayConductor.cpp
@@ -93,22 +93,22 @@ void OverlayConductor::update(float dt) {
 
     bool shouldRecenter = false;
 
-    if (_flags & SuppressedByHead) {
+    if (_suppressedByHead) {
         if (isAtRest) {
-            _flags &= ~SuppressedByHead;
+            _suppressedByHead = false;
             shouldRecenter = true;
         }
     } else {
         if (_hmdMode && headOutsideOverlay()) {
-            _flags |= SuppressedByHead;
+            _suppressedByHead = true;
         }
     }
 
-    bool targetVisible = Menu::getInstance()->isOptionChecked(MenuOption::Overlays) && (0 == (_flags & SuppressedByHead));
+    bool targetVisible = Menu::getInstance()->isOptionChecked(MenuOption::Overlays) && !_suppressedByHead;
     if (targetVisible != currentVisible) {
         offscreenUi->setPinned(!targetVisible);
     }
-    if (shouldRecenter && !_flags) {
+    if (shouldRecenter && !_suppressedByHead) {
         centerUI();
     }
 }

--- a/interface/src/ui/OverlayConductor.h
+++ b/interface/src/ui/OverlayConductor.h
@@ -26,12 +26,10 @@ private:
     bool updateAvatarIsAtRest();
 
     enum SupressionFlags {
-        SuppressedByMove = 0x01,
-        SuppressedByHead = 0x02,
-        SuppressMask = 0x03,
+        SuppressedByHead = 0x01
     };
 
-    uint8_t _flags { SuppressedByMove };
+    uint8_t _flags { SuppressedByHead };
     bool _hmdMode { false };
 
     // used by updateAvatarIsAtRest

--- a/interface/src/ui/OverlayConductor.h
+++ b/interface/src/ui/OverlayConductor.h
@@ -29,7 +29,7 @@ private:
         SuppressedByHead = 0x01
     };
 
-    uint8_t _flags { SuppressedByHead };
+    bool _suppressedByHead { false };
     bool _hmdMode { false };
 
     // used by updateAvatarIsAtRest

--- a/interface/src/ui/OverlayConductor.h
+++ b/interface/src/ui/OverlayConductor.h
@@ -25,10 +25,6 @@ private:
     bool headOutsideOverlay() const;
     bool updateAvatarIsAtRest();
 
-    enum SupressionFlags {
-        SuppressedByHead = 0x01
-    };
-
     bool _suppressedByHead { false };
     bool _hmdMode { false };
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -161,12 +161,6 @@ void setupPreferences() {
         preferences->addPreference(new CheckPreference(UI_CATEGORY, "Use reticle cursor instead of arrow", getter, setter));
     }
 
-    {
-        auto getter = [=]()->bool { return myAvatar->getClearOverlayWhenMoving(); };
-        auto setter = [=](bool value) { myAvatar->setClearOverlayWhenMoving(value); };
-        preferences->addPreference(new CheckPreference(UI_CATEGORY, "Clear overlays when moving", getter, setter));
-    }
-
     static const QString VIEW_CATEGORY{ "View" };
     {
         auto getter = [=]()->float { return myAvatar->getRealWorldFieldOfView(); };

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -17,7 +17,6 @@ var SNAPSHOT_DELAY = 500; // 500ms
 var FINISH_SOUND_DELAY = 350;
 var resetOverlays;
 var reticleVisible;
-var clearOverlayWhenMoving;
 
 var buttonName = "SNAP";
 var buttonConnected = false;
@@ -438,11 +437,6 @@ function takeSnapshot() {
     isUploadingPrintableStill = true;
     updatePrintPermissions();
 
-    // Raising the desktop for the share dialog at end will interact badly with clearOverlayWhenMoving.
-    // Turn it off now, before we start futzing with things (and possibly moving).
-    clearOverlayWhenMoving = MyAvatar.getClearOverlayWhenMoving(); // Do not use Settings. MyAvatar keeps a separate copy.
-    MyAvatar.setClearOverlayWhenMoving(false);
-
     // We will record snapshots based on the starting location. That could change, e.g., when recording a .gif.
     // Even the domainID could change (e.g., if the user falls into a teleporter while recording).
     href = location.href;
@@ -544,9 +538,6 @@ function stillSnapshotTaken(pathStillSnapshot, notify) {
     // last element in data array tells dialog whether we can share or not
     Settings.setValue("previousStillSnapPath", pathStillSnapshot);
 
-    if (clearOverlayWhenMoving) {
-        MyAvatar.setClearOverlayWhenMoving(true); // not until after the share dialog
-    }
     HMD.openTablet();
 
     isDomainOpen(domainID, function (canShare) {
@@ -590,9 +581,6 @@ function processingGifStarted(pathStillSnapshot) {
     }
     Settings.setValue("previousStillSnapPath", pathStillSnapshot);
 
-    if (clearOverlayWhenMoving) {
-        MyAvatar.setClearOverlayWhenMoving(true); // not until after the share dialog
-    }
     HMD.openTablet();
     
     isDomainOpen(domainID, function (canShare) {


### PR DESCRIPTION
Implements [MS16257](https://highfidelity.fogbugz.com/f/cases/16257/Remove-the-setting-Settings-General-Clear-Overlays-when-moving).

This fixes recent frustrations our users of Master builds have had because of the implementation of PR #13341. According to @alexiamandeville:
>We see no value, and users are frustrated by it. The option to hide them will persist.