### PR TITLE
Fix MS17168: Filter My Purchases when clicking View link on Confirmation

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -876,7 +876,7 @@ Rectangle {
             horizontalAlignment: Text.AlignLeft;
             verticalAlignment: Text.AlignVCenter;
             onLinkActivated: {
-                sendToScript({method: 'checkout_goToPurchases'});
+                sendToScript({method: 'checkout_goToPurchases', filterText: root.itemName});
             }
         }
 


### PR DESCRIPTION
Fixes [MS17168](https://highfidelity.fogbugz.com/f/cases/17168/My-Purchases-not-filtered-when-clicking-View-this-item-in-My-Purchases-Link-from-the-Purchase-Confirmation-dialog).