### PR TITLE
Use key codes for entity camera keys

### DIFF
--- a/scripts/system/libraries/entityCameraTool.js
+++ b/scripts/system/libraries/entityCameraTool.js
@@ -39,7 +39,6 @@ var EASING_MULTIPLIER = 8;
 var INITIAL_ZOOM_DISTANCE = 2;
 var INITIAL_ZOOM_DISTANCE_FIRST_PERSON = 3;
 
-
 var easeOutCubic = function(t) {
     t--;
     return t * t * t + 1;

--- a/scripts/system/libraries/entityCameraTool.js
+++ b/scripts/system/libraries/entityCameraTool.js
@@ -39,8 +39,6 @@ var EASING_MULTIPLIER = 8;
 var INITIAL_ZOOM_DISTANCE = 2;
 var INITIAL_ZOOM_DISTANCE_FIRST_PERSON = 3;
 
-var KEY_A = 80;
-var KEY_D = 80;
 
 var easeOutCubic = function(t) {
     t--;

--- a/scripts/system/libraries/entityCameraTool.js
+++ b/scripts/system/libraries/entityCameraTool.js
@@ -39,6 +39,9 @@ var EASING_MULTIPLIER = 8;
 var INITIAL_ZOOM_DISTANCE = 2;
 var INITIAL_ZOOM_DISTANCE_FIRST_PERSON = 3;
 
+var KEY_A = 80;
+var KEY_D = 80;
+
 var easeOutCubic = function(t) {
     t--;
     return t * t * t + 1;
@@ -77,17 +80,17 @@ CameraManager = function() {
     }
 
     var keyToActionMapping = {
-        "a": "orbitLeft",
-        "d": "orbitRight",
-        "w": "orbitForward",
-        "s": "orbitBackward",
-        "e": "orbitUp",
-        "c": "orbitDown",
-
-        "LEFT": "orbitLeft",
-        "RIGHT": "orbitRight",
-        "UP": "orbitForward",
-        "DOWN": "orbitBackward",
+        65: "orbitLeft",    // "a"
+        68: "orbitRight",   // "d"
+        87: "orbitForward", // "w"
+        83: "orbitBackward",// "s"
+        69: "orbitUp",      // "e"
+        67: "orbitDown",    // "c"
+        
+        16777234: "orbitLeft",    //"LEFT"
+        16777236: "orbitRight",   //"RIGHT"
+        16777235: "orbitForward", //"UP"
+        16777237: "orbitBackward",//"DOWN"
     }
 
     var CAPTURED_KEYS = [];
@@ -96,7 +99,7 @@ CameraManager = function() {
     }
 
     function getActionForKeyEvent(event) {
-        var action = keyToActionMapping[event.text];
+        var action = keyToActionMapping[event.key];
         if (action !== undefined) {
             if (event.isShifted) {
                 if (action === "orbitForward") {

--- a/scripts/system/libraries/entityCameraTool.js
+++ b/scripts/system/libraries/entityCameraTool.js
@@ -80,17 +80,17 @@ CameraManager = function() {
     }
 
     var keyToActionMapping = {
-        65: "orbitLeft",    // "a"
-        68: "orbitRight",   // "d"
-        87: "orbitForward", // "w"
-        83: "orbitBackward",// "s"
-        69: "orbitUp",      // "e"
-        67: "orbitDown",    // "c"
+        65: "orbitLeft",     // "a"
+        68: "orbitRight",    // "d"
+        87: "orbitForward",  // "w"
+        83: "orbitBackward", // "s"
+        69: "orbitUp",       // "e"
+        67: "orbitDown",     // "c"
         
-        16777234: "orbitLeft",    //"LEFT"
-        16777236: "orbitRight",   //"RIGHT"
-        16777235: "orbitForward", //"UP"
-        16777237: "orbitBackward",//"DOWN"
+        16777234: "orbitLeft",     // "LEFT"
+        16777236: "orbitRight",    // "RIGHT"
+        16777235: "orbitForward",  // "UP"
+        16777237: "orbitBackward", // "DOWN"
     }
 
     var CAPTURED_KEYS = [];


### PR DESCRIPTION
Fixes: https://highfidelity.manuscript.com/f/cases/edit/17125

Test Plan:
- Enter Interface in desktop mode
- Open Create app and select any entity
- Press F on keyboard to focus camera on selected entity
- While in entity camera, press and hold the following keys to verify their expected behavior:

A:  orbit left
D:  orbit right
W:  orbit forward
S:  orbit backward
E:  orbit up
C:  orbit down
Left arrow:  orbit left
Right arrow:  orbit right
Up arrow:  orbit forward
Down arrow:  orbit backward

- For each above key, press and hold the key and verify that once clicking away from the Interface window the key is considered released