### PR TITLE
Fixing web tablet JavaScript error

### DIFF
--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -596,7 +596,7 @@ WebTablet.prototype.scheduleMouseMoveProcessor = function() {
     }
 };
 
-WebTablet.prototype.handleMouseButtonHover = function(x, y) {
+WebTablet.prototype.handleHomeButtonHover = function(x, y) {
     var pickRay = Camera.computePickRay(x, y);
     var entityPickResults;
     var homebuttonHovered = false;


### PR DESCRIPTION
- Fixing typo between function name calls
- Related to #13774

**Test Plan**
- Launch Interface in Desktop Mode
- Enable developer menu via `Settings > Developer Menu`
- De-select `Developer > UI > Desktop Tablet Becomes Toolbar`
- Open `Developer > Script Log (HMD Friendly)...`
- The error below (or something similar) should not show up in the debug window

```
[defaultScripts.js] ERROR - [UncaughtException signalHandlerException] Error: Result of expression 'this.handleHomeButtonHover' [undefined] is not a function. in file:///~/development/hifi-fork/build/interface/Release/scripts/system/libraries/WebTablet.js:622
[Backtrace]
    <anonymous>(event = [object Object]) at file:///~/development/hifi-fork/build/interface/Release/scripts/system/libraries/WebTablet.js:622
    <anonymous>(event = [object Object]) at file:///~/development/hifi-fork/build/interface/Release/scripts/system/libraries/WebTablet.js:265
    <global>() at -1
```