### PR TITLE
Guard against memory corruption in Space::processResets()

### DIFF
--- a/libraries/workload/src/workload/Space.cpp
+++ b/libraries/workload/src/workload/Space.cpp
@@ -44,6 +44,11 @@ void Space::processResets(const Transaction::Resets& transactions) {
     for (auto& reset : transactions) {
         // Access the true item
         auto proxyID = std::get<0>(reset);
+
+        // Guard against proxyID being past the end of the list.
+        if (proxyID >= _proxies.size() || proxyID >= _owners.size()) {
+            continue;
+        }
         auto& item = _proxies[proxyID];
 
         // Reset the item with a new payload

--- a/libraries/workload/src/workload/Space.cpp
+++ b/libraries/workload/src/workload/Space.cpp
@@ -46,7 +46,7 @@ void Space::processResets(const Transaction::Resets& transactions) {
         auto proxyID = std::get<0>(reset);
 
         // Guard against proxyID being past the end of the list.
-        if (proxyID >= _proxies.size() || proxyID >= _owners.size()) {
+        if (proxyID < 0 || proxyID >= (int32_t)_proxies.size() || proxyID >= (int32_t)_owners.size()) {
             continue;
         }
         auto& item = _proxies[proxyID];


### PR DESCRIPTION
Check the proxyID before reading from the _proxies vector and writing into the _owners vector.