### PR TITLE
Implement MS17039: Don't delete entities during DDV when Metaverse API call returns error

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -522,11 +522,8 @@ void EntityServer::startDynamicDomainVerification() {
                             qCDebug(entities) << "Entity passed dynamic domain verification:" << entityID;
                         }
                     } else {
-                        qCDebug(entities) << "Call to" << networkReply->url() << "failed with error" << networkReply->error() << "; deleting entity" << entityID
+                        qCDebug(entities) << "Call to" << networkReply->url() << "failed with error" << networkReply->error() << "; NOT deleting entity" << entityID
                             << "More info:" << jsonObject;
-                        tree->withWriteLock([&] {
-                            tree->deleteEntity(entityID, true);
-                        });
                     }
 
                     networkReply->deleteLater();


### PR DESCRIPTION
Implements [MS17039](https://highfidelity.manuscript.com/f/cases/17039/Don-t-delete-entities-during-DDV-when-Metaverse-API-call-returns-error).