### PR TITLE
Safe landing client-side improvements

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6166,6 +6166,7 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType) {
         _octreeQuery.setOctreeSizeScale(DEFAULT_OCTREE_SIZE_SCALE);
         static constexpr float MIN_LOD_ADJUST = -20.0f;
         _octreeQuery.setBoundaryLevelAdjust(MIN_LOD_ADJUST);
+        _octreeProcessor.startEntitySequence();
     } else {
         _octreeQuery.setConicalViews(_conicalViews);
         auto lodManager = DependencyManager::get<LODManager>();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6322,9 +6322,10 @@ void Application::clearDomainOctreeDetails() {
         _octreeServerSceneStats.clear();
     });
 
-    _octreeProcessor.resetCompletionSequenceNumber();
     // reset the model renderer
     getEntities()->clear();
+
+    _octreeProcessor.startEntitySequence();
 
     auto skyStage = DependencyManager::get<SceneScriptingInterface>()->getSkyStage();
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5495,6 +5495,7 @@ void Application::update(float deltaTime) {
     if (!_physicsEnabled) {
         if (!domainLoadingInProgress) {
             PROFILE_ASYNC_BEGIN(app, "Scene Loading", "");
+            _octreeProcessor.startEntitySequence();
             domainLoadingInProgress = true;
         }
 
@@ -5504,7 +5505,7 @@ void Application::update(float deltaTime) {
         // Check for flagged EntityData having arrived.
         auto entityTreeRenderer = getEntities();
         if (isServerlessMode() || 
-            (entityTreeRenderer && _octreeProcessor.octreeSequenceIsComplete(entityTreeRenderer->getLastOctreeMessageSequence()) )) {
+            (_octreeProcessor.isLoadSequenceComplete() )) {
             // we've received a new full-scene octree stats packet, or it's been long enough to try again anyway
             _lastPhysicsCheckTime = now;
             _fullSceneCounterAtLastPhysicsCheck = _fullSceneReceivedCounter;
@@ -6166,7 +6167,6 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType) {
         _octreeQuery.setOctreeSizeScale(DEFAULT_OCTREE_SIZE_SCALE);
         static constexpr float MIN_LOD_ADJUST = -20.0f;
         _octreeQuery.setBoundaryLevelAdjust(MIN_LOD_ADJUST);
-        _octreeProcessor.startEntitySequence();
     } else {
         _octreeQuery.setConicalViews(_conicalViews);
         auto lodManager = DependencyManager::get<LODManager>();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5272,6 +5272,7 @@ void Application::resetPhysicsReadyInformation() {
     _nearbyEntitiesCountAtLastPhysicsCheck = 0;
     _nearbyEntitiesStabilityCount = 0;
     _physicsEnabled = false;
+    _octreeProcessor.startEntitySequence();
 }
 
 
@@ -6323,8 +6324,6 @@ void Application::clearDomainOctreeDetails() {
 
     // reset the model renderer
     getEntities()->clear();
-
-    _octreeProcessor.startEntitySequence();
 
     auto skyStage = DependencyManager::get<SceneScriptingInterface>()->getSkyStage();
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5495,7 +5495,6 @@ void Application::update(float deltaTime) {
     if (!_physicsEnabled) {
         if (!domainLoadingInProgress) {
             PROFILE_ASYNC_BEGIN(app, "Scene Loading", "");
-            _octreeProcessor.startEntitySequence();
             domainLoadingInProgress = true;
         }
 
@@ -5514,7 +5513,7 @@ void Application::update(float deltaTime) {
             // process octree stats packets are sent in between full sends of a scene (this isn't currently true).
             // We keep physics disabled until we've received a full scene and everything near the avatar in that
             // scene is ready to compute its collision shape.
-            if (nearbyEntitiesAreReadyForPhysics() && getMyAvatar()->isReadyForPhysics()) {
+            if (getMyAvatar()->isReadyForPhysics()) {
                 _physicsEnabled = true;
                 getMyAvatar()->updateMotionBehaviorFromMenu();
             }

--- a/interface/src/octree/OctreePacketProcessor.cpp
+++ b/interface/src/octree/OctreePacketProcessor.cpp
@@ -16,6 +16,7 @@
 #include "Application.h"
 #include "Menu.h"
 #include "SceneScriptingInterface.h"
+#include "SafeLanding.h"
 
 OctreePacketProcessor::OctreePacketProcessor() {
     setObjectName("Octree Packet Processor");
@@ -25,6 +26,8 @@ OctreePacketProcessor::OctreePacketProcessor() {
         { PacketType::OctreeStats, PacketType::EntityData, PacketType::EntityErase, PacketType::EntityQueryInitialResultsComplete };
     packetReceiver.registerDirectListenerForTypes(octreePackets, this, "handleOctreePacket");
 }
+
+OctreePacketProcessor::~OctreePacketProcessor() { }
 
 void OctreePacketProcessor::handleOctreePacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
     queueReceivedPacket(message, senderNode);

--- a/interface/src/octree/OctreePacketProcessor.cpp
+++ b/interface/src/octree/OctreePacketProcessor.cpp
@@ -112,7 +112,7 @@ void OctreePacketProcessor::processPacket(QSharedPointer<ReceivedMessage> messag
                 auto renderer = qApp->getEntities();
                 if (renderer) {
                     renderer->processDatagram(*message, sendingNode);
-                    _safeLanding->sequenceNumberReceived(renderer->getLastOctreeMessageSequence());
+                    _safeLanding->noteReceivedsequenceNumber(renderer->getLastOctreeMessageSequence());
                 }
             }
         } break;

--- a/interface/src/octree/OctreePacketProcessor.cpp
+++ b/interface/src/octree/OctreePacketProcessor.cpp
@@ -121,8 +121,6 @@ void OctreePacketProcessor::processPacket(QSharedPointer<ReceivedMessage> messag
             // Read sequence #
             OCTREE_PACKET_SEQUENCE completionNumber;
             message->readPrimitive(&completionNumber);
-
-            completionNumber;
             _safeLanding->setCompletionSequenceNumbers(0, completionNumber);
         } break;
 

--- a/interface/src/octree/OctreePacketProcessor.cpp
+++ b/interface/src/octree/OctreePacketProcessor.cpp
@@ -18,7 +18,9 @@
 #include "SceneScriptingInterface.h"
 #include "SafeLanding.h"
 
-OctreePacketProcessor::OctreePacketProcessor() {
+OctreePacketProcessor::OctreePacketProcessor():
+    _safeLanding(new SafeLanding())
+{
     setObjectName("Octree Packet Processor");
 
     auto& packetReceiver = DependencyManager::get<NodeList>()->getPacketReceiver();
@@ -120,6 +122,7 @@ void OctreePacketProcessor::processPacket(QSharedPointer<ReceivedMessage> messag
             message->readPrimitive(&completionNumber);
 
             _completionSequenceNumber = completionNumber;
+            _safeLanding->setCompletionSequenceNumbers(0, completionNumber);
         } break;
 
         default: {
@@ -146,4 +149,8 @@ bool OctreePacketProcessor::octreeSequenceIsComplete(int sequenceNumber) const {
     // If we've received the flagged seq # and the current one is >= it.
     return _completionSequenceNumber != INVALID_SEQUENCE &&
         !lessThanWraparound<OCTREE_PACKET_SEQUENCE>(sequenceNumber, _completionSequenceNumber);
+}
+
+void OctreePacketProcessor::startEntitySequence() {
+    _safeLanding->startEntitySequence(qApp->getEntities());
 }

--- a/interface/src/octree/OctreePacketProcessor.cpp
+++ b/interface/src/octree/OctreePacketProcessor.cpp
@@ -122,7 +122,7 @@ void OctreePacketProcessor::processPacket(QSharedPointer<ReceivedMessage> messag
             OCTREE_PACKET_SEQUENCE completionNumber;
             message->readPrimitive(&completionNumber);
 
-            _completionSequenceNumber = completionNumber;
+            completionNumber;
             _safeLanding->setCompletionSequenceNumbers(0, completionNumber);
         } break;
 
@@ -131,26 +131,6 @@ void OctreePacketProcessor::processPacket(QSharedPointer<ReceivedMessage> messag
         } break;
     }
 }
-
-void OctreePacketProcessor::resetCompletionSequenceNumber() {
-    _completionSequenceNumber = INVALID_SEQUENCE;
-}
-
-namespace {
-    template<typename T> bool lessThanWraparound(int a, int b) {
-        constexpr int MAX_T_VALUE = std::numeric_limits<T>::max();
-        if (b <= a) {
-            b += MAX_T_VALUE;
-        }
-        return (b - a) < (MAX_T_VALUE / 2);
-    }
-}
-
-//bool OctreePacketProcessor::octreeSequenceIsComplete(int sequenceNumber) const {
-//    // If we've received the flagged seq # and the current one is >= it.
-//    return _completionSequenceNumber != INVALID_SEQUENCE &&
-//        !lessThanWraparound<OCTREE_PACKET_SEQUENCE>(sequenceNumber, _completionSequenceNumber);
-//}
 
 void OctreePacketProcessor::startEntitySequence() {
     _safeLanding->startEntitySequence(qApp->getEntities());

--- a/interface/src/octree/OctreePacketProcessor.cpp
+++ b/interface/src/octree/OctreePacketProcessor.cpp
@@ -112,6 +112,7 @@ void OctreePacketProcessor::processPacket(QSharedPointer<ReceivedMessage> messag
                 auto renderer = qApp->getEntities();
                 if (renderer) {
                     renderer->processDatagram(*message, sendingNode);
+                    _safeLanding->sequenceNumberReceived(renderer->getLastOctreeMessageSequence());
                 }
             }
         } break;
@@ -145,12 +146,16 @@ namespace {
     }
 }
 
-bool OctreePacketProcessor::octreeSequenceIsComplete(int sequenceNumber) const {
-    // If we've received the flagged seq # and the current one is >= it.
-    return _completionSequenceNumber != INVALID_SEQUENCE &&
-        !lessThanWraparound<OCTREE_PACKET_SEQUENCE>(sequenceNumber, _completionSequenceNumber);
-}
+//bool OctreePacketProcessor::octreeSequenceIsComplete(int sequenceNumber) const {
+//    // If we've received the flagged seq # and the current one is >= it.
+//    return _completionSequenceNumber != INVALID_SEQUENCE &&
+//        !lessThanWraparound<OCTREE_PACKET_SEQUENCE>(sequenceNumber, _completionSequenceNumber);
+//}
 
 void OctreePacketProcessor::startEntitySequence() {
     _safeLanding->startEntitySequence(qApp->getEntities());
+}
+
+bool OctreePacketProcessor::isLoadSequenceComplete() const {
+    return _safeLanding->isLoadSequenceComplete();
 }

--- a/interface/src/octree/OctreePacketProcessor.h
+++ b/interface/src/octree/OctreePacketProcessor.h
@@ -31,9 +31,6 @@ public:
 signals:
     void packetVersionMismatch();
 
-public slots:
-    void resetCompletionSequenceNumber();
-
 protected:
     virtual void processPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode) override;
 
@@ -41,8 +38,6 @@ private slots:
     void handleOctreePacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
 
 private:
-    static constexpr int INVALID_SEQUENCE = -1;
-    std::atomic<int> _completionSequenceNumber { INVALID_SEQUENCE };
     std::unique_ptr<SafeLanding> _safeLanding;
 };
 #endif // hifi_OctreePacketProcessor_h

--- a/interface/src/octree/OctreePacketProcessor.h
+++ b/interface/src/octree/OctreePacketProcessor.h
@@ -25,6 +25,7 @@ public:
     OctreePacketProcessor();
     ~OctreePacketProcessor();
 
+    void startEntitySequence();
     bool octreeSequenceIsComplete(int sequenceNumber) const;
 
 signals:

--- a/interface/src/octree/OctreePacketProcessor.h
+++ b/interface/src/octree/OctreePacketProcessor.h
@@ -26,7 +26,7 @@ public:
     ~OctreePacketProcessor();
 
     void startEntitySequence();
-    bool octreeSequenceIsComplete(int sequenceNumber) const;
+    bool isLoadSequenceComplete() const;
 
 signals:
     void packetVersionMismatch();

--- a/interface/src/octree/OctreePacketProcessor.h
+++ b/interface/src/octree/OctreePacketProcessor.h
@@ -15,12 +15,15 @@
 #include <ReceivedPacketProcessor.h>
 #include <ReceivedMessage.h>
 
+class SafeLanding;
+
 /// Handles processing of incoming voxel packets for the interface application. As with other ReceivedPacketProcessor classes
 /// the user is responsible for reading inbound packets and adding them to the processing queue by calling queueReceivedPacket()
 class OctreePacketProcessor : public ReceivedPacketProcessor {
     Q_OBJECT
 public:
     OctreePacketProcessor();
+    ~OctreePacketProcessor();
 
     bool octreeSequenceIsComplete(int sequenceNumber) const;
 
@@ -39,6 +42,6 @@ private slots:
 private:
     static constexpr int INVALID_SEQUENCE = -1;
     std::atomic<int> _completionSequenceNumber { INVALID_SEQUENCE };
-
+    std::unique_ptr<SafeLanding> _safeLanding;
 };
 #endif // hifi_OctreePacketProcessor_h

--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -95,7 +95,7 @@ void SafeLanding::setCompletionSequenceNumbers(int first, int last) {
     }
 }
 
-void SafeLanding::sequenceNumberReceived(int sequenceNumber) {
+void SafeLanding::noteReceivedsequenceNumber(int sequenceNumber) {
     if (_trackingEntities) {
         Locker lock(_lock);
         _sequenceNumbers.insert(sequenceNumber);
@@ -103,7 +103,7 @@ void SafeLanding::sequenceNumberReceived(int sequenceNumber) {
 }
 
 bool SafeLanding::isLoadSequenceComplete() {
-    if (entityPhysicsComplete() && sequenceNumbersComplete()) {
+    if (isEntityPhysicsComplete() && isSequenceNumbersComplete()) {
         Locker lock(_lock);
         _trackedEntities.clear();
         _initialStart = INVALID_SEQUENCE;
@@ -116,7 +116,7 @@ bool SafeLanding::isLoadSequenceComplete() {
     return !_trackingEntities;
 }
 
-bool SafeLanding::sequenceNumbersComplete() {
+bool SafeLanding::isSequenceNumbersComplete() {
     if (_initialStart != INVALID_SEQUENCE) {
         Locker lock(_lock);
         int sequenceSize = _initialStart <= _initialEnd ? _initialEnd - _initialStart:
@@ -134,7 +134,7 @@ bool SafeLanding::sequenceNumbersComplete() {
     return false;
 }
 
-bool SafeLanding::entityPhysicsComplete() {
+bool SafeLanding::isEntityPhysicsComplete() {
     Locker lock(_lock);
     for (auto entityMapIter = _trackedEntities.begin(); entityMapIter != _trackedEntities.end(); ++entityMapIter) {
         auto entity = entityMapIter->second;

--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -35,6 +35,7 @@ void SafeLanding::startEntitySequence(QSharedPointer<EntityTreeRenderer> entityT
         auto entityTree = entityTreeRenderer->getTree();
 
         if (entityTree) {
+            Locker lock(_lock);
             _entityTree = entityTree;
             connect(std::const_pointer_cast<EntityTree>(_entityTree).get(),
                 &EntityTree::addingEntity, this, &SafeLanding::addTrackedEntity);
@@ -47,6 +48,7 @@ void SafeLanding::startEntitySequence(QSharedPointer<EntityTreeRenderer> entityT
 }
 
 void SafeLanding::stopEntitySequence() {
+    Locker lock(_lock);
     _trackingEntities = false;
     _initialStart = INVALID_SEQUENCE;
     _initialEnd = INVALID_SEQUENCE;
@@ -62,10 +64,11 @@ void SafeLanding::addTrackedEntity(const EntityItemID& entityID) {
             const auto& entityType = entity->getType();
             if (entityType == EntityTypes::Model) {
                 ModelEntityItem * modelEntity = std::dynamic_pointer_cast<ModelEntityItem>(entity).get();
-                auto shapeType = modelEntity->getShapeType();
-                if (shapeType == SHAPE_TYPE_COMPOUND || shapeType == SHAPE_TYPE_STATIC_MESH ||
-                    shapeType == SHAPE_TYPE_SIMPLE_COMPOUND) {
+                static const std::set<ShapeType> downloadedCollisionTypes
+                    { SHAPE_TYPE_COMPOUND, SHAPE_TYPE_SIMPLE_COMPOUND, SHAPE_TYPE_STATIC_MESH,  SHAPE_TYPE_SIMPLE_HULL };
+                if (downloadedCollisionTypes.count(modelEntity->getShapeType()) != 0) {
                     // Only track entities with downloaded collision bodies.
+                    Locker lock(_lock);
                     _trackedEntities.emplace(entityID, entity);
                     qCDebug(interfaceapp) << "Safe Landing: Tracking entity " << entity->getItemName();
                 }
@@ -75,27 +78,37 @@ void SafeLanding::addTrackedEntity(const EntityItemID& entityID) {
 }
 
 void SafeLanding::deleteTrackedEntity(const EntityItemID& entityID) {
+    Locker lock(_lock);
     _trackedEntities.erase(entityID);
 }
 
 void SafeLanding::setCompletionSequenceNumbers(int first, int last) {
+    Locker lock(_lock);
     _initialStart = first;
     _initialEnd = (last + 1) % SEQUENCE_MODULO;
-    auto firstIter = _sequenceNumbers.find(_initialStart);
-    if (firstIter != _sequenceNumbers.end()) {
-        _sequenceNumbers.erase(_sequenceNumbers.begin(), firstIter);
-    }
-    _sequenceNumbers.erase(_sequenceNumbers.find(_initialEnd), _sequenceNumbers.end());
 }
 
 void SafeLanding::sequenceNumberReceived(int sequenceNumber) {
     if (_trackingEntities) {
+        Locker lock(_lock);
         _sequenceNumbers.insert(sequenceNumber);
     }
 }
 
+bool SafeLanding::isLoadSequenceComplete() {
+    if (sequenceNumbersComplete() && entityPhysicsComplete()) {
+        Locker lock(_lock);
+        _trackingEntities = false;
+        _trackedEntities.clear();
+        qCDebug(interfaceapp) << "Safe Landing: load sequence complete";
+    }
+
+    return !_trackingEntities;
+}
+
 bool SafeLanding::sequenceNumbersComplete() {
     if (_initialStart != INVALID_SEQUENCE) {
+        Locker lock(_lock);
         auto startIter = _sequenceNumbers.find(_initialStart);
         if (startIter != _sequenceNumbers.end()) {
             _sequenceNumbers.erase(_sequenceNumbers.begin(), startIter);
@@ -109,27 +122,8 @@ bool SafeLanding::sequenceNumbersComplete() {
     return false;
 }
 
-void SafeLanding::resourceLoaded() {
-    QObject * sender = QObject::sender();
-    if (sender) {
-        Resource * resource = dynamic_cast<Resource*>(sender);
-        const QString resourceURL = resource->getURL().toString();
-        _trackedURLs.erase(resourceURL);
-        qCDebug(interfaceapp) << "Safe Landing: Removed tracked URL" << resourceURL;
-    }
-}
-
-bool SafeLanding::isLoadSequenceComplete() {
-    if (sequenceNumbersComplete() && entityPhysicsComplete()) {
-        _trackingEntities = false;
-        _trackedEntities.clear();
-        qCDebug(interfaceapp) << "Safe Landing: load sequence complete";
-    }
-
-    return !_trackingEntities;
-}
-
 bool SafeLanding::entityPhysicsComplete() {
+    Locker lock(_lock);
     for (auto entityMapIter = _trackedEntities.begin(); entityMapIter != _trackedEntities.end(); ++entityMapIter) {
         auto entity = entityMapIter->second;
         if (!entity->shouldBePhysical() || entity->isReadyToComputeShape()) {

--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -1,0 +1,17 @@
+//
+//  SafeLanding.cpp
+//  interface/src/octree
+//
+//  Created by Simon Walton.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "SafeLanding.h"
+
+SafeLanding::SafeLanding() {
+}
+
+SafeLanding::~SafeLanding() { }

--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -10,8 +10,104 @@
 //
 
 #include "SafeLanding.h"
+#include "EntityTreeRenderer.h"
+
+const int SafeLanding::SEQUENCE_MODULO = std::numeric_limits<OCTREE_PACKET_SEQUENCE>::max() + 1;
+
+namespace {
+    template<typename T> bool lessThanWraparound(int a, int b) {
+        constexpr int MAX_T_VALUE = std::numeric_limits<T>::max();
+        if (b <= a) {
+            b += MAX_T_VALUE;
+        }
+        return (b - a) < (MAX_T_VALUE / 2);
+    }
+}
+
+bool SafeLanding::SequenceLessThan::operator()(const int& a, const int& b) const {
+    return lessThanWraparound<OCTREE_PACKET_SEQUENCE>(a, b);
+}
 
 SafeLanding::SafeLanding() {
 }
 
 SafeLanding::~SafeLanding() { }
+
+void SafeLanding::startEntitySequence(QSharedPointer<EntityTreeRenderer> entityTreeRenderer) {
+    if (!_trackingEntities) {
+        auto entityTree = entityTreeRenderer->getTree();
+
+        if (entityTree) {
+            _entityTree = entityTree;
+            connect(std::const_pointer_cast<EntityTree>(_entityTree).get(),
+                &EntityTree::addingEntity, this, &SafeLanding::addTrackedEntity);
+            connect(std::const_pointer_cast<EntityTree>(_entityTree).get(),
+                &EntityTree::deletingEntity, this, &SafeLanding::deleteTrackedEntity);
+            _trackingEntities = true;
+            _sequenceNumbers.clear();
+            _isSequenceComplete = false;
+        }
+    }
+}
+
+void SafeLanding::stopEntitySequence() {
+    _trackingEntities = false;
+    _initialStart = INVALID_SEQUENCE;
+    _initialEnd = INVALID_SEQUENCE;
+    _trackedEntities.clear();
+    _sequenceNumbers.clear();
+}
+
+void SafeLanding::addTrackedEntity(const EntityItemID& entityID) {
+    volatile EntityItemID id = entityID;
+    if (_trackingEntities) {
+        EntityItemPointer entity = _entityTree->findEntityByID(entityID);
+        if (entity) {
+            const auto& entityType = entity->getType();
+            // Entity types of interest:
+            static const std::set<EntityTypes::EntityType> solidTypes
+                { EntityTypes::Box, EntityTypes::Sphere, EntityTypes::Shape, EntityTypes::Model };
+
+            if (solidTypes.count(entity->getType()) && !entity->getCollisionless()) {
+                _trackedEntities.emplace(entityID, entity);
+            }
+
+        }
+
+    }
+}
+
+void SafeLanding::deleteTrackedEntity(const EntityItemID& entityID) {
+    _trackedEntities.erase(entityID);
+}
+
+void SafeLanding::setCompletionSequenceNumbers(int first, int last) {
+    _initialStart = first;
+    _initialEnd = (last + 1) % SEQUENCE_MODULO;
+    auto firstIter = _sequenceNumbers.find(_initialStart);
+    if (firstIter != _sequenceNumbers.end()) {
+        _sequenceNumbers.erase(_sequenceNumbers.begin(), firstIter);
+    }
+    _sequenceNumbers.erase(_sequenceNumbers.find(_initialEnd), _sequenceNumbers.end());
+}
+
+void SafeLanding::sequenceNumberReceived(int sequenceNumber) {
+    if (_trackingEntities) {
+        _sequenceNumbers.insert(sequenceNumber);
+    }
+}
+
+bool SafeLanding::sequenceNumbersComplete() {
+    if (_initialStart != INVALID_SEQUENCE) {
+        auto startIter = _sequenceNumbers.find(_initialStart);
+        if (startIter != _sequenceNumbers.end()) {
+            _sequenceNumbers.erase(_sequenceNumbers.begin(), startIter);
+            _sequenceNumbers.erase(_sequenceNumbers.find(_initialEnd), _sequenceNumbers.end());
+            int sequenceSize = _initialStart < _initialEnd ? _initialEnd - _initialStart :
+                _initialEnd + SEQUENCE_MODULO - _initialStart;
+            // First no. exists, nothing outside of first, last exists, so complete iff set size is sequence size.
+            return (int) _sequenceNumbers.size() == sequenceSize;
+        }
+    }
+    return false;
+}

--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -85,7 +85,7 @@ void SafeLanding::deleteTrackedEntity(const EntityItemID& entityID) {
 void SafeLanding::setCompletionSequenceNumbers(int first, int last) {
     Locker lock(_lock);
     _initialStart = first;
-    _initialEnd = (last + 1) % SEQUENCE_MODULO;
+    _initialEnd = last;
 }
 
 void SafeLanding::sequenceNumberReceived(int sequenceNumber) {
@@ -96,7 +96,7 @@ void SafeLanding::sequenceNumberReceived(int sequenceNumber) {
 }
 
 bool SafeLanding::isLoadSequenceComplete() {
-    if (sequenceNumbersComplete() && entityPhysicsComplete()) {
+    if (entityPhysicsComplete() && sequenceNumbersComplete()) {
         Locker lock(_lock);
         _trackingEntities = false;
         _trackedEntities.clear();
@@ -109,14 +109,19 @@ bool SafeLanding::isLoadSequenceComplete() {
 bool SafeLanding::sequenceNumbersComplete() {
     if (_initialStart != INVALID_SEQUENCE) {
         Locker lock(_lock);
-        auto startIter = _sequenceNumbers.find(_initialStart);
-        if (startIter != _sequenceNumbers.end()) {
-            _sequenceNumbers.erase(_sequenceNumbers.begin(), startIter);
-            _sequenceNumbers.erase(_sequenceNumbers.find(_initialEnd), _sequenceNumbers.end());
-            int sequenceSize = _initialStart < _initialEnd ? _initialEnd - _initialStart :
+        //auto startIter = _sequenceNumbers.find(_initialStart);
+        //if (startIter != _sequenceNumbers.end()) {
+        //    _sequenceNumbers.erase(_sequenceNumbers.begin(), startIter);
+        //    _sequenceNumbers.erase(_sequenceNumbers.find(_initialEnd), _sequenceNumbers.end());
+        int sequenceSize = _initialStart < _initialEnd ? _initialEnd - _initialStart:
                 _initialEnd + SEQUENCE_MODULO - _initialStart;
-            // First no. exists, nothing outside of first, last exists, so complete iff set size is sequence size.
-            return (int) _sequenceNumbers.size() == sequenceSize;
+        //    // First no. exists, nothing outside of first, last exists, so complete iff set size is sequence size.
+        //    return (int) _sequenceNumbers.size() == sequenceSize;
+        //}
+        auto startIter = _sequenceNumbers.find(_initialStart);
+        auto endIter = _sequenceNumbers.find(_initialEnd);
+        if (startIter != _sequenceNumbers.end() && endIter != _sequenceNumbers.end() && std::distance(startIter, endIter) == sequenceSize) {
+            return true;
         }
     }
     return false;

--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -45,6 +45,7 @@ void SafeLanding::startEntitySequence(QSharedPointer<EntityTreeRenderer> entityT
             _sequenceNumbers.clear();
             _initialStart = INVALID_SEQUENCE;
             _initialEnd = INVALID_SEQUENCE;
+            EntityTreeRenderer::setEntityLoadingPriorityFunction(&ElevatedPriority);
         }
     }
 }
@@ -106,6 +107,7 @@ bool SafeLanding::isLoadSequenceComplete() {
         _initialStart = INVALID_SEQUENCE;
         _initialEnd = INVALID_SEQUENCE;
         _entityTree = nullptr;
+        EntityTreeRenderer::setEntityLoadingPriorityFunction(StandardPriority);
         qCDebug(interfaceapp) << "Safe Landing: load sequence complete";
     }
 

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -25,26 +25,30 @@ class EntityItemID;
 class SafeLanding : public QObject {
 public:
     SafeLanding();
-    ~SafeLanding();
+    ~SafeLanding() = default;
 
     void startEntitySequence(QSharedPointer<EntityTreeRenderer> entityTreeRenderer);
     void stopEntitySequence();
     void setCompletionSequenceNumbers(int first, int last);
     void sequenceNumberReceived(int sequenceNumber);
-    bool isSequenceComplete() const { return _isSequenceComplete; }
+    bool isLoadSequenceComplete();
 
 private slots:
     void addTrackedEntity(const EntityItemID& entityID);
     void deleteTrackedEntity(const EntityItemID& entityID);
+    void resourceLoaded();
+
 private:
     bool sequenceNumbersComplete();
+    void trackResources(EntityItemPointer entity);
+    void DebugDumpSequenceIDs() const;
+
     bool _trackingEntities { false };
     EntityTreePointer _entityTree;
     using EntityMap = std::map<EntityItemID, EntityItemPointer>;
     EntityMap _trackedEntities;
 
     static constexpr int INVALID_SEQUENCE = -1;
-    bool _isSequenceComplete { true };
     int _initialStart { INVALID_SEQUENCE };
     int _initialEnd { INVALID_SEQUENCE }; // final sequence, exclusive.
 
@@ -53,6 +57,7 @@ private:
     };
 
     std::set<int, SequenceLessThan> _sequenceNumbers;
+    std::set<QString> _trackedURLs;
 
     static const int SEQUENCE_MODULO;
 };

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -55,9 +55,8 @@ private:
     };
 
     std::set<int, SequenceLessThan> _sequenceNumbers;
-    std::set<QString> _trackedURLs;
 
-    static float ElevatedPriority(const EntityItem&) { return 10.0f; }
+    static float ElevatedPriority(const EntityItem& entityItem);
     static float StandardPriority(const EntityItem&) { return 0.0f; }
 
     static const int SEQUENCE_MODULO;

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -14,13 +14,47 @@
 #ifndef hifi_SafeLanding_h
 #define hifi_SafeLanding_h
 
-class SafeLanding {
+#include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
+
+#include "EntityItem.h"
+
+class EntityTreeRenderer;
+class EntityItemID;
+
+class SafeLanding : public QObject {
 public:
-        SafeLanding();
-        ~SafeLanding();
+    SafeLanding();
+    ~SafeLanding();
 
+    void startEntitySequence(QSharedPointer<EntityTreeRenderer> entityTreeRenderer);
+    void stopEntitySequence();
+    void setCompletionSequenceNumbers(int first, int last);
+    void sequenceNumberReceived(int sequenceNumber);
+    bool isSequenceComplete() const { return _isSequenceComplete; }
+
+private slots:
+    void addTrackedEntity(const EntityItemID& entityID);
+    void deleteTrackedEntity(const EntityItemID& entityID);
 private:
+    bool sequenceNumbersComplete();
+    bool _trackingEntities { false };
+    EntityTreePointer _entityTree;
+    using EntityMap = std::map<EntityItemID, EntityItemPointer>;
+    EntityMap _trackedEntities;
 
+    static constexpr int INVALID_SEQUENCE = -1;
+    bool _isSequenceComplete { true };
+    int _initialStart { INVALID_SEQUENCE };
+    int _initialEnd { INVALID_SEQUENCE }; // final sequence, exclusive.
+
+    struct SequenceLessThan {
+        bool operator()(const int& a, const int& b) const;
+    };
+
+    std::set<int, SequenceLessThan> _sequenceNumbers;
+
+    static const int SEQUENCE_MODULO;
 };
 
 #endif  // hifi_SafeLanding_h

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -24,9 +24,6 @@ class EntityItemID;
 
 class SafeLanding : public QObject {
 public:
-    SafeLanding();
-    ~SafeLanding() = default;
-
     void startEntitySequence(QSharedPointer<EntityTreeRenderer> entityTreeRenderer);
     void stopEntitySequence();
     void setCompletionSequenceNumbers(int first, int last);
@@ -40,8 +37,8 @@ private slots:
 
 private:
     bool sequenceNumbersComplete();
-    void trackResources(EntityItemPointer entity);
-    void DebugDumpSequenceIDs() const;
+    void debugDumpSequenceIDs() const;
+    bool entityPhysicsComplete();
 
     bool _trackingEntities { false };
     EntityTreePointer _entityTree;

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -27,7 +27,7 @@ public:
     void startEntitySequence(QSharedPointer<EntityTreeRenderer> entityTreeRenderer);
     void stopEntitySequence();
     void setCompletionSequenceNumbers(int first, int last);
-    void sequenceNumberReceived(int sequenceNumber);
+    void noteReceivedsequenceNumber(int sequenceNumber);
     bool isLoadSequenceComplete();
 
 private slots:
@@ -35,9 +35,9 @@ private slots:
     void deleteTrackedEntity(const EntityItemID& entityID);
 
 private:
-    bool sequenceNumbersComplete();
+    bool isSequenceNumbersComplete();
     void debugDumpSequenceIDs() const;
-    bool entityPhysicsComplete();
+    bool isEntityPhysicsComplete();
 
     std::mutex _lock;
     using Locker = std::lock_guard<std::mutex>;

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -48,7 +48,7 @@ private:
 
     static constexpr int INVALID_SEQUENCE = -1;
     int _initialStart { INVALID_SEQUENCE };
-    int _initialEnd { INVALID_SEQUENCE }; // final sequence, exclusive.
+    int _initialEnd { INVALID_SEQUENCE };
 
     struct SequenceLessThan {
         bool operator()(const int& a, const int& b) const;

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -57,6 +57,9 @@ private:
     std::set<int, SequenceLessThan> _sequenceNumbers;
     std::set<QString> _trackedURLs;
 
+    static float ElevatedPriority(const EntityItem&) { return 10.0f; }
+    static float StandardPriority(const EntityItem&) { return 0.0f; }
+
     static const int SEQUENCE_MODULO;
 };
 

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -1,0 +1,26 @@
+//
+//  SafeLanding.h
+//  interface/src/octree
+//
+//  Created by Simon Walton.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+// Controller for logic to wait for local collision bodies before enabling physics.
+
+#ifndef hifi_SafeLanding_h
+#define hifi_SafeLanding_h
+
+class SafeLanding {
+public:
+        SafeLanding();
+        ~SafeLanding();
+
+private:
+
+};
+
+#endif  // hifi_SafeLanding_h

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -33,13 +33,14 @@ public:
 private slots:
     void addTrackedEntity(const EntityItemID& entityID);
     void deleteTrackedEntity(const EntityItemID& entityID);
-    void resourceLoaded();
 
 private:
     bool sequenceNumbersComplete();
     void debugDumpSequenceIDs() const;
     bool entityPhysicsComplete();
 
+    std::mutex _lock;
+    using Locker = std::lock_guard<std::mutex>;
     bool _trackingEntities { false };
     EntityTreePointer _entityTree;
     using EntityMap = std::map<EntityItemID, EntityItemPointer>;

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -642,6 +642,14 @@ bool EntityTreeRenderer::applyLayeredZones() {
 }
 
 void EntityTreeRenderer::processEraseMessage(ReceivedMessage& message, const SharedNodePointer& sourceNode) {
+    OCTREE_PACKET_FLAGS flags;
+    message.readPrimitive(&flags);
+
+    OCTREE_PACKET_SEQUENCE sequence;
+    message.readPrimitive(&sequence);
+
+    _lastOctreeMessageSequence = sequence;
+    message.seek(0);
     std::static_pointer_cast<EntityTree>(_tree)->processEraseMessage(message, sourceNode);
 }
 


### PR DESCRIPTION
Client-side improvements to the physics delayed-enabling.

When arriving at a domain track EntityData packets for the initial query and the collision state of the entities they specify. Enable physics after all initial entities and their collision state received.

https://highfidelity.manuscript.com/f/cases/17187/