### PR TITLE
HMD Flying Settings Fix for 70.2

### DIFF
--- a/interface/resources/qml/hifi/tablet/ControllerSettings.qml
+++ b/interface/resources/qml/hifi/tablet/ControllerSettings.qml
@@ -299,7 +299,7 @@ Item {
             anchors.fill: stackView
             id: controllerPrefereneces
             objectName: "TabletControllerPreferences"
-            showCategories: [( (HMD.active) ? "VR Movement" : "Movement"), "Game Controller", "Sixense Controllers", "Perception Neuron", "Leap Motion"]
+            showCategories: ["VR Movement", "Game Controller", "Sixense Controllers", "Perception Neuron", "Leap Motion"]
             categoryProperties: {
                 "VR Movement" : {
                     "User real-world height (meters)" : { "anchors.right" : "undefined" },

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4826,12 +4826,6 @@ void Application::loadSettings() {
 
         isFirstPerson = (qApp->isHMDMode());
 
-        // Flying should be disabled by default in HMD mode on first run, and it
-        // should be enabled by default in desktop mode.
-
-        auto myAvatar = getMyAvatar();
-        myAvatar->setFlyingEnabled(!isFirstPerson);
-
     } else {
         // if this is not the first run, the camera will be initialized differently depending on user settings
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1115,7 +1115,6 @@ void MyAvatar::saveData() {
     settings.setValue("userHeight", getUserHeight());
     settings.setValue("flyingDesktop", getFlyingDesktopPref());
     settings.setValue("flyingHMD", getFlyingHMDPref());
-    settings.setValue("enabledFlying", getFlyingEnabled());
 
     settings.endGroup();
 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2842,8 +2842,6 @@ void MyAvatar::setFlyingDesktopPref(bool enabled) {
         return;
     }
 
-    //if (!(qApp->isHMDMode())) { _enableFlying = enabled; }
-
     _flyingPrefDesktop = enabled;
 }
 
@@ -2856,8 +2854,6 @@ void MyAvatar::setFlyingHMDPref(bool enabled) {
         QMetaObject::invokeMethod(this, "setFlyingHMDPref", Q_ARG(bool, enabled));
         return;
     }
-
-    //if ((qApp->isHMDMode())) { _enableFlying = enabled; }
 
     _flyingPrefHMD = enabled;
 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -557,8 +557,10 @@ void MyAvatar::updateChildCauterization(SpatiallyNestablePointer object, bool ca
 
 void MyAvatar::simulate(float deltaTime) {
     PerformanceTimer perfTimer("simulate");
-
+    
     animateScaleChanges(deltaTime);
+
+    setFlyingEnabled(getFlyingEnabled());
 
     if (_cauterizationNeedsUpdate) {
         _cauterizationNeedsUpdate = false;
@@ -1111,6 +1113,8 @@ void MyAvatar::saveData() {
     settings.setValue("collisionSoundURL", _collisionSoundURL);
     settings.setValue("useSnapTurn", _useSnapTurn);
     settings.setValue("userHeight", getUserHeight());
+    settings.setValue("flyingDesktop", getFlyingDesktopPref());
+    settings.setValue("flyingHMD", getFlyingHMDPref());
     settings.setValue("enabledFlying", getFlyingEnabled());
 
     settings.endGroup();
@@ -1261,8 +1265,13 @@ void MyAvatar::loadData() {
         settings.remove("avatarEntityData");
     }
     setAvatarEntityDataChanged(true);
-    Setting::Handle<bool> firstRunVal { Settings::firstRun, true};
-    setFlyingEnabled(firstRunVal.get() ? getFlyingEnabled() : settings.value("enabledFlying").toBool());
+
+    // Flying preferences must be loaded before calling setFlyingEnabled()
+    Setting::Handle<bool> firstRunVal { Settings::firstRun, true };
+    setFlyingDesktopPref(firstRunVal.get() ? true : settings.value("flyingDesktop").toBool());
+    setFlyingHMDPref(firstRunVal.get() ? false : settings.value("flyingHMD").toBool());
+    setFlyingEnabled(getFlyingEnabled());
+
     setDisplayName(settings.value("displayName").toString());
     setCollisionSoundURL(settings.value("collisionSoundURL", DEFAULT_AVATAR_COLLISION_SOUND_URL).toString());
     setSnapTurn(settings.value("useSnapTurn", _useSnapTurn).toBool());
@@ -2803,6 +2812,12 @@ void MyAvatar::setFlyingEnabled(bool enabled) {
         return;
     }
 
+    if (qApp->isHMDMode()) {
+        setFlyingHMDPref(enabled);
+    } else {
+        setFlyingDesktopPref(enabled);
+    }
+
     _enableFlying = enabled;
 }
 
@@ -2818,7 +2833,37 @@ bool MyAvatar::isInAir() {
 
 bool MyAvatar::getFlyingEnabled() {
     // May return true even if client is not allowed to fly in the zone.
-    return _enableFlying;
+    return (qApp->isHMDMode() ? getFlyingHMDPref() : getFlyingDesktopPref());
+}
+
+void MyAvatar::setFlyingDesktopPref(bool enabled) {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setFlyingDesktopPref", Q_ARG(bool, enabled));
+        return;
+    }
+
+    //if (!(qApp->isHMDMode())) { _enableFlying = enabled; }
+
+    _flyingPrefDesktop = enabled;
+}
+
+bool MyAvatar::getFlyingDesktopPref() {
+    return _flyingPrefDesktop;
+}
+
+void MyAvatar::setFlyingHMDPref(bool enabled) {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setFlyingHMDPref", Q_ARG(bool, enabled));
+        return;
+    }
+
+    //if ((qApp->isHMDMode())) { _enableFlying = enabled; }
+
+    _flyingPrefHMD = enabled;
+}
+
+bool MyAvatar::getFlyingHMDPref() {
+    return _flyingPrefHMD;
 }
 
 // Public interface for targetscale

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -929,6 +929,30 @@ public:
      */
     Q_INVOKABLE bool getFlyingEnabled();
 
+    /**jsdoc
+     * @function MyAvatar.setFlyingDesktopPref
+     * @param {boolean} enabled
+     */
+    Q_INVOKABLE void setFlyingDesktopPref(bool enabled);
+
+    /**jsdoc
+     * @function MyAvatar.getFlyingDesktopPref
+     * @returns {boolean}
+     */
+    Q_INVOKABLE bool getFlyingDesktopPref();
+
+    /**jsdoc
+     * @function MyAvatar.setFlyingDesktopPref
+     * @param {boolean} enabled
+     */
+    Q_INVOKABLE void setFlyingHMDPref(bool enabled);
+
+    /**jsdoc
+     * @function MyAvatar.getFlyingDesktopPref
+     * @returns {boolean}
+     */
+    Q_INVOKABLE bool getFlyingHMDPref();
+
 
     /**jsdoc
      * @function MyAvatar.getAvatarScale
@@ -1462,6 +1486,8 @@ private:
     std::bitset<MAX_DRIVE_KEYS> _disabledDriveKeys;
 
     bool _enableFlying { false };
+    bool _flyingPrefDesktop { true };
+    bool _flyingPrefHMD { false };
     bool _wasPushing { false };
     bool _isPushing { false };
     bool _isBeingPushed { false };

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -266,44 +266,6 @@ void setupPreferences() {
         preferences->addPreference(new SliderPreference(FACE_TRACKING, "Eye Deflection", getter, setter));
     }
 
-<<<<<<< HEAD
-    static const QString MOVEMENT{ "Movement" };
-    {
-        static const QString movementsControlChannel = QStringLiteral("Hifi-Advanced-Movement-Disabler");
-        auto getter = [=]()->bool { return myAvatar->useAdvancedMovementControls(); };
-        auto setter = [=](bool value) { myAvatar->setUseAdvancedMovementControls(value); };
-        preferences->addPreference(new CheckPreference(MOVEMENT,
-                                                       QStringLiteral("Advanced movement for hand controllers"),
-                                                       getter, setter));
-    }
-    {
-        auto getter = [=]()->int { return myAvatar->getSnapTurn() ? 0 : 1; };
-        auto setter = [=](int value) { myAvatar->setSnapTurn(value == 0); };
-        auto preference = new RadioButtonsPreference(MOVEMENT, "Snap turn / Smooth turn", getter, setter);
-        QStringList items;
-        items << "Snap turn" << "Smooth turn";
-        preference->setItems(items);
-        preferences->addPreference(preference);
-    }
-    {
-        auto getter = [=]()->float { return myAvatar->getUserHeight(); };
-        auto setter = [=](float value) { myAvatar->setUserHeight(value); };
-        auto preference = new SpinnerPreference(MOVEMENT, "User real-world height (meters)", getter, setter);
-        preference->setMin(1.0f);
-        preference->setMax(2.2f);
-        preference->setDecimals(3);
-        preference->setStep(0.001f);
-        preferences->addPreference(preference);
-    }
-    {
-        auto preference = new ButtonPreference(MOVEMENT, "RESET SENSORS", [] {
-            qApp->resetSensors();
-        });
-        preferences->addPreference(preference);
-    }
-
-=======
->>>>>>> 35740956b0... Change flying settings so HMD flying is exposed to users in both Desktop and HMD modes.
     static const QString VR_MOVEMENT{ "VR Movement" };
     {
         static const QString movementsControlChannel = QStringLiteral("Hifi-Advanced-Movement-Disabler");

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -266,6 +266,7 @@ void setupPreferences() {
         preferences->addPreference(new SliderPreference(FACE_TRACKING, "Eye Deflection", getter, setter));
     }
 
+<<<<<<< HEAD
     static const QString MOVEMENT{ "Movement" };
     {
         static const QString movementsControlChannel = QStringLiteral("Hifi-Advanced-Movement-Disabler");
@@ -301,6 +302,8 @@ void setupPreferences() {
         preferences->addPreference(preference);
     }
 
+=======
+>>>>>>> 35740956b0... Change flying settings so HMD flying is exposed to users in both Desktop and HMD modes.
     static const QString VR_MOVEMENT{ "VR Movement" };
     {
         static const QString movementsControlChannel = QStringLiteral("Hifi-Advanced-Movement-Disabler");

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -311,8 +311,8 @@ void setupPreferences() {
             getter, setter));
     }
     {
-        auto getter = [=]()->bool { return myAvatar->getFlyingEnabled(); };
-        auto setter = [=](bool value) { myAvatar->setFlyingEnabled(value); };
+        auto getter = [=]()->bool { return myAvatar->getFlyingHMDPref(); };
+        auto setter = [=](bool value) { myAvatar->setFlyingHMDPref(value); };
         preferences->addPreference(new CheckPreference(VR_MOVEMENT, "Flying & jumping", getter, setter));
     }
     {


### PR DESCRIPTION
Divorces HMD flying settings from Desktop flying settings in our C++, saving them as separate values. Preserves functionality of setFlyingEnabled() to avoid breaking scripts.

HMD flying settings will also be respected between launches.

On first run, flying is enabled in desktop mode and disabled in HMD mode.

**TEST PLAN:**
_Goals:_
1.) Verify that flying is enabled in Desktop on first launch.
2.) Verify that flying is disabled in HMD on first launch.
3.) Verify that setting flying to enabled or disabled alters the value in HMD.
4.) Verify that flying settings are respected between launches.
5.) Verify that flying settings are separate for desktop and HMD.

_Steps:_
- Launch interface.exe on a clean install (nothing in %appdata%) in desktop mode.
- Verify that flying is enabled. If so, Goal 1 is good.

- Switch to HMD mode. Verify that flying is now disabled. If so, goal 2 is good.

- Open Tablet > Menu > Settings > Controls... and enable "Flying & jumping".
- Verify that flying is now enabled. If so, goal 3 is good.

- Close interface and re-launch in HMD mode.
- Verify that flying is still enabled. If so, goal 4 is good.

- Switch to desktop mode.
- Enable the developer menu (Settings > Developer Menus").
- Open the console (Developer > Console)
- Enter: "setFlyingEnabled(false);" without quotes.
- Attempt to fly. Should be disabled now for desktop mode.
- Switch to HMD and enable flying in Tablet > Menu > Settings > Controls..
- Close interface.
- Re-open in Desktop mode.
- Verify that flying is disabled still in desktop mode.
- Switch to HMD mode.
- Verify that flying is still enabled in HMD mode. If so, goal 5 is good.