### PR TITLE
Only clamp edit handles in HMD when outside bounding box

### DIFF
--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1186,10 +1186,17 @@ SelectionDisplay = (function() {
             var localRotationZ = Quat.fromPitchYawRollDegrees(rotationDegrees, 0, 0);
             var rotationZ = Quat.multiply(rotation, localRotationZ);
             worldRotationZ = rotationZ;
+            
+            var selectionBoxGeometry = {
+                position: position,
+                rotation: rotation,
+                dimensions: dimensions
+            };
+            var isCameraInsideBox = isPointInsideBox(Camera.position, selectionBoxGeometry);
 
-            // in HMD we clamp the overlays to the bounding box for now so lasers can hit them
+            // in HMD if outside the bounding box clamp the overlays to the bounding box for now so lasers can hit them
             var maxHandleDimension = 0;
-            if (HMD.active) {
+            if (HMD.active && !isCameraInsideBox) {
                 maxHandleDimension = Math.max(dimensions.x, dimensions.y, dimensions.z);
             }
 
@@ -1438,12 +1445,6 @@ SelectionDisplay = (function() {
             var inModeRotate = isActiveTool(handleRotatePitchRing) || 
                                isActiveTool(handleRotateYawRing) || 
                                isActiveTool(handleRotateRollRing);
-            var selectionBoxGeometry = {
-                position: position,
-                rotation: rotation,
-                dimensions: dimensions
-            };
-            var isCameraInsideBox = isPointInsideBox(Camera.position, selectionBoxGeometry);
             selectionBoxGeometry.visible = !inModeRotate && !isCameraInsideBox;
             Overlays.editOverlay(selectionBox, selectionBoxGeometry);
 


### PR DESCRIPTION
Previously we had added a rule where in HMD the edit handles should not position themselves to be inside of the entity's bounding box and become untriggerable with lasers, and they should thus use at least the bounding box dimensions. However, if you are inside the bounding box of the entity we can allow the edit handles to size/position themselves normally.

Fixes: https://highfidelity.manuscript.com/f/cases/edit/16569

Test Plan:
-Enter Interface in HMD mode
-Create or find a very huge entity that you can stand inside of and select it
-When inside the huge entity, verify that the edit handles are sized/positioned appropriately and as expected for the approximate distance from the camera to the center of the entity (or basically that they sized/positioned the same as in 1st person in desktop mode here)
-Move around while inside the huge entity and verify the edit handles continue to size/position appropriately relative to camera
-Move so that you are outside the bounding box of the huge entity and verify the edit handles are now clamping to be at least sized/positioned to the bounding box
-Enter desktop mode and verify size/position of the edit handles uses the same relative to camera rules whether inside or outside of an entity