### PR TITLE
ScriptsModel instances should be created & destroyed on the same thread (for ESS)

### DIFF
--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -68,9 +68,6 @@ EntityScriptServer::EntityScriptServer(ReceivedMessage& message) : ThreadedAssig
     DependencyManager::set<AudioInjectorManager>();
 
     DependencyManager::set<ScriptCache>();
-    DependencyManager::set<ScriptEngines>(ScriptEngine::ENTITY_SERVER_SCRIPT);
-
-    DependencyManager::set<EntityScriptServerServices>();
 
 
     // Needed to ensure the creation of the DebugDraw instance on the main thread
@@ -253,6 +250,9 @@ void EntityScriptServer::handleEntityScriptCallMethodPacket(QSharedPointer<Recei
 
 
 void EntityScriptServer::run() {
+    DependencyManager::set<ScriptEngines>(ScriptEngine::ENTITY_SERVER_SCRIPT);
+    DependencyManager::set<EntityScriptServerServices>();
+
     // make sure we request our script once the agent connects to the domain
     auto nodeList = DependencyManager::get<NodeList>();
 


### PR DESCRIPTION
A limitation of QFileSystemWatcher is that it should be destroyed on the same thread that it was created on. This is because it installs a native event filter on the thread's event loop, and removes it upon destruction. Incorrect use results in freed filters still being installed on an event loop; in particular, on Windows, this is a 100% repeatable crash in debug builds.

Possibly related: https://highfidelity.fogbugz.com/f/cases/16124/