### PR TITLE
Fix SpinnerSliderPreference Class, Update Mouse Sensitivity Menu

### DIFF
--- a/interface/resources/qml/dialogs/preferences/SpinnerSliderPreference.qml
+++ b/interface/resources/qml/dialogs/preferences/SpinnerSliderPreference.qml
@@ -56,8 +56,8 @@ Preference {
             id: slider
             value: preference.value
             width: 100
-            minimumValue: MyAvatar.getDomainMinScale()
-            maximumValue: MyAvatar.getDomainMaxScale()
+            minimumValue: preference.min
+            maximumValue: preference.max
             stepSize: preference.step
             onValueChanged: {
                 spinner.realValue = value
@@ -74,8 +74,8 @@ Preference {
             id: spinner
             decimals: preference.decimals
             realValue: preference.value
-            minimumValue: MyAvatar.getDomainMinScale()
-            maximumValue: MyAvatar.getDomainMaxScale()
+            minimumValue: preference.min
+            maximumValue: preference.max
             width: 100
             onValueChanged: {
                 slider.value = realValue;

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -312,7 +312,7 @@ void setupPreferences() {
     {
         auto getter = [=]()->float { return myAvatar->getPitchSpeed(); };
         auto setter = [=](float value) { myAvatar->setPitchSpeed(value); };
-        auto preference = new SpinnerSliderPreference(AVATAR_CAMERA, "Y axis:", getter, setter);
+        auto preference = new SpinnerSliderPreference(AVATAR_CAMERA, "Y input:", getter, setter);
         preference->setMin(1.0f);
         preference->setMax(360.0f);
         preference->setStep(1);
@@ -322,7 +322,7 @@ void setupPreferences() {
     {
         auto getter = [=]()->float { return myAvatar->getYawSpeed(); };
         auto setter = [=](float value) { myAvatar->setYawSpeed(value); };
-        auto preference = new SpinnerSliderPreference(AVATAR_CAMERA, "X axis: ", getter, setter);
+        auto preference = new SpinnerSliderPreference(AVATAR_CAMERA, "X input:", getter, setter);
         preference->setMin(1.0f);
         preference->setMax(360.0f);
         preference->setStep(1);

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -288,7 +288,6 @@ void setupPreferences() {
         preferences->addPreference(new CheckPreference(MOVEMENT, "Flying & jumping", getter, setter));
     }
     {
-        
         auto getter = [=]()->int { return myAvatar->getSnapTurn() ? 0 : 1; };
         auto setter = [=](int value) { myAvatar->setSnapTurn(value == 0); };
         auto preference = new RadioButtonsPreference(MOVEMENT, "Snap turn / Smooth turn", getter, setter);

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -233,6 +233,8 @@ void setupPreferences() {
         auto getter = [=]()->float { return myAvatar->getTargetScale(); };
         auto setter = [=](float value) { myAvatar->setTargetScale(value); };
         auto preference = new SpinnerSliderPreference(AVATAR_TUNING, "Avatar Scale", getter, setter);
+        preference->setMin(0.25);
+        preference->setMax(4);
         preference->setStep(0.05f);
         preference->setDecimals(2);
         preferences->addPreference(preference);
@@ -286,6 +288,7 @@ void setupPreferences() {
         preferences->addPreference(new CheckPreference(MOVEMENT, "Flying & jumping", getter, setter));
     }
     {
+        
         auto getter = [=]()->int { return myAvatar->getSnapTurn() ? 0 : 1; };
         auto setter = [=](int value) { myAvatar->setSnapTurn(value == 0); };
         auto preference = new RadioButtonsPreference(MOVEMENT, "Snap turn / Smooth turn", getter, setter);
@@ -309,17 +312,21 @@ void setupPreferences() {
     {
         auto getter = [=]()->float { return myAvatar->getPitchSpeed(); };
         auto setter = [=](float value) { myAvatar->setPitchSpeed(value); };
-        auto preference = new SpinnerPreference(AVATAR_CAMERA, "Pitch speed (degrees/second)", getter, setter);
+        auto preference = new SpinnerSliderPreference(AVATAR_CAMERA, "Pitch speed (degrees/second)", getter, setter);
         preference->setMin(1.0f);
         preference->setMax(360.0f);
+        preference->setStep(1);
+        preference->setDecimals(1);
         preferences->addPreference(preference);
     }
     {
         auto getter = [=]()->float { return myAvatar->getYawSpeed(); };
         auto setter = [=](float value) { myAvatar->setYawSpeed(value); };
-        auto preference = new SpinnerPreference(AVATAR_CAMERA, "Yaw speed (degrees/second)", getter, setter);
+        auto preference = new SpinnerSliderPreference(AVATAR_CAMERA, "Yaw speed (degrees/second)", getter, setter);
         preference->setMin(1.0f);
         preference->setMax(360.0f);
+        preference->setStep(1);
+        preference->setDecimals(1);
         preferences->addPreference(preference);
     }
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -312,7 +312,7 @@ void setupPreferences() {
     {
         auto getter = [=]()->float { return myAvatar->getPitchSpeed(); };
         auto setter = [=](float value) { myAvatar->setPitchSpeed(value); };
-        auto preference = new SpinnerSliderPreference(AVATAR_CAMERA, "Pitch speed (degrees/second)", getter, setter);
+        auto preference = new SpinnerSliderPreference(AVATAR_CAMERA, "Y axis:", getter, setter);
         preference->setMin(1.0f);
         preference->setMax(360.0f);
         preference->setStep(1);
@@ -322,7 +322,7 @@ void setupPreferences() {
     {
         auto getter = [=]()->float { return myAvatar->getYawSpeed(); };
         auto setter = [=](float value) { myAvatar->setYawSpeed(value); };
-        auto preference = new SpinnerSliderPreference(AVATAR_CAMERA, "Yaw speed (degrees/second)", getter, setter);
+        auto preference = new SpinnerSliderPreference(AVATAR_CAMERA, "X axis: ", getter, setter);
         preference->setMin(1.0f);
         preference->setMax(360.0f);
         preference->setStep(1);


### PR DESCRIPTION
Changed SpinnerSliderPreference.qml to general-case UI element as originally intended, updated PreferencesDialog.cpp's Avatar Scale slider to hard-coded bounds [0.25, 4.0]. Though the Avatar Scale slider will be removed with the inclusion of the Avatar App, so that is the least important part of this PR.