### PR TITLE
Avatar bookmarks missing from Avatar Favorites

### DIFF
--- a/interface/src/AvatarBookmarks.cpp
+++ b/interface/src/AvatarBookmarks.cpp
@@ -171,6 +171,13 @@ void AvatarBookmarks::loadBookmark(const QString& bookmarkName) {
 
     if (bookmarkEntry != _bookmarks.end()) {
         QVariantMap bookmark = bookmarkEntry.value().toMap();
+        if (bookmark.empty()) { // compatibility with bookmarks like this: "Wooden Doll": "http://mpassets.highfidelity.com/7fe80a1e-f445-4800-9e89-40e677b03bee-v1/mannequin.fst?noDownload=false",
+            auto avatarUrl = bookmarkEntry.value().toString();
+            if (!avatarUrl.isEmpty()) {
+                bookmark.insert(ENTRY_AVATAR_URL, avatarUrl);
+            }
+        }
+
         if (!bookmark.empty()) {
             auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
             auto treeRenderer = DependencyManager::get<EntityTreeRenderer>();


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/16914/Avatar-bookmarks-missing-from-Avatar-Favorites

**Test plan**

1. Overwrite default avatarbookmarks with this one: 
[avatarbookmarks.zip](https://github.com/highfidelity/hifi/files/2284560/avatarbookmarks.zip)
2. Launch interface, open avatarapp
3. Ensure bookmarks are visible (although some of them might not have thumbnails, which is expected)
4. Ensure loading 'Firefighter Michelle' results in changing avatar. 