### PR TITLE
MS17413 Triggerable value does not reset on entity deselect

### DIFF
--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -980,7 +980,7 @@ function loaded() {
                         elCollideOtherAvatar.checked = false;
 
                         elGrabbable.checked = false;
-                        elWantsTrigger.checked = false;
+                        elTriggerable.checked = false;
                         elIgnoreIK.checked = false;
 
                         elCloneable.checked = false;


### PR DESCRIPTION
Fixes https://highfidelity.manuscript.com/f/cases/17413/Triggerable-value-does-not-reset-on-entity-deselect


## QA test

- Open the create app
- Create a Box Entity
- Delete the Box Entity (should clear your selection)
- Verify that the following line is not present in the log `Uncaught ReferenceError: elWantsTrigger is not defined`