### PR TITLE
Particle spreads backwards compatibility

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -2521,6 +2521,13 @@ bool EntityTree::readFromMap(QVariantMap& map) {
             }
         }
 
+        // Zero out the spread values that were fixed in version ParticleEntityFix so they behave the same as before
+        if (contentVersion < (int)EntityVersion::ParticleEntityFix) {
+            properties.setRadiusSpread(0.f);
+            properties.setAlphaSpread(0.f);
+            properties.setColorSpread({0, 0, 0});
+        }
+
         EntityItemPointer entity = addEntity(entityItemID, properties);
         if (!entity) {
             qCDebug(entities) << "adding Entity failed:" << entityItemID << properties.getType();

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -2523,8 +2523,8 @@ bool EntityTree::readFromMap(QVariantMap& map) {
 
         // Zero out the spread values that were fixed in version ParticleEntityFix so they behave the same as before
         if (contentVersion < (int)EntityVersion::ParticleEntityFix) {
-            properties.setRadiusSpread(0.f);
-            properties.setAlphaSpread(0.f);
+            properties.setRadiusSpread(0.0f);
+            properties.setAlphaSpread(0.0f);
             properties.setColorSpread({0, 0, 0});
         }
 


### PR DESCRIPTION
Zero out radiusSpread, alphaSpread, and colorSpread for entity versions before ParticleEntityFix from PR https://github.com/highfidelity/hifi/pull/13382/ which makes these values work as intended, however, we want to maintain the behavior of existing content so we don't want any values previously set there (despite previously doing nothing) to now cause different particle behavior.

Fixes: https://highfidelity.manuscript.com/f/cases/16307/

Test Plan:
-Launch Interface into the sandbox from this PR in desktop mode
-Rez this particle https://hifi-content.s3.amazonaws.com/davidback/particletest90.json
-With this new particle selected, verify in the particle properties tab of Create that the Radius Spread and Alpha Spread values are all 0 and that the red, green, blue for Color Spread are all 0
-Create a new particle from Create and verify the rezzed particle above looks exactly the same as the default particle
-In the particle properties tab for the rezzed particle above, modify Radius Spread and Alpha Spread sliders to their max values (4 and 1 respectively) as well as Color Spread to be 200 for red, green, and blue
-Verify the modified particle is now alternating different colors, different sizes, and different visibilities
-Rez this particle https://hifi-content.s3.amazonaws.com/davidback/particletest91.json
-Verify the newly rezzed particle matches the modified particle behavior above in terms of varying colors, sizes, and visibilities