### PR TITLE
Render Scale Resolution applied only to 3D rendering not HUD

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3271,6 +3271,16 @@ void Application::resizeGL() {
         DependencyManager::get<FramebufferCache>()->setFrameBufferSize(fromGlm(renderSize));
     }
 
+    auto renderResolutionScale = getRenderResolutionScale();
+    if (displayPlugin->getRenderResolutionScale() != renderResolutionScale) {
+        auto renderConfig = _renderEngine->getConfiguration();
+        assert(renderConfig);
+        auto mainView = renderConfig->getConfig("RenderMainView.RenderDeferredTask");
+        assert(mainView);
+        mainView->setProperty("resolutionScale", renderResolutionScale);
+        displayPlugin->setRenderResolutionScale(renderResolutionScale);
+    }
+
     // FIXME the aspect ratio for stereo displays is incorrect based on this.
     float aspectRatio = displayPlugin->getRecommendedAspectRatio();
     _myCamera.setProjection(glm::perspective(glm::radians(_fieldOfView.get()), aspectRatio,

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3265,8 +3265,7 @@ void Application::resizeGL() {
     // Set the desired FBO texture size. If it hasn't changed, this does nothing.
     // Otherwise, it must rebuild the FBOs
     uvec2 framebufferSize = displayPlugin->getRecommendedRenderSize();
-    float renderResolutionScale = getRenderResolutionScale();
-    uvec2 renderSize = uvec2(vec2(framebufferSize) * renderResolutionScale);
+    uvec2 renderSize = uvec2(framebufferSize);
     if (_renderResolution != renderSize) {
         _renderResolution = renderSize;
         DependencyManager::get<FramebufferCache>()->setFrameBufferSize(fromGlm(renderSize));
@@ -3283,7 +3282,6 @@ void Application::resizeGL() {
     }
 
     DependencyManager::get<OffscreenUi>()->resize(fromGlm(displayPlugin->getRecommendedUiSize()));
-    displayPlugin->setRenderResolutionScale(renderResolutionScale);
 }
 
 void Application::handleSandboxStatus(QNetworkReply* reply) {

--- a/interface/src/Application_render.cpp
+++ b/interface/src/Application_render.cpp
@@ -102,7 +102,7 @@ void Application::paintGL() {
         PerformanceTimer perfTimer("renderOverlay");
         // NOTE: There is no batch associated with this renderArgs
         // the ApplicationOverlay class assumes it's viewport is setup to be the device size
-        renderArgs._viewport = glm::ivec4(0, 0, getDeviceSize() * getRenderResolutionScale());
+        renderArgs._viewport = glm::ivec4(0, 0, getDeviceSize());
         _applicationOverlay.renderOverlay(&renderArgs);
     }
 
@@ -118,7 +118,7 @@ void Application::paintGL() {
         // Primary rendering pass
         auto framebufferCache = DependencyManager::get<FramebufferCache>();
         finalFramebufferSize = framebufferCache->getFrameBufferSize();
-        // Final framebuffer that will be handled to the display-plugin
+        // Final framebuffer that will be handed to the display-plugin
         finalFramebuffer = framebufferCache->getFramebuffer();
     }
 

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -179,7 +179,7 @@ static const auto DEPTH_FORMAT = gpu::Element(gpu::SCALAR, gpu::FLOAT, gpu::DEPT
 void ApplicationOverlay::buildFramebufferObject() {
     PROFILE_RANGE(app, __FUNCTION__);
 
-    auto uiSize = glm::uvec2(glm::vec2(qApp->getUiSize()) * qApp->getRenderResolutionScale());
+    auto uiSize = glm::uvec2(qApp->getUiSize());
     if (!_overlayFramebuffer || uiSize != _overlayFramebuffer->getSize()) {
         _overlayFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("ApplicationOverlay"));
     }

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -116,7 +116,7 @@ void Overlays::renderHUD(RenderArgs* renderArgs) {
     auto geometryCache = DependencyManager::get<GeometryCache>();
     auto textureCache = DependencyManager::get<TextureCache>();
 
-    auto size = glm::uvec2(glm::vec2(qApp->getUiSize()) * qApp->getRenderResolutionScale());
+    auto size = glm::uvec2(qApp->getUiSize());
     int width = size.x;
     int height = size.y;
     mat4 legacyProjection = glm::ortho<float>(0, width, height, 0, -1000, 1000);

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.cpp
@@ -275,7 +275,7 @@ bool CompositorHelper::getReticleOverDesktop() const {
     // as being over the desktop.
     if (isHMD()) {
         QMutexLocker locker(&_reticleLock);
-        glm::vec2 maxOverlayPosition = glm::vec2(_currentDisplayPlugin->getRecommendedUiSize()) * _currentDisplayPlugin->getRenderResolutionScale();
+        glm::vec2 maxOverlayPosition = glm::vec2(_currentDisplayPlugin->getRecommendedUiSize());
         static const glm::vec2 minOverlayPosition;
         if (glm::any(glm::lessThan(_reticlePositionInHMD, minOverlayPosition)) ||
             glm::any(glm::greaterThan(_reticlePositionInHMD, maxOverlayPosition))) {
@@ -317,7 +317,7 @@ void CompositorHelper::sendFakeMouseEvent() {
 
 void CompositorHelper::setReticlePosition(const glm::vec2& position, bool sendFakeEvent) {
     if (isHMD()) {
-        glm::vec2 maxOverlayPosition = glm::vec2(_currentDisplayPlugin->getRecommendedUiSize()) * _currentDisplayPlugin->getRenderResolutionScale();
+        glm::vec2 maxOverlayPosition = glm::vec2(_currentDisplayPlugin->getRecommendedUiSize());
         // FIXME don't allow negative mouseExtra
         glm::vec2 mouseExtra = (MOUSE_EXTENTS_PIXELS - maxOverlayPosition) / 2.0f;
         glm::vec2 minMouse = vec2(0) - mouseExtra;

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -888,7 +888,7 @@ OpenGLDisplayPlugin::~OpenGLDisplayPlugin() {
 }
 
 void OpenGLDisplayPlugin::updateCompositeFramebuffer() {
-    auto renderSize = glm::uvec2(glm::vec2(getRecommendedRenderSize()) * getRenderResolutionScale());
+    auto renderSize = glm::uvec2(getRecommendedRenderSize());
     if (!_compositeFramebuffer || _compositeFramebuffer->getSize() != renderSize) {
         _compositeFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("OpenGLDisplayPlugin::composite", gpu::Element::COLOR_RGBA_32, renderSize.x, renderSize.y));
     }

--- a/libraries/render-utils/src/DeferredLightingEffect.h
+++ b/libraries/render-utils/src/DeferredLightingEffect.h
@@ -93,13 +93,34 @@ private:
     friend class RenderDeferredCleanup;
 };
 
+class PreparePrimaryFramebufferConfig : public render::Job::Config {
+    Q_OBJECT
+        Q_PROPERTY(float resolutionScale MEMBER resolutionScale NOTIFY dirty)
+public:
+
+    float resolutionScale{ 1.0f };
+
+signals:
+    void dirty();
+};
+
 class PreparePrimaryFramebuffer {
 public:
-    using JobModel = render::Job::ModelO<PreparePrimaryFramebuffer, gpu::FramebufferPointer>;
 
-    void run(const render::RenderContextPointer& renderContext, gpu::FramebufferPointer& primaryFramebuffer);
+    using Output = gpu::FramebufferPointer;
+    using Config = PreparePrimaryFramebufferConfig;
+    using JobModel = render::Job::ModelO<PreparePrimaryFramebuffer, Output, Config>;
+
+    PreparePrimaryFramebuffer(float resolutionScale = 1.0f) : _resolutionScale{resolutionScale} {}
+    void configure(const Config& config);
+    void run(const render::RenderContextPointer& renderContext, Output& primaryFramebuffer);
 
     gpu::FramebufferPointer _primaryFramebuffer;
+    float _resolutionScale{ 1.0f };
+
+private:
+
+    static gpu::FramebufferPointer createFramebuffer(const char* name, const glm::uvec2& size);
 };
 
 class PrepareDeferred {

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -26,6 +26,7 @@
 #include <render/DrawStatus.h>
 #include <render/DrawSceneOctree.h>
 #include <render/BlurTask.h>
+#include <render/ResampleTask.h>
 
 #include "RenderHifi.h"
 #include "RenderCommonTask.h"
@@ -59,8 +60,14 @@ RenderDeferredTask::RenderDeferredTask()
 {
 }
 
-void RenderDeferredTask::configure(const Config& config)
-{
+void RenderDeferredTask::configure(const Config& config) {
+    // Propagate resolution scale to sub jobs who need it
+    auto preparePrimaryBufferConfig = config.getConfig<PreparePrimaryFramebuffer>("PreparePrimaryBuffer");
+    auto upsamplePrimaryBufferConfig = config.getConfig<Upsample>("PrimaryBufferUpscale");
+    assert(preparePrimaryBufferConfig);
+    assert(upsamplePrimaryBufferConfig);
+    preparePrimaryBufferConfig->setProperty("resolutionScale", config.resolutionScale);
+    upsamplePrimaryBufferConfig->setProperty("factor", 1.0f / config.resolutionScale);
 }
 
 const render::Varying RenderDeferredTask::addSelectItemJobs(JobModel& task, const char* selectionName,
@@ -103,17 +110,17 @@ void RenderDeferredTask::build(JobModel& task, const render::Varying& input, ren
     
 
     // GPU jobs: Start preparing the primary, deferred and lighting buffer
-    const auto primaryFramebuffer = task.addJob<PreparePrimaryFramebuffer>("PreparePrimaryBuffer");
+    const auto scaledPrimaryFramebuffer = task.addJob<PreparePrimaryFramebuffer>("PreparePrimaryBuffer");
 
     const auto opaqueRangeTimer = task.addJob<BeginGPURangeTimer>("BeginOpaqueRangeTimer", "DrawOpaques");
 
-    const auto prepareDeferredInputs = PrepareDeferred::Inputs(primaryFramebuffer, lightingModel).asVarying();
+    const auto prepareDeferredInputs = PrepareDeferred::Inputs(scaledPrimaryFramebuffer, lightingModel).asVarying();
     const auto prepareDeferredOutputs = task.addJob<PrepareDeferred>("PrepareDeferred", prepareDeferredInputs);
     const auto deferredFramebuffer = prepareDeferredOutputs.getN<PrepareDeferred::Outputs>(0);
     const auto lightingFramebuffer = prepareDeferredOutputs.getN<PrepareDeferred::Outputs>(1);
 
     // draw a stencil mask in hidden regions of the framebuffer.
-    task.addJob<PrepareStencil>("PrepareStencil", primaryFramebuffer);
+    task.addJob<PrepareStencil>("PrepareStencil", scaledPrimaryFramebuffer);
 
     // Render opaque objects in DeferredBuffer
     const auto opaqueInputs = DrawStateSortDeferred::Inputs(opaques, lightingModel, jitter).asVarying();
@@ -223,7 +230,7 @@ void RenderDeferredTask::build(JobModel& task, const render::Varying& input, ren
     task.addJob<Bloom>("Bloom", bloomInputs);
 
     // Lighting Buffer ready for tone mapping
-    const auto toneMappingInputs = ToneMappingDeferred::Inputs(lightingFramebuffer, primaryFramebuffer).asVarying();
+    const auto toneMappingInputs = ToneMappingDeferred::Inputs(lightingFramebuffer, scaledPrimaryFramebuffer).asVarying();
     task.addJob<ToneMappingDeferred>("ToneMapping", toneMappingInputs);
 
     { // Debug the bounds of the rendered items, still look at the zbuffer
@@ -283,6 +290,9 @@ void RenderDeferredTask::build(JobModel& task, const render::Varying& input, ren
 
         task.addJob<DebugZoneLighting>("DrawZoneStack", deferredFrameTransform);
     }
+
+    // Upscale to finale resolution
+    const auto primaryFramebuffer = task.addJob<render::Upsample>("PrimaryBufferUpscale", scaledPrimaryFramebuffer);
 
     // Composite the HUD and HUD overlays
     task.addJob<CompositeHUD>("HUD");

--- a/libraries/render-utils/src/RenderDeferredTask.cpp
+++ b/libraries/render-utils/src/RenderDeferredTask.cpp
@@ -104,13 +104,12 @@ void RenderDeferredTask::build(JobModel& task, const render::Varying& input, ren
 
     const auto jitter = task.addJob<JitterSample>("JitterCam");
 
-    // Prepare deferred, generate the shared Deferred Frame Transform
-    const auto deferredFrameTransform = task.addJob<GenerateDeferredFrameTransform>("DeferredFrameTransform", jitter);
-    const auto lightingModel = task.addJob<MakeLightingModel>("LightingModel");
-    
-
     // GPU jobs: Start preparing the primary, deferred and lighting buffer
     const auto scaledPrimaryFramebuffer = task.addJob<PreparePrimaryFramebuffer>("PreparePrimaryBuffer");
+
+    // Prepare deferred, generate the shared Deferred Frame Transform. Only valid with the scaled frame buffer
+    const auto deferredFrameTransform = task.addJob<GenerateDeferredFrameTransform>("DeferredFrameTransform", jitter);
+    const auto lightingModel = task.addJob<MakeLightingModel>("LightingModel");
 
     const auto opaqueRangeTimer = task.addJob<BeginGPURangeTimer>("BeginOpaqueRangeTimer", "DrawOpaques");
 

--- a/libraries/render-utils/src/RenderDeferredTask.h
+++ b/libraries/render-utils/src/RenderDeferredTask.h
@@ -105,11 +105,13 @@ class RenderDeferredTaskConfig : public render::Task::Config {
     Q_OBJECT
     Q_PROPERTY(float fadeScale MEMBER fadeScale NOTIFY dirty)
     Q_PROPERTY(float fadeDuration MEMBER fadeDuration NOTIFY dirty)
+    Q_PROPERTY(float resolutionScale MEMBER resolutionScale NOTIFY dirty)
     Q_PROPERTY(bool debugFade MEMBER debugFade NOTIFY dirty)
     Q_PROPERTY(float debugFadePercent MEMBER debugFadePercent NOTIFY dirty)
 public:
     float fadeScale{ 0.5f };
     float fadeDuration{ 3.0f };
+    float resolutionScale{ 1.f };
     float debugFadePercent{ 0.f };
     bool debugFade{ false };
 

--- a/libraries/render/src/render/ResampleTask.h
+++ b/libraries/render/src/render/ResampleTask.h
@@ -36,6 +36,37 @@ namespace render {
 
         gpu::FramebufferPointer getResampledFrameBuffer(const gpu::FramebufferPointer& sourceFramebuffer);
     };
+
+    class UpsampleConfig : public render::Job::Config {
+        Q_OBJECT
+            Q_PROPERTY(float factor MEMBER factor NOTIFY dirty)
+    public:
+
+        float factor{ 1.0f };
+
+    signals:
+        void dirty();
+    };
+
+    class Upsample {
+    public:
+        using Config = UpsampleConfig;
+        using JobModel = Job::ModelIO<Upsample, gpu::FramebufferPointer, gpu::FramebufferPointer, Config>;
+
+        Upsample(float factor = 2.0f) : _factor{ factor } {}
+
+        void configure(const Config& config);
+        void run(const RenderContextPointer& renderContext, const gpu::FramebufferPointer& sourceFramebuffer, gpu::FramebufferPointer& resampledFrameBuffer);
+
+    protected:
+
+        static gpu::PipelinePointer _pipeline;
+
+        gpu::FramebufferPointer _destinationFrameBuffer;
+        float _factor{ 2.0f };
+
+        gpu::FramebufferPointer getResampledFrameBuffer(const gpu::FramebufferPointer& sourceFramebuffer);
+    };
 }
 
 #endif // hifi_render_ResampleTask_h


### PR DESCRIPTION
With this PR the resolution scale settings available in the menu _developer/render_ only change the resolution of the 3D rendering, not any HUD UI which remain at full resolution.

In HMD view the tablet being a 3D element logically suffers from the downscaling.

# TEST PLAN
In all display modes (Desktop, HMD, ...).
Activate the developer menu. Go to the _Developer_ menu, sub menu _Render_ and then choose one of the _Scale Resolution_ factors. The resolution of the 3D rendering should be downscaled accordingly but all the UI elements such as task bar, panels and mouse pointer should remain at full resolution.

![scaleres](https://user-images.githubusercontent.com/14199381/42569988-a86b182a-8512-11e8-9ef8-555a7304c2c4.jpg)

With a downscaled resolution, all the render engine tests (materials, lighting, bloom, highlight, ...) should be checked even though it can be hard to validate as the test images are saved in full resolution. Temporal antialising and FXAA should also be working correctly.