### PR TITLE
Fix the local lights not working on AMD

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendShader.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendShader.cpp
@@ -256,7 +256,7 @@ GLint GLBackend::getRealUniformLocation(GLint location) const {
         // uniforms.  If someone is requesting a uniform that isn't in the remapping structure
         // that's a bug from the calling code, because it means that location wasn't in the 
         // reflection
-		qWarning() << "Unexpected location requested for shader: #" << location;
+        qWarning() << "Unexpected location requested for shader: #" << location;
         return INVALID_UNIFORM_INDEX;
     }
     return itr->second;

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendShader.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendShader.cpp
@@ -212,6 +212,8 @@ GLShader* GLBackend::compileBackendProgram(const Shader& program, const Shader::
             glprogram = ::gl::buildProgram(shaderGLObjects);
 
             if (!::gl::linkProgram(glprogram, compilationLogs[version].message)) {
+                qCWarning(gpugllogging) << "GLBackend::compileBackendProgram - Program didn't link:\n" << compilationLogs[version].message.c_str();
+                compilationLogs[version].compiled = false;                
                 glDeleteProgram(glprogram);
                 glprogram = 0;
                 return nullptr;
@@ -254,7 +256,7 @@ GLint GLBackend::getRealUniformLocation(GLint location) const {
         // uniforms.  If someone is requesting a uniform that isn't in the remapping structure
         // that's a bug from the calling code, because it means that location wasn't in the 
         // reflection
-        qWarning() << "Unexpected location requested for shader";
+		qWarning() << "Unexpected location requested for shader: #" << location;
         return INVALID_UNIFORM_INDEX;
     }
     return itr->second;

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -135,7 +135,7 @@ static void loadLightProgram(int programId, bool lightVolume, gpu::PipelinePoint
     if (lightVolume) {
         PrepareStencil::testShape(*state);
        
-        state->setCullMode(gpu::State::CULL_NONE);
+        state->setCullMode(gpu::State::CULL_BACK);
         //state->setCullMode(gpu::State::CULL_FRONT);
         //state->setDepthTest(true, false, gpu::GREATER_EQUAL);
         //state->setDepthClampEnable(true);

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -135,7 +135,7 @@ static void loadLightProgram(int programId, bool lightVolume, gpu::PipelinePoint
     if (lightVolume) {
         PrepareStencil::testShape(*state);
        
-        state->setCullMode(gpu::State::CULL_BACK);
+        state->setCullMode(gpu::State::CULL_NONE);
         //state->setCullMode(gpu::State::CULL_FRONT);
         //state->setDepthTest(true, false, gpu::GREATER_EQUAL);
         //state->setDepthClampEnable(true);
@@ -496,9 +496,10 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
             batch.setPipeline(program);
         }
 
+        // NOTE: WE are assuming that the deferred lighting pass is always full screen so this texture transform is not needed (and cause problems on AMD)
         // Adjust the texcoordTransform in the case we are rendeirng a sub region(mini mirror)
-        auto textureFrameTransform = gpu::Framebuffer::evalSubregionTexcoordTransformCoefficients(deferredFramebuffer->getFrameSize(), args->_viewport);
-        batch._glUniform4fv(ru::Uniform::TexcoordTransform, 1, reinterpret_cast< const float* >(&textureFrameTransform));
+        //  auto textureFrameTransform = gpu::Framebuffer::evalSubregionTexcoordTransformCoefficients(deferredFramebuffer->getFrameSize(), args->_viewport);
+        //  batch._glUniform4fv(ru::Uniform::TexcoordTransform, 1, reinterpret_cast< const float* >(&textureFrameTransform));
 
         // Setup the global lighting
         deferredLightingEffect->setupKeyLightBatch(args, batch);
@@ -560,7 +561,8 @@ void RenderDeferredLocals::run(const render::RenderContextPointer& renderContext
         batch.setViewportTransform(viewport);
         batch.setStateScissorRect(viewport);
 
-        auto textureFrameTransform = gpu::Framebuffer::evalSubregionTexcoordTransformCoefficients(deferredFramebuffer->getFrameSize(), viewport);
+        // NOTE: WE are assuming that the deferred lighting pass is always full screen so this texture transform is not needed (and cause problems on AMD)
+        // auto textureFrameTransform = gpu::Framebuffer::evalSubregionTexcoordTransformCoefficients(deferredFramebuffer->getFrameSize(), viewport);
 
 
         auto& lightIndices = lightClusters->_visibleLightIndices;
@@ -569,14 +571,14 @@ void RenderDeferredLocals::run(const render::RenderContextPointer& renderContext
 
             // Local light pipeline
             batch.setPipeline(deferredLightingEffect->_localLight);
-            batch._glUniform4fv(ru::Uniform::TexcoordTransform, 1, reinterpret_cast<const float*>(&textureFrameTransform));
+            // batch._glUniform4fv(ru::Uniform::TexcoordTransform, 1, reinterpret_cast<const float*>(&textureFrameTransform));
 
             batch.draw(gpu::TRIANGLE_STRIP, 4);
 
              // Draw outline as well ?
             if (lightingModel->isShowLightContourEnabled()) {
                 batch.setPipeline(deferredLightingEffect->_localLightOutline);
-                batch._glUniform4fv(ru::Uniform::TexcoordTransform, 1, reinterpret_cast<const float*>(&textureFrameTransform));
+                // batch._glUniform4fv(ru::Uniform::TexcoordTransform, 1, reinterpret_cast<const float*>(&textureFrameTransform));
 
                 batch.draw(gpu::TRIANGLE_STRIP, 4);
             }

--- a/libraries/render-utils/src/DeferredLightingEffect.cpp
+++ b/libraries/render-utils/src/DeferredLightingEffect.cpp
@@ -496,11 +496,6 @@ void RenderDeferredSetup::run(const render::RenderContextPointer& renderContext,
             batch.setPipeline(program);
         }
 
-        // NOTE: WE are assuming that the deferred lighting pass is always full screen so this texture transform is not needed (and cause problems on AMD)
-        // Adjust the texcoordTransform in the case we are rendeirng a sub region(mini mirror)
-        //  auto textureFrameTransform = gpu::Framebuffer::evalSubregionTexcoordTransformCoefficients(deferredFramebuffer->getFrameSize(), args->_viewport);
-        //  batch._glUniform4fv(ru::Uniform::TexcoordTransform, 1, reinterpret_cast< const float* >(&textureFrameTransform));
-
         // Setup the global lighting
         deferredLightingEffect->setupKeyLightBatch(args, batch);
 
@@ -561,24 +556,18 @@ void RenderDeferredLocals::run(const render::RenderContextPointer& renderContext
         batch.setViewportTransform(viewport);
         batch.setStateScissorRect(viewport);
 
-        // NOTE: WE are assuming that the deferred lighting pass is always full screen so this texture transform is not needed (and cause problems on AMD)
-        // auto textureFrameTransform = gpu::Framebuffer::evalSubregionTexcoordTransformCoefficients(deferredFramebuffer->getFrameSize(), viewport);
-
-
         auto& lightIndices = lightClusters->_visibleLightIndices;
         if (!lightIndices.empty() && lightIndices[0] > 0) {
             deferredLightingEffect->setupLocalLightsBatch(batch, lightClusters);
 
             // Local light pipeline
             batch.setPipeline(deferredLightingEffect->_localLight);
-            // batch._glUniform4fv(ru::Uniform::TexcoordTransform, 1, reinterpret_cast<const float*>(&textureFrameTransform));
 
             batch.draw(gpu::TRIANGLE_STRIP, 4);
 
              // Draw outline as well ?
             if (lightingModel->isShowLightContourEnabled()) {
                 batch.setPipeline(deferredLightingEffect->_localLightOutline);
-                // batch._glUniform4fv(ru::Uniform::TexcoordTransform, 1, reinterpret_cast<const float*>(&textureFrameTransform));
 
                 batch.draw(gpu::TRIANGLE_STRIP, 4);
             }

--- a/libraries/render-utils/src/deferred_light.slv
+++ b/libraries/render-utils/src/deferred_light.slv
@@ -16,7 +16,7 @@
 
 layout(location=RENDER_UTILS_ATTR_TEXCOORD01) out vec4 _texCoord01;
 
-layout(location=RENDER_UTILS_UNIFORM_LIGHT_TEXCOORD_TRANSFORM) uniform vec4 texcoordFrameTransform;
+//layout(location=RENDER_UTILS_UNIFORM_LIGHT_TEXCOORD_TRANSFORM) uniform vec4 texcoordFrameTransform;
 
 void main(void) {
     const float depth = 1.0;
@@ -30,8 +30,8 @@ void main(void) {
 
     _texCoord01.xy = (pos.xy + 1.0) * 0.5;
 
-    _texCoord01.xy *= texcoordFrameTransform.zw;
-    _texCoord01.xy += texcoordFrameTransform.xy;
+ //   _texCoord01.xy *= texcoordFrameTransform.zw;
+ //   _texCoord01.xy += texcoordFrameTransform.xy;
 
     gl_Position = pos;
 }

--- a/libraries/render-utils/src/deferred_light.slv
+++ b/libraries/render-utils/src/deferred_light.slv
@@ -16,11 +16,6 @@
 
 layout(location=RENDER_UTILS_ATTR_TEXCOORD01) out vec4 _texCoord01;
 
-#ifdef RENDER_UTILS_USE_TEXCOORD_FRAME_TRANSFORM 
-// NOTE: WE are assuming that the deferred lighting pass is always full screen so this texture transform is not needed (and cause problems on AMD)
-layout(location=RENDER_UTILS_UNIFORM_LIGHT_TEXCOORD_TRANSFORM) uniform vec4 texcoordFrameTransform;
-#endif
-
 void main(void) {
     const float depth = 1.0;
     const vec4 UNIT_QUAD[4] = vec4[4](
@@ -32,11 +27,6 @@ void main(void) {
     vec4 pos = UNIT_QUAD[gl_VertexID];
 
     _texCoord01.xy = (pos.xy + 1.0) * 0.5;
-
-#ifdef RENDER_UTILS_USE_TEXCOORD_FRAME_TRANSFORM 
-    _texCoord01.xy *= texcoordFrameTransform.zw;
-    _texCoord01.xy += texcoordFrameTransform.xy;
-#endif
 
     gl_Position = pos;
 }

--- a/libraries/render-utils/src/deferred_light.slv
+++ b/libraries/render-utils/src/deferred_light.slv
@@ -16,8 +16,10 @@
 
 layout(location=RENDER_UTILS_ATTR_TEXCOORD01) out vec4 _texCoord01;
 
+#ifdef RENDER_UTILS_USE_TEXCOORD_FRAME_TRANSFORM 
 // NOTE: WE are assuming that the deferred lighting pass is always full screen so this texture transform is not needed (and cause problems on AMD)
-//layout(location=RENDER_UTILS_UNIFORM_LIGHT_TEXCOORD_TRANSFORM) uniform vec4 texcoordFrameTransform;
+layout(location=RENDER_UTILS_UNIFORM_LIGHT_TEXCOORD_TRANSFORM) uniform vec4 texcoordFrameTransform;
+#endif
 
 void main(void) {
     const float depth = 1.0;
@@ -31,8 +33,10 @@ void main(void) {
 
     _texCoord01.xy = (pos.xy + 1.0) * 0.5;
 
- //   _texCoord01.xy *= texcoordFrameTransform.zw;
- //   _texCoord01.xy += texcoordFrameTransform.xy;
+#ifdef RENDER_UTILS_USE_TEXCOORD_FRAME_TRANSFORM 
+    _texCoord01.xy *= texcoordFrameTransform.zw;
+    _texCoord01.xy += texcoordFrameTransform.xy;
+#endif
 
     gl_Position = pos;
 }

--- a/libraries/render-utils/src/deferred_light.slv
+++ b/libraries/render-utils/src/deferred_light.slv
@@ -16,6 +16,7 @@
 
 layout(location=RENDER_UTILS_ATTR_TEXCOORD01) out vec4 _texCoord01;
 
+// NOTE: WE are assuming that the deferred lighting pass is always full screen so this texture transform is not needed (and cause problems on AMD)
 //layout(location=RENDER_UTILS_UNIFORM_LIGHT_TEXCOORD_TRANSFORM) uniform vec4 texcoordFrameTransform;
 
 void main(void) {


### PR DESCRIPTION
Removed the texture Transform for deferred_light slv which then makes the shader compile and link correctly on AMD. SInce that feature wasn;t needed we removed completely the uniforms  and associated c++ code.

Addressing this bug: https://highfidelity.fogbugz.com/f/cases/17551/Light-entities-do-not-cast-any-light-on-Windows-machine-with-AMD-graphics-adapter

## TEST PLAN
On a windows PC with AMD GPU, the local lights do not render in master. THey do render with this PR
Of course all the Other platforms should be tested too (PC with NVIDIA and MAC with NVIDIA/AMD gpu )
