### PR TITLE
Fix ScriptEngine begin held onto after script stopped runnning

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -344,8 +344,6 @@ void Agent::scriptRequestFinished() {
 void Agent::executeScript() {
     _scriptEngine = scriptEngineFactory(ScriptEngine::AGENT_SCRIPT, _scriptContents, _payload);
 
-    DependencyManager::get<RecordingScriptingInterface>()->setScriptEngine(_scriptEngine);
-
     // setup an Avatar for the script to use
     auto scriptedAvatar = DependencyManager::get<ScriptableAvatar>();
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6525,9 +6525,6 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEnginePointe
     entityScriptingInterface->setPacketSender(&_entityEditSender);
     entityScriptingInterface->setEntityTree(getEntities()->getTree());
 
-    // give the script engine to the RecordingScriptingInterface for its callbacks
-    DependencyManager::get<RecordingScriptingInterface>()->setScriptEngine(scriptEngine);
-
     if (property(hifi::properties::TEST).isValid()) {
         scriptEngine->registerGlobalObject("Test", TestScriptingInterface::getInstance());
     }

--- a/libraries/script-engine/src/RecordingScriptingInterface.cpp
+++ b/libraries/script-engine/src/RecordingScriptingInterface.cpp
@@ -59,7 +59,7 @@ void RecordingScriptingInterface::playClip(NetworkClipLoaderPointer clipLoader, 
 
     if (callback.isFunction()) {
         QScriptValueList args { true, url };
-        callback.call(_scriptEngine->globalObject(), args);
+        callback.call(QScriptValue(), args);
     }
 }
 
@@ -78,7 +78,7 @@ void RecordingScriptingInterface::loadRecording(const QString& url, QScriptValue
     auto weakClipLoader = clipLoader.toWeakRef();
 
     // when clip loaded, call the callback with the URL and success boolean
-    connect(clipLoader.data(), &recording::NetworkClipLoader::clipLoaded, this,
+    connect(clipLoader.data(), &recording::NetworkClipLoader::clipLoaded, callback.engine(),
             [this, weakClipLoader, url, callback]() mutable {
 
         if (auto clipLoader = weakClipLoader.toStrongRef()) {
@@ -92,12 +92,12 @@ void RecordingScriptingInterface::loadRecording(const QString& url, QScriptValue
     });
 
     // when clip load fails, call the callback with the URL and failure boolean
-    connect(clipLoader.data(), &recording::NetworkClipLoader::failed, this, [this, weakClipLoader, url, callback](QNetworkReply::NetworkError error) mutable {
+    connect(clipLoader.data(), &recording::NetworkClipLoader::failed, callback.engine(), [this, weakClipLoader, url, callback](QNetworkReply::NetworkError error) mutable {
         qCDebug(scriptengine) << "Failed to load recording from" << url;
 
         if (callback.isFunction()) {
             QScriptValueList args { false, url };
-            callback.call(_scriptEngine->currentContext()->thisObject(), args);
+            callback.call(QScriptValue(), args);
         }
 
         if (auto clipLoader = weakClipLoader.toStrongRef()) {

--- a/libraries/script-engine/src/RecordingScriptingInterface.h
+++ b/libraries/script-engine/src/RecordingScriptingInterface.h
@@ -36,8 +36,6 @@ class RecordingScriptingInterface : public QObject, public Dependency {
 public:
     RecordingScriptingInterface();
 
-    void setScriptEngine(QSharedPointer<BaseScriptEngine> scriptEngine) { _scriptEngine = scriptEngine; }
-
 public slots:
 
     /**jsdoc
@@ -246,7 +244,6 @@ protected:
     Flag _useSkeletonModel { false };
     recording::ClipPointer _lastClip;
 
-    QSharedPointer<BaseScriptEngine> _scriptEngine;
     QSet<recording::NetworkClipLoaderPointer> _clipLoaders;
 
 private:


### PR DESCRIPTION
Fixed the issue of the ScriptEngine not being released when stopping a script because the RecordingScriptingInterface still had a reference to the shared pointer.

ticket - https://highfidelity.fogbugz.com/f/cases/15944/Script-memory-sometimes-not-immediately-released-when-script-stopped