### PR TITLE
Remove the duplicated AccountManager used for android

### DIFF
--- a/android/app/src/main/cpp/native.cpp
+++ b/android/app/src/main/cpp/native.cpp
@@ -228,7 +228,7 @@ Java_io_highfidelity_hifiinterface_fragment_LoginFragment_nativeLogin(JNIEnv *en
     env->ReleaseStringUTFChars(username_, c_username);
     env->ReleaseStringUTFChars(password_, c_password);
 
-    auto accountManager = AndroidHelper::instance().getAccountManager();
+    auto accountManager = DependencyManager::get<AccountManager>();
 
     __loginCompletedListener = QAndroidJniObject(instance);
     __usernameChangedListener = QAndroidJniObject(usernameChangedListener);
@@ -270,18 +270,18 @@ Java_io_highfidelity_hifiinterface_SplashActivity_registerLoadCompleteListener(J
 }
 JNIEXPORT jboolean JNICALL
 Java_io_highfidelity_hifiinterface_MainActivity_nativeIsLoggedIn(JNIEnv *env, jobject instance) {
-    return AndroidHelper::instance().getAccountManager()->isLoggedIn();
+    return DependencyManager::get<AccountManager>()->isLoggedIn();
 }
 
 JNIEXPORT void JNICALL
 Java_io_highfidelity_hifiinterface_MainActivity_nativeLogout(JNIEnv *env, jobject instance) {
-    AndroidHelper::instance().getAccountManager()->logout();
+    DependencyManager::get<AccountManager>()->logout();
 }
 
 JNIEXPORT jstring JNICALL
 Java_io_highfidelity_hifiinterface_MainActivity_nativeGetDisplayName(JNIEnv *env,
                                                                      jobject instance) {
-    QString username = AndroidHelper::instance().getAccountManager()->getAccountInfo().getUsername();
+    QString username = DependencyManager::get<AccountManager>()->getAccountInfo().getUsername();
     return env->NewStringUTF(username.toLatin1().data());
 }
 

--- a/interface/src/AndroidHelper.cpp
+++ b/interface/src/AndroidHelper.cpp
@@ -10,31 +10,11 @@
 //
 #include "AndroidHelper.h"
 #include <QDebug>
-#include <AccountManager.h>
 
 AndroidHelper::AndroidHelper() {
 }
 
 AndroidHelper::~AndroidHelper() {
-    workerThread.quit();
-    workerThread.wait();
-}
-
-void AndroidHelper::init() {
-    workerThread.start();
-    _accountManager = QSharedPointer<AccountManager>(new AccountManager, &QObject::deleteLater);
-    _accountManager->setIsAgent(true);
-    _accountManager->setAuthURL(NetworkingConstants::METAVERSE_SERVER_URL());
-    _accountManager->setSessionID(DependencyManager::get<AccountManager>()->getSessionID());
-    connect(_accountManager.data(), &AccountManager::loginComplete, [](const QUrl& authURL) {
-            DependencyManager::get<AccountManager>()->setAccountInfo(AndroidHelper::instance().getAccountManager()->getAccountInfo());
-            DependencyManager::get<AccountManager>()->setAuthURL(authURL);
-    });
-
-    connect(_accountManager.data(), &AccountManager::logoutComplete, [] () {
-            DependencyManager::get<AccountManager>()->logout();
-    });
-    _accountManager->moveToThread(&workerThread);
 }
 
 void AndroidHelper::requestActivity(const QString &activityName, const bool backToScene) {

--- a/interface/src/AndroidHelper.h
+++ b/interface/src/AndroidHelper.h
@@ -13,8 +13,6 @@
 #define hifi_Android_Helper_h
 
 #include <QObject>
-#include <QThread>
-#include <AccountManager.h>
 
 class AndroidHelper : public QObject {
     Q_OBJECT
@@ -23,7 +21,6 @@ public:
             static AndroidHelper instance;
             return instance;
     }
-    void init();
     void requestActivity(const QString &activityName, const bool backToScene);
     void notifyLoadComplete();
     void notifyEnterForeground();
@@ -31,7 +28,6 @@ public:
 
     void performHapticFeedback(int duration);
 
-    QSharedPointer<AccountManager> getAccountManager() { return _accountManager; }
     AndroidHelper(AndroidHelper const&)  = delete;
     void operator=(AndroidHelper const&) = delete;
 
@@ -49,8 +45,6 @@ signals:
 private:
     AndroidHelper();
     ~AndroidHelper();
-    QSharedPointer<AccountManager> _accountManager;
-    QThread workerThread;
 };
 
 #endif

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2256,7 +2256,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     qCDebug(interfaceapp) << "Metaverse session ID is" << uuidStringWithoutCurlyBraces(accountManager->getSessionID());
 
 #if defined(Q_OS_ANDROID)
-    AndroidHelper::instance().init();
     connect(&AndroidHelper::instance(), &AndroidHelper::enterBackground, this, &Application::enterBackground);
     connect(&AndroidHelper::instance(), &AndroidHelper::enterForeground, this, &Application::enterForeground);
     AndroidHelper::instance().notifyLoadComplete();


### PR DESCRIPTION
In the past the AccountManager object used to work in the Qt main thread, which is stopped when the QtActivity goes to background. The workaround to use the AccountManager in the java side (i.e. the android login) was creating a new AccountManager and synchronize both objects.

This PR undoes the workaround keeping all the java features

Testing plan:
1. Android login should continue working
2. Username and profile picture should continue working
3. Logout should continue working

