### PR TITLE
Allow empty web entities to be rendered

### DIFF
--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -178,10 +178,6 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
 
 
     withWriteLock([&] {
-        if (_contentType == ContentType::NoContent) {
-            return;
-        }
-
         // This work must be done on the main thread
         // If we couldn't create a new web surface, exit
         if (!hasWebSurface() && !buildWebSurface(entity)) {
@@ -315,7 +311,13 @@ bool WebEntityRenderer::buildWebSurface(const TypedEntityPointer& entity) {
         });
     } else if (_contentType == ContentType::QmlContent) {
         _webSurface->load(_lastSourceUrl);
+    } else if (_contentType == ContentType::NoContent) {
+        // Show empty white panel
+        _webSurface->load("controls/WebEntityView.qml", [this](QQmlContext* context, QObject* item) {
+            item->setProperty(URL_PROPERTY, "");
+        });
     }
+
     _fadeStartTime = usecTimestampNow();
     _webSurface->resume();
 


### PR DESCRIPTION
If a web entity is added via script, the sourceUrl for it can be set to empty, which makes it's content type ContentType::NoContent. With this content type the entity was previously invisible, so this allows it to be rendered as an empty white panel in this case.

Fixes: https://highfidelity.manuscript.com/f/cases/15963

Test Plan:
- Enter Interface in desktop mode
- Open Create and create a Web entity
- Verify the web entity is visible and shows the High Fidelity site by default
- On the Properties tab, change the source URL to any other website like http://google.com and verify it is shown as expected
- Change the source URL to a single letter, verify once clicking away from the source URL box that the http:// is amended to the single letter, and verify the Web entity shows the site can't be reached
- In Developer menu -> Console enter the following line and press Enter:
Entities.addEntity({ type : "Web", sourceUrl : "", position: MyAvatar.position, dimensions: {x:1.6, y:0.9, z:0.01}});
- Verify the new Web entity is a blank white panel on both sides
- In the Properties tab for the new Web entity, change the source URL to a website like http://google.com and verify it is shown as expected
- Change the source URL for the new Web entity to a single letter, verify once clicking away from the source URL box that the http:// is amended to the single letter, and verify the Web entity shows the site can't be reached