### PR TITLE
Flying Settings - Expose HMD setting through desktop and HMD settings page

### DIFF
--- a/interface/resources/qml/hifi/tablet/ControllerSettings.qml
+++ b/interface/resources/qml/hifi/tablet/ControllerSettings.qml
@@ -299,7 +299,7 @@ Item {
             anchors.fill: stackView
             id: controllerPrefereneces
             objectName: "TabletControllerPreferences"
-            showCategories: [( (HMD.active) ? "VR Movement" : "Movement"), "Game Controller", "Sixense Controllers", "Perception Neuron", "Leap Motion"]
+            showCategories: ["VR Movement", "Game Controller", "Sixense Controllers", "Perception Neuron", "Leap Motion"]
             categoryProperties: {
                 "VR Movement" : {
                     "User real-world height (meters)" : { "anchors.right" : "undefined" },

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -266,45 +266,8 @@ void setupPreferences() {
         preferences->addPreference(new SliderPreference(FACE_TRACKING, "Eye Deflection", getter, setter));
     }
 
-    static const QString MOVEMENT{ "Movement" };
-    {
-
-        static const QString movementsControlChannel = QStringLiteral("Hifi-Advanced-Movement-Disabler");
-        auto getter = [=]()->bool { return myAvatar->useAdvancedMovementControls(); };
-        auto setter = [=](bool value) { myAvatar->setUseAdvancedMovementControls(value); };
-        preferences->addPreference(new CheckPreference(MOVEMENT,
-            QStringLiteral("Advanced movement for hand controllers"),
-            getter, setter));
-    }
-    {
-        auto getter = [=]()->int { return myAvatar->getSnapTurn() ? 0 : 1; };
-        auto setter = [=](int value) { myAvatar->setSnapTurn(value == 0); };
-        auto preference = new RadioButtonsPreference(MOVEMENT, "Snap turn / Smooth turn", getter, setter);
-        QStringList items;
-        items << "Snap turn" << "Smooth turn";
-        preference->setItems(items);
-        preferences->addPreference(preference);
-    }
-    {
-        auto getter = [=]()->float { return myAvatar->getUserHeight(); };
-        auto setter = [=](float value) { myAvatar->setUserHeight(value); };
-        auto preference = new SpinnerPreference(MOVEMENT, "User real-world height (meters)", getter, setter);
-        preference->setMin(1.0f);
-        preference->setMax(2.2f);
-        preference->setDecimals(3);
-        preference->setStep(0.001f);
-        preferences->addPreference(preference);
-    }
-    {
-        auto preference = new ButtonPreference(MOVEMENT, "RESET SENSORS", [] {
-            qApp->resetSensors();
-        });
-        preferences->addPreference(preference);
-    }
-
     static const QString VR_MOVEMENT{ "VR Movement" };
     {
-
         static const QString movementsControlChannel = QStringLiteral("Hifi-Advanced-Movement-Disabler");
         auto getter = [=]()->bool { return myAvatar->useAdvancedMovementControls(); };
         auto setter = [=](bool value) { myAvatar->setUseAdvancedMovementControls(value); };


### PR DESCRIPTION
In Desktop and HMD mode, the "Flying & jumping" setting for HMD mode should be visible in settings. However, users should not be able to disable flying in desktop mode from this settings page.

**Test Plan**
_Goal:_
Ensure that users can toggle HMD flying in the Settings page.

_Steps:_
- Launch Interface.exe in desktop mode.
- Go to Settings > Controls...
- Toggle "Flying & jumping" to on and save settings.
- Go to HMD mode.
- Attempt to fly. If you can, this PR is good to go.