### PR TITLE
Fix Bloom on Mac and hopefully Windows AMD (bug #15434)

### DIFF
--- a/libraries/render-utils/src/BloomApply.shared.slh
+++ b/libraries/render-utils/src/BloomApply.shared.slh
@@ -1,0 +1,16 @@
+// glsl / C++ compatible source as interface for BloomApply
+#ifdef __cplusplus
+#   define BA_VEC3 glm::vec3
+#else
+#   define BA_VEC3 vec3
+#endif
+
+struct Parameters
+{
+    BA_VEC3 _intensities;
+};
+
+    // <@if 1@>
+    // Trigger Scribe include 
+    // <@endif@> <!def that !> 
+//

--- a/libraries/render-utils/src/BloomApply.slf
+++ b/libraries/render-utils/src/BloomApply.slf
@@ -9,11 +9,15 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+<@include BloomApply.shared.slh@>
 
 uniform sampler2D blurMap0;
 uniform sampler2D blurMap1;
 uniform sampler2D blurMap2;
-uniform vec3 intensity;
+
+layout(std140) uniform parametersBuffer {
+    Parameters parameters;
+};
 
 in vec2 varTexCoord0;
 out vec4 outFragColor;
@@ -23,5 +27,5 @@ void main(void) {
     vec4 blur1 = texture(blurMap1, varTexCoord0);
     vec4 blur2 = texture(blurMap2, varTexCoord0);
 
-    outFragColor = vec4(blur0.rgb*intensity.x + blur1.rgb*intensity.y + blur2.rgb*intensity.z, 1.0f);
+    outFragColor = vec4(blur0.rgb*parameters._intensities.x + blur1.rgb*parameters._intensities.y + blur2.rgb*parameters._intensities.z, 1.0f);
 }

--- a/libraries/render-utils/src/BloomEffect.cpp
+++ b/libraries/render-utils/src/BloomEffect.cpp
@@ -98,14 +98,19 @@ void BloomThreshold::run(const render::RenderContextPointer& renderContext, cons
     outputs = _outputBuffer;
 }
 
-BloomApply::BloomApply() : _intensities{ 1.0f, 1.0f, 1.0f } {
+BloomApply::BloomApply() {
 
 }
 
 void BloomApply::configure(const Config& config) {
-	_intensities.x = config.intensity / 3.0f;
-	_intensities.y = _intensities.x;
-	_intensities.z = _intensities.x;
+    const auto newIntensity = config.intensity / 3.0f;
+
+    if (_parameters.get()._intensities.x != newIntensity) {
+        auto& parameters = _parameters.edit();
+        parameters._intensities.x = newIntensity;
+        parameters._intensities.y = newIntensity;
+        parameters._intensities.z = newIntensity;
+    }
 }
 
 void BloomApply::run(const render::RenderContextPointer& renderContext, const Inputs& inputs) {
@@ -116,7 +121,7 @@ void BloomApply::run(const render::RenderContextPointer& renderContext, const In
     static const auto BLUR0_SLOT = 0;
     static const auto BLUR1_SLOT = 1;
     static const auto BLUR2_SLOT = 2;
-    static const auto INTENSITY_SLOT = 3;
+    static const auto PARAMETERS_SLOT = 0;
 
     if (!_pipeline) {
         auto vs = gpu::StandardShaderLib::getDrawTransformUnitQuadVS();
@@ -127,7 +132,7 @@ void BloomApply::run(const render::RenderContextPointer& renderContext, const In
         slotBindings.insert(gpu::Shader::Binding("blurMap0", BLUR0_SLOT));
         slotBindings.insert(gpu::Shader::Binding("blurMap1", BLUR1_SLOT));
         slotBindings.insert(gpu::Shader::Binding("blurMap2", BLUR2_SLOT));
-        slotBindings.insert(gpu::Shader::Binding("intensity", INTENSITY_SLOT));
+        slotBindings.insert(gpu::Shader::Binding("parametersBuffer", PARAMETERS_SLOT));
         gpu::Shader::makeProgram(*program, slotBindings);
 
         gpu::StatePointer state = gpu::StatePointer(new gpu::State());
@@ -156,7 +161,7 @@ void BloomApply::run(const render::RenderContextPointer& renderContext, const In
         batch.setResourceTexture(BLUR0_SLOT, blur0FB->getRenderBuffer(0));
         batch.setResourceTexture(BLUR1_SLOT, blur1FB->getRenderBuffer(0));
         batch.setResourceTexture(BLUR2_SLOT, blur2FB->getRenderBuffer(0));
-		batch._glUniform3f(INTENSITY_SLOT, _intensities.x, _intensities.y, _intensities.z);
+		batch.setUniformBuffer(PARAMETERS_SLOT, _parameters);
         batch.draw(gpu::TRIANGLE_STRIP, 4);
     });
 }

--- a/libraries/render-utils/src/BloomEffect.h
+++ b/libraries/render-utils/src/BloomEffect.h
@@ -61,10 +61,11 @@ public:
 
 private:
 
+#include "BloomThreshold.shared.slh"
+
     gpu::FramebufferPointer _outputBuffer;
     gpu::PipelinePointer _pipeline;
-    float _threshold;
-    unsigned int _downsamplingFactor;
+    gpu::StructBuffer<Parameters> _parameters;
 };
 
 

--- a/libraries/render-utils/src/BloomEffect.h
+++ b/libraries/render-utils/src/BloomEffect.h
@@ -96,8 +96,10 @@ public:
 
 private:
 
+#include "BloomApply.shared.slh"
+
     gpu::PipelinePointer _pipeline;
-	glm::vec3 _intensities;
+    gpu::StructBuffer<Parameters> _parameters;
 };
 
 class BloomDraw {

--- a/libraries/render-utils/src/BloomThreshold.shared.slh
+++ b/libraries/render-utils/src/BloomThreshold.shared.slh
@@ -1,4 +1,4 @@
-// glsl / C++ compatible source as interface for FadeEffect
+// glsl / C++ compatible source as interface for BloomThreshold
 #ifdef __cplusplus
 #   define BT_VEC2 glm::vec2
 #else

--- a/libraries/render-utils/src/BloomThreshold.shared.slh
+++ b/libraries/render-utils/src/BloomThreshold.shared.slh
@@ -1,0 +1,18 @@
+// glsl / C++ compatible source as interface for FadeEffect
+#ifdef __cplusplus
+#   define BT_VEC2 glm::vec2
+#else
+#   define BT_VEC2 vec2
+#endif
+
+struct Parameters
+{
+    BT_VEC2 _deltaUV;
+	float _threshold;
+    int _sampleCount;
+};
+
+    // <@if 1@>
+    // Trigger Scribe include 
+    // <@endif@> <!def that !> 
+//

--- a/libraries/render-utils/src/BloomThreshold.slf
+++ b/libraries/render-utils/src/BloomThreshold.slf
@@ -9,37 +9,35 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
+<@include BloomThreshold.shared.slh@>
 
 uniform sampler2D colorMap;
-uniform float threshold;
+layout(std140) uniform parametersBuffer {
+    Parameters parameters;
+};
 
 in vec2 varTexCoord0;
 out vec4 outFragColor;
 
-#define DOWNSAMPLING_FACTOR     4
-#define SAMPLE_COUNT            (DOWNSAMPLING_FACTOR/2)
-
 void main(void) {
-    vec2 deltaX = dFdx(varTexCoord0) / SAMPLE_COUNT;
-    vec2 deltaY = dFdy(varTexCoord0) / SAMPLE_COUNT;
     vec2 startUv = varTexCoord0;
     vec4 maskedColor = vec4(0,0,0,0);
 
-    for (int y=0 ; y<SAMPLE_COUNT ; y++) {
+    for (int y=0 ; y<parameters._sampleCount ; y++) {
         vec2 uv = startUv;
 
-        for (int x=0 ; x<SAMPLE_COUNT ; x++) {
+        for (int x=0 ; x<parameters._sampleCount ; x++) {
             vec4 color = texture(colorMap, uv);
             float luminance = (color.r+color.g+color.b) / 3.0;
-            float mask = clamp((luminance-threshold)*0.25, 0, 1);
+            float mask = clamp((luminance-parameters._threshold)*0.25, 0, 1);
 
             color *= mask;
             maskedColor += color;
-            uv += deltaX;
+            uv.x += parameters._deltaUV.x;
         }
 
-        startUv += deltaY;
+        startUv.y += parameters._deltaUV.y;
     }
-    maskedColor /= SAMPLE_COUNT*SAMPLE_COUNT;
+    maskedColor /= parameters._sampleCount * parameters._sampleCount;
     outFragColor = vec4(maskedColor.rgb, 1.0);
 }

--- a/libraries/render-utils/src/HighlightEffect.h
+++ b/libraries/render-utils/src/HighlightEffect.h
@@ -127,6 +127,7 @@ protected:
     render::ShapePlumberPointer _shapePlumber;
     HighlightSharedParametersPointer _sharedParameters;
     gpu::BufferPointer _boundsBuffer;
+    gpu::StructBuffer<glm::vec2> _outlineWidth;
 
     static gpu::PipelinePointer _stencilMaskPipeline;
     static gpu::PipelinePointer _stencilMaskFillPipeline;

--- a/libraries/render-utils/src/Highlight_aabox.slv
+++ b/libraries/render-utils/src/Highlight_aabox.slv
@@ -40,7 +40,9 @@ ItemBound getItemBound(int i) {
 }
 #endif
 
-uniform vec2 outlineWidth;
+uniform parametersBuffer {
+    vec2 outlineWidth;
+};
 
 void main(void) {
     const vec3 UNIT_BOX_VERTICES[8] = vec3[8](


### PR DESCRIPTION
This PR fixes the **bloom** not showing on Mac, as described in [bug #15434](https://highfidelity.fogbugz.com/f/cases/15434/Bloom-Rendering-effect-on-AMD-card-s-doesn-t-work). Hopefully it should address the same issue on Windows with AMD GPU.

There is also a potential fix for **highlight** issues on Windows AMD described in bugs [#14389](https://highfidelity.fogbugz.com/f/cases/14389/Highlight-broken-on-AMD) and [#15462](https://highfidelity.fogbugz.com/f/cases/15462/Highlight-Coverage-rendering-test-returns-bad-results-for-AMD-graphic-cards). As I don't have a Windows PC with AMD GPU I cannot be totally affirmative that this PR will fix this issues but the fixes will definitely make things more robust.

# TEST PLAN
## Bloom
Run the tests/render/engine/effect/bloom test on both Mac and PC.
## Highlight
If the following tests fail, this shouldn't invalidate this PR:

Run the tests/render/engine/effect/highlight test on both Mac and PC.
Goto tutorial and verify that hovering highlight effect is working correctly (see [bug #14389](https://highfidelity.fogbugz.com/f/cases/14389/Highlight-broken-on-AMD))