### PR TITLE
MS17291: Create-app increase focus distance limit

### DIFF
--- a/scripts/system/libraries/entityCameraTool.js
+++ b/scripts/system/libraries/entityCameraTool.js
@@ -28,6 +28,8 @@ var FOCUS_MIN_ZOOM = 0.5;
 var ZOOM_SCALING = 0.02;
 
 var MIN_ZOOM_DISTANCE = 0.01;
+
+// The maximum usable zoom level is somewhere around 14km, further than that the edit handles will fade-out. (FIXME: MS17493)
 var MAX_ZOOM_DISTANCE = 14000;
 
 var MODE_INACTIVE = 'inactive';

--- a/scripts/system/libraries/entityCameraTool.js
+++ b/scripts/system/libraries/entityCameraTool.js
@@ -28,7 +28,7 @@ var FOCUS_MIN_ZOOM = 0.5;
 var ZOOM_SCALING = 0.02;
 
 var MIN_ZOOM_DISTANCE = 0.01;
-var MAX_ZOOM_DISTANCE = 200;
+var MAX_ZOOM_DISTANCE = 14000;
 
 var MODE_INACTIVE = 'inactive';
 var MODE_ORBIT = 'orbit';
@@ -253,14 +253,6 @@ CameraManager = function() {
         zoom *= that.targetZoomDistance * ZOOM_SCALING;
         that.targetZoomDistance = Math.min(Math.max(that.targetZoomDistance + zoom, MIN_ZOOM_DISTANCE), MAX_ZOOM_DISTANCE);
         that.updateCamera();
-    }
-
-    that.getZoomPercentage = function() {
-        return (that.zoomDistance - MIN_ZOOM_DISTANCE) / MAX_ZOOM_DISTANCE;
-    }
-
-    that.setZoomPercentage = function(pct) {
-        that.targetZoomDistance = pct * (MAX_ZOOM_DISTANCE - MIN_ZOOM_DISTANCE);
     }
 
     that.pan = function(offset) {


### PR DESCRIPTION
Fixes https://highfidelity.manuscript.com/f/cases/17291/You-can-t-move-the-camera-out-all-the-way

## Testplan
1. Open the create app in desktop mode
2. Create a Box of size 1000x1000x1000
3. Use the `F` key to focus on the entity
4. Zoom all the way out using the scroll wheel.
5. The Edit handles should still be visible and move-able