### PR TITLE
Center of Gravity Turned off by Default

### DIFF
--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1628,7 +1628,7 @@ private:
     std::map<controller::Action, controller::Pose> _controllerPoseMap;
     mutable std::mutex _controllerPoseMapMutex;
 
-    bool _centerOfGravityModelEnabled { true };
+    bool _centerOfGravityModelEnabled { false };
     bool _hmdLeanRecenterEnabled { true };
     bool _sprint { false };
 


### PR DESCRIPTION
This pr changes the default behavior to have the center of gravity leaning code turned off.
This reverts to the previous method where the hips are placed under the head at all times.