### PR TITLE
[FIX] Use create app in tablet mode when choosing to use tablet in desktop mode

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -63,6 +63,15 @@ var createToolsWindow = new CreateWindow(
     false
 );
 
+/**
+ * @description Returns true in case we should use the tablet version of the CreateApp
+ * @returns boolean
+ */
+var shouldUseEditTabletApp = function() {
+    return HMD.active || (!HMD.active && !Settings.getValue("desktopTabletBecomesToolbar", true));
+};
+
+
 var selectionDisplay = SelectionDisplay;
 var selectionManager = SelectionManager;
 
@@ -88,11 +97,12 @@ var cameraManager = new CameraManager();
 var grid = new Grid();
 var gridTool = new GridTool({
     horizontalGrid: grid,
-    createToolsWindow: createToolsWindow
+    createToolsWindow: createToolsWindow,
+    shouldUseEditTabletApp: shouldUseEditTabletApp
 });
 gridTool.setVisible(false);
 
-var entityListTool = new EntityListTool();
+var entityListTool = new EntityListTool(shouldUseEditTabletApp);
 
 selectionManager.addEventListener(function () {
     selectionDisplay.updateHandles();
@@ -578,7 +588,8 @@ var toolBar = (function () {
         });
         createButton = activeButton;
         tablet.screenChanged.connect(function (type, url) {
-            var isGoingToHomescreenOnDesktop = (!HMD.active && (url === 'hifi/tablet/TabletHome.qml' || url === ''));
+            var isGoingToHomescreenOnDesktop = (!shouldUseEditTabletApp() &&
+                (url === 'hifi/tablet/TabletHome.qml' || url === ''));
             if (isActive && (type !== "QML" || url !== "hifi/tablet/Edit.qml") && !isGoingToHomescreenOnDesktop) {
                 that.setActive(false);
             }
@@ -605,7 +616,7 @@ var toolBar = (function () {
         });
         function createNewEntityDialogButtonCallback(entityType) {
             return function() {
-                if (HMD.active) {
+                if (shouldUseEditTabletApp()) {
                     // tablet version of new-model dialog
                     var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
                     tablet.pushOntoStack("hifi/tablet/New" + entityType + "Dialog.qml");
@@ -837,7 +848,7 @@ var toolBar = (function () {
             selectionDisplay.triggerMapping.disable();
             tablet.landscape = false;
         } else {
-            if (HMD.active) {
+            if (shouldUseEditTabletApp()) {
                 tablet.loadQMLSource("hifi/tablet/Edit.qml", true);
             } else {
                 // make other apps inactive while in desktop mode
@@ -1989,8 +2000,8 @@ var PropertiesTool = function (opts) {
 
     that.setVisible = function (newVisible) {
         visible = newVisible;
-        webView.setVisible(HMD.active && visible);
-        createToolsWindow.setVisible(!HMD.active && visible);
+        webView.setVisible(shouldUseEditTabletApp() && visible);
+        createToolsWindow.setVisible(!shouldUseEditTabletApp() && visible);
     };
 
     that.setVisible(false);
@@ -2416,7 +2427,7 @@ function selectParticleEntity(entityID) {
 
     // Switch to particle explorer
     var selectTabMethod = { method: 'selectTab', params: { id: 'particle' } };
-    if (HMD.active) {
+    if (shouldUseEditTabletApp()) {
         var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
         tablet.sendToQml(selectTabMethod);
     } else {

--- a/scripts/system/libraries/entityList.js
+++ b/scripts/system/libraries/entityList.js
@@ -11,7 +11,7 @@
 /* global EntityListTool, Tablet, selectionManager, Entities, Camera, MyAvatar, Vec3, Menu, Messages,
    cameraManager, MENU_EASE_ON_FOCUS, deleteSelectedEntities, toggleSelectedEntitiesLocked, toggleSelectedEntitiesVisible */
 
-EntityListTool = function() {
+EntityListTool = function(shouldUseEditTabletApp) {
     var that = {};
 
     var CreateWindow = Script.require('../modules/createWindow.js');
@@ -55,8 +55,8 @@ EntityListTool = function() {
 
     that.setVisible = function(newVisible) {
         visible = newVisible;
-        webView.setVisible(HMD.active && visible);
-        entityListWindow.setVisible(!HMD.active && visible);
+        webView.setVisible(shouldUseEditTabletApp() && visible);
+        entityListWindow.setVisible(!shouldUseEditTabletApp() && visible);
     };
 
     that.setVisible(false);

--- a/scripts/system/libraries/gridTool.js
+++ b/scripts/system/libraries/gridTool.js
@@ -1,6 +1,6 @@
 var GRID_CONTROLS_HTML_URL = Script.resolvePath('../html/gridControls.html');
 
-Grid = function(opts) {
+Grid = function() {
     var that = {};
     var gridColor = { red: 0, green: 0, blue: 0 };
     var gridAlpha = 0.6;
@@ -247,6 +247,7 @@ GridTool = function(opts) {
     var horizontalGrid = opts.horizontalGrid;
     var verticalGrid = opts.verticalGrid;
     var createToolsWindow = opts.createToolsWindow;
+    var shouldUseEditTabletApp = opts.shouldUseEditTabletApp;
     var listeners = [];
 
     var webView = null;
@@ -299,7 +300,7 @@ GridTool = function(opts) {
     };
 
     that.setVisible = function(visible) {
-        webView.setVisible(HMD.active && visible);
+        webView.setVisible(shouldUseEditTabletApp() && visible);
     };
 
     return that;


### PR DESCRIPTION
### Master branch PR of already merged RC70 PR: https://github.com/highfidelity/hifi/pull/13620

Fixes https://highfidelity.manuscript.com/f/cases/16765/Desktop-tablet-does-not-open-Create

## QA Test 
1) Enable tablet on Desktop (Developer > UI > Uncheck "Desktop tablet becomes toolbar")
2) Press "Tab" - Tablet should appear
3) Open "Create" - Create should open in tablet without extra windows
4) Smoke test functionality in tablet mode desktop
5) Switch back to native edit windows (Developer > UI > Check "Desktop tablet becomes toolbar")
6) Follow the testplan of https://github.com/highfidelity/hifi/pull/13495 for native desktop window functionality