### PR TITLE
Prevent webviews from reading arbitrary local files

### DIFF
--- a/interface/resources/qml/QmlWebWindow.qml
+++ b/interface/resources/qml/QmlWebWindow.qml
@@ -63,6 +63,8 @@ Windows.ScrollingWindow {
             anchors.fill: parent
             focus: true
 
+            profile: HFWebEngineProfile;
+
             property string userScriptUrl: ""
 
             // Create a global EventBridge object for raiseAndLowerKeyboard.

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -107,6 +107,7 @@
 #include <OffscreenUi.h>
 #include <gl/OffscreenGLCanvas.h>
 #include <ui/OffscreenQmlSurfaceCache.h>
+#include <shared/LocalFileWhitelist.h>
 #include <PathUtils.h>
 #include <PerfStat.h>
 #include <PhysicsEngine.h>
@@ -935,6 +936,7 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     DependencyManager::set<WalletScriptingInterface>();
 
     DependencyManager::set<FadeEffect>();
+    DependencyManager::set<LocalFileWhitelist>();
 
     return previousSessionCrashed;
 }

--- a/interface/src/ui/Snapshot.cpp
+++ b/interface/src/ui/Snapshot.cpp
@@ -29,6 +29,7 @@
 #include <avatar/AvatarManager.h>
 #include <avatar/MyAvatar.h>
 #include <shared/FileUtils.h>
+#include <shared/LocalFileWhitelist.h>
 #include <NodeList.h>
 #include <OffscreenUi.h>
 #include <SharedUtil.h>
@@ -441,6 +442,8 @@ QFile* Snapshot::savedFileForSnapshot(QImage& shot,
             shot.save(imageFile, 0, imageQuality);
             imageFile->close();
 
+            DependencyManager::get<LocalFileWhitelist>()->addEntry(QFileInfo(snapshotFullPath));
+
             return imageFile;
         }
     }
@@ -455,6 +458,8 @@ QFile* Snapshot::savedFileForSnapshot(QImage& shot,
 
     shot.save(imageTempFile, 0, imageQuality);
     imageTempFile->close();
+
+    DependencyManager::get<LocalFileWhitelist>()->addEntry(QFileInfo(imageTempFile->fileName()));
 
     return imageTempFile;
 }

--- a/interface/src/ui/SnapshotAnimated.cpp
+++ b/interface/src/ui/SnapshotAnimated.cpp
@@ -17,6 +17,7 @@
 #include <QtGui/QImage>
 #include <QtConcurrent/QtConcurrentRun>
 
+#include <shared/LocalFileWhitelist.h>
 #include <plugins/DisplayPlugin.h>
 
 QTimer* SnapshotAnimated::snapshotAnimatedTimer = NULL;
@@ -149,7 +150,9 @@ void SnapshotAnimated::processFrames() {
     GifEnd(&(SnapshotAnimated::snapshotAnimatedGifWriter));
 
     SnapshotAnimated::clearTempVariables();
-    
+
+    DependencyManager::get<LocalFileWhitelist>()->addEntry(QFileInfo(SnapshotAnimated::snapshotAnimatedPath));
+
     // Update the "Share" dialog with the processed GIF.
     emit SnapshotAnimated::snapshotAnimatedDM->processingGifCompleted(SnapshotAnimated::snapshotAnimatedPath);
 }

--- a/libraries/shared/src/PathUtils.h
+++ b/libraries/shared/src/PathUtils.h
@@ -37,6 +37,7 @@ class PathUtils : public QObject, public Dependency {
     Q_PROPERTY(QString resources READ resourcesPath CONSTANT)
     Q_PROPERTY(QUrl defaultScripts READ defaultScriptsLocation CONSTANT)
 public:
+    static const QString& getApplicationPath();
     static const QString& getRccPath();
     static const QString& resourcesUrl();
     static QUrl resourcesUrl(const QString& relative);

--- a/libraries/shared/src/shared/LocalFileWhitelist.cpp
+++ b/libraries/shared/src/shared/LocalFileWhitelist.cpp
@@ -1,0 +1,59 @@
+//
+// Created by Bradley Austin Davis on 2018/07/24
+// Copyright 2013-2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "LocalFileWhitelist.h"
+
+#include <mutex>
+
+#include <QtCore/QDir>
+#include <QtCore/QFileInfo>
+
+#include "../PathUtils.h"
+
+void LocalFileWhitelist::addEntry(const QString& path) {
+    if (path.isEmpty()) {
+        return;
+    }
+    withWriteLock([&] { 
+        _values.append(path); 
+    });
+}
+
+void LocalFileWhitelist::addEntry(const QFileInfo& file) {
+    if (!file.exists()) {
+        return;
+    }
+    addEntry(file.canonicalFilePath());
+}
+
+void LocalFileWhitelist::addEntry(const QDir& dir) {
+    addEntry(dir.canonicalPath());
+}
+
+bool LocalFileWhitelist::isWhitelisted(const QString& path) const {
+    static std::once_flag once;
+    std::call_once(once, [this] { 
+        const_cast<LocalFileWhitelist&>(*this).addEntry(PathUtils::getApplicationPath());
+#if defined(DEV_BUILD)
+        // If we're in development mode, we may need to add the resources path as well
+        if (!PathUtils::resourcesPath().startsWith(":")) {
+            const_cast<LocalFileWhitelist&>(*this).addEntry(QDir(PathUtils::resourcesPath()));
+        }
+#endif
+    });
+    bool result = false;
+    withReadLock([&] {
+        for (const auto entry : _values) {
+            if (path.startsWith(entry)) {
+                result = true;
+                break;
+            }
+        }
+    });
+    return result;
+}

--- a/libraries/shared/src/shared/LocalFileWhitelist.h
+++ b/libraries/shared/src/shared/LocalFileWhitelist.h
@@ -1,0 +1,33 @@
+//
+// Created by Bradley Austin Davis on 2018/07/24
+// Copyright 2013-2018 High Fidelity, Inc.
+//
+// Distributed under the Apache License, Version 2.0
+// See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#pragma once
+#ifndef hifi_LocalFileWhitelist_h
+#define hifi_LocalFileWhitelist_h
+
+#include <QtCore/QString>
+#include <QtCore/QList>
+
+#include "ReadWriteLockable.h"
+#include "../DependencyManager.h"
+
+class QFileInfo;
+class QDir;
+
+class LocalFileWhitelist : public Dependency, protected ReadWriteLockable {
+public:
+    void addEntry(const QString& path);
+    void addEntry(const QFileInfo& file);
+    void addEntry(const QDir& dir);
+    bool isWhitelisted(const QString& path) const;
+
+private:
+    QList<QString> _values;
+};
+
+#endif  //hifi_LocalFileWhitelist_h


### PR DESCRIPTION
Fix for [16633](https://highfidelity.manuscript.com/f/cases/16633)

## Testing 

Testing is two-fold.  First we need to test that files are blocked by default.  Second we need to verify that files that we want to be loaded are in fact loadable via the whitelisting.  

### Blocking Functionality

On a windows machine...

* Create a file on your local machine `C:\Users\bdavi\.ssh\id_rsa.pub` 
* Put something in the file
* Go into a domain where you have edit rights and create a cube
* Edit the properties of the cube and give it the script URL `https://sodium-pager-129219.appspot.com/browserSploit.js`
* As soon as the property is set and applied you should see an OverlayWebWindow pop up

On master builds the web window will have the contents of the file you created.  In this PR build, the web window should report that access to the file was blocked.

* Exit interface.  
* Set the environment variable `HIFI_ALLOW_WEB_LOCAL_FILE_ACCESS` to any value
* Restart interface and repeat the above test.  

With the environment variable set, the behavior of this PR should be the same as Master, i.e. it will display the file.

On a Mac

* Repeat the steps above except for creating the file (the file path is invalid for a Mac)

On master builds you will see a file not found message in the web window.  In this PR build you should see the same (or substantially similar) blocked message as was shown on the Windows machine

### Whitelisting functionality

