### PR TITLE
Android - Refresh domains list with swipe

### DIFF
--- a/android/app/src/main/java/io/highfidelity/hifiinterface/fragment/HomeFragment.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/fragment/HomeFragment.java
@@ -4,6 +4,7 @@ import android.app.Fragment;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.Editable;
@@ -32,6 +33,7 @@ public class HomeFragment extends Fragment {
 
 
     private OnHomeInteractionListener mListener;
+    private SwipeRefreshLayout mSwipeRefreshLayout;
 
     public native String nativeGetLastLocation();
 
@@ -57,6 +59,7 @@ public class HomeFragment extends Fragment {
         View rootView = inflater.inflate(R.layout.fragment_home, container, false);
 
         searchNoResultsView = rootView.findViewById(R.id.searchNoResultsView);
+        mSwipeRefreshLayout = rootView.findViewById(R.id.swipeRefreshLayout);
 
         mDomainsView = rootView.findViewById(R.id.rvDomains);
         int numberOfColumns = 1;
@@ -76,12 +79,14 @@ public class HomeFragment extends Fragment {
                 searchNoResultsView.setText(R.string.search_no_results);
                 searchNoResultsView.setVisibility(View.VISIBLE);
                 mDomainsView.setVisibility(View.GONE);
+                mSwipeRefreshLayout.setRefreshing(false);
             }
 
             @Override
             public void onNonEmptyAdapter() {
                 searchNoResultsView.setVisibility(View.GONE);
                 mDomainsView.setVisibility(View.VISIBLE);
+                mSwipeRefreshLayout.setRefreshing(false);
             }
 
             @Override
@@ -104,7 +109,7 @@ public class HomeFragment extends Fragment {
 
             @Override
             public void afterTextChanged(Editable editable) {
-                mDomainAdapter.loadDomains(editable.toString());
+                mDomainAdapter.loadDomains(editable.toString(), false);
                 if (editable.length() > 0) {
                     mSearchIconView.setVisibility(View.GONE);
                     mClearSearch.setVisibility(View.VISIBLE);
@@ -129,6 +134,13 @@ public class HomeFragment extends Fragment {
         });
 
         mClearSearch.setOnClickListener(view -> onSearchClear(view));
+
+        mSwipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+            @Override
+            public void onRefresh() {
+                mDomainAdapter.loadDomains(mSearchView.getText().toString(), true);
+            }
+        });
 
         getActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/provider/DomainProvider.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/provider/DomainProvider.java
@@ -10,7 +10,7 @@ import io.highfidelity.hifiinterface.view.DomainAdapter;
 
 public interface DomainProvider {
 
-    void retrieve(String filterText, DomainCallback domainCallback);
+    void retrieve(String filterText, DomainCallback domainCallback, boolean forceRefresh);
 
     interface DomainCallback {
         void retrieveOk(List<DomainAdapter.Domain> domain);

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/provider/UserStoryDomainProvider.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/provider/UserStoryDomainProvider.java
@@ -49,8 +49,8 @@ public class UserStoryDomainProvider implements DomainProvider {
     }
 
     @Override
-    public synchronized void retrieve(String filterText, DomainCallback domainCallback) {
-        if (!startedToGetFromAPI) {
+    public synchronized void retrieve(String filterText, DomainCallback domainCallback, boolean forceRefresh) {
+        if (!startedToGetFromAPI || forceRefresh) {
             startedToGetFromAPI = true;
             fillDestinations(filterText, domainCallback);
         } else {
@@ -72,6 +72,7 @@ public class UserStoryDomainProvider implements DomainProvider {
                     allStories.clear();
                     getUserStoryPage(1, allStories, null,
                             ex -> {
+                                suggestions.clear();
                                 allStories.forEach(userStory -> {
                                     if (taggedStoriesIds.contains(userStory.id)) {
                                         userStory.tagFound = true;

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/view/DomainAdapter.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/view/DomainAdapter.java
@@ -42,14 +42,14 @@ public class DomainAdapter extends RecyclerView.Adapter<DomainAdapter.ViewHolder
         mProtocol = protocol;
         mLastLocation = lastLocation;
         domainProvider = new UserStoryDomainProvider(mProtocol);
-        loadDomains("");
+        loadDomains("", true);
     }
 
     public void setListener(AdapterListener adapterListener) {
         mAdapterListener = adapterListener;
     }
 
-    public void loadDomains(String filterText) {
+    public void loadDomains(String filterText, boolean forceRefresh) {
         domainProvider.retrieve(filterText, new DomainProvider.DomainCallback() {
             @Override
             public void retrieveOk(List<Domain> domain) {
@@ -76,7 +76,7 @@ public class DomainAdapter extends RecyclerView.Adapter<DomainAdapter.ViewHolder
                 Log.e("DOMAINS", message, e);
                 if (mAdapterListener != null) mAdapterListener.onError(e, message);
             }
-        });
+        }, forceRefresh);
     }
 
     private void overrideDefaultThumbnails(List<Domain> domain) {

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -63,13 +63,18 @@
         android:visibility="gone"
         />
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/rvDomains"
+    <android.support.v4.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
         app:layout_constraintTop_toBottomOf="@id/searchView"
         app:layout_constraintBottom_toBottomOf="@id/contentHomeRoot"
         app:layout_constraintStart_toStartOf="@id/contentHomeRoot"
         app:layout_constraintEnd_toEndOf="@id/contentHomeRoot"
         android:layout_width="0dp"
-        android:layout_height="0dp" />
-
+        android:layout_height="0dp">
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/rvDomains"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+        />
+    </android.support.v4.widget.SwipeRefreshLayout>
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
One of the proposals for the domains list.

**Test Plan:**

1. Start the app
2. Should load a list of domains
3. (Optional but recommended) untag one of the appearing domains in its server settings page (remove 'mobile' tag)
4. Refresh by swiping down (Android standard way to refresh lists)
5. List should reload
6. (Optional but recommended) if any domain had removed its mobile tag, a domain was deleted or a new domain (tagged with mobile) was created, that change should be reflected in the list.
