### PR TITLE
Fixing fading

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -40,7 +40,7 @@
 
 #include <PointerManager.h>
 
-std::function<bool()> EntityTreeRenderer::_entitiesShouldFadeFunction;
+std::function<bool()> EntityTreeRenderer::_entitiesShouldFadeFunction = []() { return true; };
 
 QString resolveScriptURL(const QString& scriptUrl) {
     auto normalizedScriptUrl = DependencyManager::get<ResourceManager>()->normalizeURL(scriptUrl);

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -19,6 +19,7 @@
 #include "EntitiesRendererLogging.h"
 #include <graphics-scripting/Forward.h>
 #include <RenderHifi.h>
+#include "EntityTreeRenderer.h"
 
 class EntityTreeRenderer;
 
@@ -96,7 +97,7 @@ protected:
     // Called by the `render` method after `needsRenderUpdate`
     virtual void doRender(RenderArgs* args) = 0;
 
-    bool isFading() const { return _isFading; }
+    virtual bool isFading() const { return _isFading; }
     void updateModelTransformAndBound();
     virtual bool isTransparent() const { return _isFading ? Interpolate::calculateFadeRatio(_fadeStartTime) < 1.0f : false; }
     inline bool isValidRenderItem() const { return _renderItemID != Item::INVALID_ITEM_ID; }
@@ -121,7 +122,6 @@ protected:
         
 
     static void makeStatusGetters(const EntityItemPointer& entity, Item::Status::Getters& statusGetters);
-    static std::function<bool()> _entitiesShouldFadeFunction;
     const Transform& getModelTransform() const;
 
     Item::Bound _bound;
@@ -131,7 +131,7 @@ protected:
     ItemIDs _subRenderItemIDs;
     uint64_t _fadeStartTime{ usecTimestampNow() };
     uint64_t _updateTime{ usecTimestampNow() }; // used when sorting/throttling render updates
-    bool _isFading{ _entitiesShouldFadeFunction() };
+    bool _isFading { EntityTreeRenderer::getEntitiesShouldFadeFunction()() };
     bool _prevIsTransparent { false };
     bool _visible { false };
     bool _isVisibleInSecondaryCamera { false };

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -146,6 +146,9 @@ public:
     void addMaterial(graphics::MaterialLayer material, const std::string& parentMaterialName) override;
     void removeMaterial(graphics::MaterialPointer material, const std::string& parentMaterialName) override;
 
+    // FIXME: model mesh parts should fade individually
+    bool isFading() const override { return false; }
+
 protected:
     virtual void removeFromScene(const ScenePointer& scene, Transaction& transaction) override;
     virtual void onRemoveFromSceneTyped(const TypedEntityPointer& entity) override;


### PR DESCRIPTION
- Entities were always fading.  They were only supposed to fade while physics wasn't loaded.
- Cleans up fading checks to make sure we aren't doing extra work.
- Make sure fading on models is completely disabled since it doesn't seem to work anyways.

Test plan:
- In engine-dev, look around so everything loads.  Open your stats.  Your simulation time should be in the single digits, not closer to 20 ms.  Reload content a few times.  It might be higher for the first few seconds, but then it should go down.
- After physics have loaded, create a cube.  It shouldn't fade in.