### PR TITLE
Fix safe-landing protocol for sparse domains

### DIFF
--- a/assignment-client/src/entities/EntityTreeSendThread.cpp
+++ b/assignment-client/src/entities/EntityTreeSendThread.cpp
@@ -164,7 +164,7 @@ bool EntityTreeSendThread::traverseTreeAndSendContents(SharedNodePointer node, O
         // Send EntityQueryInitialResultsComplete reliable packet ...
         auto initialCompletion = NLPacket::create(PacketType::EntityQueryInitialResultsComplete,
             sizeof(OCTREE_PACKET_SEQUENCE), true);
-        initialCompletion->writePrimitive(OCTREE_PACKET_SEQUENCE(nodeData->getSequenceNumber() - 1U));
+        initialCompletion->writePrimitive(OCTREE_PACKET_SEQUENCE(nodeData->getSequenceNumber()));
         DependencyManager::get<NodeList>()->sendPacket(std::move(initialCompletion), *node);
     }
 

--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -122,11 +122,11 @@ bool SafeLanding::isSequenceNumbersComplete() {
         int sequenceSize = _initialStart <= _initialEnd ? _initialEnd - _initialStart:
                 _initialEnd + SEQUENCE_MODULO - _initialStart;
         auto startIter = _sequenceNumbers.find(_initialStart);
-        auto endIter = _sequenceNumbers.find(_initialEnd);
+        auto endIter = _sequenceNumbers.find(_initialEnd - 1);
         if (sequenceSize == 0 ||
             (startIter != _sequenceNumbers.end()
             && endIter != _sequenceNumbers.end()
-            && distance(startIter, endIter) == sequenceSize) ) {
+            && distance(startIter, endIter) == sequenceSize - 1) ) {
             _trackingEntities = false; // Don't track anything else that comes in.
             return true;
         }

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -26,7 +26,7 @@ class SafeLanding : public QObject {
 public:
     void startEntitySequence(QSharedPointer<EntityTreeRenderer> entityTreeRenderer);
     void stopEntitySequence();
-    void setCompletionSequenceNumbers(int first, int last);
+    void setCompletionSequenceNumbers(int first, int last);  // 'last' exclusive.
     void noteReceivedsequenceNumber(int sequenceNumber);
     bool isLoadSequenceComplete();
 

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -95,7 +95,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::AvatarIdentityRequest:
             return 22;
         case PacketType::EntityQueryInitialResultsComplete:
-            return 23;
+            return static_cast<PacketVersion>(EntityVersion::ParticleSpin);
         default:
             return 22;
     }

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -95,7 +95,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::AvatarIdentityRequest:
             return 22;
         default:
-            return 22;
+            return 23;
     }
 }
 

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -94,8 +94,10 @@ PacketVersion versionForPacketType(PacketType packetType) {
             return static_cast<PacketVersion>(AvatarQueryVersion::ConicalFrustums);
         case PacketType::AvatarIdentityRequest:
             return 22;
-        default:
+        case PacketType::EntityQueryInitialResultsComplete:
             return 23;
+        default:
+            return 22;
     }
 }
 


### PR DESCRIPTION
The protocol wasn't handling cases where no entities are nearby very well.