### PR TITLE
Raise POSIX descriptor-limit in AC Monitor if necessary

### DIFF
--- a/assignment-client/src/AssignmentClientMonitor.cpp
+++ b/assignment-client/src/AssignmentClientMonitor.cpp
@@ -74,7 +74,7 @@ AssignmentClientMonitor::AssignmentClientMonitor(const unsigned int numAssignmen
     auto& packetReceiver = DependencyManager::get<NodeList>()->getPacketReceiver();
     packetReceiver.registerListener(PacketType::AssignmentClientStatus, this, "handleChildStatusPacket");
 
-    adjustOsResources(std::max(_numAssignmentClientForks, _maxAssignmentClientForks));
+    adjustOSResources(std::max(_numAssignmentClientForks, _maxAssignmentClientForks));
     // use QProcess to fork off a process for each of the child assignment clients
     for (unsigned int i = 0; i < _numAssignmentClientForks; i++) {
         spawnChildClient();
@@ -377,7 +377,7 @@ bool AssignmentClientMonitor::handleHTTPRequest(HTTPConnection* connection, cons
     return true;
 }
 
-void AssignmentClientMonitor::adjustOsResources(unsigned int numForks) const
+void AssignmentClientMonitor::adjustOSResources(unsigned int numForks) const
 {
 #ifdef _POSIX_SOURCE
     // QProcess on Unix uses six (I think) descriptors, some temporarily, for each child proc.

--- a/assignment-client/src/AssignmentClientMonitor.cpp
+++ b/assignment-client/src/AssignmentClientMonitor.cpp
@@ -25,6 +25,9 @@
 #include "AssignmentClientChildData.h"
 #include "SharedUtil.h"
 #include <QtCore/QJsonDocument>
+#ifdef POSIX_SOURCE
+#include <sys/resource.h>
+#endif
 
 const QString ASSIGNMENT_CLIENT_MONITOR_TARGET_NAME = "assignment-client-monitor";
 const int WAIT_FOR_CHILD_MSECS = 1000;
@@ -71,6 +74,7 @@ AssignmentClientMonitor::AssignmentClientMonitor(const unsigned int numAssignmen
     auto& packetReceiver = DependencyManager::get<NodeList>()->getPacketReceiver();
     packetReceiver.registerListener(PacketType::AssignmentClientStatus, this, "handleChildStatusPacket");
 
+    adjustOsResources(_numAssignmentClientForks);
     // use QProcess to fork off a process for each of the child assignment clients
     for (unsigned int i = 0; i < _numAssignmentClientForks; i++) {
         spawnChildClient();
@@ -371,4 +375,24 @@ bool AssignmentClientMonitor::handleHTTPRequest(HTTPConnection* connection, cons
 
 
     return true;
+}
+
+void AssignmentClientMonitor::adjustOsResources(unsigned int numForks) const
+{
+#ifdef _POSIX_SOURCE
+    // QProcess on Unix uses six descriptors, some temporarily, for each child proc.
+    unsigned requiredDescriptors = 30 + 6 * numForks;
+    struct rlimit descLimits;
+    if (getrlimit(RLIMIT_NOFILE, &descLimits) == 0) {
+        if (descLimits.rlim_cur < requiredDescriptors) {
+            descLimits.rlim_cur = requiredDescriptors;
+            if (setrlimit(RLIMIT_NOFILE, &descLimits) == 0) {
+                qDebug() << "Resetting descriptor limit to" << requiredDescriptors;
+            } else {
+                const char *const errorString = strerror(errno);
+                qDebug() << "Failed to reset descriptor limit to" << requiredDescriptors << ":" << errorString;
+            }
+        }
+    }
+#endif
 }

--- a/assignment-client/src/AssignmentClientMonitor.cpp
+++ b/assignment-client/src/AssignmentClientMonitor.cpp
@@ -25,7 +25,7 @@
 #include "AssignmentClientChildData.h"
 #include "SharedUtil.h"
 #include <QtCore/QJsonDocument>
-#ifdef POSIX_SOURCE
+#ifdef _POSIX_SOURCE
 #include <sys/resource.h>
 #endif
 

--- a/assignment-client/src/AssignmentClientMonitor.h
+++ b/assignment-client/src/AssignmentClientMonitor.h
@@ -23,7 +23,6 @@
 #include "AssignmentClientChildData.h"
 #include <HTTPManager.h>
 #include <HTTPConnection.h>
-#include <sys/resource.h>
 
 extern const char* NUM_FORKS_PARAMETER;
 

--- a/assignment-client/src/AssignmentClientMonitor.h
+++ b/assignment-client/src/AssignmentClientMonitor.h
@@ -23,6 +23,7 @@
 #include "AssignmentClientChildData.h"
 #include <HTTPManager.h>
 #include <HTTPConnection.h>
+#include <sys/resource.h>
 
 extern const char* NUM_FORKS_PARAMETER;
 
@@ -55,6 +56,7 @@ public slots:
 private:
     void spawnChildClient();
     void simultaneousWaitOnChildren(int waitMsecs);
+    void adjustOsResources(unsigned int numForks) const;
 
     QTimer _checkSparesTimer; // every few seconds see if it need fewer or more spare children
 

--- a/assignment-client/src/AssignmentClientMonitor.h
+++ b/assignment-client/src/AssignmentClientMonitor.h
@@ -55,7 +55,7 @@ public slots:
 private:
     void spawnChildClient();
     void simultaneousWaitOnChildren(int waitMsecs);
-    void adjustOsResources(unsigned int numForks) const;
+    void adjustOSResources(unsigned int numForks) const;
 
     QTimer _checkSparesTimer; // every few seconds see if it need fewer or more spare children
 

--- a/assignment-client/src/AssignmentClientMonitor.h
+++ b/assignment-client/src/AssignmentClientMonitor.h
@@ -23,6 +23,7 @@
 #include "AssignmentClientChildData.h"
 #include <HTTPManager.h>
 #include <HTTPConnection.h>
+#include <sys/resource.h>
 
 extern const char* NUM_FORKS_PARAMETER;
 


### PR DESCRIPTION
The QProcess operation uses several file descriptors per child process. On Ubuntu Linux launching many assignment clients may cause the process's soft limit on file descriptors (1024 normally) to be hit. This PR uses the POSIX interface to raise the limit if required.

https://highfidelity.manuscript.com/f/cases/15683/