### PR TITLE
Relocate Avatar Spawn Point from the Hips to the Feet

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1247,7 +1247,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     accountManager->setAuthURL(NetworkingConstants::METAVERSE_SERVER_URL());
 
     // use our MyAvatar position and quat for address manager path
-    addressManager->setPositionGetter([this]{ return getMyAvatar()->getWorldPosition(); });
+    addressManager->setPositionGetter([this]{ return getMyAvatar()->getWorldFeetPosition(); });
     addressManager->setOrientationGetter([this]{ return getMyAvatar()->getWorldOrientation(); });
 
     connect(addressManager.data(), &AddressManager::hostChanged, this, &Application::updateWindowTitle);

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2636,12 +2636,7 @@ void MyAvatar::goToFeetLocation(const glm::vec3& newPosition,
     glm::vec3 localFeetPos = shapeInfo.getOffset() - glm::vec3(0.0f, halfExtents.y + halfExtents.x, 0.0f);
     glm::mat4 localFeet = createMatFromQuatAndPos(Quaternions::IDENTITY, localFeetPos);
     
-    glm::mat4 worldFeet;
-    if (hasOrientation) {
-        worldFeet = createMatFromQuatAndPos(newOrientation, newPosition);
-    } else {
-        worldFeet = createMatFromQuatAndPos(Quaternions::IDENTITY, newPosition);
-    }
+    glm::mat4 worldFeet = createMatFromQuatAndPos(Quaternions::IDENTITY, newPosition);
     
     glm::mat4 avatarMat = worldFeet * glm::inverse(localFeet);
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1134,6 +1134,20 @@ public slots:
     float getGravity();
 
     /**jsdoc
+     * Move the avatar to a new position and/or orientation in the domain, while taking into account Avatar leg-length.
+     * @function MyAvatar.goToFeetLocation
+     * @param {Vec3} position - The new position for the avatar, in world coordinates.
+     * @param {boolean} [hasOrientation=false] - Set to <code>true</code> to set the orientation of the avatar.
+     * @param {Quat} [orientation=Quat.IDENTITY] - The new orientation for the avatar.
+     * @param {boolean} [shouldFaceLocation=false] - Set to <code>true</code> to position the avatar a short distance away from
+     *      the new position and orientate the avatar to face the position.
+     */
+
+    void goToFeetLocation(const glm::vec3& newPosition,
+        bool hasOrientation, const glm::quat& newOrientation,
+        bool shouldFaceLocation);
+
+    /**jsdoc
      * Move the avatar to a new position and/or orientation in the domain.
      * @function MyAvatar.goToLocation
      * @param {Vec3} position - The new position for the avatar, in world coordinates.

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1577,6 +1577,14 @@ void Avatar::getCapsule(glm::vec3& start, glm::vec3& end, float& radius) {
     radius = halfExtents.x;
 }
 
+glm::vec3 Avatar::getWorldFeetPosition() {
+    ShapeInfo shapeInfo;
+    computeShapeInfo(shapeInfo);
+    glm::vec3 halfExtents = shapeInfo.getHalfExtents(); // x = radius, y = halfHeight
+    glm::vec3 localFeet(0.0f, shapeInfo.getOffset().y - halfExtents.y - halfExtents.x, 0.0f);
+    return getWorldOrientation() * localFeet + getWorldPosition();
+}
+
 float Avatar::computeMass() {
     float radius;
     glm::vec3 start, end;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -252,7 +252,7 @@ public:
     /**jsdoc
      * Get the position of the current avatar's feet (or rather, bottom of its collision capsule) in world coordinates.
      * @function MyAvatar.getWorldFeetPosition
-     * @returns {Vec3} The position of the Avatar's feet in world coordinates.
+     * @returns {Vec3} The position of the avatar's feet in world coordinates.
     */
     Q_INVOKABLE glm::vec3 getWorldFeetPosition();
 

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -249,6 +249,12 @@ public:
     virtual void computeShapeInfo(ShapeInfo& shapeInfo);
     void getCapsule(glm::vec3& start, glm::vec3& end, float& radius);
     float computeMass();
+    /**jsdoc
+     * Get the position of the current avatar's feet (or rather, bottom of its collision capsule) in world coordinates.
+     * @function MyAvatar.getWorldFeetPosition()
+     * @returns {Vec3}
+    */
+    Q_INVOKABLE glm::vec3 getWorldFeetPosition();
 
     void setPositionViaScript(const glm::vec3& position) override;
     void setOrientationViaScript(const glm::quat& orientation) override;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -251,8 +251,8 @@ public:
     float computeMass();
     /**jsdoc
      * Get the position of the current avatar's feet (or rather, bottom of its collision capsule) in world coordinates.
-     * @function MyAvatar.getWorldFeetPosition()
-     * @returns {Vec3}
+     * @function MyAvatar.getWorldFeetPosition
+     * @returns {Vec3} The position of the Avatar's feet in world coordinates.
     */
     Q_INVOKABLE glm::vec3 getWorldFeetPosition();
 


### PR DESCRIPTION
Moves the spawn point, via how we set the AddressManager's PositionGetter in Application.cpp, from the Avatar's hips to the 'feet'. This is done via a new function, getWorldFeetPosition(), in Avatar.cpp. This function computes the bottom of the collision capsule.

[Relevant MS ticket.](https://highfidelity.fogbugz.com/f/cases/17249/Relocate-Avatar-Spawn-Point-from-the-Hips-to-the-Feet)

**Test Plan:**
_Goal:_ Verify that teleporting between domains with a large avatar does not cause the avatar to spawn in the floor and pop up.

_Steps:_
- Open Interface
- Equip a large avatar (such as the Barbarian) from the Marketplace.
- Transition between worlds via a teleporter.
- If no 'pop up' occurs (slight falling is acceptable), this PR is good.

**_NOTE:_**
For additional verification that the point that's being calculated is correct, I used the attached test script to spawn an orange circle3d overlay at the calculated position. The circle is centered on this point. To further verify, enable drawing the collision geometry for the avatar in Developer > Avatar > Show Bounding Collision Shapes. You'll notice the very bottom of the lower sphere on the 'capsule' makes contact with drawn overlay, at its tangent.

```"use strict";

(function() {
	var overlayType = "circle3d";
	var overlayColor = { red: 255, green: 128, blue: 0 };
	var overlayPosition = MyAvatar.getWorldFeetPosition();
	var overlayRotation = Quat.angleAxis(90, Vec3.UNIT_X);
	var overlayProps = {
		color: overlayColor,
		visible: true,
		name: "avatarFeetOverlay",
		position: overlayPosition,
		parentID: MyAvatar.sessionUUID,
		filled: true,
		localRotation: overlayRotation
	};
	
	Vec3.print("Adding sphere overlay at: ", overlayPosition);
	var overlayID = Overlays.addOverlay(overlayType, overlayProps);
	
	
	var shutdown = function() {
		Overlays.deleteOverlay(overlayID);
	}
	
	Script.scriptEnding.connect(shutdown);
}());```