### PR TITLE
Use case-insensitive matching on friends lists in DomainGatekeeper

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -207,7 +207,7 @@ NodePermissions DomainGatekeeper::setPermissionsForUser(bool isLocalUser, QStrin
 #endif
 
             // if this user is a friend of the domain-owner, give them friend's permissions
-            if (_domainOwnerFriends.contains(verifiedUsername)) {
+            if (_domainOwnerFriends.contains(verifiedUsername.toLower())) {
                 userPerms |= _server->_settingsManager.getStandardPermissionsForName(NodePermissions::standardNameFriends);
 #ifdef WANT_DEBUG
                 qDebug() << "|  user-permissions: user is friends with domain-owner, so:" << userPerms;
@@ -993,7 +993,7 @@ void DomainGatekeeper::getDomainOwnerFriendsListJSONCallback(QNetworkReply* requ
         _domainOwnerFriends.clear();
         QJsonArray friends = jsonObject["data"].toObject()["friends"].toArray();
         for (int i = 0; i < friends.size(); i++) {
-            _domainOwnerFriends += friends.at(i).toString();
+            _domainOwnerFriends += friends.at(i).toString().toLower();
         }
     } else {
         qDebug() << "getDomainOwnerFriendsList api call returned:" << QJsonDocument(jsonObject).toJson(QJsonDocument::Compact);

--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -207,7 +207,7 @@ NodePermissions DomainGatekeeper::setPermissionsForUser(bool isLocalUser, QStrin
 #endif
 
             // if this user is a friend of the domain-owner, give them friend's permissions
-            if (_domainOwnerFriends.contains(verifiedUsername.toLower())) {
+            if (_domainOwnerFriends.contains(verifiedUsername)) {
                 userPerms |= _server->_settingsManager.getStandardPermissionsForName(NodePermissions::standardNameFriends);
 #ifdef WANT_DEBUG
                 qDebug() << "|  user-permissions: user is friends with domain-owner, so:" << userPerms;
@@ -412,7 +412,7 @@ SharedNodePointer DomainGatekeeper::processAgentConnectRequest(const NodeConnect
         } else if (verifyUserSignature(username, usernameSignature, nodeConnection.senderSockAddr)) {
             // they sent us a username and the signature verifies it
             getGroupMemberships(username);
-            verifiedUsername = username;
+            verifiedUsername = username.toLower();
         } else {
             // they sent us a username, but it didn't check out
             requestUserPublicKey(username);


### PR DESCRIPTION
The username is stored lower-case; the friends list is supplied mixed-case.

https://highfidelity.manuscript.com/f/cases/15499/
