### PR TITLE
Fix Avatar.scale

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -207,13 +207,15 @@ void Avatar::animateScaleChanges(float deltaTime) {
 }
 
 void Avatar::setTargetScale(float targetScale) {
-    float newValue = glm::clamp(targetScale, MIN_AVATAR_SCALE, MAX_AVATAR_SCALE);
+    float minScale = getDomainMinScale();
+    float maxScale = getDomainMaxScale();
+    float newValue = glm::clamp(targetScale, minScale, maxScale);
     if (_targetScale != newValue) {
         _targetScale = newValue;
         _scaleChanged = usecTimestampNow();
         _isAnimatingScale = true;
 
-        emit targetScaleChanged(targetScale);
+        emit targetScaleChanged(newValue);
     }
 }
 


### PR DESCRIPTION
See [MS ticket 17434](https://highfidelity.fogbugz.com/f/cases/17434/MyAvatar-scale-doesn-t-report-correct-values). MyAvatar.scale was not reporting correct values if a user attempted to change to a value outside the range allowed in a domain, breaking expected behavior that could break scripts and does break the Avatar App's scaling mechanism.

_Goal:_ Verify that MyAvatar scale is being reportedly properly in JS.

**Test Plan:**
- In a domain that limits avatar heights (e.g., to between 0.4 and 5.2m).
- Default wooden avatar.
- Run the attached script.
- Use the Avatar app to change the scale to 0.1.
- The script should report your avatar scale changing to the correct value.

[avatarScale.zip](https://github.com/highfidelity/hifi/files/2272232/avatarScale.zip)