### PR TITLE
Re-added mouse sensitivity settings to General Preferences dialog.

### DIFF
--- a/interface/resources/qml/hifi/dialogs/GeneralPreferencesDialog.qml
+++ b/interface/resources/qml/hifi/dialogs/GeneralPreferencesDialog.qml
@@ -17,7 +17,7 @@ PreferencesDialog {
     id: root
     objectName: "GeneralPreferencesDialog"
     title: "General Settings"
-    showCategories: ["User Interface", "HMD", "Snapshots", "Privacy"]
+    showCategories: ["User Interface", "Mouse Sensitivity", "HMD", "Snapshots", "Privacy"]
     property var settings: Settings {
         category: root.objectName
         property alias x: root.x

--- a/interface/resources/qml/hifi/tablet/TabletGeneralPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletGeneralPreferences.qml
@@ -32,6 +32,6 @@ StackView {
     TabletPreferencesDialog {
         id: root
         objectName: "TabletGeneralPreferences"
-        showCategories: ["User Interface", "Mouse Settings", "HMD", "Snapshots", "Privacy"]
+        showCategories: ["User Interface", "Mouse Sensitivity", "HMD", "Snapshots", "Privacy"]
     }
 }

--- a/interface/resources/qml/hifi/tablet/TabletGeneralPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletGeneralPreferences.qml
@@ -32,6 +32,6 @@ StackView {
     TabletPreferencesDialog {
         id: root
         objectName: "TabletGeneralPreferences"
-        showCategories: ["User Interface", "HMD", "Snapshots", "Privacy"]
+        showCategories: ["User Interface", "Mouse Settings", "HMD", "Snapshots", "Privacy"]
     }
 }


### PR DESCRIPTION
**Relevant Manuscript Case:**
https://highfidelity.fogbugz.com/f/cases/16259/Mouse-Sensitivity-is-missing-from-Settings-General