### PR TITLE
don't squash delete events during shutdown so that QtWebEngine process gets destoryed

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3667,7 +3667,7 @@ bool Application::event(QEvent* event) {
 
 bool Application::eventFilter(QObject* object, QEvent* event) {
 
-    if (_aboutToQuit) {
+    if (_aboutToQuit && event->type() != QEvent::DeferredDelete && event->type() != QEvent::Destroy) {
         return true;
     }
 


### PR DESCRIPTION
- fix a bug that kept QtWebEngine process from being destroyed when interface shuts down

https://highfidelity.fogbugz.com/f/cases/17596/Interface-hangs-and-crashes-when-trying-to-close-it-after-updating-to-v71
