### PR TITLE
MS16958: deactivate Create App when desktop windows are closed

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -806,6 +806,14 @@ var toolBar = (function () {
 
         addButton("newMaterialButton", createNewEntityDialogButtonCallback("Material"));
 
+        var deactiveCreateIfDesktopWindowsHidden = function() {
+            if (!shouldUseEditTabletApp() && !entityListTool.isVisible() && !createToolsWindow.isVisible()) {
+                that.setActive(false);
+            }
+        };
+        entityListTool.interactiveWindowHidden.addListener(this, deactiveCreateIfDesktopWindowsHidden);
+        createToolsWindow.interactiveWindowHidden.addListener(this, deactiveCreateIfDesktopWindowsHidden);
+
         that.setActive(false);
     }
 

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -806,13 +806,13 @@ var toolBar = (function () {
 
         addButton("newMaterialButton", createNewEntityDialogButtonCallback("Material"));
 
-        var deactiveCreateIfDesktopWindowsHidden = function() {
+        var deactivateCreateIfDesktopWindowsHidden = function() {
             if (!shouldUseEditTabletApp() && !entityListTool.isVisible() && !createToolsWindow.isVisible()) {
                 that.setActive(false);
             }
         };
-        entityListTool.interactiveWindowHidden.addListener(this, deactiveCreateIfDesktopWindowsHidden);
-        createToolsWindow.interactiveWindowHidden.addListener(this, deactiveCreateIfDesktopWindowsHidden);
+        entityListTool.interactiveWindowHidden.addListener(this, deactivateCreateIfDesktopWindowsHidden);
+        createToolsWindow.interactiveWindowHidden.addListener(this, deactivateCreateIfDesktopWindowsHidden);
 
         that.setActive(false);
     }

--- a/scripts/system/libraries/entityList.js
+++ b/scripts/system/libraries/entityList.js
@@ -59,6 +59,10 @@ EntityListTool = function(shouldUseEditTabletApp) {
         entityListWindow.setVisible(!shouldUseEditTabletApp() && visible);
     };
 
+    that.isVisible = function() {
+        return entityListWindow.isVisible();
+    };
+
     that.setVisible(false);
 
     function emitJSONScriptEvent(data) {
@@ -244,6 +248,7 @@ EntityListTool = function(shouldUseEditTabletApp) {
 
     webView.webEventReceived.connect(onWebEventReceived);
     entityListWindow.webEventReceived.addListener(onWebEventReceived);
+    that.interactiveWindowHidden = entityListWindow.interactiveWindowHidden;
 
     return that;
 };

--- a/scripts/system/modules/createWindow.js
+++ b/scripts/system/modules/createWindow.js
@@ -75,6 +75,7 @@ module.exports = (function() {
         this.settingsKey = settingsKey;
         this.defaultRect = defaultRect;
         this.webEventReceived = new CallableEvent();
+        this.interactiveWindowHidden = new CallableEvent();
         this.fromQml = new CallableEvent();
         if (createOnStartup) {
             this.createWindow();
@@ -108,8 +109,14 @@ module.exports = (function() {
             this.window.sizeChanged.connect(this, windowRectChanged);
             this.window.positionChanged.connect(this, windowRectChanged);
 
-            this.window.webEventReceived.connect(this, function (data) {
+            this.window.webEventReceived.connect(this, function(data) {
                 this.webEventReceived.call(data);
+            });
+
+            this.window.visibleChanged.connect(this, function() {
+                if (!this.window.visible) {
+                    this.interactiveWindowHidden.call();
+                }
             });
 
             this.window.fromQml.connect(this, function (data) {
@@ -133,6 +140,12 @@ module.exports = (function() {
                 }
             }
         },
+        isVisible: function() {
+            if (this.window) {
+                return this.window.visible;
+            }
+            return false;
+        },
         emitScriptEvent: function(data) {
             if (this.window) {
                 this.window.emitScriptEvent(data);
@@ -144,6 +157,7 @@ module.exports = (function() {
             }
         },
         webEventReceived: null,
+        interactiveWindowHidden: null,
         fromQml: null
     };
 


### PR DESCRIPTION
Fixes https://highfidelity.fogbugz.com/f/cases/16958/Create-menu-does-not-close-when-its-windows-are-closed-in-Desktop

## QA test

1. Open Create in desktop mode
2. Close both the `Create Tools` and `Entity List` windows
3. Create should be de-activated.
4. Re-activate the Create app and repeat step 2 and 3.