### PR TITLE
Fixing a bug if the last session display plugin is an invalid name, resolve to default

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2719,7 +2719,7 @@ void Application::initializeDisplayPlugins() {
     setDisplayPlugin(defaultDisplayPlugin);
 
     // Now set the desired plugin if it's not the same as the default plugin
-    if (targetDisplayPlugin != defaultDisplayPlugin) {
+    if (!targetDisplayPlugin && (targetDisplayPlugin != defaultDisplayPlugin)) {
         setDisplayPlugin(targetDisplayPlugin);
     }
 


### PR DESCRIPTION
Potentially fixing this bug:
https://highfidelity.fogbugz.com/f/cases/16229/Crash-on-startup-when-firstRun-Setting-is-true-or-not-set-might-be-related-to-Rift-hardware-status

## TEST PLAN ##
Follow the repro in the bug above