### PR TITLE
Fix for audio continuing on destroyed Web 3D overlays

### DIFF
--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -138,11 +138,8 @@ void Web3DOverlay::destroyWebSurface() {
     // Fix for crash in QtWebEngineCore when rapidly switching domains
     // Call stop on the QWebEngineView before destroying OffscreenQMLSurface.
     if (rootItem) {
-        QObject* obj = rootItem->findChild<QObject*>("webEngineView");
-        if (obj) {
-            // stop loading
-            QMetaObject::invokeMethod(obj, "stop");
-        }
+        // stop loading
+        QMetaObject::invokeMethod(rootItem, "stop");
     }
 
     _webSurface->pause();
@@ -152,6 +149,11 @@ void Web3DOverlay::destroyWebSurface() {
 
     // If the web surface was fetched out of the cache, release it back into the cache
     if (_cachedWebSurface) {
+        // If it's going back into the cache make sure to explicitly set the URL to a blank page
+        // in order to stop any resource consumption or audio related to the page.
+        if (rootItem) {
+            rootItem->setProperty("url", "about:blank");
+        }
         auto offscreenCache = DependencyManager::get<OffscreenQmlSurfaceCache>();
         // FIXME prevents crash on shutdown, but we shoudln't have to do this check
         if (offscreenCache) {


### PR DESCRIPTION
Fix for case [16762](https://highfidelity.manuscript.com/f/cases/edit/16762/Killing-web-overlay-with-audio-doesn-t-stop-the-audio-stream).  

## Testing 

Follow the repro steps in the bug.  On master, the audio from web overlays will continue after they're destroyed.  On this PR build, the audio should stop when the overlay disappears.  