### PR TITLE
Include inputCalibrationData in InputRecordings

### DIFF
--- a/libraries/controllers/src/controllers/InputRecorder.cpp
+++ b/libraries/controllers/src/controllers/InputRecorder.cpp
@@ -220,6 +220,7 @@ namespace controller {
         _framesRecorded = 0;
         _poseStateList.clear();
         _actionStateList.clear();
+        _inputCalibrationDataList.clear();
     }
 
     QJsonObject InputRecorder::recordDataToJson() {
@@ -278,6 +279,7 @@ namespace controller {
         resetFrame();
         _poseStateList.clear();
         _actionStateList.clear();
+        _inputCalibrationDataList.clear();
         QUrl urlPath(path);
         QString filePath = urlPath.toLocalFile();
         QFileInfo info(filePath);

--- a/libraries/controllers/src/controllers/InputRecorder.h
+++ b/libraries/controllers/src/controllers/InputRecorder.h
@@ -25,7 +25,7 @@ namespace controller {
     public:
         using PoseStates = std::map<QString, Pose>;
         using ActionStates = std::map<QString, float>;
-    
+
         InputRecorder();
         ~InputRecorder();
 
@@ -44,6 +44,7 @@ namespace controller {
         bool isPlayingback() { return (_playback && !_loading); }
         void setActionState(const QString& action, float value);
         void setActionState(const QString& action, const controller::Pose& pose);
+        void setInputCalibrationData(const InputCalibrationData& inputCalibrationData);
         float getActionState(const QString&  action);
         controller::Pose getPoseState(const QString& action);
         QString getSaveDirectory();
@@ -53,13 +54,15 @@ namespace controller {
         bool _recording { false };
         bool _playback { false };
         bool _loading { false };
-        std::vector<PoseStates> _poseStateList = std::vector<PoseStates>();
-        std::vector<ActionStates> _actionStateList = std::vector<ActionStates>();
+        std::vector<PoseStates> _poseStateList;
+        std::vector<ActionStates> _actionStateList;
+        std::vector<InputCalibrationData> _inputCalibrationDataList;
         PoseStates _currentFramePoses;
         ActionStates _currentFrameActions;
-        
+        InputCalibrationData _currentInputCalibrationData;
+
         int _framesRecorded { 0 };
         int _playCount { 0 };
     };
-}    
+}
 #endif

--- a/libraries/controllers/src/controllers/InputRecorder.h
+++ b/libraries/controllers/src/controllers/InputRecorder.h
@@ -49,9 +49,10 @@ namespace controller {
         QString getSaveDirectory();
         void frameTick(const InputCalibrationData& inputCalibrationData);
     private:
-        QJsonObject recordDataToJson();
+        QByteArray recordDataToJson();
 
-        std::mutex _mutex;
+        std::recursive_mutex _mutex;
+        using LockGuard = std::lock_guard<std::recursive_mutex>;
 
         bool _recording { false };
         bool _playback { false };

--- a/libraries/controllers/src/controllers/InputRecorder.h
+++ b/libraries/controllers/src/controllers/InputRecorder.h
@@ -47,7 +47,7 @@ namespace controller {
         float getActionState(const QString&  action);
         controller::Pose getPoseState(const QString& action);
         QString getSaveDirectory();
-        void frameTick();
+        void frameTick(const InputCalibrationData& inputCalibrationData);
     private:
         QJsonObject recordDataToJson();
 

--- a/libraries/controllers/src/controllers/InputRecorder.h
+++ b/libraries/controllers/src/controllers/InputRecorder.h
@@ -44,22 +44,25 @@ namespace controller {
         bool isPlayingback() { return (_playback && !_loading); }
         void setActionState(const QString& action, float value);
         void setActionState(const QString& action, const controller::Pose& pose);
-        void setInputCalibrationData(const InputCalibrationData& inputCalibrationData);
         float getActionState(const QString&  action);
         controller::Pose getPoseState(const QString& action);
         QString getSaveDirectory();
         void frameTick();
     private:
         QJsonObject recordDataToJson();
+
+        std::mutex _mutex;
+
         bool _recording { false };
         bool _playback { false };
         bool _loading { false };
+
         std::vector<PoseStates> _poseStateList;
         std::vector<ActionStates> _actionStateList;
         std::vector<InputCalibrationData> _inputCalibrationDataList;
+
         PoseStates _currentFramePoses;
         ActionStates _currentFrameActions;
-        InputCalibrationData _currentInputCalibrationData;
 
         int _framesRecorded { 0 };
         int _playCount { 0 };

--- a/libraries/controllers/src/controllers/UserInputMapper.cpp
+++ b/libraries/controllers/src/controllers/UserInputMapper.cpp
@@ -303,7 +303,8 @@ void UserInputMapper::update(float deltaTime) {
             emit inputEvent(input.id, value);
         }
     }
-    inputRecorder->frameTick();
+
+    inputRecorder->frameTick(getInputCalibrationData());
 }
 
 Input::NamedVector UserInputMapper::getAvailableInputs(uint16 deviceID) const {

--- a/libraries/controllers/src/controllers/impl/endpoints/ActionEndpoint.cpp
+++ b/libraries/controllers/src/controllers/impl/endpoints/ActionEndpoint.cpp
@@ -17,6 +17,7 @@ using namespace controller;
 
 void ActionEndpoint::apply(float newValue, const Pointer& source) {
     auto userInputMapper = DependencyManager::get<UserInputMapper>();
+    InputRecorder* inputRecorder = InputRecorder::getInstance();
     QString actionName;
     if (inputRecorder->isPlayingback() || inputRecorder->isRecording()) {
         actionName = userInputMapper->getActionName(Action(_input.getChannel()));

--- a/libraries/controllers/src/controllers/impl/endpoints/ActionEndpoint.cpp
+++ b/libraries/controllers/src/controllers/impl/endpoints/ActionEndpoint.cpp
@@ -25,12 +25,17 @@ void ActionEndpoint::apply(float newValue, const Pointer& source) {
             newValue = inputRecorder->getActionState(actionName);
         }
     }
-    
+
     _currentValue += newValue;
     if (_input != Input::INVALID_INPUT) {
         userInputMapper->deltaActionState(Action(_input.getChannel()), newValue);
     }
     inputRecorder->setActionState(actionName, newValue);
+
+    // record the current inputCalibrationData information.
+    if (inputRecorder->isRecording()) {
+        inputRecorder->setInputCalibrationData(userInputMapper->getInputCalibrationData());
+    }
 }
 
 void ActionEndpoint::apply(const Pose& value, const Pointer& source) {
@@ -41,7 +46,7 @@ void ActionEndpoint::apply(const Pose& value, const Pointer& source) {
         QString actionName = userInputMapper->getActionName(Action(_input.getChannel()));
         inputRecorder->setActionState(actionName, _currentPose);
     }
-    
+
     if (!_currentPose.isValid()) {
         return;
     }

--- a/libraries/controllers/src/controllers/impl/endpoints/ActionEndpoint.cpp
+++ b/libraries/controllers/src/controllers/impl/endpoints/ActionEndpoint.cpp
@@ -17,7 +17,6 @@ using namespace controller;
 
 void ActionEndpoint::apply(float newValue, const Pointer& source) {
     auto userInputMapper = DependencyManager::get<UserInputMapper>();
-    InputRecorder* inputRecorder = InputRecorder::getInstance();
     QString actionName;
     if (inputRecorder->isPlayingback() || inputRecorder->isRecording()) {
         actionName = userInputMapper->getActionName(Action(_input.getChannel()));
@@ -31,11 +30,6 @@ void ActionEndpoint::apply(float newValue, const Pointer& source) {
         userInputMapper->deltaActionState(Action(_input.getChannel()), newValue);
     }
     inputRecorder->setActionState(actionName, newValue);
-
-    // record the current inputCalibrationData information.
-    if (inputRecorder->isRecording()) {
-        inputRecorder->setInputCalibrationData(userInputMapper->getInputCalibrationData());
-    }
 }
 
 void ActionEndpoint::apply(const Pose& value, const Pointer& source) {


### PR DESCRIPTION
This is mostly an internal tool, used to record performers wearing Vive trackers for analysis and debugging.
This change includes more detail in the recording, specifically the avatar's current position & orientation.  As well as the current location of the tracked volume in world space, i.e. the sensor to world matrix.  This can help our analysis and machine learning analysis.  Because we can now properly transform the input data into sensor or world space.

It also supports longer recordings which should fix the following issue: https://highfidelity.manuscript.com/f/cases/17464/Input-Recording-is-Corrupted-Empty