### PR TITLE
Fix cloning a parented entity

### DIFF
--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -3743,6 +3743,8 @@ bool EntityItemProperties::verifyStaticCertificateProperties() {
 void EntityItemProperties::convertToCloneProperties(const EntityItemID& entityIDToClone) {
     setName(getName() + "-clone-" + entityIDToClone.toString());
     setLocked(false);
+    setParentID(QUuid());
+    setParentJointIndex(-1);
     setLifetime(getCloneLifetime());
     setDynamic(getCloneDynamic());
     setClientOnly(getCloneAvatarEntity());

--- a/scripts/system/controllers/controllerModules/nearActionGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/nearActionGrabEntity.js
@@ -174,10 +174,12 @@ Script.include("/~/system/libraries/cloneEntityUtils.js");
                         Controller.triggerHapticPulse(HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, this.hand);
                         this.hapticTargetID = props.id;
                     }
-                    // if we've attempted to grab a child, roll up to the root of the tree
-                    var groupRootProps = findGroupParent(controllerData, props);
-                    if (entityIsGrabbable(groupRootProps)) {
-                        return groupRootProps;
+                    if (!entityIsCloneable(props)) {
+                        // if we've attempted to grab a non-cloneable child, roll up to the root of the tree
+                        var groupRootProps = findGroupParent(controllerData, props);
+                        if (entityIsGrabbable(groupRootProps)) {
+                            return groupRootProps;
+                        }
                     }
                     return props;
                 }

--- a/scripts/system/controllers/controllerModules/nearParentGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/nearParentGrabEntity.js
@@ -268,10 +268,12 @@ Script.include("/~/system/libraries/controllers.js");
                         Controller.triggerHapticPulse(HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, this.hand);
                         this.hapticTargetID = props.id;
                     }
-                    // if we've attempted to grab a child, roll up to the root of the tree
-                    var groupRootProps = findGroupParent(controllerData, props);
-                    if (entityIsGrabbable(groupRootProps)) {
-                        return groupRootProps;
+                    if (!entityIsCloneable(props)) {
+                        // if we've attempted to grab a non-cloneable child, roll up to the root of the tree
+                        var groupRootProps = findGroupParent(controllerData, props);
+                        if (entityIsGrabbable(groupRootProps)) {
+                            return groupRootProps;
+                        }
                     }
                     return props;
                 }


### PR DESCRIPTION
If an entity is cloneable, clone that entity when grabbing instead of going up the parent hierarchy to grab it by the parent entity.

Fixes: https://highfidelity.manuscript.com/f/cases/16715

Test Plan:
- Enter Interface in HMD mode
- Open Create and create several entities that are parented or parent existing entities together (at minimum having Entity C child of Entity B child of Entity A)
- Verify that when grabbing any parent or child entity that the whole parent/child hierarchy moves together
- In Create Properties, set children entities to be cloneable (Entity C and Entity B in above case) with a cloneable limit above 0
- Verify that you can grab and clone each cloneable child and that only that single entity you grabbed gets cloned (not any of it's parents or children)
- Verify you can clone each cloneable child only up to it's clone limit