### PR TITLE
Remove deprecated flying setting from MyAvatar.cpp saveData()

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1137,7 +1137,6 @@ void MyAvatar::saveData() {
     settings.setValue("userHeight", getUserHeight());
     settings.setValue("flyingDesktop", getFlyingDesktopPref());
     settings.setValue("flyingHMD", getFlyingHMDPref());
-    settings.setValue("enabledFlying", getFlyingEnabled());
 
     settings.endGroup();
 }


### PR DESCRIPTION
Addresses [MS#17170](https://highfidelity.fogbugz.com/f/cases/17170/crash-on-exit-related-to-saving-flying-settings), removing unnecessary setting from MyAvatar.cpp's saveData() function.

**Test Plan:**

_Goal:_ Confirm no crash on exit.

_Steps:_
- Load interface.exe
- Join a domain, wait for content to load.
- Close interface.exe
- Re-open interface.exe. If no crash on last run dialog appears, this bug fix is good to go.

Also run the test from https://github.com/highfidelity/hifi/pull/13702
