### PR TITLE
Stack tester changes

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -365,7 +365,6 @@ void Agent::executeScript() {
     // give scripts access to the Users object
     _scriptEngine->registerGlobalObject("Users", DependencyManager::get<UsersScriptingInterface>().data());
 
-
     auto player = DependencyManager::get<recording::Deck>();
     connect(player.data(), &recording::Deck::playbackStateChanged, [=] {
         if (player->isPlaying()) {

--- a/assignment-client/src/AssignmentClientApp.cpp
+++ b/assignment-client/src/AssignmentClientApp.cpp
@@ -11,6 +11,8 @@
 
 #include "AssignmentClientApp.h"
 
+#include <iostream>
+
 #include <QtCore/QCommandLineParser>
 #include <QtCore/QDir>
 #include <QtCore/QStandardPaths>
@@ -42,9 +44,8 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
     // parse command-line
     QCommandLineParser parser;
     parser.setApplicationDescription("High Fidelity Assignment Client");
-    parser.addHelpOption();
-
     const QCommandLineOption helpOption = parser.addHelpOption();
+    const QCommandLineOption versionOption = parser.addVersionOption();
 
     QString typeDescription = "run single assignment client of given type\n# | Type\n============================";
     for (Assignment::Type type = Assignment::FirstType;
@@ -97,8 +98,13 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
     parser.addOption(parentPIDOption);
 
     if (!parser.parse(QCoreApplication::arguments())) {
-        qCritical() << parser.errorText() << endl;
+        std::cout << parser.errorText().toStdString() << std::endl; // Avoid Qt log spam
         parser.showHelp();
+        Q_UNREACHABLE();
+    }
+
+    if (parser.isSet(versionOption)) {
+        parser.showVersion();
         Q_UNREACHABLE();
     }
 

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -59,6 +59,8 @@ public:
     DomainServer(int argc, char* argv[]);
     ~DomainServer();
 
+    static void parseCommandLine(int argc, char* argv[]);
+
     enum DomainType {
         NonMetaverse,
         MetaverseDomain,
@@ -138,7 +140,6 @@ signals:
 
 private:
     QUuid getID();
-    void parseCommandLine();
 
     QString getContentBackupDir();
     QString getEntitiesDirPath();
@@ -228,7 +229,7 @@ private:
     QQueue<SharedAssignmentPointer> _unfulfilledAssignments;
     TransactionHash _pendingAssignmentCredits;
 
-    bool _isUsingDTLS;
+    bool _isUsingDTLS { false };
 
     QUrl _oauthProviderURL;
     QString _oauthClientID;
@@ -265,10 +266,11 @@ private:
     friend class DomainGatekeeper;
     friend class DomainMetadata;
 
-    QString _iceServerAddr;
-    int _iceServerPort;
-    bool _overrideDomainID { false }; // should we override the domain-id from settings?
-    QUuid _overridingDomainID { QUuid() }; // what should we override it with?
+    static QString _iceServerAddr;
+    static int _iceServerPort;
+    static bool _overrideDomainID; // should we override the domain-id from settings?
+    static QUuid _overridingDomainID; // what should we override it with?
+    static int _parentPID;
 
     bool _sendICEServerAddressToMetaverseAPIInProgress { false };
     bool _sendICEServerAddressToMetaverseAPIRedo { false };

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -270,6 +270,8 @@ private:
     static int _iceServerPort;
     static bool _overrideDomainID; // should we override the domain-id from settings?
     static QUuid _overridingDomainID; // what should we override it with?
+    static bool _getTempName;
+    static QString _userConfigFilename;
     static int _parentPID;
 
     bool _sendICEServerAddressToMetaverseAPIInProgress { false };

--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -191,13 +191,12 @@ void DomainServerSettingsManager::processSettingsRequestPacket(QSharedPointer<Re
     nodeList->sendPacketList(std::move(packetList), message->getSenderSockAddr());
 }
 
-void DomainServerSettingsManager::setupConfigMap(const QStringList& argumentList) {
+void DomainServerSettingsManager::setupConfigMap(const QString& userConfigFilename) {
     // since we're called from the DomainServerSettingsManager constructor, we don't take a write lock here
     // even though we change the underlying config map
 
-    _argumentList = argumentList;
-
-    _configMap.loadConfig(_argumentList);
+    _configMap.setUserConfigFilename(userConfigFilename);
+    _configMap.loadConfig();
 
     static const auto VERSION_SETTINGS_KEYPATH = "version";
     QVariant* versionVariant = _configMap.valueForKeyPath(VERSION_SETTINGS_KEYPATH);
@@ -1736,7 +1735,7 @@ void DomainServerSettingsManager::persistToFile() {
         // failed to write, reload whatever the current config state is
         // with a write lock since we're about to overwrite the config map
         QWriteLocker locker(&_settingsLock);
-        _configMap.loadConfig(_argumentList);
+        _configMap.loadConfig();
     }
 }
 

--- a/domain-server/src/DomainServerSettingsManager.h
+++ b/domain-server/src/DomainServerSettingsManager.h
@@ -49,7 +49,7 @@ public:
     DomainServerSettingsManager();
     bool handleAuthenticatedHTTPRequest(HTTPConnection* connection, const QUrl& url);
 
-    void setupConfigMap(const QStringList& argumentList);
+    void setupConfigMap(const QString& userConfigFilename);
 
     // each of the three methods in this group takes a read lock of _settingsLock
     // and cannot be called when the a write lock is held by the same thread
@@ -144,8 +144,6 @@ private slots:
     void processUsernameFromIDRequestPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
 
 private:
-    QStringList _argumentList;
-
     QJsonArray filteredDescriptionArray(bool isContentSettings);
     void updateSetting(const QString& key, const QJsonValue& newValue, QVariantMap& settingMap,
                        const QJsonObject& settingDescription);

--- a/domain-server/src/main.cpp
+++ b/domain-server/src/main.cpp
@@ -24,6 +24,8 @@
 int main(int argc, char* argv[]) {
     setupHifiApplication(BuildInfo::DOMAIN_SERVER_NAME);
 
+    DomainServer::parseCommandLine(argc, argv);
+
     Setting::init();
 
     int currentExitCode = 0;

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -42,6 +42,48 @@ extern "C" {
 int main(int argc, const char* argv[]) {
     setupHifiApplication(BuildInfo::INTERFACE_NAME);
 
+    QStringList arguments;
+    for (int i = 0; i < argc; ++i) {
+        arguments << argv[i];
+    }
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription("High Fidelity Interface");
+    QCommandLineOption versionOption = parser.addVersionOption();
+    QCommandLineOption helpOption = parser.addHelpOption();
+
+    QCommandLineOption urlOption("url", "", "value");
+    QCommandLineOption noUpdaterOption("no-updater", "Do not show auto-updater");
+    QCommandLineOption checkMinSpecOption("checkMinSpec", "Check if machine meets minimum specifications");
+    QCommandLineOption runServerOption("runServer", "Whether to run the server");
+    QCommandLineOption serverContentPathOption("serverContentPath", "Where to find server content", "serverContentPath");
+    QCommandLineOption allowMultipleInstancesOption("allowMultipleInstances", "Allow multiple instances to run");
+    QCommandLineOption overrideAppLocalDataPathOption("cache", "set test cache <dir>", "dir");
+    QCommandLineOption overrideScriptsPathOption(SCRIPTS_SWITCH, "set scripts <path>", "path");
+
+    parser.addOption(urlOption);
+    parser.addOption(noUpdaterOption);
+    parser.addOption(checkMinSpecOption);
+    parser.addOption(runServerOption);
+    parser.addOption(serverContentPathOption);
+    parser.addOption(overrideAppLocalDataPathOption);
+    parser.addOption(overrideScriptsPathOption);
+    parser.addOption(allowMultipleInstancesOption);
+
+    if (!parser.parse(arguments)) {
+        std::cout << parser.errorText().toStdString() << std::endl; // Avoid Qt log spam
+    }
+
+    if (parser.isSet(versionOption)) {
+        parser.showVersion();
+        Q_UNREACHABLE();
+    }
+    if (parser.isSet(helpOption)) {
+        QCoreApplication mockApp(argc, const_cast<char**>(argv)); // required for call to showHelp()
+        parser.showHelp();
+        Q_UNREACHABLE();
+    }
+
     // Early check for --traceFile argument 
     auto tracer = DependencyManager::set<tracing::Tracer>();
     const char * traceFile = nullptr;
@@ -94,30 +136,6 @@ int main(int argc, const char* argv[]) {
         auto crashHandlerStarted = startCrashHandler(argv[0]);
         qDebug() << "Crash handler started:" << crashHandlerStarted;
     }
-
-    QStringList arguments;
-    for (int i = 0; i < argc; ++i) {
-        arguments << argv[i];
-    }
-
-    QCommandLineParser parser;
-    QCommandLineOption urlOption("url", "", "value");
-    QCommandLineOption noUpdaterOption("no-updater", "Do not show auto-updater");
-    QCommandLineOption checkMinSpecOption("checkMinSpec", "Check if machine meets minimum specifications");
-    QCommandLineOption runServerOption("runServer", "Whether to run the server");
-    QCommandLineOption serverContentPathOption("serverContentPath", "Where to find server content", "serverContentPath");
-    QCommandLineOption allowMultipleInstancesOption("allowMultipleInstances", "Allow multiple instances to run");
-    QCommandLineOption overrideAppLocalDataPathOption("cache", "set test cache <dir>", "dir");
-    QCommandLineOption overrideScriptsPathOption(SCRIPTS_SWITCH, "set scripts <path>", "path");
-    parser.addOption(urlOption);
-    parser.addOption(noUpdaterOption);
-    parser.addOption(checkMinSpecOption);
-    parser.addOption(runServerOption);
-    parser.addOption(serverContentPathOption);
-    parser.addOption(overrideAppLocalDataPathOption);
-    parser.addOption(overrideScriptsPathOption);
-    parser.addOption(allowMultipleInstancesOption);
-    parser.parse(arguments);
 
 
     const QString& applicationName = getInterfaceSharedMemoryName();

--- a/libraries/gpu/src/gpu/Texture.cpp
+++ b/libraries/gpu/src/gpu/Texture.cpp
@@ -43,14 +43,6 @@ bool recommendedSparseTextures = (QThread::idealThreadCount() >= MIN_CORES_FOR_I
 
 std::atomic<bool> Texture::_enableSparseTextures { recommendedSparseTextures };
 
-struct ReportTextureState {
-    ReportTextureState() {
-        qCDebug(gpulogging) << "[TEXTURE TRANSFER SUPPORT]"
-            << "\n\tidealThreadCount:" << QThread::idealThreadCount()
-            << "\n\tRECOMMENDED enableSparseTextures:" << recommendedSparseTextures;
-    }
-} report;
-
 void Texture::setEnableSparseTextures(bool enabled) {
 #ifdef Q_OS_WIN
     qCDebug(gpulogging) << "[TEXTURE TRANSFER SUPPORT] SETTING - Enable Sparse Textures and Dynamic Texture Management:" << enabled;

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -751,7 +751,7 @@ void ScriptEngine::init() {
     registerGlobalObject("UserActivityLogger", DependencyManager::get<UserActivityLoggerScriptingInterface>().data());
 
 #if DEV_BUILD || PR_BUILD
-    registerGlobalObject("StackTest", new StackTestScriptingInterface());
+    registerGlobalObject("StackTest", new StackTestScriptingInterface(this));
 #endif
 }
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -74,6 +74,7 @@
 #include "WebSocketClass.h"
 #include "RecordingScriptingInterface.h"
 #include "ScriptEngines.h"
+#include "StackTestScriptingInterface.h"
 #include "ModelScriptingInterface.h"
 
 
@@ -748,6 +749,10 @@ void ScriptEngine::init() {
     qScriptRegisterMetaType(this, meshesToScriptValue, meshesFromScriptValue);
 
     registerGlobalObject("UserActivityLogger", DependencyManager::get<UserActivityLoggerScriptingInterface>().data());
+
+#if DEV_BUILD || PR_BUILD
+    registerGlobalObject("StackTest", new StackTestScriptingInterface());
+#endif
 }
 
 void ScriptEngine::registerValue(const QString& valueName, QScriptValue value) {

--- a/libraries/script-engine/src/StackTestScriptingInterface.cpp
+++ b/libraries/script-engine/src/StackTestScriptingInterface.cpp
@@ -1,0 +1,31 @@
+//
+//  StackTestScriptingInterface.cpp
+//  libraries/script-engine/src
+//
+//  Created by Clement Brisset on 7/25/18.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "StackTestScriptingInterface.h"
+
+#include <QLoggingCategory>
+#include <QCoreApplication>
+
+Q_DECLARE_LOGGING_CATEGORY(stackTest)
+Q_LOGGING_CATEGORY(stackTest, "hifi.tools.stack-test")
+
+void StackTestScriptingInterface::pass(QString message) {
+    qCInfo(stackTest) << "PASS" << qPrintable(message);
+}
+
+void StackTestScriptingInterface::fail(QString message) {
+    qCInfo(stackTest) << "FAIL" << qPrintable(message);
+}
+
+void StackTestScriptingInterface::exit(QString message) {
+    qCInfo(stackTest) << "COMPLETE" << qPrintable(message);
+    qApp->exit();
+}

--- a/libraries/script-engine/src/StackTestScriptingInterface.h
+++ b/libraries/script-engine/src/StackTestScriptingInterface.h
@@ -20,6 +20,8 @@ class StackTestScriptingInterface : public QObject {
     Q_OBJECT
 
 public:
+    StackTestScriptingInterface(QObject* parent = nullptr) : QObject(parent) {}
+
     Q_INVOKABLE void pass(QString message = QString());
     Q_INVOKABLE void fail(QString message = QString());
 

--- a/libraries/script-engine/src/StackTestScriptingInterface.h
+++ b/libraries/script-engine/src/StackTestScriptingInterface.h
@@ -1,0 +1,29 @@
+//
+//  StackTestScriptingInterface.h
+//  libraries/script-engine/src
+//
+//  Created by Clement Brisset on 7/25/18.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#pragma once
+
+#ifndef hifi_StackTestScriptingInterface_h
+#define hifi_StackTestScriptingInterface_h
+
+#include <QObject>
+
+class StackTestScriptingInterface : public QObject {
+    Q_OBJECT
+
+public:
+    Q_INVOKABLE void pass(QString message = QString());
+    Q_INVOKABLE void fail(QString message = QString());
+
+    Q_INVOKABLE void exit(QString message = QString());
+};
+
+#endif // hifi_StackTestScriptingInterface_h

--- a/libraries/shared/src/HifiConfigVariantMap.cpp
+++ b/libraries/shared/src/HifiConfigVariantMap.cpp
@@ -91,58 +91,7 @@ QVariantMap HifiConfigVariantMap::mergeCLParametersWithJSONConfig(const QStringL
     return mergedMap;
 }
 
-void HifiConfigVariantMap::loadConfig(const QStringList& argumentList) {
-    // load the user config
-    const QString USER_CONFIG_FILE_OPTION = "--user-config";
-    static const QString USER_CONFIG_FILE_NAME = "config.json";
-
-    int userConfigIndex = argumentList.indexOf(USER_CONFIG_FILE_OPTION);
-    if (userConfigIndex != -1) {
-        _userConfigFilename = argumentList[userConfigIndex + 1];
-    } else {
-        // we weren't passed a user config path
-        _userConfigFilename = PathUtils::getAppDataFilePath(USER_CONFIG_FILE_NAME);
-
-        // as of 1/19/2016 this path was moved so we attempt a migration for first run post migration here
-
-        // figure out what the old path was
-
-        // if our build version is "dev" we should migrate from a different organization folder
-
-        auto oldConfigFilename = QString("%1/%2/%3/%4").arg(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation),
-                                                            QCoreApplication::organizationName(),
-                                                            QCoreApplication::applicationName(),
-                                                            USER_CONFIG_FILE_NAME);
-
-        oldConfigFilename = oldConfigFilename.replace("High Fidelity - dev", "High Fidelity");
-
-
-        // check if there's already a config file at the new path
-        QFile newConfigFile { _userConfigFilename };
-        if (!newConfigFile.exists()) {
-
-            QFile oldConfigFile { oldConfigFilename };
-
-            if (oldConfigFile.exists()) {
-                // we have the old file and not the new file - time to copy the file
-
-                // make the destination directory if it doesn't exist
-                auto dataDirectory = PathUtils::getAppDataPath();
-                if (QDir().mkpath(dataDirectory)) {
-                    if (oldConfigFile.copy(_userConfigFilename)) {
-                        qCDebug(shared) << "Migrated config file from" << oldConfigFilename << "to" << _userConfigFilename;
-                    } else {
-                        qCWarning(shared) << "Could not copy previous config file from" << oldConfigFilename << "to" << _userConfigFilename
-                        << "- please try to copy manually and restart.";
-                    }
-                } else {
-                    qCWarning(shared) << "Could not create application data directory" << dataDirectory << "- unable to migrate previous config file.";
-                }
-            }
-        }
-        
-    }
-    
+void HifiConfigVariantMap::loadConfig() {
     loadMapFromJSONFile(_userConfig, _userConfigFilename);
 }
 

--- a/libraries/shared/src/HifiConfigVariantMap.h
+++ b/libraries/shared/src/HifiConfigVariantMap.h
@@ -21,7 +21,7 @@ class HifiConfigVariantMap {
 public:
     static QVariantMap mergeCLParametersWithJSONConfig(const QStringList& argumentList);
 
-    void loadConfig(const QStringList& argumentList);
+    void loadConfig();
 
     const QVariant value(const QString& key) const { return _userConfig.value(key); }
     QVariant* valueForKeyPath(const QString& keyPath, bool shouldCreateIfMissing = false)
@@ -30,6 +30,7 @@ public:
     QVariantMap& getConfig() { return _userConfig; }
 
     const QString& getUserConfigFilename() const { return _userConfigFilename; }
+    void setUserConfigFilename(const QString& filename) { _userConfigFilename = filename; }
 private:
     QString _userConfigFilename;
 

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -33,17 +33,12 @@ LogHandler& LogHandler::getInstance() {
 }
 
 LogHandler::LogHandler() {
-    // when the log handler is first setup we should print our timezone
-    QString timezoneString = "Time zone: " + QDateTime::currentDateTime().toString("t");
-    printMessage(LogMsgType::LogInfo, QMessageLogContext(), timezoneString);
-
     // make sure we setup the repeated message flusher, but do it on the LogHandler thread	
     QMetaObject::invokeMethod(this, "setupRepeatedMessageFlusher");
 }
 
 LogHandler::~LogHandler() {
     flushRepeatedMessages();
-    printMessage(LogMsgType::LogDebug, QMessageLogContext(), "LogHandler shutdown.");
 }
 
 const char* stringForLogType(LogMsgType msgType) {

--- a/libraries/shared/src/PathUtils.cpp
+++ b/libraries/shared/src/PathUtils.cpp
@@ -90,7 +90,6 @@ const QString& PathUtils::resourcesPath() {
             staticResourcePath = projectRootPath() + "/interface/resources/";
         }
 #endif
-        qDebug() << "Resource path resolved to " << staticResourcePath;
     });
     return staticResourcePath;
 }
@@ -105,7 +104,6 @@ const QString& PathUtils::resourcesUrl() {
             staticResourcePath = QUrl::fromLocalFile(projectRootPath() + "/interface/resources/").toString();
         }
 #endif
-        qDebug() << "Resource url resolved to " << staticResourcePath;
     });
     return staticResourcePath;
 }


### PR DESCRIPTION
This PR makes some changes required by the new stack tester tool:

- Adds a `StackTest` scripting interface only enable in dev and PR builds
- Cleans up old code to pass a config file to the DS via cli
- Cleans up cli processing to get a clean output that's easier to process
- Removes static prints from the code