### PR TITLE
Avatarapp: hover animation for 'get more avatars' button

### DIFF
--- a/interface/resources/qml/hifi/AvatarApp.qml
+++ b/interface/resources/qml/hifi/AvatarApp.qml
@@ -682,6 +682,14 @@ Rectangle {
                                 PropertyChanges { target: container; y: -5 }
                                 PropertyChanges { target: favoriteAvatarImage; dropShadowRadius: 10 }
                                 PropertyChanges { target: favoriteAvatarImage; dropShadowVerticalOffset: 6 }
+                            },
+                            State {
+                                name: "getMoreAvatarsHovered"
+                                when: getMoreAvatarsMouseArea.containsMouse;
+                                PropertyChanges { target: getMoreAvatarsMouseArea; anchors.bottomMargin: -5 }
+                                PropertyChanges { target: container; y: -5 }
+                                PropertyChanges { target: getMoreAvatarsImage; dropShadowRadius: 10 }
+                                PropertyChanges { target: getMoreAvatarsImage; dropShadowVerticalOffset: 6 }
                             }
                         ]
 
@@ -741,6 +749,7 @@ Rectangle {
                         }
 
                         ShadowRectangle {
+                            id: getMoreAvatarsImage
                             width: 92
                             height: 92
                             radius: 5
@@ -756,7 +765,9 @@ Rectangle {
                             }
 
                             MouseArea {
+                                id: getMoreAvatarsMouseArea
                                 anchors.fill: parent
+                                hoverEnabled: true
 
                                 onClicked: {
                                     popup.showBuyAvatars(function() {


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/16991/In-the-avatar-app-the-Get-more-avatars-button-does-not-have-the-correct-animation-state

1. Open avatarapp
2. Ensure 'get more avatars' button animate on hover in the same way as other bookmarks buttons

![image](https://user-images.githubusercontent.com/23638/43103177-f7c54dec-8ed5-11e8-8ac2-4f7173fb817b.png)
