### PR TITLE
FB16831 qml-related warnings in log

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2926,6 +2926,15 @@ void Application::initializeUi() {
 
     // Pre-create a couple of Web3D overlays to speed up tablet UI
     auto offscreenSurfaceCache = DependencyManager::get<OffscreenQmlSurfaceCache>();
+    offscreenSurfaceCache->setOnRootContextCreated([&](const QString& rootObject, QQmlContext* surfaceContext) {
+        if (rootObject == TabletScriptingInterface::QML) {
+            // in Qt 5.10.0 there is already an "Audio" object in the QML context
+            // though I failed to find it (from QtMultimedia??). So..  let it be "AudioScriptingInterface"
+            surfaceContext->setContextProperty("AudioScriptingInterface", DependencyManager::get<AudioScriptingInterface>().data());
+            surfaceContext->setContextProperty("Account", AccountServicesScriptingInterface::getInstance()); // DEPRECATED - TO BE REMOVED
+        }
+    });
+
     offscreenSurfaceCache->reserve(TabletScriptingInterface::QML, 1);
     offscreenSurfaceCache->reserve(Web3DOverlay::QML, 2);
 

--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -184,9 +184,11 @@ void Web3DOverlay::buildWebSurface() {
             _webSurface->getRootItem()->setProperty("scriptURL", _scriptURL);
         } else {
             _webSurface = QSharedPointer<OffscreenQmlSurface>(new OffscreenQmlSurface(), qmlSurfaceDeleter);
+            connect(_webSurface.data(), &hifi::qml::OffscreenSurface::rootContextCreated, [this](QQmlContext* surfaceContext) {
+                setupQmlSurface(_url == TabletScriptingInterface::QML);
+            });
             _webSurface->load(_url);
             _cachedWebSurface = false;
-            setupQmlSurface();
         }
         _webSurface->getSurfaceContext()->setContextProperty("globalPosition", vec3toVariant(getWorldPosition()));
         onResizeWebSurface();
@@ -214,7 +216,7 @@ bool Web3DOverlay::isWebContent() const {
     return false;
 }
 
-void Web3DOverlay::setupQmlSurface() {
+void Web3DOverlay::setupQmlSurface(bool isTablet) {
     _webSurface->getSurfaceContext()->setContextProperty("Users", DependencyManager::get<UsersScriptingInterface>().data());
     _webSurface->getSurfaceContext()->setContextProperty("HMD", DependencyManager::get<HMDScriptingInterface>().data());
     _webSurface->getSurfaceContext()->setContextProperty("UserActivityLogger", DependencyManager::get<UserActivityLoggerScriptingInterface>().data());
@@ -225,7 +227,7 @@ void Web3DOverlay::setupQmlSurface() {
     _webSurface->getSurfaceContext()->setContextProperty("Entities", DependencyManager::get<EntityScriptingInterface>().data());
     _webSurface->getSurfaceContext()->setContextProperty("Snapshot", DependencyManager::get<Snapshot>().data());
 
-    if (_webSurface->getRootItem() && _webSurface->getRootItem()->objectName() == "tabletRoot") {
+    if (isTablet) {
         auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
         auto flags = tabletScriptingInterface->getFlags();
 

--- a/interface/src/ui/overlays/Web3DOverlay.h
+++ b/interface/src/ui/overlays/Web3DOverlay.h
@@ -79,7 +79,7 @@ protected:
     Transform evalRenderTransform() override;
 
 private:
-    void setupQmlSurface();
+    void setupQmlSurface(bool isTablet);
     void rebuildWebSurface();
     bool isWebContent() const;
 

--- a/libraries/ui/src/ui/OffscreenQmlSurfaceCache.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurfaceCache.cpp
@@ -48,8 +48,9 @@ QSharedPointer<OffscreenQmlSurface> OffscreenQmlSurfaceCache::buildSurface(const
     auto surface = QSharedPointer<OffscreenQmlSurface>(new OffscreenQmlSurface());
 
     QObject::connect(surface.data(), &hifi::qml::OffscreenSurface::rootContextCreated, [this, rootSource](QQmlContext* surfaceContext) {
-        if (_onRootContextCreated)
+        if (_onRootContextCreated) {
             _onRootContextCreated(rootSource, surfaceContext);
+        }
     });
 
     surface->load(rootSource);

--- a/libraries/ui/src/ui/OffscreenQmlSurfaceCache.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurfaceCache.cpp
@@ -46,8 +46,17 @@ void OffscreenQmlSurfaceCache::release(const QString& rootSource, const QSharedP
 
 QSharedPointer<OffscreenQmlSurface> OffscreenQmlSurfaceCache::buildSurface(const QString& rootSource) {
     auto surface = QSharedPointer<OffscreenQmlSurface>(new OffscreenQmlSurface());
+
+    QObject::connect(surface.data(), &hifi::qml::OffscreenSurface::rootContextCreated, [this, rootSource](QQmlContext* surfaceContext) {
+        if (_onRootContextCreated)
+            _onRootContextCreated(rootSource, surfaceContext);
+    });
+
     surface->load(rootSource);
     surface->resize(QSize(100, 100));
     return surface;
 }
 
+void OffscreenQmlSurfaceCache::setOnRootContextCreated(const std::function<void(const QString& rootSource, QQmlContext* rootContext)>& onRootContextCreated) {
+    _onRootContextCreated = onRootContextCreated;
+}

--- a/libraries/ui/src/ui/OffscreenQmlSurfaceCache.h
+++ b/libraries/ui/src/ui/OffscreenQmlSurfaceCache.h
@@ -13,6 +13,7 @@
 
 #include <QtCore/QSharedPointer>
 
+class QQmlContext;
 class OffscreenQmlSurface;
 
 class OffscreenQmlSurfaceCache : public Dependency {
@@ -25,10 +26,12 @@ public:
     QSharedPointer<OffscreenQmlSurface> acquire(const QString& rootSource);
     void release(const QString& rootSource, const QSharedPointer<OffscreenQmlSurface>& surface);
     void reserve(const QString& rootSource, int count = 1);
+    void setOnRootContextCreated(const std::function<void(const QString& rootSource, QQmlContext* rootContext)> & onRootContextCreated);
 
 private:
     QSharedPointer<OffscreenQmlSurface> buildSurface(const QString& rootSource);
     QHash<QString, QList<QSharedPointer<OffscreenQmlSurface>>> _cache;
+    std::function<void(const QString& rootSource, QQmlContext* rootContext)> _onRootContextCreated;
 };
 
 #endif


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/16831/qml-related-warnings-in-log

note: fix is based on exposing C++ objects to QML before root object is created (as root object might already require C++ objects)

**Test plan**

1. Cleanup / backup logs
2. Start interface
3. Switch to desktop
4. In 'developer => UI' check 'desktop tablet becomes toolbar'
5. In 'developer => UI' uncheck 'desktop tablet becomes toolbar'
6. Open / close tablet. 
7. Switch to VR
8. In 'developer => UI' check 'HMD tablet becomes toolbar'
9. In 'developer => UI' uncheck 'HMD tablet becomes toolbar'
10. Open / close tablet. 
11. Review logs - it **must not** have entries like this ('ReferenceError: Account is not defined' or 'ReferenceError: AudioScriptingInterface is not defined): 

[07/18 22:07:56] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/tablet/TabletHome.qml:70: ReferenceError: Account is not defined
[07/18 22:07:56] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/audio/MicBar.qml:18: ReferenceError: AudioScriptingInterface is not defined