### PR TITLE
Fix blurry tablet if overlay is drawing

### DIFF
--- a/libraries/render-utils/src/RenderCommonTask.cpp
+++ b/libraries/render-utils/src/RenderCommonTask.cpp
@@ -60,7 +60,7 @@ void DrawOverlay3D::run(const RenderContextPointer& renderContext, const Inputs&
         if (_opaquePass) {
             gpu::doInBatch("DrawOverlay3D::run::clear", args->_context, [&](gpu::Batch& batch){
                 batch.enableStereo(false);
-                batch.clearFramebuffer(gpu::Framebuffer::BUFFER_DEPTHSTENCIL, glm::vec4(), 1.f, 0, false);
+                batch.clearFramebuffer(gpu::Framebuffer::BUFFER_DEPTH, glm::vec4(), 1.f, 0, false);
             });
         }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/16386/HMD-Create-Menu-List-Becomes-blurry

Test plan:
- Bring up the tablet.  Go to the list tab.  Click any entity.  The tablet should not become blurry.