### PR TITLE
FB16560 Active  Avatar App - New Bookmarks Not correctly Starred

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/AvatarsModel.qml
+++ b/interface/resources/qml/hifi/avatarapp/AvatarsModel.qml
@@ -126,7 +126,7 @@ ListModel {
                 var v2 = o2[prop];
 
 
-                if(v1 !== v2 && Math.round(v1 * 500) != Math.round(v2 * 500)) {
+                if(v1 !== v2 && Math.round(v1 * 100) != Math.round(v2 * 100)) {
                     return false;
                 }
             }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/16560/Avatar-App-New-Bookmarks-Not-correctly-Starred

*** Test plan *** 

1. Select avatar with some wearables
2. Adjust wearables, save changes
3. Save bookmark under new name
4. Ensure newly-saved bookmark is the first in list of bookmarks, it has selection rectangle and star is yellow. 
5. Repeat 1-4 several times for different avatars making different adjustments of wearables. 
