### PR TITLE
Corrects loading of texture and default visibility.

### DIFF
--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -139,9 +139,6 @@ void ModelOverlay::update(float deltatime) {
 
     if (!_texturesLoaded && _model->getGeometry() && _model->getGeometry()->areTexturesLoaded()) {
         _texturesLoaded = true;
-        if (!_modelTextures.isEmpty()) {
-            _model->setTextures(_modelTextures);
-        }
 
         _model->setVisibleInScene(getVisible(), scene);
         _model->updateRenderItems();

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -27,10 +27,6 @@ ModelOverlay::ModelOverlay()
 {
     _model->setLoadingPriority(_loadPriority);
     _isLoaded = false;
-
-    // Don't show overlay until textures have loaded
-    _visible = false;
-
     render::ScenePointer scene = qApp->getMain3DScene();
     _model->setVisibleInScene(false, scene);
 }
@@ -135,6 +131,11 @@ void ModelOverlay::update(float deltatime) {
         transaction.updateItem<Overlay>(getRenderItemID(), [](Overlay& data) {});
     }
     scene->enqueueTransaction(transaction);
+
+    if (_texturesDirty && !_modelTextures.isEmpty()) {
+        _texturesDirty = false;
+        _model->setTextures(_modelTextures);
+    }
 
     if (!_texturesLoaded && _model->getGeometry() && _model->getGeometry()->areTexturesLoaded()) {
         _texturesLoaded = true;
@@ -242,6 +243,7 @@ void ModelOverlay::setProperties(const QVariantMap& properties) {
         _texturesLoaded = false;
         QVariantMap textureMap = texturesValue.toMap();
         _modelTextures = textureMap;
+        _texturesDirty = true;
     }
 
     auto groupCulledValue = properties["isGroupCulled"];

--- a/interface/src/ui/overlays/ModelOverlay.h
+++ b/interface/src/ui/overlays/ModelOverlay.h
@@ -94,6 +94,7 @@ private:
     ModelPointer _model;
     QVariantMap _modelTextures;
     bool _texturesLoaded { false };
+    bool _texturesDirty{ false };
 
     render::ItemIDs _subRenderItemIDs;
 

--- a/interface/src/ui/overlays/ModelOverlay.h
+++ b/interface/src/ui/overlays/ModelOverlay.h
@@ -94,7 +94,7 @@ private:
     ModelPointer _model;
     QVariantMap _modelTextures;
     bool _texturesLoaded { false };
-    bool _texturesDirty{ false };
+    bool _texturesDirty { false };
 
     render::ItemIDs _subRenderItemIDs;
 


### PR DESCRIPTION
# Description
This PR corrects an issue with PR https://github.com/highfidelity/hifi/pull/13635.  It also unearthed a missing "dirty" flag for texture loading.

The issue was that the default value of "isVisible" was being ignored.  This became apparent in https://highfidelity.manuscript.com/f/cases/16943/Missing-models-from-Rendering-test-Engine-Render-LOD-Overlay-Model

# Testing
1.  In master, go to dev-welcome and orient yourself so that you can you are looking at the recorded moving mannequin at all times. (i.e., it starts in one spot and walks forward. then repeats. Position yourself at the head of that so that it walks towards you and you can always see it.)
Now open the PEOPLE app while looking at the recorded mannequin. When the green overlay appears, it initially shows up as a large green square.

2. Test the PEOPLE app in another domain with multiple avatars.
Verify that no square appears, and also that the overlay appears as follows:
image
![image](https://user-images.githubusercontent.com/29026026/43226855-d2aa4624-9011-11e8-8d45-48ca38281ea2.png)


3.  Follow this test: https://github.com/NissimHadar/hifi_tests/blob/bug16645/tests/content/entity/model/visibility/test.md

Repeat the previous test, and quickly toggle the visibility at Step 3 and Step 10

4.  Follow this test (this is the test that is referred to in the bug report above): https://github.com/highfidelity/hifi_tests/blob/master/tests/engine/render/lod/overlay/model/test.md