### PR TITLE
Fix edit log spam with -1 hand

### DIFF
--- a/scripts/system/libraries/controllers.js
+++ b/scripts/system/libraries/controllers.js
@@ -38,30 +38,34 @@ getGrabPointSphereOffset = function(handController, ignoreSensorToWorldScale) {
 getControllerWorldLocation = function (handController, doOffset) {
     var orientation;
     var position;
-    var pose = Controller.getPoseValue(handController);
-    var valid = pose.valid;
-    var controllerJointIndex;
-    if (pose.valid) {
-        if (handController === Controller.Standard.RightHand) {
-            controllerJointIndex = MyAvatar.getJointIndex("_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND");
-        } else {
-            controllerJointIndex = MyAvatar.getJointIndex("_CAMERA_RELATIVE_CONTROLLER_LEFTHAND");
-        }
-        orientation = Quat.multiply(MyAvatar.orientation, MyAvatar.getAbsoluteJointRotationInObjectFrame(controllerJointIndex));
-        position = Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, MyAvatar.getAbsoluteJointTranslationInObjectFrame(controllerJointIndex)));
+    var valid = false;
+    
+    if (handController >= 0) {
+        var pose = Controller.getPoseValue(handController);
+        valid = pose.valid;
+        var controllerJointIndex;
+        if (pose.valid) {
+            if (handController === Controller.Standard.RightHand) {
+                controllerJointIndex = MyAvatar.getJointIndex("_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND");
+            } else {
+                controllerJointIndex = MyAvatar.getJointIndex("_CAMERA_RELATIVE_CONTROLLER_LEFTHAND");
+            }
+            orientation = Quat.multiply(MyAvatar.orientation, MyAvatar.getAbsoluteJointRotationInObjectFrame(controllerJointIndex));
+            position = Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, MyAvatar.getAbsoluteJointTranslationInObjectFrame(controllerJointIndex)));
 
-        // add to the real position so the grab-point is out in front of the hand, a bit
-        if (doOffset) {
-            var offset = getGrabPointSphereOffset(handController);
-            position = Vec3.sum(position, Vec3.multiplyQbyV(orientation, offset));
-        }
+            // add to the real position so the grab-point is out in front of the hand, a bit
+            if (doOffset) {
+                var offset = getGrabPointSphereOffset(handController);
+                position = Vec3.sum(position, Vec3.multiplyQbyV(orientation, offset));
+            }
 
-    } else if (!HMD.isHandControllerAvailable()) {
-        // NOTE: keep this offset in sync with scripts/system/controllers/handControllerPointer.js:493
-        var VERTICAL_HEAD_LASER_OFFSET = 0.1 * MyAvatar.sensorToWorldScale;
-        position = Vec3.sum(Camera.position, Vec3.multiplyQbyV(Camera.orientation, {x: 0, y: VERTICAL_HEAD_LASER_OFFSET, z: 0}));
-        orientation = Quat.multiply(Camera.orientation, Quat.angleAxis(-90, { x: 1, y: 0, z: 0 }));
-        valid = true;
+        } else if (!HMD.isHandControllerAvailable()) {
+            // NOTE: keep this offset in sync with scripts/system/controllers/handControllerPointer.js:493
+            var VERTICAL_HEAD_LASER_OFFSET = 0.1 * MyAvatar.sensorToWorldScale;
+            position = Vec3.sum(Camera.position, Vec3.multiplyQbyV(Camera.orientation, {x: 0, y: VERTICAL_HEAD_LASER_OFFSET, z: 0}));
+            orientation = Quat.multiply(Camera.orientation, Quat.angleAxis(-90, { x: 1, y: 0, z: 0 }));
+            valid = true;
+        }
     }
 
     return {position: position,


### PR DESCRIPTION
Fixes: https://highfidelity.fogbugz.com/f/cases/17323

Test Plan:
- Enter Interface in desktop mode
- Open Create and perform various different actions including manipulating entities with the edit handles, clicking around the entity list, and changing properties while observing the log output
- Verify there is no output lines of - Unknown input: "ffffffff"
- Verify Create actions perform as expected
- Enter HMD mode and open Create again
- Select and entity and perform various different actions with the edit handles using the lasers and verify all actions perform as expected
- Exit Create and verify the entity can be near-grabbed as expected with hands
- Verify the entity can be far-grabbed as expected with the lasers
- Add a flaregun from the marketplace
- Verify when your hand is near the flaregun that the purple sphere for equipping appears
- Verify the flaregun can be equipped to your hand and unequipped as expected