### PR TITLE
Fix edit.js not being able to delete after creating entity

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -392,6 +392,8 @@ var toolBar = (function () {
         entityListTool.sendUpdate();
         selectionManager.setSelections([entityID]);
 
+        Window.setFocus();
+
         return entityID;
     }
 


### PR DESCRIPTION
This fix puts focus back on the main window when creating an entity so that the user can use shortcuts like 'f' and 'delete'