### PR TITLE
RC70.2: Fix the other avatars not being removed when Avatar mixer reset

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -411,9 +411,6 @@ void AvatarManager::clearOtherAvatars() {
     while (avatarIterator != _avatarHash.end()) {
         auto avatar = std::static_pointer_cast<Avatar>(avatarIterator.value());
         if (avatar != _myAvatar) {
-            if (avatar->isInScene()) {
-                avatar->removeFromScene(avatar, scene, transaction);
-            }
             handleRemovedAvatar(avatar);
             avatarIterator = _avatarHash.erase(avatarIterator);
         } else {


### PR DESCRIPTION
Every time the Avatar mixer reset, all the other avatars are destroyed. but the removed avatars are staying stuck in the "_avatarsToFade" never finding a way out.
This pr fixes that, the removed avatars are destroyed correctly.

Do not remove the avatar from the scene explicitly in clearOtherAvatars. instead let it be fade out or removed by the standard path.

## TEST PLAN
In 'distributed2' there are 200 bots currently constantly reseting simulating a avatar mixer crash.

In stable and in the current rc70.2 building pr (https://github.com/highfidelity/hifi/pull/13745) when looking at the expanded stats, the time spent in the Game loop (/idle/update) is growing.
the time spent in "otherAvatars" is growing over 30ms and more as the reset of the server happen.

In this PR it doesn't happen anymore, the game rate stays good. the time spent in otherAvatars never go overboard.


