### PR TITLE
Fix parabola rendering on AMD GPUs

### DIFF
--- a/libraries/render-utils/src/parabola.slf
+++ b/libraries/render-utils/src/parabola.slf
@@ -9,10 +9,10 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+<@include DeferredBufferWrite.slh@>
+
 layout(location=0) in vec4 _color;
 
-layout(location=0) out vec4 _fragColor;
-
 void main(void) {
-    _fragColor = _color;
+    packDeferredFragmentUnlit(vec3(1.0, 0.0, 0.0), 1.0, _color.rgb);
 }


### PR DESCRIPTION
Fix for case [17666](https://highfidelity.manuscript.com/f/cases/17666).

## Testing

Testing requires an AMD system and an HMD.  Refer to the case above for reproduction steps.  On the current development build, the bug will still exist (the parabola beam will render black and emissive items that are crossed by the beam will be visible).  In this PR build the parabola should render the same as on the nVidia systems... as an unlit blue beam.  