### PR TITLE
17016 flying settings

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4844,12 +4844,6 @@ void Application::loadSettings() {
 
         isFirstPerson = (qApp->isHMDMode());
 
-        // Flying should be disabled by default in HMD mode on first run, and it
-        // should be enabled by default in desktop mode.
-
-        auto myAvatar = getMyAvatar();
-        myAvatar->setFlyingEnabled(!isFirstPerson);
-
     } else {
         // if this is not the first run, the camera will be initialized differently depending on user settings
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2864,8 +2864,6 @@ void MyAvatar::setFlyingDesktopPref(bool enabled) {
         return;
     }
 
-    //if (!(qApp->isHMDMode())) { _enableFlying = enabled; }
-
     _flyingPrefDesktop = enabled;
 }
 
@@ -2878,8 +2876,6 @@ void MyAvatar::setFlyingHMDPref(bool enabled) {
         QMetaObject::invokeMethod(this, "setFlyingHMDPref", Q_ARG(bool, enabled));
         return;
     }
-
-    //if ((qApp->isHMDMode())) { _enableFlying = enabled; }
 
     _flyingPrefHMD = enabled;
 }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -953,6 +953,30 @@ public:
      */
     Q_INVOKABLE bool getFlyingEnabled();
 
+    /**jsdoc
+     * @function MyAvatar.setFlyingDesktopPref
+     * @param {boolean} enabled
+     */
+    Q_INVOKABLE void setFlyingDesktopPref(bool enabled);
+
+    /**jsdoc
+     * @function MyAvatar.getFlyingDesktopPref
+     * @returns {boolean}
+     */
+    Q_INVOKABLE bool getFlyingDesktopPref();
+
+    /**jsdoc
+     * @function MyAvatar.setFlyingDesktopPref
+     * @param {boolean} enabled
+     */
+    Q_INVOKABLE void setFlyingHMDPref(bool enabled);
+
+    /**jsdoc
+     * @function MyAvatar.getFlyingDesktopPref
+     * @returns {boolean}
+     */
+    Q_INVOKABLE bool getFlyingHMDPref();
+
 
     /**jsdoc
      * @function MyAvatar.getAvatarScale
@@ -1503,6 +1527,8 @@ private:
     std::bitset<MAX_DRIVE_KEYS> _disabledDriveKeys;
 
     bool _enableFlying { false };
+    bool _flyingPrefDesktop { true };
+    bool _flyingPrefHMD { false };
     bool _wasPushing { false };
     bool _isPushing { false };
     bool _isBeingPushed { false };

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -313,8 +313,8 @@ void setupPreferences() {
                                                        getter, setter));
     }
     {
-        auto getter = [=]()->bool { return myAvatar->getFlyingEnabled(); };
-        auto setter = [=](bool value) { myAvatar->setFlyingEnabled(value); };
+        auto getter = [=]()->bool { return myAvatar->getFlyingHMDPref(); };
+        auto setter = [=](bool value) { myAvatar->setFlyingHMDPref(value); };
         preferences->addPreference(new CheckPreference(VR_MOVEMENT, "Flying & jumping", getter, setter));
     }
     {


### PR DESCRIPTION
Divorces HMD flying settings from Desktop flying settings in our C++, saving them as separate values. Preserves functionality of setFlyingEnabled() to avoid breaking scripts.

While the tickbox for flying in desktop has still been removed, if the user sets flying via MyAvatar.setFlyingEnabled() in desktop mode the preference will still be respected between launches of interface.

HMD flying settings will also be respected between launches.

On first run, flying is enabled in desktop mode and disabled in HMD mode.

**TEST PLAN:**
_Goals:_
1.) Verify that flying is enabled in Desktop on first launch.
2.) Verify that flying is disabled in HMD on first launch.
3.) Verify that setting flying to enabled or disabled in HMD mode (via tablet) is respected between launches, independent of desktop mode.
4.) Verify that setting flying to enabled or disabled in Desktop mode (via MyAvatar.setFlyingEnabled() in Developer > Console) is respected between launches.

_Steps:_
- Launch interface.exe on a clean install (nothing in %appdata%) in desktop mode.
- Verify that flying is enabled. If so, Goal 1 is good.
- Switch to HMD mode with Display > (insert name of relevant HMD here)
- Verify that flying is now disabled. If so, Goal 2 is good.
- Open the tablet, go to "Menu > Settings > Control..." and enable "Flying and jumping" and "Advanced movement for hand controllers". Save these settings.
- Verify that flying is now enabled.
- Switch to Desktop mode ("Display > Desktop").
- Enable Developer menu ("Settings > Developer Menu")
- Open Console ("Developer > Console")
- Type "MyAvatar.setFlightEnabled(false)" and hit enter (should say "undefined" after enter).
- Close interface.exe and re-open in HMD mode.
- Verify that flying is still enabled in HMD. If so, Goal 3 is good.
- Switch to Desktop mode ("Display > Desktop").
- Verify that flying is still disabled in Desktop. If so, Goal 4 is good.