### PR TITLE
MS14743 again: More bandaids for preventing Snappy printouts from falling thru floor

### DIFF
--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -308,6 +308,7 @@ function printToPolaroid(image_url) {
         "density": 200,
         "restitution": 0.15,                            
         "gravity": { "x": 0, "y": -2.0, "z": 0 },
+        "damping": 0.45,
 
         "dynamic": true, 
         "collisionsWillMove": true,

--- a/scripts/system/snapshot.js
+++ b/scripts/system/snapshot.js
@@ -285,7 +285,7 @@ function printToPolaroid(image_url) {
     var polaroid_url = image_url;                  
 
     var model_pos = Vec3.sum(MyAvatar.position, Vec3.multiply(1.25, Quat.getForward(MyAvatar.orientation)));
-    model_pos.y += 0.2; // Print a bit closer to the head
+    model_pos.y += 0.39; // Print a bit closer to the head
     
     var model_q1 = MyAvatar.orientation;
     var model_q2 = Quat.angleAxis(90, Quat.getRight(model_q1));
@@ -307,10 +307,7 @@ function printToPolaroid(image_url) {
 
         "density": 200,
         "restitution": 0.15,                            
-        "gravity": { "x": 0, "y": -2.5, "z": 0 },
-        
-        "velocity": { "x": 0, "y": 1.95, "z": 0 },
-        "angularVelocity": Vec3.multiplyQbyV(MyAvatar.orientation, { "x": -1.0, "y": 0, "z": -1.3 }),
+        "gravity": { "x": 0, "y": -2.0, "z": 0 },
 
         "dynamic": true, 
         "collisionsWillMove": true,


### PR DESCRIPTION
Attempts again to fix [MS14743](https://highfidelity.manuscript.com/f/cases/edit/14743/Snappy-pics-fall-through-the-floor) by applying bandaids:

1. Removed linear and rotational velocity from printed snaps, but kept gravity. This means printed snappys will hang in the air until someone touches them.
2. Further decreased downward acceleration due to gravity on the snappy printouts.
3. Printed the Snappy a bit higher
4. Slightly increased linear damping