### PR TITLE
Fix for "PAL orbs are no longer visible through tablet/toolbar and objects in world"

### DIFF
--- a/libraries/render-utils/src/RenderCommonTask.cpp
+++ b/libraries/render-utils/src/RenderCommonTask.cpp
@@ -51,19 +51,19 @@ void DrawOverlay3D::run(const RenderContextPointer& renderContext, const Inputs&
     config->setNumDrawn((int)inItems.size());
     emit config->numDrawnChanged();
 
+    RenderArgs* args = renderContext->args;
+
+    // Clear the framebuffer without stereo
+    // Needs to be distinct from the other batch because using the clear call 
+    // while stereo is enabled triggers a warning
+    if (_opaquePass) {
+        gpu::doInBatch("DrawOverlay3D::run::clear", args->_context, [&](gpu::Batch& batch) {
+            batch.enableStereo(false);
+            batch.clearFramebuffer(gpu::Framebuffer::BUFFER_DEPTH, glm::vec4(), 1.f, 0, false);
+        });
+    }
+
     if (!inItems.empty()) {
-        RenderArgs* args = renderContext->args;
-
-        // Clear the framebuffer without stereo
-        // Needs to be distinct from the other batch because using the clear call 
-        // while stereo is enabled triggers a warning
-        if (_opaquePass) {
-            gpu::doInBatch("DrawOverlay3D::run::clear", args->_context, [&](gpu::Batch& batch){
-                batch.enableStereo(false);
-                batch.clearFramebuffer(gpu::Framebuffer::BUFFER_DEPTH, glm::vec4(), 1.f, 0, false);
-            });
-        }
-
         // Render the items
         gpu::doInBatch("DrawOverlay3D::main", args->_context, [&](gpu::Batch& batch) {
             args->_batch = &batch;


### PR DESCRIPTION
# Description
This PR addresses https://highfidelity.manuscript.com/f/cases/16595/.

# Testing
1.  Enter a domain with people in it and select People from the tablet.
2.  Verify that orbs (small spheres on avatars) appear over the tablet and any objects.

3.  In addition - run the automated test `tests\content\overlay\alpha\test.js`