### PR TITLE
Fix MS16615: Don't early-remove .app.json we JUST installed

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -129,7 +129,7 @@ Rectangle {
         }
 
         onAppInstalled: {
-            if (appHref === root.itemHref) {
+            if (appID === root.itemId) {
                 root.isInstalled = true;
             }
         }

--- a/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
@@ -67,13 +67,13 @@ Item {
         }
 
         onAppInstalled: {
-            if (appHref === root.itemHref) {
+            if (appID === root.itemId) {
                 root.isInstalled = true;
             }
         }
 
         onAppUninstalled: {
-            if (appHref === root.itemHref) {
+            if (appID === root.itemId) {
                 root.isInstalled = false;
             }
         }

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -98,7 +98,7 @@ Rectangle {
         }
 
         onAppInstalled: {
-            root.installedApps = Commerce.getInstalledApps();
+            root.installedApps = Commerce.getInstalledApps(appID);
         }
 
         onAppUninstalled: {

--- a/interface/src/commerce/QmlCommerce.h
+++ b/interface/src/commerce/QmlCommerce.h
@@ -53,8 +53,8 @@ signals:
 
     void contentSetChanged(const QString& contentSetHref);
 
-    void appInstalled(const QString& appHref);
-    void appUninstalled(const QString& appHref);
+    void appInstalled(const QString& appID);
+    void appUninstalled(const QString& appID);
 
 protected:
     Q_INVOKABLE void getWalletStatus();
@@ -86,7 +86,7 @@ protected:
 
     Q_INVOKABLE void replaceContentSet(const QString& itemHref, const QString& certificateID);
 
-    Q_INVOKABLE QString getInstalledApps();
+    Q_INVOKABLE QString getInstalledApps(const QString& justInstalledAppID = "");
     Q_INVOKABLE bool installApp(const QString& appHref);
     Q_INVOKABLE bool uninstallApp(const QString& appHref);
     Q_INVOKABLE bool openApp(const QString& appHref);


### PR DESCRIPTION
This PR fixes [MS16615](https://highfidelity.fogbugz.com/f/cases/16615/Unable-to-open-Spectator-Camera-from-My-Purchases-in-HMD-from-the-Tablet) which started occurring after we merged #13347, which was the fix for [MS15721](https://highfidelity.fogbugz.com/f/cases/15721/Installed-tablet-apps-automatically-re-install-themselves-when-visiting-My-Purchases).