### PR TITLE
remove thread-unsafe socket errorString call

### DIFF
--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -229,7 +229,7 @@ qint64 Socket::writeDatagram(const QByteArray& datagram, const HifiSockAddr& soc
 
     if (bytesWritten < 0) {
         // when saturating a link this isn't an uncommon message - suppress it so it doesn't bomb the debug
-        HIFI_FCDEBUG(networking(), "Socket::writeDatagram" << _udpSocket.error() << "-" << qPrintable(_udpSocket.errorString()) );
+        HIFI_FCDEBUG(networking(), "Socket::writeDatagram" << _udpSocket.error());
     }
 
     return bytesWritten;
@@ -513,7 +513,7 @@ std::vector<HifiSockAddr> Socket::getConnectionSockAddrs() {
 }
 
 void Socket::handleSocketError(QAbstractSocket::SocketError socketError) {
-    HIFI_FCDEBUG(networking(), "udt::Socket error - " << socketError << _udpSocket.errorString());
+    HIFI_FCDEBUG(networking(), "udt::Socket error - " << socketError);
 }
 
 void Socket::handleStateChanged(QAbstractSocket::SocketState socketState) {


### PR DESCRIPTION
Fixed getting the `errorString` for QUdpSocket - it isn't thread-safe and causes a crash if called from multiple threads.