### PR TITLE
Fix MS17495: Initially wire sendMessage to ignore in appUi module

### DIFF
--- a/scripts/modules/appUi.js
+++ b/scripts/modules/appUi.js
@@ -91,7 +91,7 @@ function AppUi(properties) {
         icon: that.normalButton,
         activeIcon: that.activeButton,
         text: that.buttonName,
-        sortOrder: that.sortOrder
+        sortOrder: that.sortOrder || undefined
     });
     that.ignore = function ignore() { };
 
@@ -126,6 +126,7 @@ function AppUi(properties) {
     // (Although injected javascript still has to use JSON.stringify/JSON.parse.)
     that.sendToHtml = function (messageObject) { that.tablet.emitScriptEvent(JSON.stringify(messageObject)); };
     that.fromHtml = function (messageString) { that.onMessage(JSON.parse(messageString)); };
+    that.sendMessage = that.ignore;
     that.wireEventBridge = function wireEventBridge(on) {
         // Uniquivocally sets that.sendMessage(messageObject) to do the right thing.
         // Sets hasEventBridge and wires onMessage to eventSignal as appropriate, IFF onMessage defined.

--- a/scripts/modules/appUi.js
+++ b/scripts/modules/appUi.js
@@ -87,12 +87,18 @@ function AppUi(properties) {
     defaultButton('activeButton', 'a.svg');
     defaultButton('normalMessagesButton', 'i-msg.svg');
     defaultButton('activeMessagesButton', 'a-msg.svg');
-    that.button = that.tablet.addButton({
+    var buttonOptions = {
         icon: that.normalButton,
         activeIcon: that.activeButton,
-        text: that.buttonName,
-        sortOrder: that.sortOrder || undefined
-    });
+        text: that.buttonName
+    };
+    // `TabletScriptingInterface` looks for the presence of a `sortOrder` key.
+    // What it SHOULD do is look to see if the value inside that key is defined.
+    // To get around the current code, we do this instead.
+    if (that.sortOrder) {
+        buttonOptions.sortOrder = that.sortOrder;
+    }
+    that.button = that.tablet.addButton(buttonOptions);
     that.ignore = function ignore() { };
 
     // Handlers


### PR DESCRIPTION
Fixes [MS17495](https://highfidelity.manuscript.com/f/cases/17495). Also fixes an unticketed bug where an app that uses the `appUi.js` module and doesn't define a `sortOrder` would break the app.