### PR TITLE
Fix quickly clicking an edit handle causing selected entity change

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1075,15 +1075,19 @@ function mouseReleaseEvent(event) {
     }
 }
 
-function wasTabletClicked(event) {
+function wasTabletOrEditHandleClicked(event) {
     var rayPick = Camera.computePickRay(event.x, event.y);
-    var tabletIDs = getMainTabletIDs();
-    if (tabletIDs.length === 0) {
-        return false;
-    } else {
-        var result = Overlays.findRayIntersection(rayPick, true, getMainTabletIDs());
-        return result.intersects;
+    var result = Overlays.findRayIntersection(rayPick, true);
+    if (result.intersects) {
+        var overlayID = result.overlayID;
+        var tabletIDs = getMainTabletIDs();
+        if (tabletIDs.indexOf(overlayID) >= 0) {
+            return true;
+        } else if (selectionDisplay.isEditHandle(overlayID)) {
+            return true;
+        }
     }
+    return false;
 }
 
 function mouseClickEvent(event) {
@@ -1091,8 +1095,8 @@ function mouseClickEvent(event) {
     var result, properties, tabletClicked;
     if (isActive && event.isLeftButton) {
         result = findClickedEntity(event);
-        tabletClicked = wasTabletClicked(event);
-        if (tabletClicked) {
+        tabletOrEditHandleClicked = wasTabletOrEditHandleClicked(event);
+        if (tabletOrEditHandleClicked) {
             return;
         }
 

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -658,6 +658,7 @@ SelectionDisplay = (function() {
         selectionBox,
         iconSelectionBox
     ];
+    var maximumHandleInAllOverlays = handleCloner;
 
     overlayNames[handleTranslateXCone] = "handleTranslateXCone";
     overlayNames[handleTranslateXCylinder] = "handleTranslateXCylinder";
@@ -781,6 +782,12 @@ SelectionDisplay = (function() {
         return Math.abs(position.x) <= box.dimensions.x / 2 && Math.abs(position.y) <= box.dimensions.y / 2
             && Math.abs(position.z) <= box.dimensions.z / 2;
     }
+    
+    that.isEditHandle = function(overlayID) {
+        var overlayIndex = allOverlays.indexOf(overlayID);
+        var maxHandleIndex = allOverlays.indexOf(maximumHandleInAllOverlays);
+        return overlayIndex >= 0 && overlayIndex <= maxHandleIndex;
+    };
 
     // FUNCTION: MOUSE PRESS EVENT
     that.mousePressEvent = function (event) {


### PR DESCRIPTION
Fixes: https://highfidelity.manuscript.com/f/cases/16557/

Test Plan:
- Enter Interface in desktop mode
- Ensure you have at least 2 small entities you can select or Create 2 or more entities using Create
- Position one entity so that it is in between you and the 2nd entity
- In Create, select the closest entity to you
- Orient so that at least some edit handles of the selected entity are between the camera and the 2nd entity
- Attempt to quickly click and release any edit handles that are in front of / overlapping the 2nd entity and verify the selected entity does not change
- Attempt to select and use any edit handles on the selected entity and verify the selected entity does not change and the edit handles work as expected
- Repeat selecting different edit handles of the selected entity that are in front of / overlapping the 2nd entity and verify the selected entity does not change
- With the closer entity still selected, verify clicking anywhere on the 2nd entity that is within the edit handle area of the selected entity (but not on any edit handles) allows the selection to change to the 2nd entity
- Find or Create a very large entity and stand inside it (such as a Cube with My Avatar collisions turned off)
- Place another entity inside the above large entity with you and select it
- Attempt to quickly click and release any edit handles on the selected entity and verify the selected entity does not change
- Attempt to select and use any edit handles on the selected entity and verify the selected entity does not change and the edit handles work as expected
- Click outside of the selected entity's edit handles and verify the selected entity changes to the large one you are inside
- Click the previously selected entity again and verify the selected entity switches back to it