### PR TITLE
Don't include old attachment data on new avatar recordings

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -184,7 +184,6 @@ MyAvatar::MyAvatar(QThread* thread) :
             if (recordingInterface->getPlayFromCurrentLocation()) {
                 setRecordingBasis();
             }
-            createRecordingIDs();
             _previousCollisionGroup = _characterController.computeCollisionGroup();
             _characterController.setCollisionless(true);
         } else {
@@ -203,6 +202,7 @@ MyAvatar::MyAvatar(QThread* thread) :
 
     connect(recorder.data(), &Recorder::recordingStateChanged, [=] {
         if (recorder->isRecording()) {
+            createRecordingIDs();
             setRecordingBasis();
         } else {
             clearRecordingBasis();

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -184,6 +184,7 @@ MyAvatar::MyAvatar(QThread* thread) :
             if (recordingInterface->getPlayFromCurrentLocation()) {
                 setRecordingBasis();
             }
+            createRecordingIDs();
             _previousCollisionGroup = _characterController.computeCollisionGroup();
             _characterController.setCollisionless(true);
         } else {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -236,8 +236,6 @@ void Avatar::updateAvatarEntities() {
         return;
     }
 
-    createRecordingIDs();
-
     if (getID().isNull() ||
         getID() == AVATAR_SELF_ID ||
         DependencyManager::get<NodeList>()->getSessionUUID() == QUuid()) {
@@ -367,6 +365,9 @@ void Avatar::updateAvatarEntities() {
                     _avatarEntityDataHashes.erase(stateItr);
                 }
             }
+        }
+        if (avatarEntities.size() != _avatarEntityForRecording.size()) {
+            createRecordingIDs();
         }
     });
 

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -236,6 +236,8 @@ void Avatar::updateAvatarEntities() {
         return;
     }
 
+    createRecordingIDs();
+
     if (getID().isNull() ||
         getID() == AVATAR_SELF_ID ||
         DependencyManager::get<NodeList>()->getSessionUUID() == QUuid()) {

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2255,6 +2255,7 @@ static const QString JSON_AVATAR_HEAD_MODEL = QStringLiteral("headModel");
 static const QString JSON_AVATAR_BODY_MODEL = QStringLiteral("bodyModel");
 static const QString JSON_AVATAR_DISPLAY_NAME = QStringLiteral("displayName");
 // It isn't meaningful to persist sessionDisplayName.
+static const QString JSON_AVATAR_ATTACHMENTS = QStringLiteral("attachments");
 static const QString JSON_AVATAR_ENTITIES = QStringLiteral("attachedEntities");
 static const QString JSON_AVATAR_SCALE = QStringLiteral("scale");
 static const QString JSON_AVATAR_VERSION = QStringLiteral("version");
@@ -2302,7 +2303,6 @@ QJsonObject AvatarData::toJson() const {
     if (!getDisplayName().isEmpty()) {
         root[JSON_AVATAR_DISPLAY_NAME] = getDisplayName();
     }
-
     _avatarEntitiesLock.withReadLock([&] {
         if (!_avatarEntityData.empty()) {
             QJsonArray avatarEntityJson;
@@ -2416,6 +2416,19 @@ void AvatarData::fromJson(const QJsonObject& json, bool useFrameSkeleton) {
 
     if (json.contains(JSON_AVATAR_SCALE)) {
         setTargetScale((float)json[JSON_AVATAR_SCALE].toDouble());
+    }
+
+    QVector<AttachmentData> attachments;
+    if (json.contains(JSON_AVATAR_ATTACHMENTS) && json[JSON_AVATAR_ATTACHMENTS].isArray()) {
+        QJsonArray attachmentsJson = json[JSON_AVATAR_ATTACHMENTS].toArray();
+        for (auto attachmentJson : attachmentsJson) {
+            AttachmentData attachment;
+            attachment.fromJson(attachmentJson.toObject());
+            attachments.push_back(attachment);
+        }
+    }
+    if (attachments != getAttachmentData()) {
+        setAttachmentData(attachments);
     }
 
     if (json.contains(JSON_AVATAR_JOINT_ARRAY)) {

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2448,7 +2448,6 @@ void AvatarData::fromJson(const QJsonObject& json, bool useFrameSkeleton) {
              if (attachmentJson.isObject()) {                 
                  QVariantMap entityData = attachmentJson.toObject().toVariantMap();
                  QUuid entityID = entityData.value("id").toUuid();
-                 auto ds = QByteArray::fromBase64(entityData.value("properties").toString().toUtf8());
                  QByteArray properties = QByteArray::fromBase64(entityData.value("properties").toByteArray());
                  updateAvatarEntity(entityID, properties);
              }

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2443,15 +2443,15 @@ void AvatarData::fromJson(const QJsonObject& json, bool useFrameSkeleton) {
     }
 
     if (json.contains(JSON_AVATAR_ENTITIES) && json[JSON_AVATAR_ENTITIES].isArray()) {
-         QJsonArray attachmentsJson = json[JSON_AVATAR_ENTITIES].toArray();
-         for (auto attachmentJson : attachmentsJson) {
-             if (attachmentJson.isObject()) {                 
-                 QVariantMap entityData = attachmentJson.toObject().toVariantMap();
-                 QUuid entityID = entityData.value("id").toUuid();
-                 QByteArray properties = QByteArray::fromBase64(entityData.value("properties").toByteArray());
-                 updateAvatarEntity(entityID, properties);
-             }
-         }
+        QJsonArray attachmentsJson = json[JSON_AVATAR_ENTITIES].toArray();
+        for (auto attachmentJson : attachmentsJson) {
+            if (attachmentJson.isObject()) {
+                QVariantMap entityData = attachmentJson.toObject().toVariantMap();
+                QUuid entityID = entityData.value("id").toUuid();
+                QByteArray properties = QByteArray::fromBase64(entityData.value("properties").toByteArray());
+                updateAvatarEntity(entityID, properties);
+            }
+        }
     }
 
     if (json.contains(JSON_AVATAR_JOINT_ARRAY)) {

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2255,7 +2255,6 @@ static const QString JSON_AVATAR_HEAD_MODEL = QStringLiteral("headModel");
 static const QString JSON_AVATAR_BODY_MODEL = QStringLiteral("bodyModel");
 static const QString JSON_AVATAR_DISPLAY_NAME = QStringLiteral("displayName");
 // It isn't meaningful to persist sessionDisplayName.
-static const QString JSON_AVATAR_ATTACHMENTS = QStringLiteral("attachments");
 static const QString JSON_AVATAR_ENTITIES = QStringLiteral("attachedEntities");
 static const QString JSON_AVATAR_SCALE = QStringLiteral("scale");
 static const QString JSON_AVATAR_VERSION = QStringLiteral("version");
@@ -2302,13 +2301,6 @@ QJsonObject AvatarData::toJson() const {
     }
     if (!getDisplayName().isEmpty()) {
         root[JSON_AVATAR_DISPLAY_NAME] = getDisplayName();
-    }
-    if (!getAttachmentData().isEmpty()) {
-        QJsonArray attachmentsJson;
-        for (auto attachment : getAttachmentData()) {
-            attachmentsJson.push_back(attachment.toJson());
-        }
-        root[JSON_AVATAR_ATTACHMENTS] = attachmentsJson;
     }
 
     _avatarEntitiesLock.withReadLock([&] {
@@ -2425,26 +2417,6 @@ void AvatarData::fromJson(const QJsonObject& json, bool useFrameSkeleton) {
     if (json.contains(JSON_AVATAR_SCALE)) {
         setTargetScale((float)json[JSON_AVATAR_SCALE].toDouble());
     }
-
-    QVector<AttachmentData> attachments;
-    if (json.contains(JSON_AVATAR_ATTACHMENTS) && json[JSON_AVATAR_ATTACHMENTS].isArray()) {
-        QJsonArray attachmentsJson = json[JSON_AVATAR_ATTACHMENTS].toArray();
-        for (auto attachmentJson : attachmentsJson) {
-            AttachmentData attachment;
-            attachment.fromJson(attachmentJson.toObject());
-            attachments.push_back(attachment);
-        }
-    }
-    if (attachments != getAttachmentData()) {
-        setAttachmentData(attachments);
-    }
-
-    // if (json.contains(JSON_AVATAR_ENTITIES) && json[JSON_AVATAR_ENTITIES].isArray()) {
-    //     QJsonArray attachmentsJson = json[JSON_AVATAR_ATTACHMENTS].toArray();
-    //     for (auto attachmentJson : attachmentsJson) {
-    //         // TODO -- something
-    //     }
-    // }
 
     if (json.contains(JSON_AVATAR_JOINT_ARRAY)) {
         if (version == (int)JsonAvatarFrameVersion::JointRotationsInRelativeFrame) {

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2431,6 +2431,18 @@ void AvatarData::fromJson(const QJsonObject& json, bool useFrameSkeleton) {
         setAttachmentData(attachments);
     }
 
+    if (json.contains(JSON_AVATAR_ENTITIES) && json[JSON_AVATAR_ENTITIES].isArray()) {
+         QJsonArray attachmentsJson = json[JSON_AVATAR_ATTACHMENTS].toArray();
+         for (auto attachmentJson : attachmentsJson) {
+             if (attachmentJson.isObject()) {
+                 QVariantMap entityData = attachmentJson.toObject().toVariantMap();
+                 QUuid entityID = entityData.value("id").toUuid();
+                 QByteArray properties = entityData.value("properties").toByteArray();
+                 updateAvatarEntity(entityID, properties);
+             }
+         }
+    }
+
     if (json.contains(JSON_AVATAR_JOINT_ARRAY)) {
         if (version == (int)JsonAvatarFrameVersion::JointRotationsInRelativeFrame) {
             // because we don't have the full joint hierarchy skeleton of the model,

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2432,7 +2432,7 @@ void AvatarData::fromJson(const QJsonObject& json, bool useFrameSkeleton) {
     }
 
     if (json.contains(JSON_AVATAR_ENTITIES) && json[JSON_AVATAR_ENTITIES].isArray()) {
-         QJsonArray attachmentsJson = json[JSON_AVATAR_ATTACHMENTS].toArray();
+         QJsonArray attachmentsJson = json[JSON_AVATAR_ENTITIES].toArray();
          for (auto attachmentJson : attachmentsJson) {
              if (attachmentJson.isObject()) {
                  QVariantMap entityData = attachmentJson.toObject().toVariantMap();

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1077,6 +1077,7 @@ public:
     void clearRecordingBasis();
     TransformPointer getRecordingBasis() const;
     void setRecordingBasis(TransformPointer recordingBasis = TransformPointer());
+    void createRecordingIDs();
     QJsonObject toJson() const;
     void fromJson(const QJsonObject& json, bool useFrameSkeleton = true);
 
@@ -1410,6 +1411,7 @@ protected:
 
     mutable ReadWriteLockable _avatarEntitiesLock;
     AvatarEntityIDs _avatarEntityDetached; // recently detached from this avatar
+    AvatarEntityIDs _avatarEntityForRecording; // create new entities id for avatar recording
     AvatarEntityMap _avatarEntityData;
     bool _avatarEntityDataLocallyEdited { false };
     bool _avatarEntityDataChanged { false };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17590/Include-avatar-entities-in-recordings

This PR won't include avatar attachments on new avatar recordings. It will still load attachments included on previous recordings. Now avatar entities will be added to the recordings.