### PR TITLE
Fix MS16600: Prevent duplicate Spectator Camera models after crash

### DIFF
--- a/unpublishedScripts/marketplace/spectator-camera/spectatorCamera.js
+++ b/unpublishedScripts/marketplace/spectator-camera/spectatorCamera.js
@@ -74,6 +74,7 @@
             "collisionMask": 7,
             "dynamic": false,
             "modelURL": Script.resolvePath("spectator-camera.fbx"),
+            "name": "Spectator Camera",
             "registrationPoint": {
                 "x": 0.56,
                 "y": 0.545,
@@ -101,6 +102,18 @@
             volume: 0.15,
             position: cameraPosition,
             localOnly: true
+        });
+
+        // Remove the existing camera model from the domain if one exists.
+        // It's easy for this to happen if the user crashes while the Spectator Camera is on.
+        // We do this down here (after the new one is rezzed) so that we don't accidentally delete
+        // the newly-rezzed model.
+        var entityIDs = Entities.findEntitiesByName("Spectator Camera", MyAvatar.position, 100, false);
+        entityIDs.forEach(function (currentEntityID) {
+            var currentEntityOwner = Entities.getEntityProperties(currentEntityID, ['owningAvatarID']).owningAvatarID;
+            if (currentEntityOwner === MyAvatar.sessionUUID && currentEntityID !== camera) {
+                Entities.deleteEntity(currentEntityID);
+            }
         });
     }
 


### PR DESCRIPTION
Fixes [MS16600](https://highfidelity.manuscript.com/f/cases/16600).

The "RC71" milestone isn't that accurate, because I'll make the fix live by publishing a marketplace app update once QA passes.