### PR TITLE
Tablet Asset Server dialog was instantiated twice

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6979,7 +6979,9 @@ void Application::showAssetServerWidget(QString filePath) {
             DependencyManager::get<OffscreenUi>()->show(url, "AssetServer", startUpload);
         } else {
             static const QUrl url("hifi/dialogs/TabletAssetServer.qml");
-            tablet->pushOntoStack(url);
+            if (!tablet->isPathLoaded(url)) {
+                tablet->pushOntoStack(url);
+            }
         }
     }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/10501/In-VR-mode-when-dragging-an-asset-onto-the-interface-to-upload-it-to-the-asset-browser-the-upload-is-attempted-twice

Test plan:
- Launch the interface with an HMD
- While still in VR mode, drag a file into the interface to upload it to the asset browser
- On the upload prompt, click OK or CANCEL.
- Make sure when dragging a file into the Interface to upload it, clicking OK or CANCEL will complete the upload process. The upload is not attempted a second time.
