### PR TITLE
Fix aligning selection to grid

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1853,13 +1853,7 @@ var keyReleaseEvent = function (event) {
         }
     } else if (event.text === 'g') {
         if (isActive && selectionManager.hasSelection()) {
-            var newPosition = selectionManager.worldPosition;
-            newPosition = Vec3.subtract(newPosition, {
-                x: 0,
-                y: selectionManager.worldDimensions.y * 0.5,
-                z: 0
-            });
-            grid.setPosition(newPosition);
+            grid.moveToSelection();
         }
     } else if (event.key === KEY_P && event.isControl && !event.isAutoRepeat ) {
         if (event.isShifted) {

--- a/scripts/system/libraries/gridTool.js
+++ b/scripts/system/libraries/gridTool.js
@@ -154,6 +154,12 @@ Grid = function(opts) {
             that.emitUpdate();
         }
     };
+    
+    that.moveToSelection = function() {
+        var newPosition = SelectionManager.worldPosition;
+        newPosition = Vec3.subtract(newPosition, { x: 0, y: SelectionManager.worldDimensions.y * 0.5, z: 0 });
+        that.setPosition(newPosition);
+    };
 
     that.emitUpdate = function() {
         if (that.onUpdate) {
@@ -263,6 +269,8 @@ GridTool = function(opts) {
             print("gridTool.js: Error parsing JSON: " + e.name + " data " + data);
             return;
         }
+        
+        print("DBACKTEST webEventReceived " + data.type);
 
         if (data.type == "init") {
             horizontalGrid.emitUpdate();
@@ -272,6 +280,7 @@ GridTool = function(opts) {
                 listeners[i] && listeners[i](data);
             }
         } else if (data.type == "action") {
+            print("DBACKTEST webEventReceived action " + data.action);
             var action = data.action;
             if (action == "moveToAvatar") {
                 var position = MyAvatar.getJointPosition("LeftFoot");
@@ -280,9 +289,7 @@ GridTool = function(opts) {
                 }
                 horizontalGrid.setPosition(position);
             } else if (action == "moveToSelection") {
-                var newPosition = selectionManager.worldPosition;
-                newPosition = Vec3.subtract(newPosition, { x: 0, y: selectionManager.worldDimensions.y * 0.5, z: 0 });
-                grid.setPosition(newPosition);
+                horizontalGrid.moveToSelection();
             }
         }
     };

--- a/scripts/system/libraries/gridTool.js
+++ b/scripts/system/libraries/gridTool.js
@@ -269,8 +269,6 @@ GridTool = function(opts) {
             print("gridTool.js: Error parsing JSON: " + e.name + " data " + data);
             return;
         }
-        
-        print("DBACKTEST webEventReceived " + data.type);
 
         if (data.type == "init") {
             horizontalGrid.emitUpdate();
@@ -280,7 +278,6 @@ GridTool = function(opts) {
                 listeners[i] && listeners[i](data);
             }
         } else if (data.type == "action") {
-            print("DBACKTEST webEventReceived action " + data.action);
             var action = data.action;
             if (action == "moveToAvatar") {
                 var position = MyAvatar.getJointPosition("LeftFoot");


### PR DESCRIPTION
Fixes: https://highfidelity.manuscript.com/f/cases/edit/16559

Test Plan:
-Enter Interface in desktop mode
-Open Create and select any entity or entities
-Select the Grid tab and make it visible
-Click Align to Selection and verify the grid is now aligned to the bottom of the selected entities
-Click Align to Avatar and verify the grid is now aligned to the bottom of your avatar
-Click on any selected entity to set focus in world and away from Create window
-Press G key and verify the grid is now aligned to the bottom of the selected entity
-Repeat a few times selecting different entities and aligning them to selection either via Align to Selection button on grid window or pressing G when focused in world