### PR TITLE
Redesign and enable hand's Pole Vectors for elbow simulation

### DIFF
--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -612,8 +612,6 @@ public:
 
     const MyHead* getMyHead() const;
 
-    Q_INVOKABLE void toggleHandPoleVectors() { _skeletonModel->getRig().toggleHandPoleVectors(); }
-
     /**jsdoc
      * Get the current position of the avatar's "Head" joint.
      * @function MyAvatar.getHeadPosition

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -612,6 +612,8 @@ public:
 
     const MyHead* getMyHead() const;
 
+    Q_INVOKABLE void toggleSmoothPoleVectors() { _skeletonModel->getRig().toggleSmoothPoleVectors(); };
+
     /**jsdoc
      * Get the current position of the avatar's "Head" joint.
      * @function MyAvatar.getHeadPosition

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -612,6 +612,8 @@ public:
 
     const MyHead* getMyHead() const;
 
+    Q_INVOKABLE void toggleHandPoleVectors() { _skeletonModel->getRig().toggleHandPoleVectors(); }
+
     /**jsdoc
      * Get the current position of the avatar's "Head" joint.
      * @function MyAvatar.getHeadPosition

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1500,8 +1500,6 @@ bool Rig::calculateElbowPoleVector(int handIndex, int elbowIndex, int armIndex, 
     }
 
     glm::vec3 armToHandDir = armToHand / armToHandDistance;
-    glm::vec3 armToElbowDir = armToElbow / armToElbowDistance;
-
     glm::vec3 armToHeadPlaneNormal = glm::cross(armToHead, armToHandDir);
 
     // The strenght of the resulting pole determined by the arm flex.

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1464,8 +1464,6 @@ bool Rig::calculateElbowPoleVector(int handIndex, int elbowIndex, int armIndex, 
     // pointing forward and with height aprox to the avatar head. The position of the horizontal point will be determined by the hands Y component.
     // The third vector apply a weighted correction to the resulting pole vector to avoid interpenetration and force a more natural pose.
 
-    float avatarScale = extractUniformScale(_modelOffset);
-
     AnimPose oppositeArmPose = _externalPoseSet._absolutePoses[oppositeArmIndex];
     AnimPose handPose = _externalPoseSet._absolutePoses[handIndex];
     AnimPose armPose = _externalPoseSet._absolutePoses[armIndex];
@@ -1492,7 +1490,6 @@ bool Rig::calculateElbowPoleVector(int handIndex, int elbowIndex, int armIndex, 
 
     float armToHandDistance = glm::length(armToHand);
     float armToElbowDistance = glm::length(armToElbow);
-    float armToHeadDistance = glm::length(armToHead);
     float elbowToHandDistance = glm::length(elbowToHand);
 
     float armTotalDistance = armToElbowDistance + elbowToHandDistance;
@@ -1504,8 +1501,7 @@ bool Rig::calculateElbowPoleVector(int handIndex, int elbowIndex, int armIndex, 
 
     glm::vec3 armToHandDir = armToHand / armToHandDistance;
     glm::vec3 armToElbowDir = armToElbow / armToElbowDistance;
-    
-    glm::vec3 armToHandPlaneNormal = glm::cross(armToHandDir, armToElbowDir);
+
     glm::vec3 armToHeadPlaneNormal = glm::cross(armToHead, armToHandDir);
 
     // The strenght of the resulting pole determined by the arm flex.

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1247,10 +1247,6 @@ void Rig::updateHands(bool leftHandEnabled, bool rightHandEnabled, bool hipsEnab
                       const FBXJointShapeInfo& spine1ShapeInfo, const FBXJointShapeInfo& spine2ShapeInfo,
                       const glm::mat4& rigToSensorMatrix, const glm::mat4& sensorToRigMatrix) {
 
-    float avatarScale = extractUniformScale(_modelOffset);
-
-    int hipsIndex = indexOfJoint("Hips");
-
     if (leftHandEnabled) {
 
         glm::vec3 handPosition = leftHandPose.trans();
@@ -1270,7 +1266,7 @@ void Rig::updateHands(bool leftHandEnabled, bool rightHandEnabled, bool hipsEnab
         int armJointIndex = _animSkeleton->nameToJointIndex("LeftArm");
         int elbowJointIndex = _animSkeleton->nameToJointIndex("LeftForeArm");
         int oppositeArmJointIndex = _animSkeleton->nameToJointIndex("RightArm");
-        if (_enablePoleVectors && handJointIndex >= 0 && armJointIndex >= 0 && elbowJointIndex >= 0 && oppositeArmJointIndex >= 0) {
+        if (handJointIndex >= 0 && armJointIndex >= 0 && elbowJointIndex >= 0 && oppositeArmJointIndex >= 0) {
             glm::vec3 poleVector;
             bool usePoleVector = calculateElbowPoleVector(handJointIndex, elbowJointIndex, armJointIndex, oppositeArmJointIndex, poleVector);
             if (usePoleVector) {
@@ -1313,7 +1309,7 @@ void Rig::updateHands(bool leftHandEnabled, bool rightHandEnabled, bool hipsEnab
         int elbowJointIndex = _animSkeleton->nameToJointIndex("RightForeArm");
         int oppositeArmJointIndex = _animSkeleton->nameToJointIndex("LeftArm");
 
-        if (_enablePoleVectors && handJointIndex >= 0 && armJointIndex >= 0 && elbowJointIndex >= 0 && oppositeArmJointIndex >= 0) {
+        if (handJointIndex >= 0 && armJointIndex >= 0 && elbowJointIndex >= 0 && oppositeArmJointIndex >= 0) {
             glm::vec3 poleVector;
             bool usePoleVector = calculateElbowPoleVector(handJointIndex, elbowJointIndex, armJointIndex, oppositeArmJointIndex, poleVector);
             if (usePoleVector) {
@@ -1508,11 +1504,8 @@ bool Rig::calculateElbowPoleVector(int handIndex, int elbowIndex, int armIndex, 
 
     glm::vec3 armToHandDir = armToHand / armToHandDistance;
     glm::vec3 armToElbowDir = armToElbow / armToElbowDistance;
-    glm::vec3 armToHeadDir = armToHead / armToHeadDistance;
     
     glm::vec3 armToHandPlaneNormal = glm::cross(armToHandDir, armToElbowDir);
-    glm::vec3 currentPoleVector = glm::normalize(glm::cross(armToHandPlaneNormal, armToHandDir));
-
     glm::vec3 armToHeadPlaneNormal = glm::cross(armToHead, armToHandDir);
 
     // The strenght of the resulting pole determined by the arm flex.

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -218,6 +218,8 @@ public:
     // input assumed to be in rig space
     void computeHeadFromHMD(const AnimPose& hmdPose, glm::vec3& headPositionOut, glm::quat& headOrientationOut) const;
 
+    void toggleHandPoleVectors() { _enablePoleVectors = !_enablePoleVectors; };
+
 signals:
     void onLoadComplete();
 
@@ -240,7 +242,7 @@ protected:
     void updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm::quat& modelRotation, const glm::vec3& lookAt, const glm::vec3& saccade);
     void calcAnimAlpha(float speed, const std::vector<float>& referenceSpeeds, float* alphaOut) const;
 
-    glm::vec3 calculateElbowPoleVector(int handIndex, int elbowIndex, int armIndex, int hipsIndex, bool isLeft) const;
+    bool calculateElbowPoleVector(int handIndex, int elbowIndex, int armIndex, int oppositeArmIndex, glm::vec3& outPoleVector) const;
     glm::vec3 calculateKneePoleVector(int footJointIndex, int kneeJoint, int upLegIndex, int hipsIndex, const AnimPose& targetFootPose) const;
     glm::vec3 deflectHandFromTorso(const glm::vec3& handPosition, const FBXJointShapeInfo& hipsShapeInfo, const FBXJointShapeInfo& spineShapeInfo,
                                    const FBXJointShapeInfo& spine1ShapeInfo, const FBXJointShapeInfo& spine2ShapeInfo) const;
@@ -368,11 +370,7 @@ protected:
     glm::vec3 _prevLeftFootPoleVector { Vectors::UNIT_Z }; // sensor space
     bool _prevLeftFootPoleVectorValid { false };
 
-    glm::vec3 _prevRightHandPoleVector { -Vectors::UNIT_Z }; // sensor space
-    bool _prevRightHandPoleVectorValid { false };
-
-    glm::vec3 _prevLeftHandPoleVector { -Vectors::UNIT_Z }; // sensor space
-    bool _prevLeftHandPoleVectorValid { false };
+    bool _enablePoleVectors{ true };
 
     int _rigId;
 };

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -217,7 +217,7 @@ public:
 
     // input assumed to be in rig space
     void computeHeadFromHMD(const AnimPose& hmdPose, glm::vec3& headPositionOut, glm::quat& headOrientationOut) const;
-
+    void toggleSmoothPoleVectors() { _smoothPoleVectors = !_smoothPoleVectors; };
 signals:
     void onLoadComplete();
 
@@ -244,6 +244,7 @@ protected:
     glm::vec3 calculateKneePoleVector(int footJointIndex, int kneeJoint, int upLegIndex, int hipsIndex, const AnimPose& targetFootPose) const;
     glm::vec3 deflectHandFromTorso(const glm::vec3& handPosition, const FBXJointShapeInfo& hipsShapeInfo, const FBXJointShapeInfo& spineShapeInfo,
                                    const FBXJointShapeInfo& spine1ShapeInfo, const FBXJointShapeInfo& spine2ShapeInfo) const;
+
 
     AnimPose _modelOffset;  // model to rig space
     AnimPose _geometryOffset; // geometry to model space (includes unit offset & fst offsets)
@@ -367,6 +368,14 @@ protected:
 
     glm::vec3 _prevLeftFootPoleVector { Vectors::UNIT_Z }; // sensor space
     bool _prevLeftFootPoleVectorValid { false };
+
+    glm::vec3 _prevRightHandPoleVector{ -Vectors::UNIT_Z }; // sensor space
+    bool _prevRightHandPoleVectorValid{ false };
+
+    glm::vec3 _prevLeftHandPoleVector{ -Vectors::UNIT_Z }; // sensor space
+    bool _prevLeftHandPoleVectorValid{ false };
+
+    bool _smoothPoleVectors { false };
 
     int _rigId;
 };

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -218,8 +218,6 @@ public:
     // input assumed to be in rig space
     void computeHeadFromHMD(const AnimPose& hmdPose, glm::vec3& headPositionOut, glm::quat& headOrientationOut) const;
 
-    void toggleHandPoleVectors() { _enablePoleVectors = !_enablePoleVectors; };
-
 signals:
     void onLoadComplete();
 
@@ -369,8 +367,6 @@ protected:
 
     glm::vec3 _prevLeftFootPoleVector { Vectors::UNIT_Z }; // sensor space
     bool _prevLeftFootPoleVectorValid { false };
-
-    bool _enablePoleVectors{ true };
 
     int _rigId;
 };

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -240,7 +240,7 @@ protected:
     void updateEyeJoint(int index, const glm::vec3& modelTranslation, const glm::quat& modelRotation, const glm::vec3& lookAt, const glm::vec3& saccade);
     void calcAnimAlpha(float speed, const std::vector<float>& referenceSpeeds, float* alphaOut) const;
 
-    bool calculateElbowPoleVector(int handIndex, int elbowIndex, int armIndex, int oppositeArmIndex, glm::vec3& outPoleVector) const;
+    bool calculateElbowPoleVector(int handIndex, int elbowIndex, int armIndex, int oppositeArmIndex, glm::vec3& poleVector) const;
     glm::vec3 calculateKneePoleVector(int footJointIndex, int kneeJoint, int upLegIndex, int hipsIndex, const AnimPose& targetFootPose) const;
     glm::vec3 deflectHandFromTorso(const glm::vec3& handPosition, const FBXJointShapeInfo& hipsShapeInfo, const FBXJointShapeInfo& spineShapeInfo,
                                    const FBXJointShapeInfo& spine1ShapeInfo, const FBXJointShapeInfo& spine2ShapeInfo) const;


### PR DESCRIPTION
This PR redesign and enables the pole vector's that determine the correct position of the elbows.
It fixes the issue where the arms end up inside the body when the user crosses arms or they leave the controls on the desk.

 https://highfidelity.manuscript.com/f/cases/16758/Elbows-Penetrating-the-Body-of-Humanoid-Avatars