### PR TITLE
Louder audio (new distance attenuation curve)

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1883,8 +1883,10 @@ float AudioClient::azimuthForSource(const glm::vec3& relativePosition) {
 float AudioClient::gainForSource(float distance, float volume) {
 
     // attenuation = -6dB * log2(distance)
-    // reference attenuation of 0dB at distance = 1.0m
-    float gain = volume / std::max(distance, HRTF_NEARFIELD_MIN);
+    // with reference attenuation of 0dB at distance = ATTN_DISTANCE_REF
+    float d = (1.0f / ATTN_DISTANCE_REF) * std::max(distance, HRTF_NEARFIELD_MIN);
+    float gain = volume / d;
+    gain = std::min(gain, ATTN_GAIN_MAX);
 
     return gain;
 }

--- a/libraries/audio/src/AudioHRTF.h
+++ b/libraries/audio/src/AudioHRTF.h
@@ -29,6 +29,10 @@ static const float HRTF_NEARFIELD_MAX = 1.0f;   // distance in meters
 static const float HRTF_NEARFIELD_MIN = 0.125f; // distance in meters
 static const float HRTF_HEAD_RADIUS = 0.0875f;  // average human head in meters
 
+// Distance attenuation
+static const float ATTN_DISTANCE_REF = 5.0f;    // distance where attn is 0dB
+static const float ATTN_GAIN_MAX = 100.0f;      // max gain allowed by distance attn (+40dB)
+
 class AudioHRTF {
 
 public:


### PR DESCRIPTION
By popular demand, this PR increases the audio loudness of all sources that undergo distance attenuation. The new curve sets the 0dB reference at 5m (instead of 1m) and peak gain at +40dB (instead of +18dB). This means sources closer than 5m from you are amplified rather than attenuated, and will be +14dB louder than before. The default falloff is still -6dB per log2(distance) and adjustable as before (via domain-server audio zones). The graph below shows the new curve in red, for low, default, and high falloff coefficients.

![dist_attn_ref5m](https://user-images.githubusercontent.com/13965157/43037428-cee51d96-8cc1-11e8-8533-93005cd11b23.png)

Side Effects:
1) With this change, post-mix dynamic range compression will be active most of the time. Loud sources in the nearfield, or many people in one domain, may result in extreme compression (instantaneous gain reduction >-30dB) and audible pumping artifacts. Digital clipping will still not occur; this is mathematically guaranteed by the look-ahead peak limiter.

2) Nearfield HRTF is still enabled, but is slightly less effective than before.

2) The balance between distance-attenuated and unattenuated sounds (eg. Ambisonic environments, web entities) will be changed, hopefully for the better.

3) Placing mono "system sounds" at MyAvatar.position with volume=1.0 is no longer a good idea, as they will be too loud with compressed dynamic range.