### PR TITLE
MS17562: CreateApp - newly created Entity rotation should be zero

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -314,8 +314,6 @@ var toolBar = (function () {
                 direction = MyAvatar.orientation;
             }
             direction = Vec3.multiplyQbyV(direction, Vec3.UNIT_Z);
-            // Align entity with Avatar orientation.
-            properties.rotation = MyAvatar.orientation;
 
             var PRE_ADJUST_ENTITY_TYPES = ["Box", "Sphere", "Shape", "Text", "Web", "Material"];
             if (PRE_ADJUST_ENTITY_TYPES.indexOf(properties.type) !== -1) {


### PR DESCRIPTION
Fixes https://highfidelity.manuscript.com/f/cases/17562/Create-newly-created-Entity-rotation-should-be-zero

## QA Test plan

1. Open the Create app
2. Create a box
3. With the box selected go to the properties and verify that Rotation Yaw Pitch and Roll are set to 0 (see image)
![image](https://user-images.githubusercontent.com/607735/43986296-3f59f13e-9d0f-11e8-8131-21379dc63c79.png)

