### PR TITLE
Windows System-tray wording change 

### DIFF
--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -405,7 +405,7 @@ LogWindow.prototype = {
     }
 };
 
-function goHomeClicked() {
+function visitSandboxClicked() {
     if (interfacePath) {
         startInterface('hifi://localhost');
     } else {
@@ -439,8 +439,8 @@ var labels = {
         }
     },
     goHome: {
-        label: 'Go Home',
-        click: goHomeClicked,
+        label: 'Visit Sandbox',
+        click: visitSandboxClicked,
         enabled: false
     },
     quit: {


### PR DESCRIPTION
Change the 'Go Home' menu item in the sandbox hidden-icon menu (in sys tray) to the more accurate 'Visit Sandbox'.

https://highfidelity.manuscript.com/f/cases/16743/
