### PR TITLE
MS14979: Fix Animation FPS changeability

### DIFF
--- a/libraries/entities/src/AnimationPropertyGroup.cpp
+++ b/libraries/entities/src/AnimationPropertyGroup.cpp
@@ -22,13 +22,14 @@ const float AnimationPropertyGroup::MAXIMUM_POSSIBLE_FRAME = 100000.0f;
 
 bool operator==(const AnimationPropertyGroup& a, const AnimationPropertyGroup& b) {
     return
-
         (a._currentFrame == b._currentFrame) &&
         (a._running == b._running) &&
         (a._loop == b._loop) &&
         (a._hold == b._hold) &&
         (a._firstFrame == b._firstFrame) &&
         (a._lastFrame == b._lastFrame) &&
+        (a._fps == b._fps) &&
+        (a._allowTranslation == b._allowTranslation) &&
         (a._url == b._url);
 }
 
@@ -40,6 +41,8 @@ bool operator!=(const AnimationPropertyGroup& a, const AnimationPropertyGroup& b
         (a._hold != b._hold) ||
         (a._firstFrame != b._firstFrame) ||
         (a._lastFrame != b._lastFrame) ||
+        (a._fps != b._fps) ||
+        (a._allowTranslation != b._allowTranslation) ||
         (a._url != b._url);
 }
 


### PR DESCRIPTION
Fixes https://highfidelity.manuscript.com/f/cases/14979/Animation-FPS-can-not-be-changed

## QA Test (slightly modified repro)

1) Load into the users Sandbox
2) Download ["Mason_Idle.fbx"](https://highfidelity.testrail.net/index.php?/attachments/get/245)
  Download ["right12.fbx"](https://highfidelity.testrail.net/index.php?/attachments/get/243)
3) Add "Mason_Idle.fbx" to your asset server
  Add "right12.fbx" to your asset server
4) Add "Mason_Idle.fbx" to the world
5) Open "Create" and go to the "Properties" tab
6) Select the "Mason_Idle.fbx" model and scroll down to the 'Model' section of the Properties tab
7) Add app:/right12.fbx in the animation url text box
8) Enable animation playing - animation should be playing now
9) Toggle the Allow Translate checkbox off. - The feet should look better now.
10) Attempt to change "Animation FPS" to 120.    - the animation should play 4x the usual speed.

**Note: the issue is only fix when both Server and Client have the fix. Otherwise the server will ignore the FPS change and flip back FPS / allowTranslate changes.**