### PR TITLE
FB16702 - Avatar App does not save Animation JSON Override URL

### DIFF
--- a/interface/resources/qml/hifi/AvatarApp.qml
+++ b/interface/resources/qml/hifi/AvatarApp.qml
@@ -244,7 +244,7 @@ Rectangle {
             var avatarSettings = {
                 dominantHand : settings.dominantHandIsLeft ? 'left' : 'right',
                 collisionsEnabled : settings.avatarCollisionsOn,
-                animGraphUrl : settings.avatarAnimationJSON,
+                animGraphOverrideUrl : settings.avatarAnimationOverrideJSON,
                 collisionSoundUrl : settings.avatarCollisionSoundUrl
             };
 

--- a/interface/resources/qml/hifi/avatarapp/Settings.qml
+++ b/interface/resources/qml/hifi/avatarapp/Settings.qml
@@ -20,7 +20,8 @@ Rectangle {
     property real scaleValue: scaleSlider.value / 10
     property alias dominantHandIsLeft: leftHandRadioButton.checked
     property alias avatarCollisionsOn: collisionsEnabledRadiobutton.checked
-    property alias avatarAnimationJSON: avatarAnimationUrlInputText.text
+    property alias avatarAnimationOverrideJSON: avatarAnimationUrlInputText.text
+    property alias avatarAnimationJSON: avatarAnimationUrlInputText.placeholderText
     property alias avatarCollisionSoundUrl: avatarCollisionSoundUrlInputText.text
 
     property real avatarScaleBackup;
@@ -45,6 +46,7 @@ Rectangle {
         }
 
         avatarAnimationJSON = settings.animGraphUrl;
+        avatarAnimationOverrideJSON = settings.animGraphOverrideUrl;
         avatarCollisionSoundUrl = settings.collisionSoundUrl;
 
         visible = true;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2051,6 +2051,8 @@ void MyAvatar::initAnimGraph() {
         graphUrl = PathUtils::resourcesUrl("avatar/avatar-animation.json");
     }
 
+    emit animGraphUrlChanged(graphUrl);
+
     _skeletonModel->getRig().initAnimGraph(graphUrl);
     _currentAnimGraphUrl.set(graphUrl);
     connect(&(_skeletonModel->getRig()), SIGNAL(onLoadComplete()), this, SLOT(animGraphLoaded()));

--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -67,7 +67,8 @@ function getMyAvatarSettings() {
         dominantHand: MyAvatar.getDominantHand(),
         collisionsEnabled : MyAvatar.getCollisionsEnabled(),
         collisionSoundUrl : MyAvatar.collisionSoundURL,
-        animGraphUrl : MyAvatar.getAnimGraphUrl(),
+        animGraphUrl: MyAvatar.getAnimGraphUrl(),
+        animGraphOverrideUrl : MyAvatar.getAnimGraphOverrideUrl(),
     }
 }
 
@@ -142,9 +143,14 @@ function onNewCollisionSoundUrl(url) {
 }
 
 function onAnimGraphUrlChanged(url) {
-    if(currentAvatarSettings.animGraphUrl !== url) {
+    if (currentAvatarSettings.animGraphUrl !== url) {
         currentAvatarSettings.animGraphUrl = url;
-        sendToQml({'method' : 'settingChanged', 'name' : 'animGraphUrl', 'value' : url})
+        sendToQml({ 'method': 'settingChanged', 'name': 'animGraphUrl', 'value': currentAvatarSettings.animGraphUrl })
+
+        if (currentAvatarSettings.animGraphOverrideUrl !== MyAvatar.getAnimGraphOverrideUrl()) {
+            currentAvatarSettings.animGraphOverrideUrl = MyAvatar.getAnimGraphOverrideUrl();
+            sendToQml({ 'method': 'settingChanged', 'name': 'animGraphOverrideUrl', 'value': currentAvatarSettings.animGraphOverrideUrl })
+        }
     }
 }
 
@@ -282,7 +288,7 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
         MyAvatar.setDominantHand(message.settings.dominantHand);
         MyAvatar.setCollisionsEnabled(message.settings.collisionsEnabled);
         MyAvatar.collisionSoundURL = message.settings.collisionSoundUrl;
-        MyAvatar.setAnimGraphUrl(message.settings.animGraphUrl);
+        MyAvatar.setAnimGraphOverrideUrl(message.settings.animGraphOverrideUrl);
 
         settings = getMyAvatarSettings();
         break;


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/16702/Avatar-App-does-not-save-Animation-JSON-Override-URL

note: PR also changes logic of 'hint' - previously it showed hard-coded senseless text, now - current value of 'animation URL'

**Test plan**

1. Open the Avatar App
2. Select the settings icon in the upper right.
3. Edit the Avatar Animation JSON field to the following:  https://s3.amazonaws.com/hifi-public/tony/scoot-animation.json
4. Press Save
5. Your avatar should now appear in the sitting state.
6. Quit interface
7. Reload interface
8. Ensure avatar is still sitting
9. Open the Avatar App, go to settings
10. Delete Avatar Animation JSON field
11. Press Save.
12. Avatar should stand
13. Quit & Reload interface
14. Ensure Avatar is still standing