### PR TITLE
Fix MS16003: In PAL/GoTo WebView, 'BACK' closes app when you can't go back

### DIFF
--- a/interface/resources/qml/controls/TabletWebView.qml
+++ b/interface/resources/qml/controls/TabletWebView.qml
@@ -52,12 +52,18 @@ Item {
                 id: back
                 enabledColor: hifi.colors.darkGray
                 disabledColor: hifi.colors.lightGrayText
-                enabled: historyIndex > 0
+                enabled: true
                 text: "BACK"
 
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: goBack()
+                    onClicked: {
+                        if (historyIndex > 0) {
+                            goBack();
+                        } else {
+                            closeWebEngine();
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes [MS16003](https://highfidelity.manuscript.com/f/cases/16003/web-view-back-button-behavior-is-nonsensical-when-embedded-in-a-qml-app-like-People-or-Goto).

Approved by Mark.