### PR TITLE
Repair Transition effect

### DIFF
--- a/libraries/render-utils/src/Fade.slh
+++ b/libraries/render-utils/src/Fade.slh
@@ -15,19 +15,20 @@
 #define CATEGORY_COUNT    5
 
 <@include Fade_shared.slh@>
+<@include FadeObjectParams.shared.slh@>
 
 layout(std140) uniform fadeParametersBuffer {
     FadeParameters fadeParameters[CATEGORY_COUNT];
 };
 uniform sampler2D fadeMaskMap;
 
-struct FadeObjectParams {
-    int category;
-    float threshold;
-    vec3 noiseOffset;
-    vec3 baseOffset;
-    vec3 baseInvSize;
-};
+vec3 getNoiseInverseSize(int category) {
+    return fadeParameters[category]._noiseInvSizeAndLevel.xyz;
+}
+
+float getNoiseLevel(int category) {
+    return fadeParameters[category]._noiseInvSizeAndLevel.w;
+}
 
 vec2 hash2D(vec3 position) {
     return position.xy* vec2(0.1677,  0.221765) + position.z*0.561;
@@ -40,7 +41,7 @@ float noise3D(vec3 position) {
 
 float evalFadeNoiseGradient(FadeObjectParams params, vec3 position) {
     // Do tri-linear interpolation
-    vec3    noisePosition = position * fadeParameters[params.category]._noiseInvSizeAndLevel.xyz + params.noiseOffset;
+    vec3    noisePosition = position * getNoiseInverseSize(params.category) + params.noiseOffset.xyz;
     vec3    noisePositionFloored = floor(noisePosition);
     vec3    noisePositionFraction = fract(noisePosition);
 
@@ -61,11 +62,11 @@ float evalFadeNoiseGradient(FadeObjectParams params, vec3 position) {
 
     float noise = mix(maskY.x, maskY.y, noisePositionFraction.y);
     noise -= 0.5;   // Center on value 0
-    return noise * fadeParameters[params.category]._noiseInvSizeAndLevel.w;
+    return noise * getNoiseLevel(params.category);
 }
 
 float evalFadeBaseGradient(FadeObjectParams params, vec3 position) {
-    float gradient = length((position - params.baseOffset) * params.baseInvSize.xyz);
+    float gradient = length((position - params.baseOffset.xyz) * params.baseInvSize.xyz);
     gradient = gradient-0.5;  // Center on value 0.5
     gradient *= fadeParameters[params.category]._baseLevel;
     return gradient;
@@ -112,20 +113,14 @@ void applyFade(FadeObjectParams params, vec3 position, out vec3 emissive) {
 
 <@func declareFadeFragmentUniform()@>
 
-uniform int fadeCategory;
-uniform vec3 fadeNoiseOffset;
-uniform vec3 fadeBaseOffset;
-uniform vec3 fadeBaseInvSize;
-uniform float fadeThreshold;
+layout(std140) uniform fadeObjectParametersBuffer {
+    FadeObjectParams fadeObjectParams;
+};
 
 <@endfunc@>
 
 <@func fetchFadeObjectParams(fadeParams)@>
-    <$fadeParams$>.category = fadeCategory;
-    <$fadeParams$>.threshold = fadeThreshold;
-    <$fadeParams$>.noiseOffset = fadeNoiseOffset;
-    <$fadeParams$>.baseOffset = fadeBaseOffset;
-    <$fadeParams$>.baseInvSize = fadeBaseInvSize;
+    <$fadeParams$> = fadeObjectParams;
 <@endfunc@>
 
 <@func declareFadeFragmentVertexInput()@>
@@ -139,9 +134,9 @@ in vec4 _fadeData3;
 <@func fetchFadeObjectParamsInstanced(fadeParams)@>
     <$fadeParams$>.category = int(_fadeData1.w);
     <$fadeParams$>.threshold = _fadeData2.w;
-    <$fadeParams$>.noiseOffset = _fadeData1.xyz;
-    <$fadeParams$>.baseOffset = _fadeData2.xyz;
-    <$fadeParams$>.baseInvSize = _fadeData3.xyz;
+    <$fadeParams$>.noiseOffset = _fadeData1;
+    <$fadeParams$>.baseOffset = _fadeData2;
+    <$fadeParams$>.baseInvSize = _fadeData3;
 <@endfunc@>
 
 <@func declareFadeFragment()@>

--- a/libraries/render-utils/src/FadeEffect.cpp
+++ b/libraries/render-utils/src/FadeEffect.cpp
@@ -41,14 +41,12 @@ render::ShapePipeline::BatchSetter FadeEffect::getBatchSetter() const {
 render::ShapePipeline::ItemSetter FadeEffect::getItemUniformSetter() const {
     return [](const render::ShapePipeline& shapePipeline, render::Args* args, const render::Item& item) {
         if (!render::TransitionStage::isIndexInvalid(item.getTransitionId())) {
-            auto scene = args->_scene;
-            auto batch = args->_batch;
-            auto transitionStage = scene->getStage<render::TransitionStage>(render::TransitionStage::getName());
-            auto& transitionState = transitionStage->getTransition(item.getTransitionId());
-            auto program = shapePipeline.pipeline->getProgram();
-            auto objectParamBufferLocation = program->getUniformBuffers().findLocation("fadeObjectParametersBuffer");
+            if (shapePipeline.locations->fadeObjectParameterBufferUnit >= 0) {
+                auto scene = args->_scene;
+                auto batch = args->_batch;
+                auto transitionStage = scene->getStage<render::TransitionStage>(render::TransitionStage::getName());
+                auto& transitionState = transitionStage->getTransition(item.getTransitionId());
 
-            if (objectParamBufferLocation >= 0) {
                 if (transitionState.paramsBuffer._size != sizeof(gpu::StructBuffer<FadeObjectParams>)) {
                     static_assert(sizeof(transitionState.paramsBuffer) == sizeof(gpu::StructBuffer<FadeObjectParams>), "Assuming gpu::StructBuffer is a helper class for gpu::BufferView");
                     transitionState.paramsBuffer = gpu::StructBuffer<FadeObjectParams>();
@@ -70,7 +68,7 @@ render::ShapePipeline::ItemSetter FadeEffect::getItemUniformSetter() const {
                     params.noiseOffset = glm::vec4(transitionState.noiseOffset, 0.0f);
                     params.baseOffset = glm::vec4(transitionState.baseOffset, 0.0f);
                 }
-                batch->setUniformBuffer(objectParamBufferLocation, transitionState.paramsBuffer);
+                batch->setUniformBuffer(shapePipeline.locations->fadeObjectParameterBufferUnit, transitionState.paramsBuffer);
             }
         }
     };

--- a/libraries/render-utils/src/FadeEffect.cpp
+++ b/libraries/render-utils/src/FadeEffect.cpp
@@ -33,15 +33,8 @@ void FadeEffect::build(render::Task::TaskConcept& task, const task::Varying& edi
 
 render::ShapePipeline::BatchSetter FadeEffect::getBatchSetter() const {
     return [this](const render::ShapePipeline& shapePipeline, gpu::Batch& batch, render::Args*) {
-        auto program = shapePipeline.pipeline->getProgram();
-        auto maskMapLocation = program->getTextures().findLocation("fadeMaskMap");
-        auto bufferLocation = program->getUniformBuffers().findLocation("fadeParametersBuffer");
-        if (maskMapLocation != -1) {
-            batch.setResourceTexture(maskMapLocation, _maskMap);
-        } 
-        if (bufferLocation != -1) {
-            batch.setUniformBuffer(bufferLocation, _configurations);
-        }
+        batch.setResourceTexture(shapePipeline.locations->fadeMaskTextureUnit, _maskMap);
+        batch.setUniformBuffer(shapePipeline.locations->fadeParameterBufferUnit, _configurations);
     };
 }
 
@@ -56,7 +49,7 @@ render::ShapePipeline::ItemSetter FadeEffect::getItemUniformSetter() const {
             auto objectParamBufferLocation = program->getUniformBuffers().findLocation("fadeObjectParametersBuffer");
 
             if (objectParamBufferLocation >= 0) {
-                if (transitionState.paramsBuffer._size == 0) {
+                if (transitionState.paramsBuffer._size != sizeof(gpu::StructBuffer<FadeObjectParams>)) {
                     static_assert(sizeof(transitionState.paramsBuffer) == sizeof(gpu::StructBuffer<FadeObjectParams>), "Assuming gpu::StructBuffer is a helper class for gpu::BufferView");
                     transitionState.paramsBuffer = gpu::StructBuffer<FadeObjectParams>();
                 }

--- a/libraries/render-utils/src/FadeObjectParams.shared.slh
+++ b/libraries/render-utils/src/FadeObjectParams.shared.slh
@@ -1,0 +1,25 @@
+// glsl / C++ compatible source as interface for FadeObjectParams
+#ifdef __cplusplus
+#   define FOP_VEC4 glm::vec4
+#   define FOP_VEC2 glm::vec2
+#   define FOP_FLOAT32 glm::float32
+#   define FOP_INT32 glm::int32
+#else
+#   define FOP_VEC4 vec4
+#   define FOP_VEC2 vec2
+#   define FOP_FLOAT32 float
+#   define FOP_INT32 int
+#endif
+
+struct FadeObjectParams {
+    FOP_VEC4 noiseOffset;
+    FOP_VEC4 baseOffset;
+    FOP_VEC4 baseInvSize;
+    FOP_INT32 category;
+    FOP_FLOAT32 threshold;
+};
+
+    // <@if 1@>
+    // Trigger Scribe include 
+    // <@endif@> <!def that !> 
+//

--- a/libraries/render/src/render/ShapePipeline.cpp
+++ b/libraries/render/src/render/ShapePipeline.cpp
@@ -124,6 +124,7 @@ void ShapePlumber::addPipeline(const Filter& filter, const gpu::ShaderPointer& p
     locations->lightAmbientMapUnit = program->getTextures().findLocation("skyboxMap");
     locations->fadeMaskTextureUnit = program->getTextures().findLocation("fadeMaskMap");
     locations->fadeParameterBufferUnit = program->getUniformBuffers().findLocation("fadeParametersBuffer");
+    locations->fadeObjectParameterBufferUnit = program->getUniformBuffers().findLocation("fadeObjectParametersBuffer");
     locations->hazeParameterBufferUnit = program->getUniformBuffers().findLocation("hazeBuffer");
     if (key.isTranslucent()) {
         locations->lightClusterGridBufferUnit = program->getUniformBuffers().findLocation("clusterGridBuffer");

--- a/libraries/render/src/render/ShapePipeline.cpp
+++ b/libraries/render/src/render/ShapePipeline.cpp
@@ -95,6 +95,7 @@ void ShapePlumber::addPipeline(const Filter& filter, const gpu::ShaderPointer& p
         slotBindings.insert(gpu::Shader::Binding(std::string("skyboxMap"), Slot::MAP::LIGHT_AMBIENT_MAP));
         slotBindings.insert(gpu::Shader::Binding(std::string("fadeMaskMap"), Slot::MAP::FADE_MASK));
         slotBindings.insert(gpu::Shader::Binding(std::string("fadeParametersBuffer"), Slot::BUFFER::FADE_PARAMETERS));
+        slotBindings.insert(gpu::Shader::Binding(std::string("fadeObjectParametersBuffer"), Slot::BUFFER::FADE_OBJECT_PARAMETERS));
         slotBindings.insert(gpu::Shader::Binding(std::string("hazeBuffer"), Slot::BUFFER::HAZE_MODEL));
 
         if (key.isTranslucent()) {

--- a/libraries/render/src/render/ShapePipeline.h
+++ b/libraries/render/src/render/ShapePipeline.h
@@ -278,6 +278,7 @@ public:
         int lightAmbientMapUnit;
         int fadeMaskTextureUnit;
         int fadeParameterBufferUnit;
+        int fadeObjectParameterBufferUnit;
         int hazeParameterBufferUnit;
         int lightClusterGridBufferUnit;
         int lightClusterContentBufferUnit;

--- a/libraries/render/src/render/ShapePipeline.h
+++ b/libraries/render/src/render/ShapePipeline.h
@@ -240,6 +240,7 @@ public:
             LIGHT_AMBIENT_BUFFER,
             HAZE_MODEL,
             FADE_PARAMETERS,
+            FADE_OBJECT_PARAMETERS,
             LIGHT_CLUSTER_GRID_FRUSTUM_GRID_SLOT,
             LIGHT_CLUSTER_GRID_CLUSTER_GRID_SLOT,
             LIGHT_CLUSTER_GRID_CLUSTER_CONTENT_SLOT,
@@ -254,9 +255,9 @@ public:
             ROUGHNESS,
             OCCLUSION,
             SCATTERING,
-            FADE_MASK,
 
             LIGHT_AMBIENT_MAP = 10,
+            FADE_MASK,
         };
     };
 

--- a/libraries/render/src/render/Transition.h
+++ b/libraries/render/src/render/Transition.h
@@ -42,6 +42,8 @@ namespace render {
         glm::vec3 baseInvSize{ 1.f, 1.f, 1.f };
         float threshold{ 0.f };
         uint8_t isFinished{ 0 };
+
+        mutable gpu::BufferView paramsBuffer;
     };
 
     typedef std::shared_ptr<Transition> TransitionPointer;


### PR DESCRIPTION
This PR repairs the partially broken fade effect. The noise layer wasn't working anymore due to a conflict between the fade mask map texture slot and the Material texture table. Resolved by pushing the fade mask map slot number to a higher value.

It also gets rid of all the glUniform calls in the fade effect.

# TEST PLAN
There isn't a dedicated autoTest for the fade effect at this time. We will have to discuss with @samcake on how to do this within the autoTest framework as the effect is dynamic.

To test it, in a non empty domain such as dev-welcome launch the _developer/utilities/render/debugTransition.js_ script and open the Transition editor by clicking on the respective button in the task bar.
Select an object to apply the transition to by clicking with the mouse on any visible 3D model (that is not a primitive). 
Select each event type in the Transition editor combo box and check that they have a similar aspect to these screenshots:
- Elements enter / leave domain: 
![elemententer1](https://user-images.githubusercontent.com/14199381/42518142-7cea9a56-8461-11e8-96b1-0b9633941a08.jpg)
![elemententer2](https://user-images.githubusercontent.com/14199381/42518145-7d0f8a78-8461-11e8-8f9d-be2c41757074.jpg)
- Bubble Isect - owner:
![bubble1](https://user-images.githubusercontent.com/14199381/42518273-becd9716-8461-11e8-8a95-151dfe7222bb.jpg)
- Bubble Isect - trespasser:
![bubble2](https://user-images.githubusercontent.com/14199381/42518311-d82d3c84-8461-11e8-8f49-b8aa97d91356.jpg)
- Another user leaves/arrives:
![avatar2](https://user-images.githubusercontent.com/14199381/42518432-208e614c-8462-11e8-88f2-2db5b9838fe2.jpg)
![avatar1](https://user-images.githubusercontent.com/14199381/42518436-20ae4f16-8462-11e8-85f1-c4d77285bedf.jpg)
- Changing an avatar: doesn't do anything at the moment.

