### PR TITLE
RC 72 Tutorial - MS17378

### DIFF
--- a/cmake/externals/serverless-content/CMakeLists.txt
+++ b/cmake/externals/serverless-content/CMakeLists.txt
@@ -4,8 +4,8 @@ set(EXTERNAL_NAME serverless-content)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC70v2.zip
-  URL_MD5 35fcc8e635e71d0b00a08455a2582448
+  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC72.zip
+  URL_MD5 b1d8faf9266bfbff88274a484911eb99
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""


### PR DESCRIPTION
Change audio format to hopefully address volume / positional issue in MS 17378
https://highfidelity.manuscript.com/f/cases/17378/New-voice-over-in-the-Bubble-section-of-the-serverless-tutorial-is-directional-and-very-quiet

Test Plan: 
- Install client-only Interface from this build
- Go to Bubble station and verify that the audio now plays like the other stations