### PR TITLE
Working on pauses in tomb domain

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.cpp
@@ -765,7 +765,6 @@ void GLBackend::recycle() const {
     }
     
     _textureManagement._transferEngine->manageMemory();
-    Texture::KtxStorage::releaseOpenKtxFiles();
 }
 
 void GLBackend::setCameraCorrection(const Mat4& correction, const Mat4& prevRenderView, bool reset) {

--- a/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
@@ -405,6 +405,7 @@ bool GLTextureTransferEngineDefault::processActiveBufferQueue() {
         _activeTransferQueue.splice(_activeTransferQueue.end(), activeBufferQueue);
     }
 
+    Texture::KtxStorage::releaseOpenKtxFiles();
     return true;
 }
 


### PR DESCRIPTION
Working on addressing [15594](https://highfidelity.manuscript.com/f/cases/15594/tomb-domain-demonstrates-major-pauses-on-the-game-loop-main-thread)

The current code performs a maintenance action on the present-thread on a per-frame basis.  In the current master and RC branches, this includes cleaning up any KTX files that might currently be open.  However, this is an extremely bad idea.  The present thread is not the primary consumer of the KTX files.  Instead, the texture transfer thread does most of the reading from these files.  Because of this there's a potential for resource contention between the present thread and the texture transfer thread.  

This PR moves the KTX cleanup to the texture transfer thread.  Additionally it fixes a bug in the management of the textures, where the container of all weak textures could grow without bound, since the remove_if code to clean it was being used incorrectly.  

## Testing 

On a high end machine (i7 or above) with a high end GPU (GTX 970 or above), this PR should load faster and demonstrate fewer pauses than the current master build when loading the Tomb domain.  