### PR TITLE
MS17041: Fix for require fail when the same script loaded simultaneously from another entity script

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -40,7 +40,6 @@
 
 #include <PointerManager.h>
 
-size_t std::hash<EntityItemID>::operator()(const EntityItemID& id) const { return qHash(id); }
 std::function<bool()> EntityTreeRenderer::_entitiesShouldFadeFunction;
 
 QString resolveScriptURL(const QString& scriptUrl) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -40,9 +40,6 @@ namespace render { namespace entities {
 
 } }
 
-// Allow the use of std::unordered_map with QUuid keys
-namespace std { template<> struct hash<EntityItemID> { size_t operator()(const EntityItemID& id) const; }; }
-
 using EntityRenderer = render::entities::EntityRenderer;
 using EntityRendererPointer = render::entities::EntityRendererPointer;
 using EntityRendererWeakPointer = render::entities::EntityRendererWeakPointer;

--- a/libraries/entities/src/EntityItemID.cpp
+++ b/libraries/entities/src/EntityItemID.cpp
@@ -69,3 +69,4 @@ QVector<EntityItemID> qVectorEntityItemIDFromScriptValue(const QScriptValue& arr
     return newVector;
 }
 
+size_t std::hash<EntityItemID>::operator()(const EntityItemID& id) const { return qHash(id); }

--- a/libraries/entities/src/EntityItemID.h
+++ b/libraries/entities/src/EntityItemID.h
@@ -45,4 +45,7 @@ QScriptValue EntityItemIDtoScriptValue(QScriptEngine* engine, const EntityItemID
 void EntityItemIDfromScriptValue(const QScriptValue &object, EntityItemID& properties);
 QVector<EntityItemID> qVectorEntityItemIDFromScriptValue(const QScriptValue& array);
 
+// Allow the use of std::unordered_map with QUuid keys
+namespace std { template<> struct hash<EntityItemID> { size_t operator()(const EntityItemID& id) const; }; }
+
 #endif // hifi_EntityItemID_h

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -223,10 +223,11 @@ ScriptEngine::ScriptEngine(Context context, const QString& scriptContents, const
     if (_type == Type::ENTITY_CLIENT || _type == Type::ENTITY_SERVER) {
         QObject::connect(this, &ScriptEngine::update, this, [this]() {
             // process pending entity script content
-            if (_contentAvailableQueue.size()) {
-                auto pending = _contentAvailableQueue.values().toStdList();
-                _contentAvailableQueue.clear();
-                for (auto& args : pending) {
+            if (!_contentAvailableQueue.empty()) {
+                EntityScriptContentAvailableMap pending;
+                std::swap(_contentAvailableQueue, pending);
+                for (auto& pair : pending) {
+                    auto& args = pair.second;
                     entityScriptContentAvailable(args.entityID, args.scriptOrURL, args.contents, args.isURL, args.success, args.status);
                 }
             }

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -219,6 +219,19 @@ ScriptEngine::ScriptEngine(Context context, const QString& scriptContents, const
         }
         logException(output);
     });
+
+    if (_type == Type::ENTITY_CLIENT || _type == Type::ENTITY_SERVER) {
+        QObject::connect(this, &ScriptEngine::update, this, [this]() {
+            // process pending entity script content
+            if (_contentAvailableQueue.size()) {
+                auto pending = _contentAvailableQueue.values().toStdList();
+                _contentAvailableQueue.clear();
+                for (auto& args : pending) {
+                    entityScriptContentAvailable(args.entityID, args.scriptOrURL, args.contents, args.isURL, args.success, args.status);
+                }
+            }
+        });
+    }
 }
 
 QString ScriptEngine::getContext() const {
@@ -2181,7 +2194,7 @@ void ScriptEngine::loadEntityScript(const EntityItemID& entityID, const QString&
                 qCDebug(scriptengine) << "loadEntityScript.contentAvailable" << status << QUrl(url).fileName() << entityID.toString();
 #endif
                 if (!isStopping() && _entityScripts.contains(entityID)) {
-                    entityScriptContentAvailable(entityID, url, contents, isURL, success, status);
+                    _contentAvailableQueue[entityID] = { entityID, url, contents, isURL, success, status };
                 } else {
 #ifdef DEBUG_ENTITY_STATES
                     qCDebug(scriptengine) << "loadEntityScript.contentAvailable -- aborting";

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -71,6 +71,15 @@ public:
     //bool forceRedownload;
 };
 
+struct EntityScriptContentAvailable {
+    EntityItemID entityID;
+    QString scriptOrURL;
+    QString contents;
+    bool isURL;
+    bool success;
+    QString status;
+};
+
 typedef QList<CallbackData> CallbackList;
 typedef QHash<QString, CallbackList> RegisteredEventHandlers;
 
@@ -762,6 +771,7 @@ protected:
     QHash<EntityItemID, EntityScriptDetails> _entityScripts;
     QHash<QString, EntityItemID> _occupiedScriptURLs;
     QList<DeferredLoadEntity> _deferredEntityLoads;
+    QMap<EntityItemID, EntityScriptContentAvailable> _contentAvailableQueue;
 
     bool _isThreaded { false };
     QScriptEngineDebugger* _debugger { nullptr };

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -12,6 +12,7 @@
 #ifndef hifi_ScriptEngine_h
 #define hifi_ScriptEngine_h
 
+#include <unordered_map>
 #include <vector>
 
 #include <QtCore/QObject>
@@ -79,6 +80,8 @@ struct EntityScriptContentAvailable {
     bool success;
     QString status;
 };
+
+typedef std::unordered_map<EntityItemID, EntityScriptContentAvailable> EntityScriptContentAvailableMap;
 
 typedef QList<CallbackData> CallbackList;
 typedef QHash<QString, CallbackList> RegisteredEventHandlers;
@@ -771,7 +774,7 @@ protected:
     QHash<EntityItemID, EntityScriptDetails> _entityScripts;
     QHash<QString, EntityItemID> _occupiedScriptURLs;
     QList<DeferredLoadEntity> _deferredEntityLoads;
-    QMap<EntityItemID, EntityScriptContentAvailable> _contentAvailableQueue;
+    EntityScriptContentAvailableMap _contentAvailableQueue;
 
     bool _isThreaded { false };
     QScriptEngineDebugger* _debugger { nullptr };


### PR DESCRIPTION
Fixes https://highfidelity.manuscript.com/f/cases/17041/require-fails-if-another-script-already-required-the-library-and-the-library-hasn-t-yet-downloaded

## QA Test Plan

1. When installing this PR, be sure to select the clean install. Don't copy. And when you re-run this PR always be sure to remove your cache folders first.
2. Go to a domain with rez permissions.
3. Check menu option `Settings -> Developer Menu`
4. Check menu option `Developer -> Verbose Logging`
5. Open the Log  (CTRL + SHIFT + L)
6. Edit -> Import Entities from URL: https://hifi-require-bug.glitch.me/require-test/require-test.json
7. Verify that the following lines show up in the log
    ```
    [DEBUG] [hifi.scriptengine.script] [about:Entities 2] QQQQ something: 0
    [DEBUG] [hifi.scriptengine.script] [about:Entities 2] QQQQ something: 1
    [DEBUG] [hifi.scriptengine.script] [about:Entities 2] QQQQ something: 2
    ```
    **Note: they could be in a different order or `[about:Entities 2]` may contain another number, which is fine**
8. Smoke test some existing entity scripts.





> special thanks to @humbletim for offering this patch