### PR TITLE
fix flying

### DIFF
--- a/interface/resources/qml/hifi/tablet/ControllerSettings.qml
+++ b/interface/resources/qml/hifi/tablet/ControllerSettings.qml
@@ -299,7 +299,7 @@ Item {
             anchors.fill: stackView
             id: controllerPrefereneces
             objectName: "TabletControllerPreferences"
-            showCategories: [( (HMD.active) ? "VR Movement" : "Movement"), "Game Controller", "Sixense Controllers", "Perception Neuron", "Leap Motion"]
+            showCategories: ["VR Movement", "Game Controller", "Sixense Controllers", "Perception Neuron", "Leap Motion"]
             categoryProperties: {
                 "VR Movement" : {
                     "User real-world height (meters)" : { "anchors.right" : "undefined" },

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1135,7 +1135,6 @@ void MyAvatar::saveData() {
     settings.setValue("collisionSoundURL", _collisionSoundURL);
     settings.setValue("useSnapTurn", _useSnapTurn);
     settings.setValue("userHeight", getUserHeight());
-    settings.setValue("flyingDesktop", getFlyingDesktopPref());
     settings.setValue("flyingHMD", getFlyingHMDPref());
 
     settings.endGroup();
@@ -1289,7 +1288,6 @@ void MyAvatar::loadData() {
 
     // Flying preferences must be loaded before calling setFlyingEnabled()
     Setting::Handle<bool> firstRunVal { Settings::firstRun, true };
-    setFlyingDesktopPref(firstRunVal.get() ? true : settings.value("flyingDesktop").toBool());
     setFlyingHMDPref(firstRunVal.get() ? false : settings.value("flyingHMD").toBool());
     setFlyingEnabled(getFlyingEnabled());
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -266,42 +266,6 @@ void setupPreferences() {
         preferences->addPreference(new SliderPreference(FACE_TRACKING, "Eye Deflection", getter, setter));
     }
 
-    static const QString MOVEMENT{ "Movement" };
-    {
-
-        static const QString movementsControlChannel = QStringLiteral("Hifi-Advanced-Movement-Disabler");
-        auto getter = [=]()->bool { return myAvatar->useAdvancedMovementControls(); };
-        auto setter = [=](bool value) { myAvatar->setUseAdvancedMovementControls(value); };
-        preferences->addPreference(new CheckPreference(MOVEMENT,
-            QStringLiteral("Advanced movement for hand controllers"),
-            getter, setter));
-    }
-    {
-        auto getter = [=]()->int { return myAvatar->getSnapTurn() ? 0 : 1; };
-        auto setter = [=](int value) { myAvatar->setSnapTurn(value == 0); };
-        auto preference = new RadioButtonsPreference(MOVEMENT, "Snap turn / Smooth turn", getter, setter);
-        QStringList items;
-        items << "Snap turn" << "Smooth turn";
-        preference->setItems(items);
-        preferences->addPreference(preference);
-    }
-    {
-        auto getter = [=]()->float { return myAvatar->getUserHeight(); };
-        auto setter = [=](float value) { myAvatar->setUserHeight(value); };
-        auto preference = new SpinnerPreference(MOVEMENT, "User real-world height (meters)", getter, setter);
-        preference->setMin(1.0f);
-        preference->setMax(2.2f);
-        preference->setDecimals(3);
-        preference->setStep(0.001f);
-        preferences->addPreference(preference);
-    }
-    {
-        auto preference = new ButtonPreference(MOVEMENT, "RESET SENSORS", [] {
-            qApp->resetSensors();
-        });
-        preferences->addPreference(preference);
-    }
-
     static const QString VR_MOVEMENT{ "VR Movement" };
     {
 
@@ -315,7 +279,7 @@ void setupPreferences() {
     {
         auto getter = [=]()->bool { return myAvatar->getFlyingHMDPref(); };
         auto setter = [=](bool value) { myAvatar->setFlyingHMDPref(value); };
-        preferences->addPreference(new CheckPreference(VR_MOVEMENT, "Flying & jumping", getter, setter));
+        preferences->addPreference(new CheckPreference(VR_MOVEMENT, "Flying & jumping (HMD)", getter, setter));
     }
     {
         auto getter = [=]()->int { return myAvatar->getSnapTurn() ? 0 : 1; };


### PR DESCRIPTION
This PR makes sure that flying is enabled by default in desktop on launch.
Desktop:
Jumping/flying is always enabled.
VR Movement menu shows, allowing users to toggle HMD Flying/Jumping.
Users can change this behavior through scripting, console.
The setting does not save or persist between sessions if the behavior is changed.

VR:
Jumping/flying is disabled by default.
VR Movement menu shows, allowing users to toggle HMD Flying/Jumping.
Users can change this behavior through scripting, console.
The setting saves and persists between sessions if the behavior is changed.