### PR TITLE
Fix server script status

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -2040,8 +2040,9 @@ var PropertiesTool = function (opts) {
     that.setVisible(false);
     
     function emitScriptEvent(data) {
-        webView.emitScriptEvent(JSON.stringify(data));
-        createToolsWindow.emitScriptEvent(JSON.stringify(data));
+        var dataString = JSON.stringify(data);
+        webView.emitScriptEvent(dataString);
+        createToolsWindow.emitScriptEvent(dataString);
     }
 
     function updateScriptStatus(info) {

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -2038,11 +2038,15 @@ var PropertiesTool = function (opts) {
     };
 
     that.setVisible(false);
+    
+    function emitScriptEvent(data) {
+        webView.emitScriptEvent(JSON.stringify(data));
+        createToolsWindow.emitScriptEvent(JSON.stringify(data));
+    }
 
     function updateScriptStatus(info) {
         info.type = "server_script_status";
-        webView.emitScriptEvent(JSON.stringify(info));
-        createToolsWindow.emitScriptEvent(JSON.stringify(info));
+        emitScriptEvent(info);
     }
 
     function resetScriptStatus() {
@@ -2095,8 +2099,7 @@ var PropertiesTool = function (opts) {
         }
         data.selections = selections;
 
-        webView.emitScriptEvent(JSON.stringify(data));
-        createToolsWindow.emitScriptEvent(JSON.stringify(data));
+        emitScriptEvent(data);
     }
     selectionManager.addEventListener(updateSelections);
 

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -2042,6 +2042,7 @@ var PropertiesTool = function (opts) {
     function updateScriptStatus(info) {
         info.type = "server_script_status";
         webView.emitScriptEvent(JSON.stringify(info));
+        createToolsWindow.emitScriptEvent(JSON.stringify(info));
     }
 
     function resetScriptStatus() {

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -36,6 +36,8 @@ var lastEntityID = null;
 
 var MATERIAL_PREFIX_STRING = "mat::";
 
+var INVALIDATE_SCRIPT_STATUS = "[ Fetching status ]";
+
 function debugPrint(message) {
     EventBridge.emitWebEvent(
         JSON.stringify({
@@ -1671,7 +1673,7 @@ function loaded() {
         elServerScripts.addEventListener('change', createEmitTextPropertyUpdateFunction('serverScripts'));
         elServerScripts.addEventListener('change', function() {
             // invalidate the current status (so that same-same updates can still be observed visually)
-            elServerScriptStatus.innerText = "[ Getting status ]";
+            elServerScriptStatus.innerText = INVALIDATE_SCRIPT_STATUS;
         });
 
         elClearUserData.addEventListener("click", function() {
@@ -2145,7 +2147,7 @@ function loaded() {
         });
         elReloadServerScriptsButton.addEventListener("click", function() {
             // invalidate the current status (so that same-same updates can still be observed visually)
-            elServerScriptStatus.innerText = "[ Getting status ]";
+            elServerScriptStatus.innerText = INVALIDATE_SCRIPT_STATUS;
             EventBridge.emitWebEvent(JSON.stringify({
                 type: "action",
                 action: "reloadServerScripts"

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -36,7 +36,7 @@ var lastEntityID = null;
 
 var MATERIAL_PREFIX_STRING = "mat::";
 
-var INVALIDATE_SCRIPT_STATUS = "[ Fetching status ]";
+var PENDING_SCRIPT_STATUS = "[ Fetching status ]";
 
 function debugPrint(message) {
     EventBridge.emitWebEvent(
@@ -1673,7 +1673,7 @@ function loaded() {
         elServerScripts.addEventListener('change', createEmitTextPropertyUpdateFunction('serverScripts'));
         elServerScripts.addEventListener('change', function() {
             // invalidate the current status (so that same-same updates can still be observed visually)
-            elServerScriptStatus.innerText = INVALIDATE_SCRIPT_STATUS;
+            elServerScriptStatus.innerText = PENDING_SCRIPT_STATUS;
         });
 
         elClearUserData.addEventListener("click", function() {
@@ -2147,7 +2147,7 @@ function loaded() {
         });
         elReloadServerScriptsButton.addEventListener("click", function() {
             // invalidate the current status (so that same-same updates can still be observed visually)
-            elServerScriptStatus.innerText = INVALIDATE_SCRIPT_STATUS;
+            elServerScriptStatus.innerText = PENDING_SCRIPT_STATUS;
             EventBridge.emitWebEvent(JSON.stringify({
                 type: "action",
                 action: "reloadServerScripts"

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1671,7 +1671,7 @@ function loaded() {
         elServerScripts.addEventListener('change', createEmitTextPropertyUpdateFunction('serverScripts'));
         elServerScripts.addEventListener('change', function() {
             // invalidate the current status (so that same-same updates can still be observed visually)
-            elServerScriptStatus.innerText = '[' + elServerScriptStatus.innerText + ']';
+            elServerScriptStatus.innerText = "[ Getting status ]";
         });
 
         elClearUserData.addEventListener("click", function() {
@@ -2145,7 +2145,7 @@ function loaded() {
         });
         elReloadServerScriptsButton.addEventListener("click", function() {
             // invalidate the current status (so that same-same updates can still be observed visually)
-            elServerScriptStatus.innerText = '[' + elServerScriptStatus.innerText + ']';
+            elServerScriptStatus.innerText = "[ Getting status ]";
             EventBridge.emitWebEvent(JSON.stringify({
                 type: "action",
                 action: "reloadServerScripts"


### PR DESCRIPTION
Fix server script status not getting the callback to show the actual status texts instead of "[]". Show "[ Fetching status ] " on refresh calls instead of "[" + existing text + "]".

Fixes: https://highfidelity.fogbugz.com/f/cases/16876/

Test Plan:
- Enter Interface in desktop mode in your sandbox (not serverless)
- Find an entity with a server script on it or import the following entity:
https://hifi-content.s3.amazonaws.com/davidback/production/flamethrower/flamethrower.json
- Open Create and view the Properties tab for the above entity
- Verify next to Server Script Status that the text shows as "Running"
- Press the reload button next to Server Script URL field
- Verify the status text first appears as "[ Fetching status ] " before possibly changing to "Loading" (this status might get quickly skipped) and finally showing as "Running"
- Mash the reload button many times 
- Verify the status text still goes from "[ Fetching status ] " to ending with "Running" and nothing else unexpected is displayed
- Delete the text in the Server Script URL field
- Verify once clicking out of the box that the status text appears as "[ Fetching status ] " before changing to "Not running"
- Enter "a" or any other non-URL in the Server Script URL field
- Verify once clicking out of the box that the status text first appears as "[ Fetching status ] " before changing to "Error loading script" with error message in the box below it
- Put the original test back into the Server Script URL field which was:
https://hifi-content.s3.amazonaws.com/davidback/production/flamethrower/flamethrowerServer.js
- Verify once clicking out of the box that the status text first appears as "[ Fetching status ] " before ending with "Running"