### PR TITLE
16726 - Remove Black Boxes ( HMD.requestShowHandControllers() )

### DIFF
--- a/scripts/system/controllers/viveControllerConfiguration.js
+++ b/scripts/system/controllers/viveControllerConfiguration.js
@@ -78,7 +78,8 @@ VIVE_CONTROLLER_CONFIGURATION_LEFT = {
 
             parts: {
                 // DISABLED FOR NOW
-                /*tips: {
+                /*
+                tips: {
                     type: "static",
                     modelURL: viveTipsModelURL,
                     naturalPosition: {"x":-0.004377640783786774,"y":-0.034371938556432724,"z":0.06769277155399323},
@@ -103,7 +104,8 @@ VIVE_CONTROLLER_CONFIGURATION_LEFT = {
                             defaultTextureURL: TIP_TEXTURE_BASE_URL + "/Teleport.png"
                         }
                     }
-                },*/
+                },
+                */
 
                 // The touchpad type draws a dot indicating the current touch/thumb position
                 // and swaps in textures based on the thumb position.

--- a/scripts/system/controllers/viveControllerConfiguration.js
+++ b/scripts/system/controllers/viveControllerConfiguration.js
@@ -77,7 +77,8 @@ VIVE_CONTROLLER_CONFIGURATION_LEFT = {
             dimensions: viveNaturalDimensions,
 
             parts: {
-                tips: {
+                // DISABLED FOR NOW
+                /*tips: {
                     type: "static",
                     modelURL: viveTipsModelURL,
                     naturalPosition: {"x":-0.004377640783786774,"y":-0.034371938556432724,"z":0.06769277155399323},
@@ -102,7 +103,7 @@ VIVE_CONTROLLER_CONFIGURATION_LEFT = {
                             defaultTextureURL: TIP_TEXTURE_BASE_URL + "/Teleport.png"
                         }
                     }
-                },
+                },*/
 
                 // The touchpad type draws a dot indicating the current touch/thumb position
                 // and swaps in textures based on the thumb position.
@@ -215,6 +216,8 @@ VIVE_CONTROLLER_CONFIGURATION_RIGHT = {
             },
 
             parts: {
+                // DISABLED FOR NOW
+                /*
                 tips: {
                     type: "static",
                     modelURL: viveTipsModelURL,
@@ -242,6 +245,7 @@ VIVE_CONTROLLER_CONFIGURATION_RIGHT = {
                         }
                     }
                 },
+                */
 
                 // The touchpad type draws a dot indicating the current touch/thumb position
                 // and swaps in textures based on the thumb position.


### PR DESCRIPTION
Addresses MS ticket number 16726: https://highfidelity.fogbugz.com/f/cases/16726/Black-boxes-on-Vive-Wand-using-HMD-requestShowHandController

**Test Plan:**

**Note: REQUIRES HTC VIVE**

Open interface.exe scripting console and enter:

`HMD.requestShowHandControllers()`

Vive hand controllers should now show in user's field of view, without black boxes appearing all over it.