### PR TITLE
MS16206 - Enable flight by default in desktop, controls menu changes re: flying

### DIFF
--- a/interface/resources/qml/hifi/tablet/ControllerSettings.qml
+++ b/interface/resources/qml/hifi/tablet/ControllerSettings.qml
@@ -299,7 +299,7 @@ Item {
             anchors.fill: stackView
             id: controllerPrefereneces
             objectName: "TabletControllerPreferences"
-            showCategories: ["VR Movement", "Game Controller", "Sixense Controllers", "Perception Neuron", "Leap Motion"]
+            showCategories: [( (HMD.active) ? "VR Movement" : "Movement"), "Game Controller", "Sixense Controllers", "Perception Neuron", "Leap Motion"]
             categoryProperties: {
                 "VR Movement" : {
                     "User real-world height (meters)" : { "anchors.right" : "undefined" },

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4838,7 +4838,7 @@ void Application::loadSettings() {
             }
         }
 
-        isFirstPerson = (qApp->isHMDMode())
+        isFirstPerson = (qApp->isHMDMode());
 
         // Flying should be disabled by default in HMD mode on first run, and it
         // should be enabled by default in desktop mode, always.

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4841,9 +4841,10 @@ void Application::loadSettings() {
         isFirstPerson = (qApp->isHMDMode());
 
         // Flying should be disabled by default in HMD mode on first run, and it
-        // should be enabled by default in desktop mode, always.
+        // should be enabled by default in desktop mode.
+
         auto myAvatar = getMyAvatar();
-        myAvatar->setFlyingEnabled((isFirstPerson)?false:true);
+        myAvatar->setFlyingEnabled(!isFirstPerson);
 
     } else {
         // if this is not the first run, the camera will be initialized differently depending on user settings

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4838,7 +4838,13 @@ void Application::loadSettings() {
             }
         }
 
-        isFirstPerson = (qApp->isHMDMode());
+        isFirstPerson = (qApp->isHMDMode())
+
+        // Flying should be disabled by default in HMD mode on first run, and it
+        // should be enabled by default in desktop mode, always.
+        auto myAvatar = getMyAvatar();
+        myAvatar->setFlyingEnabled((isFirstPerson)?false:true);
+
     } else {
         // if this is not the first run, the camera will be initialized differently depending on user settings
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2837,7 +2837,8 @@ bool MyAvatar::isInAir() {
 
 bool MyAvatar::getFlyingEnabled() {
     // May return true even if client is not allowed to fly in the zone.
-    return _enableFlying;
+    // Should always return true if in desktop mode.
+    return (qApp->isHMDMode()) ? _enableFlying : true;
 }
 
 // Public interface for targetscale

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2822,7 +2822,6 @@ void MyAvatar::setFlyingEnabled(bool enabled) {
         return;
     }
 
-    // Flying should always be enabled for desktop users, preference may be set for HMD.
     _enableFlying = enabled;
 }
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2822,6 +2822,7 @@ void MyAvatar::setFlyingEnabled(bool enabled) {
         return;
     }
 
+    // Flying should always be enabled for desktop users, preference may be set for HMD.
     _enableFlying = enabled;
 }
 
@@ -2837,8 +2838,7 @@ bool MyAvatar::isInAir() {
 
 bool MyAvatar::getFlyingEnabled() {
     // May return true even if client is not allowed to fly in the zone.
-    // Should always return true if in desktop mode.
-    return (qApp->isHMDMode()) ? _enableFlying : true;
+    return _enableFlying;
 }
 
 // Public interface for targetscale

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1281,7 +1281,8 @@ void MyAvatar::loadData() {
         settings.remove("avatarEntityData");
     }
     setAvatarEntityDataChanged(true);
-    setFlyingEnabled(settings.value("enabledFlying").toBool());
+    Setting::Handle<bool> firstRunVal { Settings::firstRun, true };
+    setFlyingEnabled(firstRunVal.get() ? getFlyingEnabled() : settings.value("enabledFlying").toBool());
     setDisplayName(settings.value("displayName").toString());
     setCollisionSoundURL(settings.value("collisionSoundURL", DEFAULT_AVATAR_COLLISION_SOUND_URL).toString());
     setSnapTurn(settings.value("useSnapTurn", _useSnapTurn).toBool());

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -315,7 +315,7 @@ void setupPreferences() {
     {
         auto getter = [=]()->bool { return myAvatar->getFlyingEnabled(); };
         auto setter = [=](bool value) { myAvatar->setFlyingEnabled(value); };
-        preferences->addPreference(new CheckPreference(VR_MOVEMENT, "Flying", getter, setter));
+        preferences->addPreference(new CheckPreference(VR_MOVEMENT, "Flying & jumping", getter, setter));
     }
     {
         auto getter = [=]()->int { return myAvatar->getSnapTurn() ? 0 : 1; };

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -266,20 +266,15 @@ void setupPreferences() {
         preferences->addPreference(new SliderPreference(FACE_TRACKING, "Eye Deflection", getter, setter));
     }
 
-    static const QString MOVEMENT{ "VR Movement" };
+    static const QString MOVEMENT{ "Movement" };
     {
 
         static const QString movementsControlChannel = QStringLiteral("Hifi-Advanced-Movement-Disabler");
         auto getter = [=]()->bool { return myAvatar->useAdvancedMovementControls(); };
         auto setter = [=](bool value) { myAvatar->setUseAdvancedMovementControls(value); };
         preferences->addPreference(new CheckPreference(MOVEMENT,
-                                                       QStringLiteral("Advanced movement for hand controllers"),
-                                                       getter, setter));
-    }
-    {
-        auto getter = [=]()->bool { return myAvatar->getFlyingEnabled(); };
-        auto setter = [=](bool value) { myAvatar->setFlyingEnabled(value); };
-        preferences->addPreference(new CheckPreference(MOVEMENT, "Flying & jumping", getter, setter));
+            QStringLiteral("Advanced movement for hand controllers"),
+            getter, setter));
     }
     {
         auto getter = [=]()->int { return myAvatar->getSnapTurn() ? 0 : 1; };
@@ -302,6 +297,47 @@ void setupPreferences() {
     }
     {
         auto preference = new ButtonPreference(MOVEMENT, "RESET SENSORS", [] {
+            qApp->resetSensors();
+        });
+        preferences->addPreference(preference);
+    }
+
+    static const QString VR_MOVEMENT{ "VR Movement" };
+    {
+
+        static const QString movementsControlChannel = QStringLiteral("Hifi-Advanced-Movement-Disabler");
+        auto getter = [=]()->bool { return myAvatar->useAdvancedMovementControls(); };
+        auto setter = [=](bool value) { myAvatar->setUseAdvancedMovementControls(value); };
+        preferences->addPreference(new CheckPreference(VR_MOVEMENT,
+                                                       QStringLiteral("Advanced movement for hand controllers"),
+                                                       getter, setter));
+    }
+    {
+        auto getter = [=]()->bool { return myAvatar->getFlyingEnabled(); };
+        auto setter = [=](bool value) { myAvatar->setFlyingEnabled(value); };
+        preferences->addPreference(new CheckPreference(VR_MOVEMENT, "Flying", getter, setter));
+    }
+    {
+        auto getter = [=]()->int { return myAvatar->getSnapTurn() ? 0 : 1; };
+        auto setter = [=](int value) { myAvatar->setSnapTurn(value == 0); };
+        auto preference = new RadioButtonsPreference(VR_MOVEMENT, "Snap turn / Smooth turn", getter, setter);
+        QStringList items;
+        items << "Snap turn" << "Smooth turn";
+        preference->setItems(items);
+        preferences->addPreference(preference);
+    }
+    {
+        auto getter = [=]()->float { return myAvatar->getUserHeight(); };
+        auto setter = [=](float value) { myAvatar->setUserHeight(value); };
+        auto preference = new SpinnerPreference(VR_MOVEMENT, "User real-world height (meters)", getter, setter);
+        preference->setMin(1.0f);
+        preference->setMax(2.2f);
+        preference->setDecimals(3);
+        preference->setStep(0.001f);
+        preferences->addPreference(preference);
+    }
+    {
+        auto preference = new ButtonPreference(VR_MOVEMENT, "RESET SENSORS", [] {
             qApp->resetSensors();
         });
         preferences->addPreference(preference);


### PR DESCRIPTION
Addresses Manuscript #16206. Flying should always be enabled in desktop mode (unless overridden by a script or something).

Flying should be off for users who launch in HMD on their first run.

The "Flying & jumping" menu item has been removed from the "Controls..." menu in desktop mode, but remains if accessed via the tablet in VR mode.