### PR TITLE
70.4 Flying Fix

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1113,7 +1113,6 @@ void MyAvatar::saveData() {
     settings.setValue("collisionSoundURL", _collisionSoundURL);
     settings.setValue("useSnapTurn", _useSnapTurn);
     settings.setValue("userHeight", getUserHeight());
-    settings.setValue("flyingDesktop", getFlyingDesktopPref());
     settings.setValue("flyingHMD", getFlyingHMDPref());
 
     settings.endGroup();
@@ -1267,7 +1266,6 @@ void MyAvatar::loadData() {
 
     // Flying preferences must be loaded before calling setFlyingEnabled()
     Setting::Handle<bool> firstRunVal { Settings::firstRun, true };
-    setFlyingDesktopPref(firstRunVal.get() ? true : settings.value("flyingDesktop").toBool());
     setFlyingHMDPref(firstRunVal.get() ? false : settings.value("flyingHMD").toBool());
     setFlyingEnabled(getFlyingEnabled());
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -278,7 +278,7 @@ void setupPreferences() {
     {
         auto getter = [=]()->bool { return myAvatar->getFlyingHMDPref(); };
         auto setter = [=](bool value) { myAvatar->setFlyingHMDPref(value); };
-        preferences->addPreference(new CheckPreference(VR_MOVEMENT, "Flying & jumping", getter, setter));
+        preferences->addPreference(new CheckPreference(VR_MOVEMENT, "Flying & jumping (HMD)", getter, setter));
     }
     {
         auto getter = [=]()->int { return myAvatar->getSnapTurn() ? 0 : 1; };


### PR DESCRIPTION
Same as Dante's PR:

This PR makes sure that flying is enabled by default in desktop on launch.
Desktop:
Jumping/flying is always enabled.
VR Movement menu shows, allowing users to toggle HMD Flying/Jumping.
Users can change this behavior through scripting, console.
The setting does not save or persist between sessions if the behavior is changed.

VR:
Jumping/flying is disabled by default.
VR Movement menu shows, allowing users to toggle HMD Flying/Jumping.
Users can change this behavior through scripting, console.
The setting saves and persists between sessions if the behavior is changed.

Related to:
[13751](https://github.com/highfidelity/hifi/pull/13751) and [13754](https://github.com/highfidelity/hifi/pull/13754)