### PR TITLE
Added _aboutToQuit guard on eventFilter()

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3650,6 +3650,10 @@ bool Application::event(QEvent* event) {
 
 bool Application::eventFilter(QObject* object, QEvent* event) {
 
+    if (_aboutToQuit) {
+        return true;
+    }
+
     if (event->type() == QEvent::Leave) {
         getApplicationCompositor().handleLeaveEvent();
     }


### PR DESCRIPTION
This addresses MS ticket [16984](https://highfidelity.fogbugz.com/f/cases/16984#BugEvent.110955), where the mouse leaving the window during shutdown caused an event to be processed incorrectly after the Application's destructor was called.

**Test Plan:**
1.) Launch interface.exe
2.) Exit cleanly.

If no crash on exit, ready for merge.