### PR TITLE
MS16809: handle both triggerable and wantsTrigger in CreateApp

### DIFF
--- a/scripts/system/html/entityProperties.html
+++ b/scripts/system/html/entityProperties.html
@@ -126,8 +126,8 @@
                                 <label for="property-grabbable">Grabbable</label>
                             </div>
                             <div class="property checkbox">
-                                <input type="checkbox" id="property-wants-trigger">
-                                <label for="property-wants-trigger">Triggerable</label>
+                                <input type="checkbox" id="property-triggerable">
+                                <label for="property-triggerable">Triggerable</label>
                             </div>
                             <div class="property checkbox">
                                 <input type="checkbox" id="property-cloneable">

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -308,9 +308,10 @@ function setUserDataFromEditor(noUpdate) {
     }
 }
 
-function multiDataUpdater(groupName, updateKeyPair, userDataElement, defaults) {
+function multiDataUpdater(groupName, updateKeyPair, userDataElement, defaults, removeKeys) {
     var properties = {};
     var parsedData = {};
+    var keysToBeRemoved = removeKeys ? removeKeys : [];
     try {
         if ($('#userdata-editor').css('height') !== "0px") {
             // if there is an expanded, we want to use its json.
@@ -342,6 +343,12 @@ function multiDataUpdater(groupName, updateKeyPair, userDataElement, defaults) {
             parsedData[groupName][key] = defaults[key];
         }
     });
+    keysToBeRemoved.forEach(function(key) {
+        if (parsedData[groupName].hasOwnProperty(key)) {
+            delete parsedData[groupName][key];
+        }
+    });
+    
     if (Object.keys(parsedData[groupName]).length === 0) {
         delete parsedData[groupName];
     }
@@ -355,11 +362,11 @@ function multiDataUpdater(groupName, updateKeyPair, userDataElement, defaults) {
 
     updateProperties(properties);
 }
-function userDataChanger(groupName, keyName, values, userDataElement, defaultValue) {
+function userDataChanger(groupName, keyName, values, userDataElement, defaultValue, removeKeys) {
     var val = {}, def = {};
     val[keyName] = values;
     def[keyName] = defaultValue;
-    multiDataUpdater(groupName, val, userDataElement, def);
+    multiDataUpdater(groupName, val, userDataElement, def, removeKeys);
 }
 
 function setMaterialDataFromEditor(noUpdate) {
@@ -711,7 +718,7 @@ function loaded() {
         var elCloneableLifetime = document.getElementById("property-cloneable-lifetime");
         var elCloneableLimit = document.getElementById("property-cloneable-limit");
 
-        var elWantsTrigger = document.getElementById("property-wants-trigger");
+        var elTriggerable = document.getElementById("property-triggerable");
         var elIgnoreIK = document.getElementById("property-ignore-ik");
 
         var elLifetime = document.getElementById("property-lifetime");
@@ -1037,7 +1044,7 @@ function loaded() {
 
                         elGrabbable.checked = properties.dynamic;
 
-                        elWantsTrigger.checked = false;
+                        elTriggerable.checked = false;
                         elIgnoreIK.checked = true;
 
                         elCloneable.checked = properties.cloneable;
@@ -1060,10 +1067,12 @@ function loaded() {
                                 } else {
                                     elGrabbable.checked = true;
                                 }
-                                if ("wantsTrigger" in grabbableData) {
-                                    elWantsTrigger.checked = grabbableData.wantsTrigger;
+                                if ("triggerable" in grabbableData) {
+                                    elTriggerable.checked = grabbableData.triggerable;
+                                } else if ("wantsTrigger" in grabbableData) {
+                                    elTriggerable.checked = grabbableData.wantsTrigger;
                                 } else {
-                                    elWantsTrigger.checked = false;
+                                    elTriggerable.checked = false;
                                 }
                                 if ("ignoreIK" in grabbableData) {
                                     elIgnoreIK.checked = grabbableData.ignoreIK;
@@ -1076,7 +1085,7 @@ function loaded() {
                         }
                         if (!grabbablesSet) {
                             elGrabbable.checked = true;
-                            elWantsTrigger.checked = false;
+                            elTriggerable.checked = false;
                             elIgnoreIK.checked = true;
                             elCloneable.checked = false;
                         }
@@ -1447,8 +1456,8 @@ function loaded() {
         elCloneableLifetime.addEventListener('change', createEmitNumberPropertyUpdateFunction('cloneLifetime'));
         elCloneableLimit.addEventListener('change', createEmitNumberPropertyUpdateFunction('cloneLimit'));
 
-        elWantsTrigger.addEventListener('change', function() {
-            userDataChanger("grabbableKey", "wantsTrigger", elWantsTrigger, elUserData, false);
+        elTriggerable.addEventListener('change', function() {
+            userDataChanger("grabbableKey", "triggerable", elTriggerable, elUserData, false, ['wantsTrigger']);
         });
         elIgnoreIK.addEventListener('change', function() {
             userDataChanger("grabbableKey", "ignoreIK", elIgnoreIK, elUserData, true);


### PR DESCRIPTION
fixes https://highfidelity.manuscript.com/f/cases/16809/Create-doesn-t-recognize-triggerable-userData-property-as-a-synonym-for-wantsTrigger

## QA Test

1. Create a Box entity
2. Set the userData (Code) property to `{"grabbableKey": { "wantsTrigger": true}}` (see image) , re-select the entity. The triggerable checkbox  should be enabled.
![image](https://user-images.githubusercontent.com/607735/43350645-7340c286-9209-11e8-9d9a-905fe000d65f.png)
3. Uncheck the triggerable checkbox ( the userData property should now be set to `{"grabbableKey": { "triggerable": false}}`
4. Check the triggerable checkbox.  ( the userData property should now be set to `{"grabbableKey": { "triggerable": true}}`
5. Un-select the entity (or select another entity), then re-select the entity again to reload the properties. Triggerable should be checked.

