### PR TITLE
fix a crash when grabbing a non-dynamic entity with an overlay child

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -726,16 +726,18 @@ void MyAvatar::simulate(float deltaTime) {
                         properties.setQueryAACubeDirty();
                         properties.setLastEdited(now);
 
-                        packetSender->queueEditEntityMessage(PacketType::EntityEdit, entityTree, entity->getID(), properties);
+                        packetSender->queueEditEntityMessage(PacketType::EntityEdit, entityTree,
+                                                             entity->getID(), properties);
                         entity->setLastBroadcast(usecTimestampNow());
 
                         entity->forEachDescendant([&](SpatiallyNestablePointer descendant) {
-                            EntityItemPointer entityDescendant = std::static_pointer_cast<EntityItem>(descendant);
-                            if (!entityDescendant->getClientOnly() && descendant->updateQueryAACube()) {
+                            EntityItemPointer entityDescendant = std::dynamic_pointer_cast<EntityItem>(descendant);
+                            if (entityDescendant && !entityDescendant->getClientOnly() && descendant->updateQueryAACube()) {
                                 EntityItemProperties descendantProperties;
                                 descendantProperties.setQueryAACube(descendant->getQueryAACube());
                                 descendantProperties.setLastEdited(now);
-                                packetSender->queueEditEntityMessage(PacketType::EntityEdit, entityTree, entityDescendant->getID(), descendantProperties);
+                                packetSender->queueEditEntityMessage(PacketType::EntityEdit, entityTree,
+                                                                     entityDescendant->getID(), descendantProperties);
                                 entityDescendant->setLastBroadcast(now); // for debug/physics status icons
                             }
                         });


### PR DESCRIPTION
- fix a crash when grabbing a non-dynamic entity with an overlay child

https://highfidelity.fogbugz.com/f/cases/17123/crash-grabbing-non-dynamic-entity-with-child-overlay
