### PR TITLE
hotfix port for 0.70.2: reduced physics load from otherAvatars

### DIFF
--- a/interface/src/avatar/AvatarMotionState.h
+++ b/interface/src/avatar/AvatarMotionState.h
@@ -74,6 +74,10 @@ public:
     friend class Avatar;
 
 protected:
+    void setRigidBody(btRigidBody* body) override;
+    void setShape(const btCollisionShape* shape) override;
+    void cacheShapeDiameter();
+
     // the dtor had been made protected to force the compiler to verify that it is only
     // ever called by the Avatar class dtor.
     ~AvatarMotionState();

--- a/libraries/physics/src/ObjectMotionState.cpp
+++ b/libraries/physics/src/ObjectMotionState.cpp
@@ -64,9 +64,9 @@ ShapeManager* ObjectMotionState::getShapeManager() {
 }
 
 ObjectMotionState::ObjectMotionState(const btCollisionShape* shape) :
-    _shape(shape),
     _lastKinematicStep(worldSimulationStep)
 {
+    setShape(shape);
 }
 
 ObjectMotionState::~ObjectMotionState() {

--- a/libraries/physics/src/ObjectMotionState.h
+++ b/libraries/physics/src/ObjectMotionState.h
@@ -175,13 +175,13 @@ protected:
     virtual void setMotionType(PhysicsMotionType motionType);
     void updateCCDConfiguration();
 
-    void setRigidBody(btRigidBody* body);
+    virtual void setRigidBody(btRigidBody* body);
     virtual void setShape(const btCollisionShape* shape);
 
     MotionStateType _type { MOTIONSTATE_TYPE_INVALID }; // type of MotionState
     PhysicsMotionType _motionType { MOTION_TYPE_STATIC }; // type of motion: KINEMATIC, DYNAMIC, or STATIC
 
-    const btCollisionShape* _shape;
+    const btCollisionShape* _shape { nullptr };
     btRigidBody* _body { nullptr };
     float _density { 1.0f };
 

--- a/libraries/shared/src/PhysicsCollisionGroups.h
+++ b/libraries/shared/src/PhysicsCollisionGroups.h
@@ -59,7 +59,11 @@ const int32_t BULLET_COLLISION_MASK_KINEMATIC = BULLET_COLLISION_MASK_STATIC;
 // MY_AVATAR does not collide with itself
 const int32_t BULLET_COLLISION_MASK_MY_AVATAR = ~(BULLET_COLLISION_GROUP_COLLISIONLESS | BULLET_COLLISION_GROUP_MY_AVATAR);
 
-const int32_t BULLET_COLLISION_MASK_OTHER_AVATAR = BULLET_COLLISION_MASK_DEFAULT;
+// OTHER_AVATARs are dynamic, but are slammed to whatever the avatar-mixer says, which means
+// their motion can't actually be affected by the local physics simulation -- we rely on the remote simulation
+// to move its avatar around correctly and to communicate its motion through the avatar-mixer.
+// Therefore, they only need to collide against things that can be affected by their motion: dynamic and MyAvatar
+const int32_t BULLET_COLLISION_MASK_OTHER_AVATAR = BULLET_COLLISION_GROUP_DYNAMIC | BULLET_COLLISION_GROUP_MY_AVATAR;
 
 // COLLISIONLESS gets an empty mask.
 const int32_t BULLET_COLLISION_MASK_COLLISIONLESS = 0;


### PR DESCRIPTION
- ignore other-avatar angularVelocity in physics simulation
- ignore other-avatar collisions against static and kinematic objects
- more correct other-avatar diameter when slaving linear motion
