### PR TITLE
clean up tablet material entities  and don't display them in create menu

### DIFF
--- a/scripts/system/controllers/controllerModules/inEditMode.js
+++ b/scripts/system/controllers/controllerModules/inEditMode.js
@@ -10,7 +10,7 @@
 /* global Script, Controller, RIGHT_HAND, LEFT_HAND, enableDispatcherModule, disableDispatcherModule, makeRunningValues,
    Messages, makeDispatcherModuleParameters, HMD, getGrabPointSphereOffset, COLORS_GRAB_SEARCHING_HALF_SQUEEZE,
    COLORS_GRAB_SEARCHING_FULL_SQUEEZE, COLORS_GRAB_DISTANCE_HOLD, DEFAULT_SEARCH_SPHERE_DISTANCE, TRIGGER_ON_VALUE,
-   getEnabledModuleByName, PICK_MAX_DISTANCE, isInEditMode, Picks, makeLaserParams
+   getEnabledModuleByName, PICK_MAX_DISTANCE, isInEditMode, Picks, makeLaserParams, Entities
 */
 
 Script.include("/~/system/libraries/controllerDispatcherUtils.js");
@@ -19,7 +19,7 @@ Script.include("/~/system/libraries/utils.js");
 
 (function () {
     var MARGIN = 25;
-    
+    var TABLET_MATERIAL_ENTITY_NAME = 'Tablet-Material-Entity';
     function InEditMode(hand) {
         this.hand = hand;
         this.triggerClicked = false;
@@ -53,7 +53,7 @@ Script.include("/~/system/libraries/utils.js");
             return (HMD.tabletScreenID && objectID === HMD.tabletScreenID)
                 || (HMD.homeButtonID && objectID === HMD.homeButtonID);
         };
-        
+
         this.calculateNewReticlePosition = function(intersection) {
             var dims = Controller.getViewportDimensions();
             this.reticleMaxX = dims.x - MARGIN;
@@ -75,10 +75,12 @@ Script.include("/~/system/libraries/utils.js");
                     }
                 }
                 if (this.selectedTarget.type === Picks.INTERSECTED_ENTITY) {
-                    Messages.sendLocalMessage("entityToolUpdates", JSON.stringify({
-                        method: "selectEntity",
-                        entityID: this.selectedTarget.objectID
-                    }));
+                    if (!this.isTabletMaterialEntity(this.selectedTarget.objectID)) {
+                        Messages.sendLocalMessage("entityToolUpdates", JSON.stringify({
+                            method: "selectEntity",
+                            entityID: this.selectedTarget.objectID
+                        }));
+                    }
                 } else if (this.selectedTarget.type === Picks.INTERSECTED_OVERLAY) {
                     Messages.sendLocalMessage("entityToolUpdates", JSON.stringify({
                         method: "selectOverlay",
@@ -88,10 +90,16 @@ Script.include("/~/system/libraries/utils.js");
 
                 this.triggerClicked = true;
             }
-            
+
             this.sendPointingAtData(controllerData);
         };
-        
+
+
+        this.isTabletMaterialEntity = function(entityID) {
+            return ((entityID === HMD.homeButtonHighlightMaterialID) ||
+                    (entityID === HMD.homeButtonUnhighlightMaterialID));
+        };
+
         this.sendPointingAtData = function(controllerData) {
             var rayPick = controllerData.rayPicks[this.hand];
             var hudRayPick = controllerData.hudRayPicks[this.hand];

--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -82,19 +82,17 @@ function calcSpawnInfo(hand, landscape) {
 }
 
 
-function cleanUpOldMaterialEntities() {
+cleanUpOldMaterialEntities = function() {
     var avatarEntityData = MyAvatar.getAvatarEntityData();
-
     for (var entityID in avatarEntityData) {
         var entityName = Entities.getEntityProperties(entityID, ["name"]).name;
 
-        if (entityName === TABLET_MATERIAL_ENTITY_NAME) {
+        if (entityName === TABLET_MATERIAL_ENTITY_NAME && entityID !== HMD.homeButtonHighlightMaterialID &&
+           entityID !== HMD.homeButtonUnhighlightMaterialID) {
             Entities.deleteEntity(entityID);
         }
     }
-}
-
-cleanUpOldMaterialEntities();
+};
 
 /**
  * WebTablet

--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -30,6 +30,8 @@ var INCHES_TO_METERS = 1 / 39.3701;
 var NO_HANDS = -1;
 var DELAY_FOR_30HZ = 33; // milliseconds
 
+var TABLET_MATERIAL_ENTITY_NAME = 'Tablet-Material-Entity';
+
 
 // will need to be recaclulated if dimensions of fbx model change.
 var TABLET_NATURAL_DIMENSIONS = {x: 32.083, y: 48.553, z: 2.269};
@@ -78,6 +80,21 @@ function calcSpawnInfo(hand, landscape) {
         rotation: landscape ? Quat.multiply(orientation, ROT_LANDSCAPE) : Quat.multiply(orientation, ROT_Y_180)
     };
 }
+
+
+function cleanUpOldMaterialEntities() {
+    var avatarEntityData = MyAvatar.getAvatarEntityData();
+
+    for (var entityID in avatarEntityData) {
+        var entityName = Entities.getEntityProperties(entityID, ["name"]).name;
+
+        if (entityName === TABLET_MATERIAL_ENTITY_NAME) {
+            Entities.deleteEntity(entityID);
+        }
+    }
+}
+
+cleanUpOldMaterialEntities();
 
 /**
  * WebTablet
@@ -134,6 +151,7 @@ WebTablet = function (url, width, dpi, hand, clientOnly, location, visible) {
     }
 
     this.cleanUpOldTablets();
+    cleanUpOldMaterialEntities();
 
     this.tabletEntityID = Overlays.addOverlay("model", tabletProperties);
 
@@ -180,6 +198,7 @@ WebTablet = function (url, width, dpi, hand, clientOnly, location, visible) {
 
     this.homeButtonUnhighlightMaterial = Entities.addEntity({
         type: "Material",
+        name: TABLET_MATERIAL_ENTITY_NAME,
         materialURL: "materialData",
         localPosition: { x: 0.0, y: 0.0, z: 0.0 },
         priority: HIGH_PRIORITY,
@@ -199,6 +218,7 @@ WebTablet = function (url, width, dpi, hand, clientOnly, location, visible) {
 
     this.homeButtonHighlightMaterial = Entities.addEntity({
         type: "Material",
+        name: TABLET_MATERIAL_ENTITY_NAME,
         materialURL: "materialData",
         localPosition: { x: 0.0, y: 0.0, z: 0.0 },
         priority: LOW_PRIORITY,

--- a/scripts/system/libraries/entityList.js
+++ b/scripts/system/libraries/entityList.js
@@ -70,6 +70,11 @@ EntityListTool = function(opts) {
         return value !== undefined ? value : "";
     }
 
+    function filterEntity(entityID) {
+        return ((entityID === HMD.homeButtonHighlightMaterialID) ||
+                (entityID === HMD.homeButtonUnhighlightMaterialID));
+    }
+
     that.sendUpdate = function() {
         var entities = [];
 
@@ -79,6 +84,10 @@ EntityListTool = function(opts) {
         } else {
             ids = Entities.findEntities(MyAvatar.position, searchRadius);
         }
+
+        ids = ids.filter(function(id) {
+            return !filterEntity(id);
+        });
 
         var cameraPosition = Camera.position;
         for (var i = 0; i < ids.length; i++) {

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -13,7 +13,7 @@
 //
 
 /* global Script, HMD, WebTablet, UIWebTablet, UserActivityLogger, Settings, Entities, Messages, Tablet, Overlays,
-   MyAvatar, Menu, AvatarInputs, Vec3 */
+   MyAvatar, Menu, AvatarInputs, Vec3, cleanUpOldMaterialEntities */
 
 (function() { // BEGIN LOCAL_SCOPE
     var tabletRezzed = false;
@@ -30,6 +30,14 @@
     var gTablet = null;
 
     Script.include("../libraries/WebTablet.js");
+
+    function cleanupMaterialEntities() {
+        if (Window.isPhysicsEnabled()) {
+            cleanUpOldMaterialEntities();
+            return;
+        }
+        Script.setTimeout(cleanupMaterialEntities, 100);
+    }
 
     function checkTablet() {
         if (gTablet === null) {
@@ -327,4 +335,5 @@
         HMD.homeButtonHighlightMaterialID = null;
         HMD.homeButtonUnhighlightMaterialID = null;
     });
+    Script.setTimeout(cleanupMaterialEntities, 100);
 }()); // END LOCAL_SCOPE


### PR DESCRIPTION
Since the tablet now uses material entities for highlighting, There are some issues of the material entities persisting after crashes and also being able to see your own tablet material entities in the create app. This PR addresses these two issues.

tickets - https://highfidelity.manuscript.com/f/cases/16517/Material-entities-from-tablet-get-stuck-at-origin

https://highfidelity.manuscript.com/f/cases/16510/VR-users-get-invisible-materialData-objects-attached-to-the-tablet 