### PR TITLE
Fix AddressManager copyAddress/copyPath functionality

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1669,8 +1669,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         return qApp->getMyAvatar()->getSnapTurn() ? 1 : 0;
     });
     _applicationStateDevice->setInputVariant(STATE_ADVANCED_MOVEMENT_CONTROLS, []() -> float {
-        auto isAdvanced = qApp->getMyAvatar()->useAdvancedMovementControls();
-        return isAdvanced ? 1 : 0;
+        return qApp->getMyAvatar()->useAdvancedMovementControls() ? 1 : 0;
     });
 
     _applicationStateDevice->setInputVariant(STATE_GROUNDED, []() -> float {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -8306,23 +8306,14 @@ void Application::saveNextPhysicsStats(QString filename) {
     _physicsEngine->saveNextPhysicsStats(filename);
 }
 
-void Application::copyAddress() {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "copyAddress");
+void Application::copyToClipboard(const QString& text) {
+    if (QThread::currentThread() != qApp->thread()) {
+        QMetaObject::invokeMethod(this, "copyToClipboard");
         return;
     }
 
     // assume that the address is being copied because the user wants a shareable address
-    QApplication::clipboard()->setText(QString("copyAddress worked!"));
-}
-
-void Application::copyPath() {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "copyPath");
-        return;
-    }
-
-    QApplication::clipboard()->setText(QString("copyPath worked!"));
+    QApplication::clipboard()->setText(text);
 }
 
 #if defined(Q_OS_ANDROID)

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -30,6 +30,7 @@
 #include <QtCore/QFileSelector>
 #include <QtConcurrent/QtConcurrentRun>
 
+#include <QtGui/QClipboard>
 #include <QtGui/QScreen>
 #include <QtGui/QWindow>
 #include <QtGui/QDesktopServices>
@@ -1668,7 +1669,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         return qApp->getMyAvatar()->getSnapTurn() ? 1 : 0;
     });
     _applicationStateDevice->setInputVariant(STATE_ADVANCED_MOVEMENT_CONTROLS, []() -> float {
-        return qApp->getMyAvatar()->useAdvancedMovementControls() ? 1 : 0;
+        auto isAdvanced = qApp->getMyAvatar()->useAdvancedMovementControls();
+        return isAdvanced ? 1 : 0;
     });
 
     _applicationStateDevice->setInputVariant(STATE_GROUNDED, []() -> float {
@@ -8302,6 +8304,25 @@ void Application::setAvatarOverrideUrl(const QUrl& url, bool save) {
 
 void Application::saveNextPhysicsStats(QString filename) {
     _physicsEngine->saveNextPhysicsStats(filename);
+}
+
+void Application::copyAddress() {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "copyAddress");
+        return;
+    }
+
+    // assume that the address is being copied because the user wants a shareable address
+    QApplication::clipboard()->setText(QString("copyAddress worked!"));
+}
+
+void Application::copyPath() {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "copyPath");
+        return;
+    }
+
+    QApplication::clipboard()->setText(QString("copyPath worked!"));
 }
 
 #if defined(Q_OS_ANDROID)

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -310,6 +310,8 @@ public:
     void loadAvatarScripts(const QVector<QString>& urls);
     void unloadAvatarScripts();
 
+    Q_INVOKABLE void copyToClipboard(const QString& text);
+
 #if defined(Q_OS_ANDROID)
     void enterBackground();
     void enterForeground();
@@ -367,8 +369,6 @@ public slots:
 
     void resetSensors(bool andReload = false);
     void setActiveFaceTracker() const;
-
-    Q_INVOKABLE void copyToClipboard(const QString& text);
 
 #if (PR_BUILD || DEV_BUILD)
     void sendWrongProtocolVersionsSignature(bool checked) { ::sendWrongProtocolVersionsSignature(checked); }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -368,6 +368,9 @@ public slots:
     void resetSensors(bool andReload = false);
     void setActiveFaceTracker() const;
 
+    void copyAddress();
+    void copyPath();
+
 #if (PR_BUILD || DEV_BUILD)
     void sendWrongProtocolVersionsSignature(bool checked) { ::sendWrongProtocolVersionsSignature(checked); }
 #endif

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -368,8 +368,7 @@ public slots:
     void resetSensors(bool andReload = false);
     void setActiveFaceTracker() const;
 
-    void copyAddress();
-    void copyPath();
+    Q_INVOKABLE void copyToClipboard(const QString& text);
 
 #if (PR_BUILD || DEV_BUILD)
     void sendWrongProtocolVersionsSignature(bool checked) { ::sendWrongProtocolVersionsSignature(checked); }

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -268,12 +268,13 @@ Menu::Menu() {
     locationBookmarks->setupMenus(this, navigateMenu);
 
     // Navigate > Copy Address
+    auto addressManager = DependencyManager::get<AddressManager>();
     addActionToQMenuAndActionHash(navigateMenu, MenuOption::CopyAddress, 0,
-        qApp, SLOT(copyAddress()));
+        addressManager.data(), SLOT(copyAddress()));
 
     // Navigate > Copy Path
     addActionToQMenuAndActionHash(navigateMenu, MenuOption::CopyPath, 0,
-        qApp, SLOT(copyPath()));
+        addressManager.data(), SLOT(copyPath()));
 
 
     // Settings menu ----------------------------------

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -268,13 +268,12 @@ Menu::Menu() {
     locationBookmarks->setupMenus(this, navigateMenu);
 
     // Navigate > Copy Address
-    auto addressManager = DependencyManager::get<AddressManager>();
     addActionToQMenuAndActionHash(navigateMenu, MenuOption::CopyAddress, 0,
-        addressManager.data(), SLOT(copyAddress()));
+        qApp, SLOT(copyAddress()));
 
     // Navigate > Copy Path
     addActionToQMenuAndActionHash(navigateMenu, MenuOption::CopyPath, 0,
-        addressManager.data(), SLOT(copyPath()));
+        qApp, SLOT(copyPath()));
 
 
     // Settings menu ----------------------------------

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -852,17 +852,16 @@ void AddressManager::refreshPreviousLookup() {
 
 void AddressManager::copyAddress() {
     if (QThread::currentThread() != qApp->thread()) {
-        QMetaObject::invokeMethod(this, "copyAddress");
+        QMetaObject::invokeMethod(qApp, "copyToClipboard", Q_ARG(QString, currentShareableAddress().toString()));
         return;
     }
-
     // assume that the address is being copied because the user wants a shareable address
     QGuiApplication::clipboard()->setText(currentShareableAddress().toString());
 }
 
 void AddressManager::copyPath() {
     if (QThread::currentThread() != qApp->thread()) {
-        QMetaObject::invokeMethod(this, "copyPath");
+        QMetaObject::invokeMethod(qApp, "copyToClipboard", Q_ARG(QString, currentPath()));
         return;
     }
 


### PR DESCRIPTION
- Fix for MS[#16444](https://highfidelity.manuscript.com/f/cases/16444/)

**Test Plan**
For copying address in using the menu:
- Launch Interface (in Desktop Mode)
- Go to any domain
- In menu, click `Navigate > Copy Address To Clipboard`
- Paste copied address somewhere (should not crash)
- Go to another, different domain
- In menu, click `Navigate > Copy Address To Clipboard`
- Paste copied address somewhere (should not crash and should be different from previously pasted result)

For copying path in using the menu:
- Launch Interface (in Desktop Mode)
- Go to any domain
- In menu, click `Navigate > Copy Path To Clipboard`
- Paste copied path somewhere (should not crash)
- Move around in the domain
- In menu, click `Navigate > Copy Path To Clipboard`
- Paste copied path somewhere (should not crash and should be different from previously pasted result)

For `location.copyAddress()`:
- Launch Interface (in Desktop Mode)
- Enable developer menus by clicking `Settings > Developer Menu`
- Open Console in `Developer > Console...`
- Go to any domain
- In Console, type `location.copyAddress()`
- Paste copied address somewhere (should not crash)
- Go to another, different domain
- In Console, type `location.copyAddress()`
- Paste copied address somewhere (should not crash and should be different from previously pasted result)

For `location.copyPath()`:
- Launch Interface (in Desktop Mode)
- Enable developer menus by clicking `Settings > Developer Menu`
- Open Console in `Developer > Console...`
- Go to any domain
- In menu, click `location.copyPath()`
- Paste copied path somewhere (should not crash)
- Move around in the domain
- In menu, click `location.copyPath()`
- Paste copied path somewhere (should not crash and should be different from previously pasted result)