### PR TITLE
Fix number of rendering issues with some transparent objects on Mac and AMD GPUs

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendPipeline.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendPipeline.cpp
@@ -48,12 +48,12 @@ void GLBackend::do_setPipeline(const Batch& batch, size_t paramOffset) {
             return;
         }
 
-        // check the program cache
-        // pick the program version 
-        // check the program cache
-        // pick the program version 
+            // check the program cache
+            // pick the program version
+            // check the program cache
+            // pick the program version
 #ifdef GPU_STEREO_CAMERA_BUFFER
-        GLuint glprogram = pipelineObject->_program->getProgram((GLShader::Version) isStereo());
+        GLuint glprogram = pipelineObject->_program->getProgram((GLShader::Version)isStereo());
 #else
         GLuint glprogram = pipelineObject->_program->getProgram();
 #endif
@@ -85,10 +85,11 @@ void GLBackend::do_setPipeline(const Batch& batch, size_t paramOffset) {
             } else {
                 cameraCorrectionBuffer = syncGPUObject(*_pipeline._cameraCorrectionBufferIdentity._buffer);
             }
+            // Invalidate uniform buffer cache slot
+            _uniform._buffers[_pipeline._cameraCorrectionLocation].reset();
             glBindBufferRange(GL_UNIFORM_BUFFER, _pipeline._cameraCorrectionLocation, cameraCorrectionBuffer->_id, 0, sizeof(CameraCorrection));
-
         }
-        (void) CHECK_GL_ERROR();
+        (void)CHECK_GL_ERROR();
         _pipeline._invalidProgram = false;
     }
 }
@@ -97,7 +98,7 @@ void GLBackend::updatePipeline() {
     if (_pipeline._invalidProgram) {
         // doing it here is aproblem for calls to glUniform.... so will do it on assing...
         glUseProgram(_pipeline._program);
-        (void) CHECK_GL_ERROR();
+        (void)CHECK_GL_ERROR();
         _pipeline._invalidProgram = false;
     }
 
@@ -106,12 +107,12 @@ void GLBackend::updatePipeline() {
             // first reset to default what should be
             // the fields which were not to default and are default now
             resetPipelineState(_pipeline._state->_signature);
-            
+
             // Update the signature cache with what's going to be touched
             _pipeline._stateSignatureCache |= _pipeline._state->_signature;
 
             // And perform
-            for (auto command: _pipeline._state->_commands) {
+            for (auto command : _pipeline._state->_commands) {
                 command->run(this);
             }
         } else {
@@ -142,8 +143,8 @@ void GLBackend::releaseUniformBuffer(uint32_t slot) {
     if (buf) {
         auto* object = Backend::getGPUObject<GLBuffer>(*buf);
         if (object) {
-            glBindBufferBase(GL_UNIFORM_BUFFER, slot, 0); // RELEASE
-            (void) CHECK_GL_ERROR();
+            glBindBufferBase(GL_UNIFORM_BUFFER, slot, 0);  // RELEASE
+            (void)CHECK_GL_ERROR();
         }
         buf.reset();
     }
@@ -157,8 +158,9 @@ void GLBackend::resetUniformStage() {
 
 void GLBackend::do_setUniformBuffer(const Batch& batch, size_t paramOffset) {
     GLuint slot = batch._params[paramOffset + 3]._uint;
-    if (slot >(GLuint)MAX_NUM_UNIFORM_BUFFERS) {
-        qCDebug(gpugllogging) << "GLBackend::do_setUniformBuffer: Trying to set a uniform Buffer at slot #" << slot << " which doesn't exist. MaxNumUniformBuffers = " << getMaxNumUniformBuffers();
+    if (slot > (GLuint)MAX_NUM_UNIFORM_BUFFERS) {
+        qCDebug(gpugllogging) << "GLBackend::do_setUniformBuffer: Trying to set a uniform Buffer at slot #" << slot
+                              << " which doesn't exist. MaxNumUniformBuffers = " << getMaxNumUniformBuffers();
         return;
     }
     BufferPointer uniformBuffer = batch._buffers.get(batch._params[paramOffset + 2]._uint);
@@ -169,7 +171,7 @@ void GLBackend::do_setUniformBuffer(const Batch& batch, size_t paramOffset) {
         releaseUniformBuffer(slot);
         return;
     }
-    
+
     // check cache before thinking
     if (_uniform._buffers[slot] == uniformBuffer) {
         return;
@@ -181,7 +183,7 @@ void GLBackend::do_setUniformBuffer(const Batch& batch, size_t paramOffset) {
         glBindBufferRange(GL_UNIFORM_BUFFER, slot, object->_buffer, rangeStart, rangeSize);
 
         _uniform._buffers[slot] = uniformBuffer;
-        (void) CHECK_GL_ERROR();
+        (void)CHECK_GL_ERROR();
     } else {
         releaseUniformBuffer(slot);
         return;
@@ -195,8 +197,8 @@ void GLBackend::releaseResourceTexture(uint32_t slot) {
         if (object) {
             GLuint target = object->_target;
             glActiveTexture(GL_TEXTURE0 + slot);
-            glBindTexture(target, 0); // RELEASE
-            (void) CHECK_GL_ERROR();
+            glBindTexture(target, 0);  // RELEASE
+            (void)CHECK_GL_ERROR();
         }
         tex.reset();
     }
@@ -212,11 +214,11 @@ void GLBackend::resetResourceStage() {
     }
 }
 
-
 void GLBackend::do_setResourceBuffer(const Batch& batch, size_t paramOffset) {
     GLuint slot = batch._params[paramOffset + 1]._uint;
     if (slot >= (GLuint)MAX_NUM_RESOURCE_BUFFERS) {
-        qCDebug(gpugllogging) << "GLBackend::do_setResourceBuffer: Trying to set a resource Buffer at slot #" << slot << " which doesn't exist. MaxNumResourceBuffers = " << getMaxNumResourceBuffers();
+        qCDebug(gpugllogging) << "GLBackend::do_setResourceBuffer: Trying to set a resource Buffer at slot #" << slot
+                              << " which doesn't exist. MaxNumResourceBuffers = " << getMaxNumResourceBuffers();
         return;
     }
 
@@ -237,7 +239,7 @@ void GLBackend::do_setResourceBuffer(const Batch& batch, size_t paramOffset) {
     // If successful bind then cache it
     if (bindResourceBuffer(slot, resourceBuffer)) {
         _resource._buffers[slot] = resourceBuffer;
-    } else { // else clear slot and cache
+    } else {  // else clear slot and cache
         releaseResourceBuffer(slot);
         return;
     }
@@ -245,8 +247,9 @@ void GLBackend::do_setResourceBuffer(const Batch& batch, size_t paramOffset) {
 
 void GLBackend::do_setResourceTexture(const Batch& batch, size_t paramOffset) {
     GLuint slot = batch._params[paramOffset + 1]._uint;
-    if (slot >= (GLuint) MAX_NUM_RESOURCE_TEXTURES) {
-        qCDebug(gpugllogging) << "GLBackend::do_setResourceTexture: Trying to set a resource Texture at slot #" << slot << " which doesn't exist. MaxNumResourceTextures = " << getMaxNumResourceTextures();
+    if (slot >= (GLuint)MAX_NUM_RESOURCE_TEXTURES) {
+        qCDebug(gpugllogging) << "GLBackend::do_setResourceTexture: Trying to set a resource Texture at slot #" << slot
+                              << " which doesn't exist. MaxNumResourceTextures = " << getMaxNumResourceTextures();
         return;
     }
 
@@ -265,11 +268,14 @@ void GLBackend::bindResourceTexture(uint32_t slot, const TexturePointer& resourc
 void GLBackend::do_setResourceFramebufferSwapChainTexture(const Batch& batch, size_t paramOffset) {
     GLuint slot = batch._params[paramOffset + 1]._uint;
     if (slot >= (GLuint)MAX_NUM_RESOURCE_TEXTURES) {
-        qCDebug(gpugllogging) << "GLBackend::do_setResourceFramebufferSwapChainTexture: Trying to set a resource Texture at slot #" << slot << " which doesn't exist. MaxNumResourceTextures = " << getMaxNumResourceTextures();
+        qCDebug(gpugllogging)
+            << "GLBackend::do_setResourceFramebufferSwapChainTexture: Trying to set a resource Texture at slot #" << slot
+            << " which doesn't exist. MaxNumResourceTextures = " << getMaxNumResourceTextures();
         return;
     }
 
-    auto swapChain = std::static_pointer_cast<FramebufferSwapChain>(batch._swapChains.get(batch._params[paramOffset + 0]._uint));
+    auto swapChain =
+        std::static_pointer_cast<FramebufferSwapChain>(batch._swapChains.get(batch._params[paramOffset + 0]._uint));
 
     if (!swapChain) {
         releaseResourceTexture(slot);

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendTransform.cpp
@@ -168,7 +168,9 @@ void GLBackend::TransformStageState::update(size_t commandIndex, const StereoSta
 
 void GLBackend::TransformStageState::bindCurrentCamera(int eye) const {
     if (_currentCameraOffset != INVALID_OFFSET) {
-        glBindBufferRange(GL_UNIFORM_BUFFER, TRANSFORM_CAMERA_SLOT, _cameraBuffer, _currentCameraOffset + eye * _cameraUboSize, sizeof(CameraBufferElement));
+        static_assert(TRANSFORM_CAMERA_SLOT >= MAX_NUM_UNIFORM_BUFFERS, "TransformCamera may overlap pipeline uniform buffer slots. Invalidate uniform buffer slot cache for safety (call _uniform._buffers[TRANSFORM_CAMERA_SLOT].reset()).");
+        glBindBufferRange(GL_UNIFORM_BUFFER, TRANSFORM_CAMERA_SLOT, _cameraBuffer, _currentCameraOffset + eye * _cameraUboSize,
+                          sizeof(CameraBufferElement));
     }
 }
 

--- a/libraries/render-utils/src/DeferredGlobalLight.slh
+++ b/libraries/render-utils/src/DeferredGlobalLight.slh
@@ -198,7 +198,7 @@ vec3 evalGlobalLightingAlphaBlended(mat4 invViewMat, float shadowAttenuation, fl
     vec3 directionalSpecular;
     evalLightingDirectional(directionalDiffuse, directionalSpecular, lightDirection, lightIrradiance, surfaceWS, metallic, fresnel, albedo, shadowAttenuation);
     color += directionalDiffuse;
-    color += (ambientSpecular + directionalSpecular) / opacity;
+    color += evalSpecularWithOpacity(ambientSpecular + directionalSpecular, opacity);
 
     return color;
 }
@@ -231,7 +231,7 @@ vec3 evalGlobalLightingAlphaBlendedWithHaze(
     vec3 directionalSpecular;
     evalLightingDirectional(directionalDiffuse, directionalSpecular, lightDirection, lightIrradiance, surfaceWS, metallic, fresnel, albedo, shadowAttenuation);
     color += directionalDiffuse;
-    color += (ambientSpecular + directionalSpecular) / opacity;
+    color += evalSpecularWithOpacity(ambientSpecular + directionalSpecular, opacity);
 
     // Haze
     if ((isHazeEnabled() > 0.0) && (hazeParams.hazeMode & HAZE_MODE_IS_ACTIVE) == HAZE_MODE_IS_ACTIVE) {
@@ -269,7 +269,7 @@ vec3 evalGlobalLightingAlphaBlendedWithHaze(
     evalLightingDirectional(directionalDiffuse, directionalSpecular, lightDirection, lightIrradiance, surface, metallic, fresnel, albedo, shadowAttenuation);
 
     color += ambientDiffuse + directionalDiffuse;
-    color += (ambientSpecular + directionalSpecular) / opacity;
+    color += evalSpecularWithOpacity(ambientSpecular + directionalSpecular, opacity);
 
     // Haze
     if ((isHazeEnabled() > 0.0) && (hazeParams.hazeMode & HAZE_MODE_IS_ACTIVE) == HAZE_MODE_IS_ACTIVE) {

--- a/libraries/render-utils/src/ForwardGlobalLight.slh
+++ b/libraries/render-utils/src/ForwardGlobalLight.slh
@@ -197,7 +197,7 @@ vec3 evalGlobalLightingAlphaBlended(mat4 invViewMat, float shadowAttenuation, fl
     vec3 directionalSpecular;
     evalLightingDirectional(directionalDiffuse, directionalSpecular, lightDirection, lightIrradiance, surfaceWS, metallic, fresnel, albedo, shadowAttenuation);
     color += directionalDiffuse;
-    color += (ambientSpecular + directionalSpecular) / opacity;
+    color += evalSpecularWithOpacity(ambientSpecular + directionalSpecular, opacity);
 
     return color;
 }
@@ -223,7 +223,7 @@ vec3 evalGlobalLightingAlphaBlendedWithHaze(
     vec3 directionalSpecular;
     evalLightingDirectional(directionalDiffuse, directionalSpecular, lightDirection, lightIrradiance, surfaceWS, metallic, fresnel, albedo, shadowAttenuation);
     color += directionalDiffuse;
-    color += (ambientSpecular + directionalSpecular) / opacity;
+    color += evalSpecularWithOpacity(ambientSpecular + directionalSpecular, opacity);
 
     // Haze
     // FIXME - temporarily removed until we support it for forward...

--- a/libraries/render-utils/src/LightLocal.slh
+++ b/libraries/render-utils/src/LightLocal.slh
@@ -143,6 +143,6 @@ vec4 evalLocalLighting(ivec3 cluster, int numLights, vec3 fragWorldPos, SurfaceD
     fragSpecular *= isSpecularEnabled();
 
     fragColor.rgb += fragDiffuse;
-    fragColor.rgb += fragSpecular / opacity;
+    fragColor.rgb += evalSpecularWithOpacity(fragSpecular, opacity);
     return fragColor;
 }

--- a/libraries/render-utils/src/LightingModel.slh
+++ b/libraries/render-utils/src/LightingModel.slh
@@ -314,6 +314,9 @@ void evalFragShadingGloss(out vec3 diffuse, out vec3 specular,
     specular = shading.xyz;
 }
 
+vec3 evalSpecularWithOpacity(vec3 specular, float opacity) {
+    return specular / max(opacity, 1e-6);
+}
 
 <@if not GETFRESNEL0@>
 <@def GETFRESNEL0@>

--- a/libraries/render-utils/src/LightingModel.slh
+++ b/libraries/render-utils/src/LightingModel.slh
@@ -315,7 +315,7 @@ void evalFragShadingGloss(out vec3 diffuse, out vec3 specular,
 }
 
 vec3 evalSpecularWithOpacity(vec3 specular, float opacity) {
-    return specular / max(opacity, 1e-6);
+    return specular / opacity;
 }
 
 <@if not GETFRESNEL0@>

--- a/libraries/render-utils/src/MaterialTextures.slh
+++ b/libraries/render-utils/src/MaterialTextures.slh
@@ -267,7 +267,7 @@ vec3 fetchLightmapMap(vec2 uv) {
 
 <@func discardTransparent(opacity)@>
 {
-    if (<$opacity$> < 1.0) {
+    if (<$opacity$> < 1e-6) {
         discard;
     }
 }

--- a/libraries/render-utils/src/forward_model_translucent.slf
+++ b/libraries/render-utils/src/forward_model_translucent.slf
@@ -41,6 +41,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _alpha;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -44,6 +44,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _alpha;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent_fade.slf
+++ b/libraries/render-utils/src/model_translucent_fade.slf
@@ -46,6 +46,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _alpha;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent_normal_map.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map.slf
@@ -45,6 +45,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _alpha;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map_fade.slf
@@ -54,6 +54,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _alpha;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent_unlit.slf
+++ b/libraries/render-utils/src/model_translucent_unlit.slf
@@ -31,6 +31,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _alpha;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent_unlit_fade.slf
+++ b/libraries/render-utils/src/model_translucent_unlit_fade.slf
@@ -41,6 +41,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _alpha;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;


### PR DESCRIPTION
This PR fixes a number of rendering bugs with transparent objects on Mac which could also potentially happen on PC with AMD GPU.
- [bug #16426](https://highfidelity.fogbugz.com/f/cases/16426/Mac-Fully-transparent-pixels-from-a-transparent-part-are-rendered-black)
- [bug #9494](https://highfidelity.fogbugz.com/f/cases/9494/Mac-Skybox-does-not-load-in-material-render-testing)
- [bug #15516](https://highfidelity.fogbugz.com/f/cases/15516/MAC-Lighting-on-Transparent-Object-fails-to-produce-the-expected-results)
- [bug #15506](https://highfidelity.fogbugz.com/f/cases/15506/Mac-Running-the-opacity-test-the-Hifi-bots-lost-all-textures-when-transparent)
- [bug #15376](https://highfidelity.fogbugz.com/f/cases/15376/Mac-Material-Entities-test-did-not-render-correctly-on-Mac-Step-14-Debug-Occlusion)
- [bug #16014](https://highfidelity.fogbugz.com/f/cases/16014/Mac-Model-Overlays-render-all-black) 

Potential fixes on windows AMD (not sure but should be checked if this is the case):
- [bug #15462](https://highfidelity.fogbugz.com/f/cases/15462/Highlight-Coverage-rendering-test-returns-bad-results-for-AMD-graphic-cards), [#14389](https://highfidelity.fogbugz.com/f/cases/14389/Highlight-broken-on-AMD) and [#15434](https://highfidelity.fogbugz.com/f/cases/15434/Bloom-Rendering-effect-on-AMD-card-s-doesn-t-work)

# TEST PLAN
Test on Mac and on PC with AMD GPU.
Go to tutorial. Check that all teleport portals render correctly without any black parts with correct lighting.
Should also refer to the various bug descriptions especially reproduction steps.
Also run the [render/material/opacity ](https://github.com/highfidelity/hifi_tests/tree/master/tests/engine/render/material/opacity)test.