### PR TITLE
Remove unused uniform buffer from polylines

### DIFF
--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
@@ -65,7 +65,6 @@ protected:
     QVector<glm::vec3> _lastStrokeColors;
     QVector<float> _lastStrokeWidths;
     gpu::BufferPointer _verticesBuffer;
-    gpu::BufferView _uniformBuffer;
     
     uint32_t _numVertices { 0 };
     bool _empty{ true };

--- a/libraries/entities-renderer/src/paintStroke.slf
+++ b/libraries/entities-renderer/src/paintStroke.slf
@@ -14,7 +14,6 @@
 
 <@include DeferredBufferWrite.slh@>
 
-
 // the albedo texture
 layout(binding=0) uniform sampler2D originalTexture;
 
@@ -23,17 +22,7 @@ layout(location=0) in vec3 interpolatedNormal;
 layout(location=1) in vec2 varTexcoord;
 layout(location=2) in vec4 varColor;
 
-struct PolyLineUniforms {
-    vec3 color;
-};
-
-layout(binding=0) uniform polyLineBuffer {
-    PolyLineUniforms polyline;
-};
-
 void main(void) {
-    
-    
     vec4 texel = texture(originalTexture, varTexcoord);
     int frontCondition = 1 -int(gl_FrontFacing) * 2;
     vec3 color = varColor.rgb;

--- a/libraries/entities-renderer/src/paintStroke.slv
+++ b/libraries/entities-renderer/src/paintStroke.slv
@@ -26,12 +26,10 @@ layout(location=1) out vec2 varTexcoord;
 layout(location=2) out vec4 varColor;
 
 void main(void) {
-    
     varTexcoord = inTexCoord0.st;
-    
+
     // pass along the diffuse color
     varColor = color_sRGBAToLinear(inColor);
-
 
     // standard transform
     TransformCamera cam = getTransformCamera();


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17507/Remove-unused-PolyLine-uniform-buffer

Test plan:
- Download the fingerpaint app from the market.
- Use it to draw polylines.  They should render correctly.  Check various color/texture options.