### PR TITLE
Fixed Readme instructions on JSDoc

### DIFF
--- a/tools/jsdoc/README.md
+++ b/tools/jsdoc/README.md
@@ -11,7 +11,7 @@ If you would like the extra functionality for gravPrep:
 To generate html documentation for the High Fidelity JavaScript API:
 
 * `cd tools/jsdoc`
-* `jsdoc . -c config.json`
+* `jsdoc root.js -c config.json`
 
 The out folder should contain index.html.
 


### PR DESCRIPTION
Before, there was only one js file in the directory and using . worked fine.  Now that there is another, you just have to specify the root.js hack file to store the comments between different scanned files 