### PR TITLE
fix 'the drop down does not shows the wearable'

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
+++ b/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
@@ -125,6 +125,7 @@ Rectangle {
             id: wearablesCombobox
             anchors.left: parent.left
             anchors.right: parent.right
+            comboBox.textRole: "text"
 
             model: ListModel {
                 function findIndexById(id) {


### PR DESCRIPTION
**Test plan**

1. Launch avatarapp
2. Select avatar with wearables. 
3. Go to adjust wearables
4. Ensure wearables combobox is filled with items and current item is visible

https://highfidelity.manuscript.com/f/cases/edit/16826/AvatarApp-and-Avatar-Wearable-Issues