### PR TITLE
Fix for ScriptEngines not being released upon AC shutdown

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -497,7 +497,7 @@ void Agent::executeScript() {
     Frame::clearFrameHandler(AUDIO_FRAME_TYPE);
     Frame::clearFrameHandler(AVATAR_FRAME_TYPE);
 
-
+    DependencyManager::destroy<RecordingScriptingInterface>();
     setFinished(true);
 }
 
@@ -847,7 +847,6 @@ void Agent::aboutToFinish() {
     DependencyManager::destroy<recording::Deck>();
     DependencyManager::destroy<recording::Recorder>();
     DependencyManager::destroy<recording::ClipCache>();
-    DependencyManager::destroy<RecordingScriptingInterface>();
     DependencyManager::destroy<ScriptEngine>();
     QMetaObject::invokeMethod(&_avatarAudioTimer, "stop");
 


### PR DESCRIPTION
https://github.com/highfidelity/hifi/pull/13536

This earlier PR fixed a Windows crash when the Agent AC was restarted by delaying the destruction of the ScriptEngines until the AC ran as an Agent again. The current PR destroys the ScriptEngine immediately upon its takedown.
