### PR TITLE
Force entity list tool to refresh when opened

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -871,6 +871,7 @@ var toolBar = (function () {
             }
             UserActivityLogger.enabledEdit();
             entityListTool.setVisible(true);
+            entityListTool.sendUpdate();
             gridTool.setVisible(true);
             grid.setEnabled(true);
             propertiesTool.setVisible(true);


### PR DESCRIPTION
When first opening Create, the entity list would not populate until you did something (change radius, refresh manually, select an entity, etc.). Now it does.