### PR TITLE
MS17434: modifying MyAvatar.scale get property

### DIFF
--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -143,8 +143,7 @@ class MyAvatar : public Avatar {
      *     registration point of the 3D model.
      *
      * @property {Vec3} position 
-     * @property {number} scale - The target scale in which the avatar is set to by the user.
-     * @property {number} domainLimitedScale - The avatar's scale limited by the domain.
+     * @property {number} scale - Returns the clamped scale of the avatar.
      * @property {number} density <em>Read-only.</em>
      * @property {Vec3} handPosition 
      * @property {number} bodyYaw - The rotation left or right about an axis running from the head to the feet of the avatar. 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -143,7 +143,8 @@ class MyAvatar : public Avatar {
      *     registration point of the 3D model.
      *
      * @property {Vec3} position 
-     * @property {number} scale 
+     * @property {number} scale - The target scale in which the avatar is set to by the user.
+     * @property {number} domainLimitedScale - The avatar's scale limited by the domain.
      * @property {number} density <em>Read-only.</em>
      * @property {Vec3} handPosition 
      * @property {number} bodyYaw - The rotation left or right about an axis running from the head to the feet of the avatar. 
@@ -982,7 +983,7 @@ public:
 
     /**jsdoc
      * @function MyAvatar.getAvatarScale
-     * @returns {number} 
+     * @returns {number}
      */
     Q_INVOKABLE float getAvatarScale();
 

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -364,6 +364,7 @@ class AvatarData : public QObject, public SpatiallyNestable {
     // The following properties have JSDoc in MyAvatar.h and ScriptableAvatar.h
     Q_PROPERTY(glm::vec3 position READ getWorldPosition WRITE setPositionViaScript)
     Q_PROPERTY(float scale READ getTargetScale WRITE setTargetScale)
+    Q_PROPERTY(float domainLimitedScale READ getDomainLimitedScale)
     Q_PROPERTY(float density READ getDensity)
     Q_PROPERTY(glm::vec3 handPosition READ getHandPosition WRITE setHandPosition)
     Q_PROPERTY(float bodyYaw READ getBodyYaw WRITE setBodyYaw)

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -363,8 +363,7 @@ class AvatarData : public QObject, public SpatiallyNestable {
 
     // The following properties have JSDoc in MyAvatar.h and ScriptableAvatar.h
     Q_PROPERTY(glm::vec3 position READ getWorldPosition WRITE setPositionViaScript)
-    Q_PROPERTY(float scale READ getTargetScale WRITE setTargetScale)
-    Q_PROPERTY(float domainLimitedScale READ getDomainLimitedScale)
+    Q_PROPERTY(float scale READ getDomainLimitedScale WRITE setTargetScale)
     Q_PROPERTY(float density READ getDensity)
     Q_PROPERTY(glm::vec3 handPosition READ getHandPosition WRITE setHandPosition)
     Q_PROPERTY(float bodyYaw READ getBodyYaw WRITE setBodyYaw)


### PR DESCRIPTION
- Fixes MS[#17434](https://highfidelity.fogbugz.com/f/cases/17434/MyAvatar-scale-doesn-t-report-correct-values)

**TEST PLAN**
- Launch Interface in desktop mode
- In a domain that limits avatar heights
- Change to default wooden avatar
- Use the Avatar app to change the scale to 0.1.
- Enable Developer Menu via `Settings > Developer Menu`
- Open `Developer > Console...`
- Type `MyAvatar.scale` into the Scripting Console.  The scale should be clamped to the domain limit (i.e. `MyAvatar.scale` should return a value larger than 0.1)