### PR TITLE
Remove AudioScriptingInterface.setStereoInput’s return value

### DIFF
--- a/libraries/script-engine/src/AudioScriptingInterface.cpp
+++ b/libraries/script-engine/src/AudioScriptingInterface.cpp
@@ -75,11 +75,10 @@ ScriptAudioInjector* AudioScriptingInterface::playSound(SharedSoundPointer sound
     }
 }
 
-bool AudioScriptingInterface::setStereoInput(bool stereo) {
+void AudioScriptingInterface::setStereoInput(bool stereo) {
     if (_localAudioInterface) {
         QMetaObject::invokeMethod(_localAudioInterface, "setIsStereoInput", Q_ARG(bool, stereo));
     }
-    return true;
 }
 
 bool AudioScriptingInterface::isStereoInput() {

--- a/libraries/script-engine/src/AudioScriptingInterface.h
+++ b/libraries/script-engine/src/AudioScriptingInterface.h
@@ -54,9 +54,8 @@ protected:
     /**jsdoc
      * @function Audio.setStereoInput
      * @param {boolean} stereo
-     * @returns {boolean}
      */
-    Q_INVOKABLE bool setStereoInput(bool stereo);
+    Q_INVOKABLE void setStereoInput(bool stereo);
 
     /**jsdoc
      * @function Audio.isStereoInput


### PR DESCRIPTION
Remove AudioScriptingInterface.setStereoInput’s return value as announced here:
https://forums.highfidelity.com/t/audioscriptinginterface-setstereoinputs-return-value-being-removed-from-the-api/14279

