### PR TITLE
Fix avatar become more and more slanted over time while in HMD mode

### DIFF
--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -269,7 +269,8 @@ void CharacterController::playerStep(btCollisionWorld* collisionWorld, btScalar 
         }
         btQuaternion deltaRot = desiredRot * startRot.inverse();
         float angularSpeed = deltaRot.getAngle() / _followTimeRemaining;
-        btQuaternion angularDisplacement = btQuaternion(deltaRot.getAxis(), angularSpeed * dt);
+        glm::vec3 rotationAxis = glm::normalize(glm::axis(bulletToGLM(deltaRot)));  // deltaRot.getAxis() is inaccurate
+        btQuaternion angularDisplacement = btQuaternion(glmToBullet(rotationAxis), angularSpeed * dt);
         btQuaternion endRot = angularDisplacement * startRot;
 
         // in order to accumulate displacement of avatar position, we need to take _shapeLocalOffset into account.


### PR DESCRIPTION
This PR fix the issue that appears when the avatar's capsule become slanted over time while moving around the domain in HMD mode. 
The function btQuaternium::getAxis() is returning an inaccurate result (non vertical) that gets accumulated over time.
https://highfidelity.manuscript.com/f/cases/10251/users-in-VR-mode-slowly-become-more-and-more-slanted-over-time