### PR TITLE
FB16840 - Qml spinboxes in UI toolkit should focus the underlying fie…

### DIFF
--- a/interface/resources/qml/controls-uit/SpinBox.qml
+++ b/interface/resources/qml/controls-uit/SpinBox.qml
@@ -124,6 +124,11 @@ SpinBox {
             color: spinBox.up.pressed || spinBox.up.hovered ? (isLightColorScheme ? hifi.colors.black : hifi.colors.white) : hifi.colors.gray
         }
     }
+    up.onPressedChanged: {
+        if(value) {
+            spinBox.forceActiveFocus();
+        }
+    }
 
     down.indicator: Item {
             x: spinBox.width - implicitWidth - 5
@@ -137,6 +142,11 @@ SpinBox {
                 size: hifi.dimensions.spinnerSize
                 color: spinBox.down.pressed || spinBox.down.hovered ? (isLightColorScheme ? hifi.colors.black : hifi.colors.white) : hifi.colors.gray
             }
+    }
+    down.onPressedChanged: {
+        if(value) {
+            spinBox.forceActiveFocus();
+        }
     }
 
     HifiControls.Label {


### PR DESCRIPTION
…ld when clicked on

https://highfidelity.fogbugz.com/f/cases/16840/Qml-spinboxes-in-UI-toolkit-should-focus-the-underlying-field-when-clicked-on

**Test plan**

1. Ensure QML spinboxes gets focused on clicking up/down indicators. 

Sample of QML spinboxes can be found in AvatarApp, General Settings or in 'controlsGallery.js' debug script