### PR TITLE
pre-fetch infinite scroll pages before reaching the end

### DIFF
--- a/interface/resources/qml/hifi/Feed.qml
+++ b/interface/resources/qml/hifi/Feed.qml
@@ -53,7 +53,7 @@ Column {
             'protocol=' + encodeURIComponent(Window.protocolSignature())
         ];
         endpoint: '/api/v1/user_stories?' + options.join('&');
-        itemsPerPage: 3;
+        itemsPerPage: 4;
         processPage: function (data) {
             return data.user_stories.map(makeModelData);
         };
@@ -106,7 +106,6 @@ Column {
         highlightMoveDuration: -1;
         highlightMoveVelocity: -1;
         currentIndex: -1;
-        onAtXEndChanged: { if (scroll.atXEnd && !scroll.atXBeginning) { suggestions.getNextPage(); } }
 
         spacing: 12;
         width: parent.width;

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -61,7 +61,7 @@ Rectangle {
                 'username';
         }
         sortAscending: connectionsTable.sortIndicatorOrder === Qt.AscendingOrder;
-        itemsPerPage: 9;
+        itemsPerPage: 10;
         listView: connectionsTable;
         processPage: function (data) {
             return data.users.map(function (user) {
@@ -786,14 +786,6 @@ Rectangle {
             }
 
             model: connectionsUserModel;
-            Connections {
-                target: connectionsTable.flickableItem;
-                onAtYEndChanged: {
-                    if (connectionsTable.flickableItem.atYEnd && !connectionsTable.flickableItem.atYBeginning) {
-                        connectionsUserModel.getNextPage();
-                    }
-                }
-            }
 
             // This Rectangle refers to each Row in the connectionsTable.
             rowDelegate: Rectangle {

--- a/interface/resources/qml/hifi/commerce/common/sendAsset/SendAsset.qml
+++ b/interface/resources/qml/hifi/commerce/common/sendAsset/SendAsset.qml
@@ -398,7 +398,7 @@ Item {
             http: root.http;
             listModelName: root.listModelName;
             endpoint: "/api/v1/users?filter=connections";
-            itemsPerPage: 8;
+            itemsPerPage: 9;
             listView: connectionsList;
             processPage: function (data) {
                 return data.users;
@@ -520,7 +520,6 @@ Item {
                     visible: !connectionsLoading.visible;
                     clip: true;
                     model: connectionsModel;
-                    onAtYEndChanged: if (connectionsList.atYEnd && !connectionsList.atYBeginning) { connectionsModel.getNextPage(); }
                     snapMode: ListView.SnapToItem;
                     // Anchors
                     anchors.fill: parent;

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -551,8 +551,9 @@ Rectangle {
 
         HifiModels.PSFListModel {
             id: purchasesModel;
-            itemsPerPage: 6;
+            itemsPerPage: 7;
             listModelName: 'purchases';
+            listView: purchasesContentsList;
             getPage: function () {
                 console.debug('getPage', purchasesModel.listModelName, root.isShowingMyItems, filterBar.primaryFilter_filterName, purchasesModel.currentPageToRetrieve, purchasesModel.itemsPerPage);
                 Commerce.inventory(
@@ -779,14 +780,6 @@ Rectangle {
                             }
                         }
                     }
-                }
-            }
-
-            
-            onAtYEndChanged: {
-                if (purchasesContentsList.atYEnd && !purchasesContentsList.atYBeginning) {
-                    console.log("User scrolled to the bottom of 'Purchases'.");
-                    purchasesModel.getNextPage();
                 }
             }
         }

--- a/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletHome.qml
@@ -212,6 +212,7 @@ Item {
         HifiModels.PSFListModel {
             id: transactionHistoryModel;
             listModelName: "transaction history"; // For debugging. Alternatively, we could specify endpoint for that purpose, even though it's not used directly.
+            listView: transactionHistory;
             itemsPerPage: 6;
             getPage: function () {
                 console.debug('getPage', transactionHistoryModel.listModelName, transactionHistoryModel.currentPageToRetrieve);
@@ -344,12 +345,6 @@ Item {
                             anchors.right: parent.right;
                             anchors.bottom: parent.bottom;
                         }
-                    }
-                }
-                onAtYEndChanged: {
-                    if (transactionHistory.atYEnd && !transactionHistory.atYBeginning) {
-                        console.log("User scrolled to the bottom of 'Recent Activity'.");
-                        transactionHistoryModel.getNextPage();
                     }
                 }
             }


### PR DESCRIPTION
machinery for fetching next page of inifinite scroll before it really is needed, and use in our infinite scrolls

completes https://highfidelity.manuscript.com/f/cases/16492/paging-display-punchlist-to-fix-loading-content-until-reach-the-end-of-queue

**Test Plan**: For each of the following, try scrolling and confirm that it feels smooth. It _is_ possible to scroll faster than the pages come in, but in normal use it should feel reasonable. (We use different scroll mechanisms in different places -- scroll bar, drag, etc.  We do not address that inconsistency here.)
- goto
- people => connections
- wallet => home (recent activity)
- wallet => send money => connections
- (wallet or marketplace) => My Purchases
- (wallet or marketplace) => My Purchases => (get the menu for any item to "flip" the card) => gift => connections