### PR TITLE
FB17023 - Make visible avatar url in the avatar app

### DIFF
--- a/interface/resources/qml/hifi/AvatarApp.qml
+++ b/interface/resources/qml/hifi/AvatarApp.qml
@@ -480,7 +480,7 @@ Rectangle {
             MouseArea {
                 anchors.fill: parent
                 onClicked: {
-                    popup.showSpecifyAvatarUrl(function() {
+                    popup.showSpecifyAvatarUrl(currentAvatar.avatarUrl, function() {
                         var url = popup.inputText.text;
                         emitSendToScript({'method' : 'applyExternalAvatar', 'avatarURL' : url})
                     }, function(link) {

--- a/interface/resources/qml/hifi/avatarapp/MessageBoxes.qml
+++ b/interface/resources/qml/hifi/avatarapp/MessageBoxes.qml
@@ -3,7 +3,7 @@ import QtQuick 2.5
 MessageBox {
     id: popup
 
-    function showSpecifyAvatarUrl(callback, linkCallback) {
+    function showSpecifyAvatarUrl(url, callback, linkCallback) {
         popup.onButton2Clicked = callback;
         popup.titleText = 'Specify Avatar URL'
         popup.bodyText = 'This will not overwrite your existing favorite if you are wearing one.<br>' +
@@ -12,6 +12,8 @@ MessageBox {
                 '</a>'
         popup.inputText.visible = true;
         popup.inputText.placeholderText = 'Enter Avatar Url';
+        popup.inputText.text = url;
+        popup.inputText.selectAll();
         popup.button1text = 'CANCEL';
         popup.button2text = 'CONFIRM';
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/17023/Make-visible-avatar-url-in-the-avatar-app

**Test plan**

1. Open avatar app
2. Open 'Select Avatar URL', ensure it shows url of currently selected avatar and this url is selected (like on the screen below)

![image](https://user-images.githubusercontent.com/23638/43160860-05243c64-8f8f-11e8-8fe1-0d7499029b99.png)
