### PR TITLE
Fix bug with texel opaque and transparent cut off shader function

### DIFF
--- a/libraries/graphics/src/graphics/MaterialTextures.slh
+++ b/libraries/graphics/src/graphics/MaterialTextures.slh
@@ -269,7 +269,14 @@ vec3 fetchLightmapMap(vec2 uv) {
 
 <@func discardTransparent(opacity)@>
 {
-    if (<$opacity$> < 1e-6) {
+    if (<$opacity$> < 1.0) {
+        discard;
+    }
+}
+<@endfunc@>
+<@func discardInvisible(opacity)@>
+{
+    if (<$opacity$> < 1.e-6) {
         discard;
     }
 }

--- a/libraries/render-utils/src/forward_model_translucent.slf
+++ b/libraries/render-utils/src/forward_model_translucent.slf
@@ -40,7 +40,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
-    <$discardTransparent(opacity)$>;
+    <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -44,7 +44,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
-    <$discardTransparent(opacity)$>;
+    <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent_normal_map.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map.slf
@@ -47,7 +47,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
-    <$discardTransparent(opacity)$>;
+    <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map_fade.slf
@@ -57,7 +57,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
-    <$discardTransparent(opacity)$>;
+    <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent_unlit.slf
+++ b/libraries/render-utils/src/model_translucent_unlit.slf
@@ -34,7 +34,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
-    <$discardTransparent(opacity)$>;
+    <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;

--- a/libraries/render-utils/src/model_translucent_unlit_fade.slf
+++ b/libraries/render-utils/src/model_translucent_unlit_fade.slf
@@ -44,7 +44,7 @@ void main(void) {
 
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
-    <$discardTransparent(opacity)$>;
+    <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);
     <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;


### PR DESCRIPTION
THis bug: https://highfidelity.fogbugz.com/f/cases/17427/bug-with-texel-opaque-and-transparent-cut-off-shader-function

in release 70 we started clipping out pixels for transparent materials
Doing so we changed the treshold value in the function "discardTransparent()"
This is the function that is used to discard the transparent texels for the "texel opaque" material (foliage)
so one broke the other.

TO fix this, we restored discardTRsansparent treshold under 1
ANd introduce a different function called discardInvisible which threshold at 0.000001 (1e-6)
Discard Invisible is now used in all the Translucent shaders instead of  discardTransparent.

## TEST PLAN
In blue, this pr should render correctly the tree foliage and transparent sea surface.
WIth current master, the tree foliage are clipped and not rendered properly