### PR TITLE
Update bubble context for RC 71

### DIFF
--- a/cmake/externals/serverless-content/CMakeLists.txt
+++ b/cmake/externals/serverless-content/CMakeLists.txt
@@ -4,8 +4,8 @@ set(EXTERNAL_NAME serverless-content)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC69.zip
-  URL_MD5 e2467b08de069da7e22ec8e032435592
+  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC70.zip
+  URL_MD5 84a2eedf568272a8098930427fc35f26
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""

--- a/cmake/externals/serverless-content/CMakeLists.txt
+++ b/cmake/externals/serverless-content/CMakeLists.txt
@@ -4,8 +4,8 @@ set(EXTERNAL_NAME serverless-content)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC70.zip
-  URL_MD5 84a2eedf568272a8098930427fc35f26
+  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC70v2.zip
+  URL_MD5 35fcc8e635e71d0b00a08455a2582448
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""


### PR DESCRIPTION
**Test Plan**
Run test rail cases for desktop and VR serverless tutorials (at least one of them - the minspec cases are listed below, but the other ones would also be acceptable) 
C15034
C14495

Instead of the content for the Bubble station saying that the bubble is enabled by default, this should now reflect the state of RC 70.1+ where the Bubble is disabled by default. Confirm that the:

- Audio Clip for Desktop
- Audio Clip for HMD
- Text for Desktop
- Text for HMD

in the Bubble station appear/play as expected and outlined in the Test Rail cases, and reflect the new bubble default.