### PR TITLE
Don't bind materials during shadow pass

### DIFF
--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -112,11 +112,14 @@ void MaterialEntityRenderer::doRender(RenderArgs* args) {
     }
 
     batch.setModelTransform(renderTransform);
-    drawMaterial->setTextureTransforms(textureTransform);
 
-    // bind the material
-    RenderPipelines::bindMaterial(drawMaterial, batch, args->_enableTexturing);
-    args->_details._materialSwitches++;
+    if (args->_renderMode != render::Args::RenderMode::SHADOW_RENDER_MODE) {
+        drawMaterial->setTextureTransforms(textureTransform);
+
+        // bind the material
+        RenderPipelines::bindMaterial(drawMaterial, batch, args->_enableTexturing);
+        args->_details._materialSwitches++;
+    }
 
     // Draw!
     DependencyManager::get<GeometryCache>()->renderSphere(batch);

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -268,8 +268,10 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
             geometryCache->renderSolidShapeInstance(args, batch, geometryShape, outColor, pipeline);
         }
     } else {
-        RenderPipelines::bindMaterial(mat, batch, args->_enableTexturing);
-        args->_details._materialSwitches++;
+        if (args->_renderMode != render::Args::RenderMode::SHADOW_RENDER_MODE) {
+            RenderPipelines::bindMaterial(mat, batch, args->_enableTexturing);
+            args->_details._materialSwitches++;
+        }
 
         geometryCache->renderShape(batch, geometryShape);
     }

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -157,8 +157,10 @@ void MeshPartPayload::render(RenderArgs* args) {
     bindMesh(batch);
 
     // apply material properties
-    RenderPipelines::bindMaterial(!_drawMaterials.empty() ? _drawMaterials.top().material : DEFAULT_MATERIAL, batch, args->_enableTexturing);
-    args->_details._materialSwitches++;
+    if (args->_renderMode != render::Args::RenderMode::SHADOW_RENDER_MODE) {
+        RenderPipelines::bindMaterial(!_drawMaterials.empty() ? _drawMaterials.top().material : DEFAULT_MATERIAL, batch, args->_enableTexturing);
+        args->_details._materialSwitches++;
+    }
 
     // Draw!
     {
@@ -417,8 +419,10 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
     bindMesh(batch);
 
     // apply material properties
-    RenderPipelines::bindMaterial(!_drawMaterials.empty() ? _drawMaterials.top().material : DEFAULT_MATERIAL, batch, args->_enableTexturing);
-    args->_details._materialSwitches++;
+    if (args->_renderMode != render::Args::RenderMode::SHADOW_RENDER_MODE) {
+        RenderPipelines::bindMaterial(!_drawMaterials.empty() ? _drawMaterials.top().material : DEFAULT_MATERIAL, batch, args->_enableTexturing);
+        args->_details._materialSwitches++;
+    }
 
     // Draw!
     {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/15885/SHadow-rendering-is-too-expensive-for-zaru-with-100-avatars

Noticeably improves performance when drawing shadows.

Test plan:
- Go to an area with lots of shadow casters (models and primitives).  Turn off shadows in the zone that you're in.  Open the stats ("/") and look at the number of material switches in the last column.
- Enable shadows in the zone.  The number of material switches should not change.
- Model textures should render correctly, and shadows should look correct when rendering.