### PR TITLE
Fix primitives always drawing as transparents

### DIFF
--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -336,6 +336,11 @@ bool EntityRenderer::needsRenderUpdate() const {
     if (_needsRenderUpdate) {
         return true;
     }
+
+    if (isFading()) {
+        return true;
+    }
+
     if (_prevIsTransparent != isTransparent()) {
         return true;
     }
@@ -380,6 +385,10 @@ void EntityRenderer::updateModelTransformAndBound() {
 void EntityRenderer::doRenderUpdateSynchronous(const ScenePointer& scene, Transaction& transaction, const EntityItemPointer& entity) {
     DETAILED_PROFILE_RANGE(simulation_physics, __FUNCTION__);
     withWriteLock([&] {
+        if (isFading()) {
+            emit requestRenderUpdate();
+        }
+
         auto transparent = isTransparent();
         if (_prevIsTransparent && !transparent) {
             _isFading = false;

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -216,7 +216,14 @@ ShapeKey ShapeEntityRenderer::getShapeKey() {
 
         return builder.build();
     } else {
-        return Parent::getShapeKey();
+        ShapeKey::Builder builder;
+        if (_procedural.isReady()) {
+            builder.withOwnPipeline();
+        }
+        if (isTransparent()) {
+            builder.withTranslucent();
+        }
+        return builder.build();
     }
 }
 


### PR DESCRIPTION
Shapes never got marked as not fading, so were always transparent.  This should improve performance when rendering primitives.

Test plan:
- Verify that primitives still render
- When you create a primitive, it should fade in.
- Run [this](https://gist.githubusercontent.com/SamGondelman/d2fe968f275be983ba2ed328437f1add/raw/47e1297e83f68665e29c63e51ed18afce5c8d4ce/CreatProcedurals.js).  You should see four procedural entities (weird spheres with smaller spheres moving around them).  4 of them should be transparent and 4 should be opaque.
- Verify that any procedural entities that you can find in various domains still render correctly.