### PR TITLE
Move scriptable caches' APIs into scripting interfaces

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -32,8 +32,8 @@
 #include <udt/PacketHeaders.h>
 #include <ResourceCache.h>
 #include <ScriptCache.h>
-#include <SoundCacheScriptingInterface.h>
 #include <ScriptEngines.h>
+#include <SoundCacheScriptingInterface.h>
 #include <SoundCache.h>
 #include <UsersScriptingInterface.h>
 #include <UUID.h>
@@ -72,6 +72,7 @@ Agent::Agent(ReceivedMessage& message) :
 
     DependencyManager::set<ResourceCacheSharedItems>();
     DependencyManager::set<SoundCache>();
+    DependencyManager::set<SoundCacheScriptingInterface>();
     DependencyManager::set<AudioScriptingInterface>();
     DependencyManager::set<AudioInjectorManager>();
 
@@ -456,8 +457,8 @@ void Agent::executeScript() {
     // register ourselves to the script engine
     _scriptEngine->registerGlobalObject("Agent", this);
 
-    _scriptEngine->registerGlobalObject("SoundCache", new SoundCacheScriptingInterface(DependencyManager::get<SoundCache>().data()));
-    _scriptEngine->registerGlobalObject("AnimationCache", new AnimationCacheScriptingInterface(DependencyManager::get<AnimationCache>().data()));
+    _scriptEngine->registerGlobalObject("AnimationCache", DependencyManager::get<AnimationCacheScriptingInterface>().data());
+    _scriptEngine->registerGlobalObject("SoundCache", DependencyManager::get<SoundCacheScriptingInterface>().data());
 
     QScriptValue webSocketServerConstructorValue = _scriptEngine->newFunction(WebSocketServerClass::constructor);
     _scriptEngine->globalObject().setProperty("WebSocketServer", webSocketServerConstructorValue);
@@ -846,6 +847,7 @@ void Agent::aboutToFinish() {
     DependencyManager::destroy<ScriptEngines>();
 
     DependencyManager::destroy<ResourceCacheSharedItems>();
+    DependencyManager::destroy<SoundCacheScriptingInterface>();
     DependencyManager::destroy<SoundCache>();
     DependencyManager::destroy<AudioScriptingInterface>();
 

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -19,6 +19,7 @@
 #include <QtNetwork/QNetworkReply>
 #include <QThread>
 
+#include <AnimationCacheScriptingInterface.h>
 #include <AssetClient.h>
 #include <AvatarHashMap.h>
 #include <AudioInjectorManager.h>
@@ -31,6 +32,7 @@
 #include <udt/PacketHeaders.h>
 #include <ResourceCache.h>
 #include <ScriptCache.h>
+#include <SoundCacheScriptingInterface.h>
 #include <ScriptEngines.h>
 #include <SoundCache.h>
 #include <UsersScriptingInterface.h>
@@ -454,8 +456,8 @@ void Agent::executeScript() {
     // register ourselves to the script engine
     _scriptEngine->registerGlobalObject("Agent", this);
 
-    _scriptEngine->registerGlobalObject("SoundCache", DependencyManager::get<SoundCache>().data());
-    _scriptEngine->registerGlobalObject("AnimationCache", DependencyManager::get<AnimationCache>().data());
+    _scriptEngine->registerGlobalObject("SoundCache", new SoundCacheScriptingInterface(DependencyManager::get<SoundCache>().data()));
+    _scriptEngine->registerGlobalObject("AnimationCache", new AnimationCacheScriptingInterface(DependencyManager::get<AnimationCache>().data()));
 
     QScriptValue webSocketServerConstructorValue = _scriptEngine->newFunction(WebSocketServerClass::constructor);
     _scriptEngine->globalObject().setProperty("WebSocketServer", webSocketServerConstructorValue);

--- a/assignment-client/src/AssignmentClient.cpp
+++ b/assignment-client/src/AssignmentClient.cpp
@@ -21,6 +21,7 @@
 #include <shared/QtHelpers.h>
 #include <AccountManager.h>
 #include <AddressManager.h>
+#include <AnimationCacheScriptingInterface.h>
 #include <Assignment.h>
 #include <AvatarHashMap.h>
 #include <EntityScriptingInterface.h>
@@ -63,6 +64,7 @@ AssignmentClient::AssignmentClient(Assignment::Type requestAssignmentType, QStri
     auto nodeList = DependencyManager::set<NodeList>(NodeType::Unassigned, listenPort);
 
     auto animationCache = DependencyManager::set<AnimationCache>();
+    DependencyManager::set<AnimationCacheScriptingInterface>();
     auto entityScriptingInterface = DependencyManager::set<EntityScriptingInterface>(false);
 
     DependencyManager::registerInheritance<EntityDynamicFactoryInterface, AssignmentDynamicFactory>();

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -26,7 +26,7 @@
 #include <ResourceManager.h>
 #include <ScriptCache.h>
 #include <ScriptEngines.h>
-#include <SoundCache.h>
+#include <SoundCacheScriptingInterface.h>
 #include <UUID.h>
 #include <WebSocketServerClass.h>
 
@@ -438,7 +438,7 @@ void EntityScriptServer::resetEntitiesScriptEngine() {
     auto webSocketServerConstructorValue = newEngine->newFunction(WebSocketServerClass::constructor);
     newEngine->globalObject().setProperty("WebSocketServer", webSocketServerConstructorValue);
 
-    newEngine->registerGlobalObject("SoundCache", DependencyManager::get<SoundCache>().data());
+    newEngine->registerGlobalObject("SoundCache", new SoundCacheScriptingInterface(DependencyManager::get<SoundCache>().data()));
 
     // connect this script engines printedMessage signal to the global ScriptEngines these various messages
     auto scriptEngines = DependencyManager::get<ScriptEngines>().data();

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -66,6 +66,7 @@ EntityScriptServer::EntityScriptServer(ReceivedMessage& message) : ThreadedAssig
 
     DependencyManager::set<ResourceCacheSharedItems>();
     DependencyManager::set<SoundCache>();
+    DependencyManager::set<SoundCacheScriptingInterface>();
     DependencyManager::set<AudioInjectorManager>();
 
     DependencyManager::set<ScriptCache>();
@@ -438,7 +439,7 @@ void EntityScriptServer::resetEntitiesScriptEngine() {
     auto webSocketServerConstructorValue = newEngine->newFunction(WebSocketServerClass::constructor);
     newEngine->globalObject().setProperty("WebSocketServer", webSocketServerConstructorValue);
 
-    newEngine->registerGlobalObject("SoundCache", new SoundCacheScriptingInterface(DependencyManager::get<SoundCache>().data()));
+    newEngine->registerGlobalObject("SoundCache", DependencyManager::get<SoundCacheScriptingInterface>().data());
 
     // connect this script engines printedMessage signal to the global ScriptEngines these various messages
     auto scriptEngines = DependencyManager::get<ScriptEngines>().data();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -869,16 +869,20 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     DependencyManager::set<recording::ClipCache>();
     DependencyManager::set<GeometryCache>();
     DependencyManager::set<ModelCache>();
+    DependencyManager::set<ModelCacheScriptingInterface>();
     DependencyManager::set<ScriptCache>();
     DependencyManager::set<SoundCache>();
+    DependencyManager::set<SoundCacheScriptingInterface>();
     DependencyManager::set<DdeFaceTracker>();
     DependencyManager::set<EyeTracker>();
     DependencyManager::set<AudioClient>();
     DependencyManager::set<AudioScope>();
     DependencyManager::set<DeferredLightingEffect>();
     DependencyManager::set<TextureCache>();
+    DependencyManager::set<TextureCacheScriptingInterface>();
     DependencyManager::set<FramebufferCache>();
     DependencyManager::set<AnimationCache>();
+    DependencyManager::set<AnimationCacheScriptingInterface>();
     DependencyManager::set<ModelBlender>();
     DependencyManager::set<UsersScriptingInterface>();
     DependencyManager::set<AvatarManager>();
@@ -2565,12 +2569,18 @@ Application::~Application() {
 
     DependencyManager::destroy<CompositorHelper>(); // must be destroyed before the FramebufferCache
 
+    DependencyManager::destroy<SoundCacheScriptingInterface>();
+
     DependencyManager::destroy<AvatarManager>();
+    DependencyManager::destroy<AnimationCacheScriptingInterface>();
     DependencyManager::destroy<AnimationCache>();
     DependencyManager::destroy<FramebufferCache>();
+    DependencyManager::destroy<TextureCacheScriptingInterface>();
     DependencyManager::destroy<TextureCache>();
+    DependencyManager::destroy<ModelCacheScriptingInterface>();
     DependencyManager::destroy<ModelCache>();
     DependencyManager::destroy<ScriptCache>();
+    DependencyManager::destroy<SoundCacheScriptingInterface>();
     DependencyManager::destroy<SoundCache>();
     DependencyManager::destroy<OctreeStatsProvider>();
     DependencyManager::destroy<GeometryCache>();
@@ -2992,10 +3002,11 @@ void Application::onDesktopRootContextCreated(QQmlContext* surfaceContext) {
     surfaceContext->setContextProperty("LocationBookmarks", DependencyManager::get<LocationBookmarks>().data());
 
     // Caches
-    surfaceContext->setContextProperty("AnimationCache", new AnimationCacheScriptingInterface(DependencyManager::get<AnimationCache>().data()));
-    surfaceContext->setContextProperty("TextureCache", new TextureCacheScriptingInterface(DependencyManager::get<TextureCache>().data()));
-    surfaceContext->setContextProperty("ModelCache", new ModelCacheScriptingInterface(DependencyManager::get<ModelCache>().data()));
-    surfaceContext->setContextProperty("SoundCache", new SoundCacheScriptingInterface(DependencyManager::get<SoundCache>().data()));
+    surfaceContext->setContextProperty("AnimationCache", DependencyManager::get<AnimationCacheScriptingInterface>().data());
+    surfaceContext->setContextProperty("TextureCache", DependencyManager::get<TextureCacheScriptingInterface>().data());
+    surfaceContext->setContextProperty("ModelCache", DependencyManager::get<ModelCacheScriptingInterface>().data());
+    surfaceContext->setContextProperty("SoundCache", DependencyManager::get<SoundCacheScriptingInterface>().data());
+
     surfaceContext->setContextProperty("InputConfiguration", DependencyManager::get<InputConfiguration>().data());
 
     surfaceContext->setContextProperty("Account", AccountServicesScriptingInterface::getInstance()); // DEPRECATED - TO BE REMOVED
@@ -6615,10 +6626,10 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEnginePointe
     scriptEngine->registerGlobalObject("Pointers", DependencyManager::get<PointerScriptingInterface>().data());
 
     // Caches
-    scriptEngine->registerGlobalObject("AnimationCache", new AnimationCacheScriptingInterface(DependencyManager::get<AnimationCache>().data()));
-    scriptEngine->registerGlobalObject("TextureCache", new TextureCacheScriptingInterface(DependencyManager::get<TextureCache>().data()));
-    scriptEngine->registerGlobalObject("ModelCache", new ModelCacheScriptingInterface(DependencyManager::get<ModelCache>().data()));
-    scriptEngine->registerGlobalObject("SoundCache", new SoundCacheScriptingInterface(DependencyManager::get<SoundCache>().data()));
+    scriptEngine->registerGlobalObject("AnimationCache", DependencyManager::get<AnimationCacheScriptingInterface>().data());
+    scriptEngine->registerGlobalObject("TextureCache", DependencyManager::get<TextureCacheScriptingInterface>().data());
+    scriptEngine->registerGlobalObject("ModelCache", DependencyManager::get<ModelCacheScriptingInterface>().data());
+    scriptEngine->registerGlobalObject("SoundCache", DependencyManager::get<SoundCacheScriptingInterface>().data());
 
     scriptEngine->registerGlobalObject("DialogsManager", _dialogsManagerScriptingInterface);
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -63,6 +63,7 @@
 #include <AddressManager.h>
 #include <AnimDebugDraw.h>
 #include <BuildInfo.h>
+#include <AnimationCacheScriptingInterface.h>
 #include <AssetClient.h>
 #include <AssetUpload.h>
 #include <AutoUpdater.h>
@@ -98,6 +99,8 @@
 #include <MainWindow.h>
 #include <MappingRequest.h>
 #include <MessagesClient.h>
+#include <model-networking/ModelCacheScriptingInterface.h>
+#include <model-networking/TextureCacheScriptingInterface.h>
 #include <ModelEntityItem.h>
 #include <NetworkAccessManager.h>
 #include <NetworkingConstants.h>
@@ -127,7 +130,7 @@
 #include <ScriptEngines.h>
 #include <ScriptCache.h>
 #include <ShapeEntityItem.h>
-#include <SoundCache.h>
+#include <SoundCacheScriptingInterface.h>
 #include <ui/TabletScriptingInterface.h>
 #include <ui/ToolbarScriptingInterface.h>
 #include <InteractiveWindow.h>
@@ -2989,10 +2992,10 @@ void Application::onDesktopRootContextCreated(QQmlContext* surfaceContext) {
     surfaceContext->setContextProperty("LocationBookmarks", DependencyManager::get<LocationBookmarks>().data());
 
     // Caches
-    surfaceContext->setContextProperty("AnimationCache", DependencyManager::get<AnimationCache>().data());
-    surfaceContext->setContextProperty("TextureCache", DependencyManager::get<TextureCache>().data());
-    surfaceContext->setContextProperty("ModelCache", DependencyManager::get<ModelCache>().data());
-    surfaceContext->setContextProperty("SoundCache", DependencyManager::get<SoundCache>().data());
+    surfaceContext->setContextProperty("AnimationCache", new AnimationCacheScriptingInterface(DependencyManager::get<AnimationCache>().data()));
+    surfaceContext->setContextProperty("TextureCache", new TextureCacheScriptingInterface(DependencyManager::get<TextureCache>().data()));
+    surfaceContext->setContextProperty("ModelCache", new ModelCacheScriptingInterface(DependencyManager::get<ModelCache>().data()));
+    surfaceContext->setContextProperty("SoundCache", new SoundCacheScriptingInterface(DependencyManager::get<SoundCache>().data()));
     surfaceContext->setContextProperty("InputConfiguration", DependencyManager::get<InputConfiguration>().data());
 
     surfaceContext->setContextProperty("Account", AccountServicesScriptingInterface::getInstance()); // DEPRECATED - TO BE REMOVED
@@ -6612,10 +6615,10 @@ void Application::registerScriptEngineWithApplicationServices(ScriptEnginePointe
     scriptEngine->registerGlobalObject("Pointers", DependencyManager::get<PointerScriptingInterface>().data());
 
     // Caches
-    scriptEngine->registerGlobalObject("AnimationCache", DependencyManager::get<AnimationCache>().data());
-    scriptEngine->registerGlobalObject("TextureCache", DependencyManager::get<TextureCache>().data());
-    scriptEngine->registerGlobalObject("ModelCache", DependencyManager::get<ModelCache>().data());
-    scriptEngine->registerGlobalObject("SoundCache", DependencyManager::get<SoundCache>().data());
+    scriptEngine->registerGlobalObject("AnimationCache", new AnimationCacheScriptingInterface(DependencyManager::get<AnimationCache>().data()));
+    scriptEngine->registerGlobalObject("TextureCache", new TextureCacheScriptingInterface(DependencyManager::get<TextureCache>().data()));
+    scriptEngine->registerGlobalObject("ModelCache", new ModelCacheScriptingInterface(DependencyManager::get<ModelCache>().data()));
+    scriptEngine->registerGlobalObject("SoundCache", new SoundCacheScriptingInterface(DependencyManager::get<SoundCache>().data()));
 
     scriptEngine->registerGlobalObject("DialogsManager", _dialogsManagerScriptingInterface);
 

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -55,7 +55,7 @@
 #include "scripting/AccountServicesScriptingInterface.h"
 #include <plugins/InputConfiguration.h>
 #include "ui/Snapshot.h"
-#include "SoundCache.h"
+#include "SoundCacheScriptingInterface.h"
 #include "raypick/PointerScriptingInterface.h"
 #include <display-plugins/CompositorHelper.h>
 #include "AboutUtil.h"
@@ -253,7 +253,7 @@ void Web3DOverlay::setupQmlSurface() {
         _webSurface->getSurfaceContext()->setContextProperty("AvatarList", DependencyManager::get<AvatarManager>().data());
         _webSurface->getSurfaceContext()->setContextProperty("DialogsManager", DialogsManagerScriptingInterface::getInstance());
         _webSurface->getSurfaceContext()->setContextProperty("InputConfiguration", DependencyManager::get<InputConfiguration>().data());
-        _webSurface->getSurfaceContext()->setContextProperty("SoundCache", DependencyManager::get<SoundCache>().data());
+        _webSurface->getSurfaceContext()->setContextProperty("SoundCache", new SoundCacheScriptingInterface(DependencyManager::get<SoundCache>().data()));
         _webSurface->getSurfaceContext()->setContextProperty("MenuInterface", MenuScriptingInterface::getInstance());
         _webSurface->getSurfaceContext()->setContextProperty("Settings", SettingsScriptingInterface::getInstance());
         _webSurface->getSurfaceContext()->setContextProperty("AvatarBookmarks", DependencyManager::get<AvatarBookmarks>().data());

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -253,7 +253,7 @@ void Web3DOverlay::setupQmlSurface() {
         _webSurface->getSurfaceContext()->setContextProperty("AvatarList", DependencyManager::get<AvatarManager>().data());
         _webSurface->getSurfaceContext()->setContextProperty("DialogsManager", DialogsManagerScriptingInterface::getInstance());
         _webSurface->getSurfaceContext()->setContextProperty("InputConfiguration", DependencyManager::get<InputConfiguration>().data());
-        _webSurface->getSurfaceContext()->setContextProperty("SoundCache", new SoundCacheScriptingInterface(DependencyManager::get<SoundCache>().data()));
+        _webSurface->getSurfaceContext()->setContextProperty("SoundCache", DependencyManager::get<SoundCacheScriptingInterface>().data());
         _webSurface->getSurfaceContext()->setContextProperty("MenuInterface", MenuScriptingInterface::getInstance());
         _webSurface->getSurfaceContext()->setContextProperty("Settings", SettingsScriptingInterface::getInstance());
         _webSurface->getSurfaceContext()->setContextProperty("AvatarBookmarks", DependencyManager::get<AvatarBookmarks>().data());

--- a/libraries/animation/src/AnimationCache.h
+++ b/libraries/animation/src/AnimationCache.h
@@ -24,71 +24,12 @@ class Animation;
 
 typedef QSharedPointer<Animation> AnimationPointer;
 
-/// Scriptable interface for FBX animation loading.
 class AnimationCache : public ResourceCache, public Dependency  {
     Q_OBJECT
     SINGLETON_DEPENDENCY
 
 public:
 
-    // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
-
-    /**jsdoc
-     * API to manage animation cache resources.
-     * @namespace AnimationCache
-     *
-     * @hifi-interface
-     * @hifi-client-entity
-     * @hifi-assignment-client
-     *
-     * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
-     * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
-     * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
-     * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
-     */
-
-    // Functions are copied over from ResourceCache (see ResourceCache.h for reason).
-
-    /**jsdoc
-     * Get the list of all resource URLs.
-     * @function AnimationCache.getResourceList
-     * @returns {string[]}
-     */
-
-    /**jsdoc
-     * @function AnimationCache.dirty
-     * @returns {Signal}
-     */
-
-    /**jsdoc
-     * @function AnimationCache.updateTotalSize
-     * @param {number} deltaSize
-     */
-
-    /**jsdoc
-     * Prefetches a resource.
-     * @function AnimationCache.prefetch
-     * @param {string} url - URL of the resource to prefetch.
-     * @param {object} [extra=null]
-     * @returns {ResourceObject}
-     */
-
-    /**jsdoc
-     * Asynchronously loads a resource from the specified URL and returns it.
-     * @function AnimationCache.getResource
-     * @param {string} url - URL of the resource to load.
-     * @param {string} [fallback=""] - Fallback URL if load of the desired URL fails.
-     * @param {} [extra=null]
-     * @returns {object}
-     */
-
-
-    /**jsdoc
-     * Returns animation resource for particular animation.
-     * @function AnimationCache.getAnimation
-     * @param {string} url - URL to load.
-     * @returns {AnimationObject} animation
-     */
     Q_INVOKABLE AnimationPointer getAnimation(const QString& url) { return getAnimation(QUrl(url)); }
     Q_INVOKABLE AnimationPointer getAnimation(const QUrl& url);
 

--- a/libraries/animation/src/AnimationCacheScriptingInterface.cpp
+++ b/libraries/animation/src/AnimationCacheScriptingInterface.cpp
@@ -11,11 +11,10 @@
 
 #include "AnimationCacheScriptingInterface.h"
 
-AnimationCacheScriptingInterface::AnimationCacheScriptingInterface(AnimationCache* animationCache) :
-    _animationCache(animationCache),
-    ScriptableResourceCache::ScriptableResourceCache(animationCache)
+AnimationCacheScriptingInterface::AnimationCacheScriptingInterface() :
+    ScriptableResourceCache::ScriptableResourceCache(DependencyManager::get<AnimationCache>())
 { }
 
 AnimationPointer AnimationCacheScriptingInterface::getAnimation(const QUrl& url) {
-    return _animationCache->getAnimation(url);
+    return DependencyManager::get<AnimationCache>()->getAnimation(url);
 }

--- a/libraries/animation/src/AnimationCacheScriptingInterface.cpp
+++ b/libraries/animation/src/AnimationCacheScriptingInterface.cpp
@@ -1,0 +1,21 @@
+//
+//  AnimationCacheScriptingInterface.cpp
+//  libraries/animation/src
+//
+//  Created by David Rowe on 25 Jul 2018.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "AnimationCacheScriptingInterface.h"
+
+AnimationCacheScriptingInterface::AnimationCacheScriptingInterface(AnimationCache* animationCache) :
+    _animationCache(animationCache),
+    ScriptableResourceCache::ScriptableResourceCache(animationCache)
+{ }
+
+AnimationPointer AnimationCacheScriptingInterface::getAnimation(const QUrl& url) {
+    return _animationCache->getAnimation(url);
+}

--- a/libraries/animation/src/AnimationCacheScriptingInterface.cpp
+++ b/libraries/animation/src/AnimationCacheScriptingInterface.cpp
@@ -15,6 +15,6 @@ AnimationCacheScriptingInterface::AnimationCacheScriptingInterface() :
     ScriptableResourceCache::ScriptableResourceCache(DependencyManager::get<AnimationCache>())
 { }
 
-AnimationPointer AnimationCacheScriptingInterface::getAnimation(const QUrl& url) {
-    return DependencyManager::get<AnimationCache>()->getAnimation(url);
+AnimationPointer AnimationCacheScriptingInterface::getAnimation(const QString& url) {
+    return DependencyManager::get<AnimationCache>()->getAnimation(QUrl(url));
 }

--- a/libraries/animation/src/AnimationCacheScriptingInterface.h
+++ b/libraries/animation/src/AnimationCacheScriptingInterface.h
@@ -1,0 +1,62 @@
+//
+//  AnimationCacheScriptingInterface.h
+//  libraries/animation/src
+//
+//  Created by David Rowe on 25 Jul 2018.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#pragma once
+
+#ifndef hifi_AnimationCacheScriptingInterface_h
+#define hifi_AnimationCacheScriptingInterface_h
+
+#include <QObject>
+
+#include <ResourceCache.h>
+
+#include "AnimationCache.h"
+
+class AnimationCacheScriptingInterface : public ScriptableResourceCache {
+    Q_OBJECT
+
+    // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
+
+    /**jsdoc
+     * API to manage animation cache resources.
+     * @namespace AnimationCache
+     *
+     * @hifi-interface
+     * @hifi-client-entity
+     * @hifi-assignment-client
+     *
+     * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
+     * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
+     * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
+     * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
+     *
+     * @borrows ResourceCache.getResourceList as getResourceList
+     * @borrows ResourceCache.updateTotalSize as updateTotalSize
+     * @borrows ResourceCache.prefetch as prefetch
+     * @borrows ResourceCache.dirty as dirty
+     */
+
+public:
+    AnimationCacheScriptingInterface(AnimationCache* animationCache);
+
+    /**jsdoc
+     * Returns animation resource for particular animation.
+     * @function AnimationCache.getAnimation
+     * @param {string} url - URL to load.
+     * @returns {AnimationObject} animation
+     */
+    Q_INVOKABLE AnimationPointer getAnimation(const QString& url) { return getAnimation(QUrl(url)); }
+    Q_INVOKABLE AnimationPointer getAnimation(const QUrl& url);
+
+private:
+    AnimationCache* _animationCache;
+};
+
+#endif // hifi_AnimationCacheScriptingInterface_h

--- a/libraries/animation/src/AnimationCacheScriptingInterface.h
+++ b/libraries/animation/src/AnimationCacheScriptingInterface.h
@@ -19,7 +19,7 @@
 
 #include "AnimationCache.h"
 
-class AnimationCacheScriptingInterface : public ScriptableResourceCache {
+class AnimationCacheScriptingInterface : public ScriptableResourceCache, public Dependency {
     Q_OBJECT
 
     // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
@@ -44,7 +44,7 @@ class AnimationCacheScriptingInterface : public ScriptableResourceCache {
      */
 
 public:
-    AnimationCacheScriptingInterface(AnimationCache* animationCache);
+    AnimationCacheScriptingInterface();
 
     /**jsdoc
      * Returns animation resource for particular animation.
@@ -54,9 +54,6 @@ public:
      */
     Q_INVOKABLE AnimationPointer getAnimation(const QString& url) { return getAnimation(QUrl(url)); }
     Q_INVOKABLE AnimationPointer getAnimation(const QUrl& url);
-
-private:
-    AnimationCache* _animationCache;
 };
 
 #endif // hifi_AnimationCacheScriptingInterface_h

--- a/libraries/animation/src/AnimationCacheScriptingInterface.h
+++ b/libraries/animation/src/AnimationCacheScriptingInterface.h
@@ -52,8 +52,7 @@ public:
      * @param {string} url - URL to load.
      * @returns {AnimationObject} animation
      */
-    Q_INVOKABLE AnimationPointer getAnimation(const QString& url) { return getAnimation(QUrl(url)); }
-    Q_INVOKABLE AnimationPointer getAnimation(const QUrl& url);
+    Q_INVOKABLE AnimationPointer getAnimation(const QString& url);
 };
 
 #endif // hifi_AnimationCacheScriptingInterface_h

--- a/libraries/audio/src/SoundCache.h
+++ b/libraries/audio/src/SoundCache.h
@@ -16,73 +16,13 @@
 
 #include "Sound.h"
 
-/// Scriptable interface for sound loading.
 class SoundCache : public ResourceCache, public Dependency {
     Q_OBJECT
     SINGLETON_DEPENDENCY
 
 public:
-
-    // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
-
-    /**jsdoc
-     * API to manage sound cache resources.
-     * @namespace SoundCache
-     *
-     * @hifi-interface
-     * @hifi-client-entity
-     * @hifi-server-entity
-     * @hifi-assignment-client
-     *
-     * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
-     * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
-     * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
-     * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
-     */
-
-
-    // Functions are copied over from ResourceCache (see ResourceCache.h for reason).
-
-    /**jsdoc
-     * Get the list of all resource URLs.
-     * @function SoundCache.getResourceList
-     * @returns {string[]}
-     */
-
-    /**jsdoc
-     * @function SoundCache.dirty
-     * @returns {Signal}
-     */
-
-    /**jsdoc
-     * @function SoundCache.updateTotalSize
-     * @param {number} deltaSize
-     */
-
-    /**jsdoc
-     * Prefetches a resource.
-     * @function SoundCache.prefetch
-     * @param {string} url - URL of the resource to prefetch.
-     * @param {object} [extra=null]
-     * @returns {ResourceObject}
-     */
-
-    /**jsdoc
-     * Asynchronously loads a resource from the specified URL and returns it.
-     * @function SoundCache.getResource
-     * @param {string} url - URL of the resource to load.
-     * @param {string} [fallback=""] - Fallback URL if load of the desired URL fails.
-     * @param {} [extra=null]
-     * @returns {object}
-     */
-
-
-    /**jsdoc 
-     * @function SoundCache.getSound
-     * @param {string} url
-     * @returns {SoundObject}
-     */
     Q_INVOKABLE SharedSoundPointer getSound(const QUrl& url);
+
 protected:
     virtual QSharedPointer<Resource> createResource(const QUrl& url, const QSharedPointer<Resource>& fallback,
         const void* extra) override;

--- a/libraries/audio/src/SoundCacheScriptingInterface.cpp
+++ b/libraries/audio/src/SoundCacheScriptingInterface.cpp
@@ -1,0 +1,21 @@
+//
+//  SoundCacheScriptingInterface.cpp
+//  libraries/audio/src
+//
+//  Created by David Rowe on 25 Jul 2018.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "SoundCacheScriptingInterface.h"
+
+SoundCacheScriptingInterface::SoundCacheScriptingInterface(SoundCache* soundCache) :
+    _soundCache(soundCache),
+    ScriptableResourceCache::ScriptableResourceCache(soundCache)
+{ }
+
+SharedSoundPointer SoundCacheScriptingInterface::getSound(const QUrl& url) {
+    return _soundCache->getSound(url);
+}

--- a/libraries/audio/src/SoundCacheScriptingInterface.cpp
+++ b/libraries/audio/src/SoundCacheScriptingInterface.cpp
@@ -11,11 +11,10 @@
 
 #include "SoundCacheScriptingInterface.h"
 
-SoundCacheScriptingInterface::SoundCacheScriptingInterface(SoundCache* soundCache) :
-    _soundCache(soundCache),
-    ScriptableResourceCache::ScriptableResourceCache(soundCache)
+SoundCacheScriptingInterface::SoundCacheScriptingInterface() :
+    ScriptableResourceCache::ScriptableResourceCache(DependencyManager::get<SoundCache>())
 { }
 
 SharedSoundPointer SoundCacheScriptingInterface::getSound(const QUrl& url) {
-    return _soundCache->getSound(url);
+    return DependencyManager::get<SoundCache>()->getSound(url);
 }

--- a/libraries/audio/src/SoundCacheScriptingInterface.h
+++ b/libraries/audio/src/SoundCacheScriptingInterface.h
@@ -1,0 +1,61 @@
+//
+//  SoundCacheScriptingInterface.h
+//  libraries/audio/src
+//
+//  Created by David Rowe on 25 Jul 2018.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#pragma once
+
+#ifndef hifi_SoundCacheScriptingInterface_h
+#define hifi_SoundCacheScriptingInterface_h
+
+#include <QObject>
+
+#include <ResourceCache.h>
+
+#include "SoundCache.h"
+
+class SoundCacheScriptingInterface : public ScriptableResourceCache {
+    Q_OBJECT
+
+    // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
+
+    /**jsdoc
+     * API to manage sound cache resources.
+     * @namespace SoundCache
+     *
+     * @hifi-interface
+     * @hifi-client-entity
+     * @hifi-server-entity
+     * @hifi-assignment-client
+     *
+     * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
+     * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
+     * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
+     * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
+     *
+     * @borrows ResourceCache.getResourceList as getResourceList
+     * @borrows ResourceCache.updateTotalSize as updateTotalSize
+     * @borrows ResourceCache.prefetch as prefetch
+     * @borrows ResourceCache.dirty as dirty
+     */
+
+public:
+    SoundCacheScriptingInterface(SoundCache* soundCache);
+
+    /**jsdoc
+     * @function SoundCache.getSound
+     * @param {string} url
+     * @returns {SoundObject}
+     */
+    Q_INVOKABLE SharedSoundPointer getSound(const QUrl& url);
+
+private:
+    SoundCache* _soundCache;
+};
+
+#endif // hifi_SoundCacheScriptingInterface_h

--- a/libraries/audio/src/SoundCacheScriptingInterface.h
+++ b/libraries/audio/src/SoundCacheScriptingInterface.h
@@ -19,7 +19,7 @@
 
 #include "SoundCache.h"
 
-class SoundCacheScriptingInterface : public ScriptableResourceCache {
+class SoundCacheScriptingInterface : public ScriptableResourceCache, public Dependency {
     Q_OBJECT
 
     // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
@@ -45,7 +45,7 @@ class SoundCacheScriptingInterface : public ScriptableResourceCache {
      */
 
 public:
-    SoundCacheScriptingInterface(SoundCache* soundCache);
+    SoundCacheScriptingInterface();
 
     /**jsdoc
      * @function SoundCache.getSound
@@ -53,9 +53,6 @@ public:
      * @returns {SoundObject}
      */
     Q_INVOKABLE SharedSoundPointer getSound(const QUrl& url);
-
-private:
-    SoundCache* _soundCache;
 };
 
 #endif // hifi_SoundCacheScriptingInterface_h

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -140,58 +140,6 @@ class ModelCache : public ResourceCache, public Dependency {
 
 public:
 
-    // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
-
-    /**jsdoc
-     * API to manage model cache resources.
-     * @namespace ModelCache
-     *
-     * @hifi-interface
-     * @hifi-client-entity
-     *
-     * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
-     * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
-     * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
-     * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
-     */
-
-
-    // Functions are copied over from ResourceCache (see ResourceCache.h for reason).
-
-    /**jsdoc
-     * Get the list of all resource URLs.
-     * @function ModelCache.getResourceList
-     * @returns {string[]}
-     */
-
-    /**jsdoc
-     * @function ModelCache.dirty
-     * @returns {Signal}
-     */
-
-    /**jsdoc
-     * @function ModelCache.updateTotalSize
-     * @param {number} deltaSize
-     */
-
-    /**jsdoc
-     * Prefetches a resource.
-     * @function ModelCache.prefetch
-     * @param {string} url - URL of the resource to prefetch.
-     * @param {object} [extra=null]
-     * @returns {ResourceObject}
-     */
-
-    /**jsdoc
-     * Asynchronously loads a resource from the specified URL and returns it.
-     * @function ModelCache.getResource
-     * @param {string} url - URL of the resource to load.
-     * @param {string} [fallback=""] - Fallback URL if load of the desired URL fails.
-     * @param {} [extra=null]
-     * @returns {object}
-     */
-
-
     GeometryResource::Pointer getGeometryResource(const QUrl& url,
                                                   const QVariantHash& mapping = QVariantHash(),
                                                   const QUrl& textureBaseUrl = QUrl());

--- a/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.cpp
@@ -11,7 +11,6 @@
 
 #include "ModelCacheScriptingInterface.h"
 
-ModelCacheScriptingInterface::ModelCacheScriptingInterface(ModelCache* modelCache) :
-    _ModelCache(modelCache),
-    ScriptableResourceCache::ScriptableResourceCache(modelCache)
+ModelCacheScriptingInterface::ModelCacheScriptingInterface() :
+    ScriptableResourceCache::ScriptableResourceCache(DependencyManager::get<ModelCache>())
 { }

--- a/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.cpp
@@ -1,0 +1,17 @@
+//
+//  ModelCacheScriptingInterface.cpp
+//  libraries/mmodel-networking/src/model-networking
+//
+//  Created by David Rowe on 25 Jul 2018.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "ModelCacheScriptingInterface.h"
+
+ModelCacheScriptingInterface::ModelCacheScriptingInterface(ModelCache* modelCache) :
+    _ModelCache(modelCache),
+    ScriptableResourceCache::ScriptableResourceCache(modelCache)
+{ }

--- a/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.h
+++ b/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.h
@@ -1,0 +1,52 @@
+//
+//  ModelCacheScriptingInterface.h
+//  libraries/mmodel-networking/src/model-networking
+//
+//  Created by David Rowe on 25 Jul 2018.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#pragma once
+
+#ifndef hifi_ModelCacheScriptingInterface_h
+#define hifi_ModelCacheScriptingInterface_h
+
+#include <QObject>
+
+#include <ResourceCache.h>
+
+#include "ModelCache.h"
+
+class ModelCacheScriptingInterface : public ScriptableResourceCache {
+    Q_OBJECT
+
+    // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
+
+    /**jsdoc
+     * API to manage model cache resources.
+     * @namespace ModelCache
+     *
+     * @hifi-interface
+     * @hifi-client-entity
+     *
+     * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
+     * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
+     * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
+     * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
+     *
+     * @borrows ResourceCache.getResourceList as getResourceList
+     * @borrows ResourceCache.updateTotalSize as updateTotalSize
+     * @borrows ResourceCache.prefetch as prefetch
+     * @borrows ResourceCache.dirty as dirty
+     */
+
+public:
+    ModelCacheScriptingInterface(ModelCache* modelCache);
+
+private:
+    ModelCache* _ModelCache;
+};
+
+#endif // hifi_ModelCacheScriptingInterface_h

--- a/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.h
+++ b/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.h
@@ -19,7 +19,7 @@
 
 #include "ModelCache.h"
 
-class ModelCacheScriptingInterface : public ScriptableResourceCache {
+class ModelCacheScriptingInterface : public ScriptableResourceCache, public Dependency {
     Q_OBJECT
 
     // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
@@ -43,10 +43,7 @@ class ModelCacheScriptingInterface : public ScriptableResourceCache {
      */
 
 public:
-    ModelCacheScriptingInterface(ModelCache* modelCache);
-
-private:
-    ModelCache* _ModelCache;
+    ModelCacheScriptingInterface();
 };
 
 #endif // hifi_ModelCacheScriptingInterface_h

--- a/libraries/model-networking/src/model-networking/TextureCache.h
+++ b/libraries/model-networking/src/model-networking/TextureCache.h
@@ -156,58 +156,6 @@ class TextureCache : public ResourceCache, public Dependency {
 
 public:
 
-    // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
-
-    /**jsdoc
-    * API to manage texture cache resources.
-    * @namespace TextureCache
-    *
-    * @hifi-interface
-    * @hifi-client-entity
-    *
-    * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
-    * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
-    * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
-    * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
-    */
-
-
-    // Functions are copied over from ResourceCache (see ResourceCache.h for reason).
-
-    /**jsdoc
-     * Get the list of all resource URLs.
-     * @function TextureCache.getResourceList
-     * @returns {string[]}
-     */
-
-    /**jsdoc
-     * @function TextureCache.dirty
-     * @returns {Signal}
-     */
-
-    /**jsdoc
-     * @function TextureCache.updateTotalSize
-     * @param {number} deltaSize
-     */
-
-    /**jsdoc
-     * Prefetches a resource.
-     * @function TextureCache.prefetch
-     * @param {string} url - URL of the resource to prefetch.
-     * @param {object} [extra=null]
-     * @returns {ResourceObject}
-     */
-
-    /**jsdoc
-     * Asynchronously loads a resource from the specified URL and returns it.
-     * @function TextureCache.getResource
-     * @param {string} url - URL of the resource to load.
-     * @param {string} [fallback=""] - Fallback URL if load of the desired URL fails.
-     * @param {} [extra=null]
-     * @returns {object}
-     */
-
-
     /// Returns the ID of the permutation/normal texture used for Perlin noise shader programs.  This texture
     /// has two lines: the first, a set of random numbers in [0, 255] to be used as permutation offsets, and
     /// the second, a set of random unit vectors to be used as noise gradients.
@@ -248,21 +196,10 @@ public:
     gpu::ContextPointer getGPUContext() const { return _gpuContext; }
 
 signals:
-    /**jsdoc 
-     * @function TextureCache.spectatorCameraFramebufferReset
-     * @returns {Signal}
-     */
     void spectatorCameraFramebufferReset();
 
 protected:
     
-    /**jsdoc
-     * @function TextureCache.prefetch
-     * @param {string} url
-     * @param {number} type
-     * @param {number} [maxNumPixels=67108864]
-     * @returns {ResourceObject}
-     */
     // Overload ResourceCache::prefetch to allow specifying texture type for loads
     Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url, int type, int maxNumPixels = ABSOLUTE_MAX_TEXTURE_NUM_PIXELS);
 
@@ -273,6 +210,7 @@ private:
     friend class ImageReader;
     friend class NetworkTexture;
     friend class DilatableNetworkTexture;
+    friend class TextureCacheScriptingInterface;
 
     TextureCache();
     virtual ~TextureCache();

--- a/libraries/model-networking/src/model-networking/TextureCacheScriptingInterface.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCacheScriptingInterface.cpp
@@ -1,0 +1,24 @@
+//
+//  TextureCacheScriptingInterface.cpp
+//  libraries/mmodel-networking/src/model-networking
+//
+//  Created by David Rowe on 25 Jul 2018.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "TextureCacheScriptingInterface.h"
+
+TextureCacheScriptingInterface::TextureCacheScriptingInterface(TextureCache* textureCache) :
+    _textureCache(textureCache),
+    ScriptableResourceCache::ScriptableResourceCache(textureCache)
+{
+    connect(_textureCache, &TextureCache::spectatorCameraFramebufferReset, 
+        this, &TextureCacheScriptingInterface::spectatorCameraFramebufferReset);
+}
+
+ScriptableResource* TextureCacheScriptingInterface::prefetch(const QUrl& url, int type, int maxNumPixels) {
+    return _textureCache->prefetch(url, type, maxNumPixels);
+}

--- a/libraries/model-networking/src/model-networking/TextureCacheScriptingInterface.cpp
+++ b/libraries/model-networking/src/model-networking/TextureCacheScriptingInterface.cpp
@@ -11,14 +11,13 @@
 
 #include "TextureCacheScriptingInterface.h"
 
-TextureCacheScriptingInterface::TextureCacheScriptingInterface(TextureCache* textureCache) :
-    _textureCache(textureCache),
-    ScriptableResourceCache::ScriptableResourceCache(textureCache)
+TextureCacheScriptingInterface::TextureCacheScriptingInterface() :
+    ScriptableResourceCache::ScriptableResourceCache(DependencyManager::get<TextureCache>())
 {
-    connect(_textureCache, &TextureCache::spectatorCameraFramebufferReset, 
+    connect(DependencyManager::get<TextureCache>().data(), &TextureCache::spectatorCameraFramebufferReset,
         this, &TextureCacheScriptingInterface::spectatorCameraFramebufferReset);
 }
 
 ScriptableResource* TextureCacheScriptingInterface::prefetch(const QUrl& url, int type, int maxNumPixels) {
-    return _textureCache->prefetch(url, type, maxNumPixels);
+    return DependencyManager::get<TextureCache>()->prefetch(url, type, maxNumPixels);
 }

--- a/libraries/model-networking/src/model-networking/TextureCacheScriptingInterface.h
+++ b/libraries/model-networking/src/model-networking/TextureCacheScriptingInterface.h
@@ -1,0 +1,68 @@
+//
+//  TextureCacheScriptingInterface.h
+//  libraries/mmodel-networking/src/model-networking
+//
+//  Created by David Rowe on 25 Jul 2018.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#pragma once
+
+#ifndef hifi_TextureCacheScriptingInterface_h
+#define hifi_TextureCacheScriptingInterface_h
+
+#include <QObject>
+
+#include <ResourceCache.h>
+
+#include "TextureCache.h"
+
+class TextureCacheScriptingInterface : public ScriptableResourceCache {
+    Q_OBJECT
+
+    // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
+
+    /**jsdoc
+     * API to manage texture cache resources.
+     * @namespace TextureCache
+     *
+     * @hifi-interface
+     * @hifi-client-entity
+     *
+     * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
+     * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
+     * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
+     * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
+     *
+     * @borrows ResourceCache.getResourceList as getResourceList
+     * @borrows ResourceCache.updateTotalSize as updateTotalSize
+     * @borrows ResourceCache.prefetch as prefetch
+     * @borrows ResourceCache.dirty as dirty
+     */
+
+public:
+    TextureCacheScriptingInterface(TextureCache* textureCache);
+
+    /**jsdoc
+     * @function TextureCache.prefetch
+     * @param {string} url
+     * @param {number} type
+     * @param {number} [maxNumPixels=67108864]
+     * @returns {ResourceObject}
+     */
+    Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url, int type, int maxNumPixels = ABSOLUTE_MAX_TEXTURE_NUM_PIXELS);
+
+signals:
+    /**jsdoc
+     * @function TextureCache.spectatorCameraFramebufferReset
+     * @returns {Signal}
+     */
+    void spectatorCameraFramebufferReset();
+
+private:
+    TextureCache* _textureCache;
+};
+
+#endif // hifi_TextureCacheScriptingInterface_h

--- a/libraries/model-networking/src/model-networking/TextureCacheScriptingInterface.h
+++ b/libraries/model-networking/src/model-networking/TextureCacheScriptingInterface.h
@@ -19,7 +19,7 @@
 
 #include "TextureCache.h"
 
-class TextureCacheScriptingInterface : public ScriptableResourceCache {
+class TextureCacheScriptingInterface : public ScriptableResourceCache, public Dependency {
     Q_OBJECT
 
     // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
@@ -43,7 +43,7 @@ class TextureCacheScriptingInterface : public ScriptableResourceCache {
      */
 
 public:
-    TextureCacheScriptingInterface(TextureCache* textureCache);
+    TextureCacheScriptingInterface();
 
     /**jsdoc
      * @function TextureCache.prefetch
@@ -60,9 +60,6 @@ signals:
      * @returns {Signal}
      */
     void spectatorCameraFramebufferReset();
-
-private:
-    TextureCache* _textureCache;
 };
 
 #endif // hifi_TextureCacheScriptingInterface_h

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -131,6 +131,24 @@ QSharedPointer<Resource> ResourceCacheSharedItems::getHighestPendingRequest() {
     return highestResource;
 }
 
+
+ScriptableResourceCache::ScriptableResourceCache(ResourceCache* resourceCache) {
+    _resourceCache = resourceCache;
+}
+
+QVariantList ScriptableResourceCache::getResourceList() {
+    return _resourceCache->getResourceList();
+}
+
+void ScriptableResourceCache::updateTotalSize(const qint64& deltaSize) {
+    _resourceCache->updateTotalSize(deltaSize);
+}
+
+ScriptableResource* ScriptableResourceCache::prefetch(const QUrl& url, void* extra) {
+    return _resourceCache->prefetch(url, extra);
+}
+
+
 ScriptableResource::ScriptableResource(const QUrl& url) :
     QObject(nullptr),
     _url(url) { }

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -132,7 +132,7 @@ QSharedPointer<Resource> ResourceCacheSharedItems::getHighestPendingRequest() {
 }
 
 
-ScriptableResourceCache::ScriptableResourceCache(ResourceCache* resourceCache) {
+ScriptableResourceCache::ScriptableResourceCache(QSharedPointer<ResourceCache> resourceCache) {
     _resourceCache = resourceCache;
 }
 

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -303,7 +303,7 @@ private:
 class ScriptableResourceCache : public QObject {
     Q_OBJECT
 
-    // JSDoc 3.5.5 doesn't augment namespaces with @property definitions so the following properties JSDoc is copied to the 
+    // JSDoc 3.5.5 doesn't augment name spaces with @property definitions so the following properties JSDoc is copied to the 
     // different exposed cache classes.
 
     /**jsdoc
@@ -318,7 +318,7 @@ class ScriptableResourceCache : public QObject {
     Q_PROPERTY(size_t sizeCached READ getSizeCachedResources NOTIFY dirty)
 
 public:
-    ScriptableResourceCache(ResourceCache* resourceCache);
+    ScriptableResourceCache(QSharedPointer<ResourceCache> resourceCache);
 
     /**jsdoc
      * Get the list of all resource URLs.
@@ -351,7 +351,7 @@ signals:
     void dirty();
 
 private:
-    ResourceCache * _resourceCache;
+    QSharedPointer<ResourceCache> _resourceCache;
 
     size_t getNumTotalResources() const { return _resourceCache->getNumTotalResources(); }
     size_t getSizeTotalResources() const { return _resourceCache->getSizeTotalResources(); }

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -124,9 +124,9 @@ public:
     virtual ~ScriptableResource() = default;
 
     /**jsdoc
-     * Release this resource.
-     * @function ResourceObject#release
-     */
+      * Release this resource.
+      * @function ResourceObject#release
+      */
     Q_INVOKABLE void release();
 
     const QUrl& getURL() const { return _url; }
@@ -186,15 +186,6 @@ Q_DECLARE_METATYPE(ScriptableResource*);
 class ResourceCache : public QObject {
     Q_OBJECT
 
-    // JSDoc 3.5.5 doesn't augment namespaces with @property or @function definitions.
-    // The ResourceCache properties and functions are copied to the different exposed cache classes.
-
-    /**jsdoc
-     * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
-     * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
-     * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
-     * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
-     */
     Q_PROPERTY(size_t numTotal READ getNumTotalResources NOTIFY dirty)
     Q_PROPERTY(size_t numCached READ getNumCachedResources NOTIFY dirty)
     Q_PROPERTY(size_t sizeTotal READ getSizeTotalResources NOTIFY dirty)
@@ -207,11 +198,6 @@ public:
     size_t getNumCachedResources() const { return _numUnusedResources; }
     size_t getSizeCachedResources() const { return _unusedResourcesSize; }
 
-    /**jsdoc
-     * Get the list of all resource URLs.
-     * @function ResourceCache.getResourceList
-     * @returns {string[]}
-     */
     Q_INVOKABLE QVariantList getResourceList();
 
     static void setRequestLimit(int limit);
@@ -237,40 +223,17 @@ public:
 
 signals:
 
-    /**jsdoc
-     * @function ResourceCache.dirty
-     * @returns {Signal}
-     */
     void dirty();
 
 protected slots:
 
-    /**jsdoc
-     * @function ResourceCache.updateTotalSize
-     * @param {number} deltaSize
-     */
     void updateTotalSize(const qint64& deltaSize);
 
-    /**jsdoc
-     * Prefetches a resource.
-     * @function ResourceCache.prefetch
-     * @param {string} url - URL of the resource to prefetch.
-     * @param {object} [extra=null]
-     * @returns {ResourceObject}
-     */
     // Prefetches a resource to be held by the QScriptEngine.
     // Left as a protected member so subclasses can overload prefetch
     // and delegate to it (see TextureCache::prefetch(const QUrl&, int).
     ScriptableResource* prefetch(const QUrl& url, void* extra);
 
-    /**jsdoc
-     * Asynchronously loads a resource from the specified URL and returns it.
-     * @function ResourceCache.getResource
-     * @param {string} url - URL of the resource to load.
-     * @param {string} [fallback=""] - Fallback URL if load of the desired URL fails.
-     * @param {} [extra=null]
-     * @returns {object}
-     */
     // FIXME: The return type is not recognized by JavaScript.
     /// Loads a resource from the specified URL and returns it.
     /// If the caller is on a different thread than the ResourceCache,
@@ -306,6 +269,7 @@ protected:
 
 private:
     friend class Resource;
+    friend class ScriptableResourceCache;
 
     void reserveUnusedResource(qint64 resourceSize);
     void resetResourceCounters();
@@ -333,6 +297,66 @@ private:
     // Pending resources
     QQueue<QUrl> _resourcesToBeGotten;
     QReadWriteLock _resourcesToBeGottenLock { QReadWriteLock::Recursive };
+};
+
+/// Wrapper to expose resource caches to JS/QML
+class ScriptableResourceCache : public QObject {
+    Q_OBJECT
+
+    // JSDoc 3.5.5 doesn't augment namespaces with @property definitions so the following properties JSDoc is copied to the 
+    // different exposed cache classes.
+
+    /**jsdoc
+     * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
+     * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
+     * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
+     * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
+     */
+    Q_PROPERTY(size_t numTotal READ getNumTotalResources NOTIFY dirty)
+    Q_PROPERTY(size_t numCached READ getNumCachedResources NOTIFY dirty)
+    Q_PROPERTY(size_t sizeTotal READ getSizeTotalResources NOTIFY dirty)
+    Q_PROPERTY(size_t sizeCached READ getSizeCachedResources NOTIFY dirty)
+
+public:
+    ScriptableResourceCache(ResourceCache* resourceCache);
+
+    /**jsdoc
+     * Get the list of all resource URLs.
+     * @function ResourceCache.getResourceList
+     * @returns {string[]}
+     */
+    Q_INVOKABLE QVariantList getResourceList();
+
+    /**jsdoc
+     * @function ResourceCache.updateTotalSize
+     * @param {number} deltaSize
+     */
+    Q_INVOKABLE void updateTotalSize(const qint64& deltaSize);
+
+    /**jsdoc
+     * Prefetches a resource.
+     * @function ResourceCache.prefetch
+     * @param {string} url - URL of the resource to prefetch.
+     * @param {object} [extra=null]
+     * @returns {ResourceObject}
+     */
+    Q_INVOKABLE ScriptableResource* prefetch(const QUrl& url, void* extra = nullptr);
+
+signals:
+
+    /**jsdoc
+     * @function ResourceCache.dirty
+     * @returns {Signal}
+     */
+    void dirty();
+
+private:
+    ResourceCache * _resourceCache;
+
+    size_t getNumTotalResources() const { return _resourceCache->getNumTotalResources(); }
+    size_t getSizeTotalResources() const { return _resourceCache->getSizeTotalResources(); }
+    size_t getNumCachedResources() const { return _resourceCache->getNumCachedResources(); }
+    size_t getSizeCachedResources() const { return _resourceCache->getSizeCachedResources(); }
 };
 
 /// Base class for resources.


### PR DESCRIPTION
Move scriptable caches' APIs - AnimationCache, ModelCache, SoundCache, and TextureCache - into scripting interfaces.

Remove the following, non-working API items which just generated JavaScript errors:
- AnimationCache.getResource()
- ModelCache.getResource()
- SoundCache.getResource()
- TextureCache.getResource()
