### PR TITLE
Fix possible assert in HRTF

### DIFF
--- a/libraries/audio/src/AudioHRTF.cpp
+++ b/libraries/audio/src/AudioHRTF.cpp
@@ -840,7 +840,7 @@ static void nearFieldGainCorrection(float azimuth, float distance, float& gainL,
     // normalized distance factor = [0,1] as distance = [HRTF_NEARFIELD_MAX,HRTF_HEAD_RADIUS]
     assert(distance < HRTF_NEARFIELD_MAX);
     assert(distance > HRTF_HEAD_RADIUS);
-	float d = (HRTF_NEARFIELD_MAX - distance) * ( 1.0f / (HRTF_NEARFIELD_MAX - HRTF_HEAD_RADIUS));
+	float d = (HRTF_NEARFIELD_MAX - distance) * (1.0f / (HRTF_NEARFIELD_MAX - HRTF_HEAD_RADIUS));
 
     // angle of incidence at each ear
     float angleL = azimuth + HALFPI;

--- a/libraries/audio/src/AudioHRTF.cpp
+++ b/libraries/audio/src/AudioHRTF.cpp
@@ -919,6 +919,9 @@ static void azimuthToIndex(float azimuth, int& index0, int& index1, float& frac)
     index1 = index0 + 1;
     frac = azimuth - (float)index0;
 
+    if (index0 >= HRTF_AZIMUTHS) {
+        index0 -= HRTF_AZIMUTHS;
+    }
     if (index1 >= HRTF_AZIMUTHS) {
         index1 -= HRTF_AZIMUTHS;
     }


### PR DESCRIPTION
This fixes a rare (and harmless) assert when computing the HRTF azimuth table index, due to floating point rounding when azimuth is a tiny (subnormal) negative value. It requires an extra modulo check.

