### PR TITLE
FB17036 Avatar App causes error on cache reload (CTRL+R)

### DIFF
--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -455,10 +455,6 @@ startup();
 
 var isWired = false;
 function off() {
-    if (isWired) { // It is not ok to disconnect these twice, hence guard.
-        isWired = false;
-    }
-
     if(adjustWearables.opened) {
         adjustWearables.setOpened(false);
         ensureWearableSelected(null);
@@ -468,16 +464,20 @@ function off() {
         Messages.unsubscribe('Hifi-Object-Manipulation');
     }
 
-    AvatarBookmarks.bookmarkLoaded.disconnect(onBookmarkLoaded);
-    AvatarBookmarks.bookmarkDeleted.disconnect(onBookmarkDeleted);
-    AvatarBookmarks.bookmarkAdded.disconnect(onBookmarkAdded);
+    if (isWired) { // It is not ok to disconnect these twice, hence guard.
+        isWired = false;
 
-    MyAvatar.skeletonModelURLChanged.disconnect(onSkeletonModelURLChanged);
-    MyAvatar.dominantHandChanged.disconnect(onDominantHandChanged);
-    MyAvatar.collisionsEnabledChanged.disconnect(onCollisionsEnabledChanged);
-    MyAvatar.newCollisionSoundURL.disconnect(onNewCollisionSoundUrl);
-    MyAvatar.animGraphUrlChanged.disconnect(onAnimGraphUrlChanged);
-    MyAvatar.targetScaleChanged.disconnect(onTargetScaleChanged);
+        AvatarBookmarks.bookmarkLoaded.disconnect(onBookmarkLoaded);
+        AvatarBookmarks.bookmarkDeleted.disconnect(onBookmarkDeleted);
+        AvatarBookmarks.bookmarkAdded.disconnect(onBookmarkAdded);
+
+        MyAvatar.skeletonModelURLChanged.disconnect(onSkeletonModelURLChanged);
+        MyAvatar.dominantHandChanged.disconnect(onDominantHandChanged);
+        MyAvatar.collisionsEnabledChanged.disconnect(onCollisionsEnabledChanged);
+        MyAvatar.newCollisionSoundURL.disconnect(onNewCollisionSoundUrl);
+        MyAvatar.animGraphUrlChanged.disconnect(onAnimGraphUrlChanged);
+        MyAvatar.targetScaleChanged.disconnect(onTargetScaleChanged);
+    }
 }
 
 function on() {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17036/Avatar-App-causes-error-on-cache-reload-CTRL-R

**Test plan**

1. Launch interface 
2. Reload scripts
3. Ensure log doesn't contain avatarapp-related errors like the following: 

[07/24 14:14:08] [CRITICAL] [hifi.scriptengine] [defaultScripts.js] [UncaughtException signalHandlerException] Error: Function.prototype.disconnect: failed to disconnect from AvatarBookmarks::bookmarkLoaded(QString) in file:///C:/Users/wayne/development/hifi-fork/build/interface/Release/scripts/system/avatarapp.js:471
[07/24 14:14:08] [CRITICAL] [hifi.scriptengine] [Backtrace]
[07/24 14:14:08] [CRITICAL] [hifi.scriptengine]    off() at file:///C:/Users/wayne/development/hifi-fork/build/interface/Release/scripts/system/avatarapp.js:471
[07/24 14:14:08] [CRITICAL] [hifi.scriptengine]    shutdown() at file:///C:/Users/wayne/development/hifi-fork/build/interface/Release/scripts/system/avatarapp.js:556
[07/24 14:14:08] [CRITICAL] [hifi.scriptengine]    <global>() at -1
