### PR TITLE
Edit handle rotation ring size

### DIFF
--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -413,7 +413,7 @@ SelectionDisplay = (function() {
     var ROTATE_CTRL_SNAP_ANGLE = 22.5;
     var ROTATE_DEFAULT_SNAP_ANGLE = 1;
     var ROTATE_DEFAULT_TICK_MARKS_ANGLE = 5;
-    var ROTATE_RING_IDLE_INNER_RADIUS = 0.95;
+    var ROTATE_RING_IDLE_INNER_RADIUS = 0.92;
     var ROTATE_RING_SELECTED_INNER_RADIUS = 0.9;
 
     // These are multipliers for sizing the rotation degrees display while rotating an entity


### PR DESCRIPTION
Small tweak to the rotation ring size to make them easier to grab. Didn't want to make them too big so will see if this change is enough.

Addresses: https://highfidelity.manuscript.com/f/cases/17466/

Test Plan:
- Ensure you have the Environment Variable HIFI_ALLOW_MULTIPLE_INSTANCES set to 1 in system properties to allow for 2 High Fidelity Interfaces to run simultaneously
- Open an Interface in desktop mode from both this PR and any other build
- Open Create in both Interfaces and select an entity
- Compare the rotation ring sizes between this PR and the other build and verify they are slightly bigger in this PR
- Stress test grabbing all 3 rotation rings from different angles/distances and verify they are always grabbable