### PR TITLE
findRayIntersection/findParabolaIntersection performance improvements

### DIFF
--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -116,6 +116,22 @@ Item {
                         visible: root.expanded
                         text: "Avatars NOT Updated: " + root.notUpdatedAvatarCount
                     }
+                    StatText {
+                        visible: root.expanded
+                        text: "Total picks:\n    " +
+                                    root.stylusPicksCount + " styluses\n    " +
+                                    root.rayPicksCount + " rays\n    " +
+                                    root.parabolaPicksCount + " parabolas\n    " +
+                                    root.collisionPicksCount + " colliders"
+                    }
+                    StatText {
+                        visible: root.expanded
+                        text: "Intersection calls: Entities/Overlays/Avatars/HUD\n    " +
+                                    root.stylusPicksUpdated.x + "/" + root.stylusPicksUpdated.y + "/" + root.stylusPicksUpdated.z + "/" + root.stylusPicksUpdated.w + "\n    " +
+                                    root.rayPicksUpdated.x + "/" + root.rayPicksUpdated.y + "/" + root.rayPicksUpdated.z + "/" + root.rayPicksUpdated.w + "\n    " +
+                                    root.parabolaPicksUpdated.x + "/" + root.parabolaPicksUpdated.y + "/" + root.parabolaPicksUpdated.z + "/" + root.parabolaPicksUpdated.w + "\n    " +
+                                    root.collisionPicksUpdated.x + "/" + root.collisionPicksUpdated.y + "/" + root.collisionPicksUpdated.z + "/" + root.collisionPicksUpdated.w
+                    }
                 }
             }
 

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -46,6 +46,7 @@
 #include "InterfaceLogging.h"
 #include "LocationBookmarks.h"
 #include "DeferredLightingEffect.h"
+#include "PickManager.h"
 
 #include "AmbientOcclusionEffect.h"
 #include "RenderShadowTask.h"
@@ -687,6 +688,11 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowBulletContactPoints, 0, false, qApp, SLOT(setShowBulletContactPoints(bool)));
     addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowBulletConstraints, 0, false, qApp, SLOT(setShowBulletConstraints(bool)));
     addCheckableActionToQMenuAndActionHash(physicsOptionsMenu, MenuOption::PhysicsShowBulletConstraintLimits, 0, false, qApp, SLOT(setShowBulletConstraintLimits(bool)));
+
+    // Developer > Picking >>>
+    MenuWrapper* pickingOptionsMenu = developerMenu->addMenu("Picking");
+    addCheckableActionToQMenuAndActionHash(pickingOptionsMenu, MenuOption::ForceCoarsePicking, 0, false,
+        DependencyManager::get<PickManager>().data(), SLOT(setForceCoarsePicking(bool)));
 
     // Developer > Display Crash Options
     addCheckableActionToQMenuAndActionHash(developerMenu, MenuOption::DisplayCrashOptions, 0, true);

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -221,6 +221,7 @@ namespace MenuOption {
     const QString NotificationSounds = "play_notification_sounds";
     const QString NotificationSoundsSnapshot = "play_notification_sounds_snapshot";
     const QString NotificationSoundsTablet = "play_notification_sounds_tablet";
+    const QString ForceCoarsePicking = "Force Coarse Picking";
 }
 
 #endif // hifi_Menu_h

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -553,8 +553,6 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersectionVector(const Pic
         return result;
     }
 
-    glm::vec3 normDirection = glm::normalize(ray.direction);
-
     auto avatarHashCopy = getHashCopy();
     for (auto avatarData : avatarHashCopy) {
         auto avatar = std::static_pointer_cast<Avatar>(avatarData);
@@ -587,14 +585,14 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersectionVector(const Pic
         glm::vec3 end;
         float radius;
         avatar->getCapsule(start, end, radius);
-        bool intersects = findRayCapsuleIntersection(ray.origin, normDirection, start, end, radius, distance);
+        bool intersects = findRayCapsuleIntersection(ray.origin, ray.direction, start, end, radius, distance);
         if (!intersects) {
             // ray doesn't intersect avatar's capsule
             continue;
         }
 
         QVariantMap extraInfo;
-        intersects = avatarModel->findRayIntersectionAgainstSubMeshes(ray.origin, normDirection,
+        intersects = avatarModel->findRayIntersectionAgainstSubMeshes(ray.origin, ray.direction,
                                                                       distance, face, surfaceNormal, extraInfo, true);
 
         if (intersects && (!result.intersects || distance < result.distance)) {
@@ -608,7 +606,7 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersectionVector(const Pic
     }
 
     if (result.intersects) {
-        result.intersection = ray.origin + normDirection * result.distance;
+        result.intersection = ray.origin + ray.direction * result.distance;
     }
 
     return result;

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -27,6 +27,8 @@
 #include "AvatarMotionState.h"
 #include "MyAvatar.h"
 
+using SortedAvatar = std::pair<float, std::shared_ptr<Avatar>>;
+
 /**jsdoc 
  * The AvatarManager API has properties and methods which manage Avatars within the same domain.
  *

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -42,6 +42,9 @@ glm::vec3 LaserPointer::getPickOrigin(const PickResultPointer& pickResult) const
 
 glm::vec3 LaserPointer::getPickEnd(const PickResultPointer& pickResult, float distance) const {
     auto rayPickResult = std::static_pointer_cast<RayPickResult>(pickResult);
+    if (!rayPickResult) {
+        return glm::vec3(0.0f);
+    }
     if (distance > 0.0f) {
         PickRay pick = PickRay(rayPickResult->pickVariant);
         return pick.origin + distance * pick.direction;

--- a/interface/src/raypick/ParabolaPick.cpp
+++ b/interface/src/raypick/ParabolaPick.cpp
@@ -13,11 +13,13 @@
 #include "avatar/AvatarManager.h"
 #include "scripting/HMDScriptingInterface.h"
 #include "DependencyManager.h"
+#include "PickManager.h"
 
 PickResultPointer ParabolaPick::getEntityIntersection(const PickParabola& pick) {
     if (glm::length2(pick.acceleration) > EPSILON && glm::length2(pick.velocity) > EPSILON) {
+        bool precisionPicking = !(getFilter().doesPickCoarse() || DependencyManager::get<PickManager>()->getForceCoarsePicking());
         ParabolaToEntityIntersectionResult entityRes =
-            DependencyManager::get<EntityScriptingInterface>()->findParabolaIntersectionVector(pick, !getFilter().doesPickCoarse(),
+            DependencyManager::get<EntityScriptingInterface>()->findParabolaIntersectionVector(pick, precisionPicking,
                 getIncludeItemsAs<EntityItemID>(), getIgnoreItemsAs<EntityItemID>(), !getFilter().doesPickInvisible(), !getFilter().doesPickNonCollidable());
         if (entityRes.intersects) {
             return std::make_shared<ParabolaPickResult>(IntersectionType::ENTITY, entityRes.entityID, entityRes.distance, entityRes.parabolicDistance, entityRes.intersection, pick, entityRes.surfaceNormal, entityRes.extraInfo);
@@ -28,8 +30,9 @@ PickResultPointer ParabolaPick::getEntityIntersection(const PickParabola& pick) 
 
 PickResultPointer ParabolaPick::getOverlayIntersection(const PickParabola& pick) {
     if (glm::length2(pick.acceleration) > EPSILON && glm::length2(pick.velocity) > EPSILON) {
+        bool precisionPicking = !(getFilter().doesPickCoarse() || DependencyManager::get<PickManager>()->getForceCoarsePicking());
         ParabolaToOverlayIntersectionResult overlayRes =
-            qApp->getOverlays().findParabolaIntersectionVector(pick, !getFilter().doesPickCoarse(),
+            qApp->getOverlays().findParabolaIntersectionVector(pick, precisionPicking,
                 getIncludeItemsAs<OverlayID>(), getIgnoreItemsAs<OverlayID>(), !getFilter().doesPickInvisible(), !getFilter().doesPickNonCollidable());
         if (overlayRes.intersects) {
             return std::make_shared<ParabolaPickResult>(IntersectionType::OVERLAY, overlayRes.overlayID, overlayRes.distance, overlayRes.parabolicDistance, overlayRes.intersection, pick, overlayRes.surfaceNormal, overlayRes.extraInfo);

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -67,6 +67,9 @@ glm::vec3 ParabolaPointer::getPickOrigin(const PickResultPointer& pickResult) co
 
 glm::vec3 ParabolaPointer::getPickEnd(const PickResultPointer& pickResult, float distance) const {
     auto parabolaPickResult = std::static_pointer_cast<ParabolaPickResult>(pickResult);
+    if (!parabolaPickResult) {
+        return glm::vec3(0.0f);
+    }
     if (distance > 0.0f) {
         PickParabola pick = PickParabola(parabolaPickResult->pickVariant);
         return pick.origin + pick.velocity * distance + 0.5f * pick.acceleration * distance * distance;

--- a/interface/src/raypick/RayPick.cpp
+++ b/interface/src/raypick/RayPick.cpp
@@ -13,10 +13,12 @@
 #include "avatar/AvatarManager.h"
 #include "scripting/HMDScriptingInterface.h"
 #include "DependencyManager.h"
+#include "PickManager.h"
 
 PickResultPointer RayPick::getEntityIntersection(const PickRay& pick) {
+    bool precisionPicking = !(getFilter().doesPickCoarse() || DependencyManager::get<PickManager>()->getForceCoarsePicking());
     RayToEntityIntersectionResult entityRes =
-        DependencyManager::get<EntityScriptingInterface>()->findRayIntersectionVector(pick, !getFilter().doesPickCoarse(),
+        DependencyManager::get<EntityScriptingInterface>()->findRayIntersectionVector(pick, precisionPicking,
             getIncludeItemsAs<EntityItemID>(), getIgnoreItemsAs<EntityItemID>(), !getFilter().doesPickInvisible(), !getFilter().doesPickNonCollidable());
     if (entityRes.intersects) {
         return std::make_shared<RayPickResult>(IntersectionType::ENTITY, entityRes.entityID, entityRes.distance, entityRes.intersection, pick, entityRes.surfaceNormal, entityRes.extraInfo);
@@ -26,8 +28,9 @@ PickResultPointer RayPick::getEntityIntersection(const PickRay& pick) {
 }
 
 PickResultPointer RayPick::getOverlayIntersection(const PickRay& pick) {
+    bool precisionPicking = !(getFilter().doesPickCoarse() || DependencyManager::get<PickManager>()->getForceCoarsePicking());
     RayToOverlayIntersectionResult overlayRes =
-        qApp->getOverlays().findRayIntersectionVector(pick, !getFilter().doesPickCoarse(),
+        qApp->getOverlays().findRayIntersectionVector(pick, precisionPicking,
             getIncludeItemsAs<OverlayID>(), getIgnoreItemsAs<OverlayID>(), !getFilter().doesPickInvisible(), !getFilter().doesPickNonCollidable());
     if (overlayRes.intersects) {
         return std::make_shared<RayPickResult>(IntersectionType::OVERLAY, overlayRes.overlayID, overlayRes.distance, overlayRes.intersection, pick, overlayRes.surfaceNormal, overlayRes.extraInfo);

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -26,6 +26,7 @@
 #include <OffscreenUi.h>
 #include <PerfStat.h>
 #include <plugins/DisplayPlugin.h>
+#include <PickManager.h>
 
 #include <gl/Context.h>
 
@@ -145,6 +146,20 @@ void Stats::updateStats(bool force) {
         STAT_UPDATE(presentdroprate, -1);
     }
     STAT_UPDATE(gameLoopRate, (int)qApp->getGameLoopRate());
+
+    auto pickManager = DependencyManager::get<PickManager>();
+    if (pickManager && (_expanded || force)) {
+        std::vector<int> totalPicks = pickManager->getTotalPickCounts();
+        STAT_UPDATE(stylusPicksCount, totalPicks[PickQuery::Stylus]);
+        STAT_UPDATE(rayPicksCount, totalPicks[PickQuery::Ray]);
+        STAT_UPDATE(parabolaPicksCount, totalPicks[PickQuery::Parabola]);
+        STAT_UPDATE(collisionPicksCount, totalPicks[PickQuery::Collision]);
+        std::vector<QVector4D> updatedPicks = pickManager->getUpdatedPickCounts();
+        STAT_UPDATE(stylusPicksUpdated, updatedPicks[PickQuery::Stylus]);
+        STAT_UPDATE(rayPicksUpdated, updatedPicks[PickQuery::Ray]);
+        STAT_UPDATE(parabolaPicksUpdated, updatedPicks[PickQuery::Parabola]);
+        STAT_UPDATE(collisionPicksUpdated, updatedPicks[PickQuery::Collision]);
+    }
 
     auto bandwidthRecorder = DependencyManager::get<BandwidthRecorder>();
     STAT_UPDATE(packetInCount, (int)bandwidthRecorder->getCachedTotalAverageInputPacketsPerSecond());
@@ -285,7 +300,7 @@ void Stats::updateStats(bool force) {
         //    downloads << (int)(resource->getProgress() * 100.0f) << "% ";
         //}
         //downloads << "(" <<  << " pending)";
-    } // expanded avatar column
+    }
 
     // Fourth column, octree stats
     int serverCount = 0;

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -22,7 +22,6 @@ public: \
 private: \
     type _##name{ initialValue };
 
-
 /**jsdoc
  * @namespace Stats
  *
@@ -168,6 +167,15 @@ private: \
  * @property {number} implicitHeight
  *
  * @property {object} layer - <em>Read-only.</em>
+
+ * @property {number} stylusPicksCount - <em>Read-only.</em>
+ * @property {number} rayPicksCount - <em>Read-only.</em>
+ * @property {number} parabolaPicksCount - <em>Read-only.</em>
+ * @property {number} collisionPicksCount - <em>Read-only.</em>
+ * @property {Vec4} stylusPicksUpdated - <em>Read-only.</em>
+ * @property {Vec4} rayPicksUpdated - <em>Read-only.</em>
+ * @property {Vec4} parabolaPicksUpdated - <em>Read-only.</em>
+ * @property {Vec4} collisionPicksUpdated - <em>Read-only.</em>
  */
 // Properties from x onwards are QQuickItem properties.
 
@@ -284,6 +292,15 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(float, engineFrameTime, 0)
     STATS_PROPERTY(float, avatarSimulationTime, 0)
     Q_PROPERTY(QStringList animStackNames READ animStackNames NOTIFY animStackNamesChanged)
+
+    STATS_PROPERTY(int, stylusPicksCount, 0)
+    STATS_PROPERTY(int, rayPicksCount, 0)
+    STATS_PROPERTY(int, parabolaPicksCount, 0)
+    STATS_PROPERTY(int, collisionPicksCount, 0)
+    STATS_PROPERTY(QVector4D, stylusPicksUpdated, QVector4D(0, 0, 0, 0))
+    STATS_PROPERTY(QVector4D, rayPicksUpdated, QVector4D(0, 0, 0, 0))
+    STATS_PROPERTY(QVector4D, parabolaPicksUpdated, QVector4D(0, 0, 0, 0))
+    STATS_PROPERTY(QVector4D, collisionPicksUpdated, QVector4D(0, 0, 0, 0))
 
 public:
     static Stats* getInstance();
@@ -1244,6 +1261,62 @@ signals:
     /**jsdoc
      * @function Stats.update
      */
+
+    /**jsdoc
+     * Triggered when the value of the <code>stylusPicksCount</code> property changes.
+     * @function Stats.stylusPicksCountChanged
+     * @returns {Signal}
+     */
+    void stylusPicksCountChanged();
+
+    /**jsdoc
+     * Triggered when the value of the <code>rayPicksCount</code> property changes.
+     * @function Stats.rayPicksCountChanged
+     * @returns {Signal}
+     */
+    void rayPicksCountChanged();
+
+    /**jsdoc
+     * Triggered when the value of the <code>parabolaPicksCount</code> property changes.
+     * @function Stats.parabolaPicksCountChanged
+     * @returns {Signal}
+     */
+    void parabolaPicksCountChanged();
+
+    /**jsdoc
+     * Triggered when the value of the <code>collisionPicksCount</code> property changes.
+     * @function Stats.collisionPicksCountChanged
+     * @returns {Signal}
+     */
+    void collisionPicksCountChanged();
+
+    /**jsdoc
+     * Triggered when the value of the <code>stylusPicksUpdated</code> property changes.
+     * @function Stats.stylusPicksUpdatedChanged
+     * @returns {Signal}
+     */
+    void stylusPicksUpdatedChanged();
+
+    /**jsdoc
+     * Triggered when the value of the <code>rayPicksUpdated</code> property changes.
+     * @function Stats.rayPicksUpdatedChanged
+     * @returns {Signal}
+     */
+    void rayPicksUpdatedChanged();
+
+    /**jsdoc
+     * Triggered when the value of the <code>parabolaPicksUpdated</code> property changes.
+     * @function Stats.parabolaPicksUpdatedChanged
+     * @returns {Signal}
+     */
+    void parabolaPicksUpdatedChanged();
+
+    /**jsdoc
+     * Triggered when the value of the <code>collisionPicksUpdated</code> property changes.
+     * @function Stats.collisionPicksUpdatedChanged
+     * @returns {Signal}
+     */
+    void collisionPicksUpdatedChanged();
 
 private:
     int _recentMaxPackets{ 0 } ; // recent max incoming voxel packets to process

--- a/interface/src/ui/overlays/ContextOverlayInterface.cpp
+++ b/interface/src/ui/overlays/ContextOverlayInterface.cpp
@@ -180,7 +180,7 @@ bool ContextOverlayInterface::createOrDestroyContextOverlay(const EntityItemID& 
                 float distance;
                 BoxFace face;
                 glm::vec3 normal;
-                boundingBox.findRayIntersection(cameraPosition, direction, distance, face, normal);
+                boundingBox.findRayIntersection(cameraPosition, direction, 1.0f / direction, distance, face, normal);
                 float offsetAngle = -CONTEXT_OVERLAY_OFFSET_ANGLE;
                 if (event.getID() == 1) { // "1" is left hand
                     offsetAngle *= -1.0f;

--- a/interface/src/ui/overlays/Volume3DOverlay.cpp
+++ b/interface/src/ui/overlays/Volume3DOverlay.cpp
@@ -88,7 +88,7 @@ bool Volume3DOverlay::findRayIntersection(const glm::vec3& origin, const glm::ve
 
     // we can use the AABox's ray intersection by mapping our origin and direction into the overlays frame
     // and testing intersection there.
-    bool hit = _localBoundingBox.findRayIntersection(overlayFrameOrigin, overlayFrameDirection, distance, face, surfaceNormal);
+    bool hit = _localBoundingBox.findRayIntersection(overlayFrameOrigin, overlayFrameDirection, 1.0f / overlayFrameDirection, distance, face, surfaceNormal);
 
     if (hit) {
         surfaceNormal = transform.getRotation() * surfaceNormal;

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1559,7 +1559,7 @@ class RayToAvatarIntersectionResult {
 public:
     bool intersects { false };
     QUuid avatarID;
-    float distance { 0.0f };
+    float distance { FLT_MAX };
     BoxFace face;
     glm::vec3 intersection;
     glm::vec3 surfaceNormal;

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -571,7 +571,6 @@ bool RenderablePolyVoxEntityItem::findDetailedRayIntersection(const glm::vec3& o
     }
 
     glm::mat4 wtvMatrix = worldToVoxelMatrix();
-    glm::mat4 vtwMatrix = voxelToWorldMatrix();
     glm::vec3 normDirection = glm::normalize(direction);
 
     // the PolyVox ray intersection code requires a near and far point.

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -584,8 +584,6 @@ bool RenderablePolyVoxEntityItem::findDetailedRayIntersection(const glm::vec3& o
     glm::vec4 originInVoxel = wtvMatrix * glm::vec4(origin, 1.0f);
     glm::vec4 farInVoxel = wtvMatrix * glm::vec4(farPoint, 1.0f);
 
-    glm::vec4 directionInVoxel = glm::normalize(farInVoxel - originInVoxel);
-
     glm::vec4 result = glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
     PolyVox::RaycastResult raycastResult = doRayCast(originInVoxel, farInVoxel, result);
     if (raycastResult == PolyVox::RaycastResults::Completed) {
@@ -599,14 +597,9 @@ bool RenderablePolyVoxEntityItem::findDetailedRayIntersection(const glm::vec3& o
     voxelBox += result3 - Vectors::HALF;
     voxelBox += result3 + Vectors::HALF;
 
-    float voxelDistance;
-    bool hit = voxelBox.findRayIntersection(glm::vec3(originInVoxel), glm::vec3(directionInVoxel),
-                                            voxelDistance, face, surfaceNormal);
-
-    glm::vec4 voxelIntersectionPoint = glm::vec4(glm::vec3(originInVoxel) + glm::vec3(directionInVoxel) * voxelDistance, 1.0);
-    glm::vec4 intersectionPoint = vtwMatrix * voxelIntersectionPoint;
-    distance = glm::distance(origin, glm::vec3(intersectionPoint));
-    return hit;
+    glm::vec4 directionInVoxel = wtvMatrix * glm::vec4(direction, 0.0f);
+    return voxelBox.findRayIntersection(glm::vec3(originInVoxel), glm::vec3(directionInVoxel),
+                                        distance, face, surfaceNormal);
 }
 
 bool RenderablePolyVoxEntityItem::findDetailedParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity,

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -596,8 +596,8 @@ bool RenderablePolyVoxEntityItem::findDetailedRayIntersection(const glm::vec3& o
     voxelBox += result3 - Vectors::HALF;
     voxelBox += result3 + Vectors::HALF;
 
-    glm::vec4 directionInVoxel = wtvMatrix * glm::vec4(direction, 0.0f);
-    return voxelBox.findRayIntersection(glm::vec3(originInVoxel), glm::vec3(directionInVoxel),
+    glm::vec3 directionInVoxel = vec3(wtvMatrix * glm::vec4(direction, 0.0f));
+    return voxelBox.findRayIntersection(glm::vec3(originInVoxel), directionInVoxel, 1.0f / directionInVoxel,
                                         distance, face, surfaceNormal);
 }
 

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -825,13 +825,36 @@ bool findRayIntersectionOp(const OctreeElementPointer& element, void* extraData)
     RayArgs* args = static_cast<RayArgs*>(extraData);
     bool keepSearching = true;
     EntityTreeElementPointer entityTreeElementPointer = std::static_pointer_cast<EntityTreeElement>(element);
-    EntityItemID entityID = entityTreeElementPointer->findRayIntersection(args->origin, args->direction, keepSearching,
+    EntityItemID entityID = entityTreeElementPointer->findRayIntersection(args->origin, args->direction,
         args->element, args->distance, args->face, args->surfaceNormal, args->entityIdsToInclude,
         args->entityIdsToDiscard, args->visibleOnly, args->collidableOnly, args->extraInfo, args->precisionPicking);
     if (!entityID.isNull()) {
         args->entityID = entityID;
+        // We recurse OctreeElements in order, so if we hit something, we can stop immediately
+        keepSearching = false;
     }
     return keepSearching;
+}
+
+float findRayIntersectionSortingOp(const OctreeElementPointer& element, void* extraData) {
+    RayArgs* args = static_cast<RayArgs*>(extraData);
+    EntityTreeElementPointer entityTreeElementPointer = std::static_pointer_cast<EntityTreeElement>(element);
+    float distance = FLT_MAX;
+    // If origin is inside the cube, always check this element first
+    if (entityTreeElementPointer->getAACube().contains(args->origin)) {
+        distance = 0.0f;
+    } else {
+        float boundDistance = FLT_MAX;
+        BoxFace face;
+        glm::vec3 surfaceNormal;
+        if (entityTreeElementPointer->getAACube().findRayIntersection(args->origin, args->direction, boundDistance, face, surfaceNormal)) {
+            // Don't add this cell if it's already farther than our best distance so far
+            if (boundDistance < args->distance) {
+                distance = boundDistance;
+            }
+        }
+    }
+    return distance;
 }
 
 EntityItemID EntityTree::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
@@ -846,7 +869,7 @@ EntityItemID EntityTree::findRayIntersection(const glm::vec3& origin, const glm:
 
     bool requireLock = lockType == Octree::Lock;
     bool lockResult = withReadLock([&]{
-        recurseTreeWithOperation(findRayIntersectionOp, &args);
+        recurseTreeWithOperationSorted(findRayIntersectionOp, findRayIntersectionSortingOp, &args);
     }, requireLock);
 
     if (accurateResult) {
@@ -860,13 +883,36 @@ bool findParabolaIntersectionOp(const OctreeElementPointer& element, void* extra
     ParabolaArgs* args = static_cast<ParabolaArgs*>(extraData);
     bool keepSearching = true;
     EntityTreeElementPointer entityTreeElementPointer = std::static_pointer_cast<EntityTreeElement>(element);
-    EntityItemID entityID = entityTreeElementPointer->findParabolaIntersection(args->origin, args->velocity, args->acceleration, keepSearching,
+    EntityItemID entityID = entityTreeElementPointer->findParabolaIntersection(args->origin, args->velocity, args->acceleration,
         args->element, args->parabolicDistance, args->face, args->surfaceNormal, args->entityIdsToInclude,
         args->entityIdsToDiscard, args->visibleOnly, args->collidableOnly, args->extraInfo, args->precisionPicking);
     if (!entityID.isNull()) {
         args->entityID = entityID;
+        // We recurse OctreeElements in order, so if we hit something, we can stop immediately
+        keepSearching = false;
     }
     return keepSearching;
+}
+
+float findParabolaIntersectionSortingOp(const OctreeElementPointer& element, void* extraData) {
+    ParabolaArgs* args = static_cast<ParabolaArgs*>(extraData);
+    EntityTreeElementPointer entityTreeElementPointer = std::static_pointer_cast<EntityTreeElement>(element);
+    float distance = FLT_MAX;
+    // If origin is inside the cube, always check this element first
+    if (entityTreeElementPointer->getAACube().contains(args->origin)) {
+        distance = 0.0f;
+    } else {
+        float boundDistance = FLT_MAX;
+        BoxFace face;
+        glm::vec3 surfaceNormal;
+        if (entityTreeElementPointer->getAACube().findParabolaIntersection(args->origin, args->velocity, args->acceleration, boundDistance, face, surfaceNormal)) {
+            // Don't add this cell if it's already farther than our best distance so far
+            if (boundDistance < args->parabolicDistance) {
+                distance = boundDistance;
+            }
+        }
+    }
+    return distance;
 }
 
 EntityItemID EntityTree::findParabolaIntersection(const PickParabola& parabola,
@@ -882,7 +928,7 @@ EntityItemID EntityTree::findParabolaIntersection(const PickParabola& parabola,
 
     bool requireLock = lockType == Octree::Lock;
     bool lockResult = withReadLock([&] {
-        recurseTreeWithOperation(findParabolaIntersectionOp, &args);
+        recurseTreeWithOperationSorted(findParabolaIntersectionOp, findParabolaIntersectionSortingOp, &args);
     }, requireLock);
 
     if (accurateResult) {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -48,6 +48,7 @@ public:
     // Inputs
     glm::vec3 origin;
     glm::vec3 direction;
+    glm::vec3 invDirection;
     const QVector<EntityItemID>& entityIdsToInclude;
     const QVector<EntityItemID>& entityIdsToDiscard;
     bool visibleOnly;
@@ -847,7 +848,7 @@ float findRayIntersectionSortingOp(const OctreeElementPointer& element, void* ex
         float boundDistance = FLT_MAX;
         BoxFace face;
         glm::vec3 surfaceNormal;
-        if (entityTreeElementPointer->getAACube().findRayIntersection(args->origin, args->direction, boundDistance, face, surfaceNormal)) {
+        if (entityTreeElementPointer->getAACube().findRayIntersection(args->origin, args->direction, args->invDirection, boundDistance, face, surfaceNormal)) {
             // Don't add this cell if it's already farther than our best distance so far
             if (boundDistance < args->distance) {
                 distance = boundDistance;
@@ -863,7 +864,7 @@ EntityItemID EntityTree::findRayIntersection(const glm::vec3& origin, const glm:
                                     OctreeElementPointer& element, float& distance,
                                     BoxFace& face, glm::vec3& surfaceNormal, QVariantMap& extraInfo,
                                     Octree::lockType lockType, bool* accurateResult) {
-    RayArgs args = { origin, direction, entityIdsToInclude, entityIdsToDiscard,
+    RayArgs args = { origin, direction, 1.0f / direction, entityIdsToInclude, entityIdsToDiscard,
             visibleOnly, collidableOnly, precisionPicking, element, distance, face, surfaceNormal, extraInfo, EntityItemID() };
     distance = FLT_MAX;
 

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -145,7 +145,6 @@ EntityItemID EntityTreeElement::findRayIntersection(const glm::vec3& origin, con
     bool visibleOnly, bool collidableOnly, QVariantMap& extraInfo, bool precisionPicking) {
 
     EntityItemID result;
-    float distanceToElementCube = FLT_MAX;
     BoxFace localFace;
     glm::vec3 localSurfaceNormal;
 
@@ -153,8 +152,6 @@ EntityItemID EntityTreeElement::findRayIntersection(const glm::vec3& origin, con
         return result;
     }
 
-    // if the distance to the element cube is not less than the current best distance, then it's not possible
-    // for any details inside the cube to be closer so we don't need to consider them.
     QVariantMap localExtraInfo;
     float distanceToElementDetails = distance;
     EntityItemID entityID = findDetailedRayIntersection(origin, direction, element, distanceToElementDetails,
@@ -285,7 +282,6 @@ EntityItemID EntityTreeElement::findParabolaIntersection(const glm::vec3& origin
     QVariantMap& extraInfo, bool precisionPicking) {
 
     EntityItemID result;
-    float distanceToElementCube = std::numeric_limits<float>::max();
     BoxFace localFace;
     glm::vec3 localSurfaceNormal;
 
@@ -293,8 +289,6 @@ EntityItemID EntityTreeElement::findParabolaIntersection(const glm::vec3& origin
         return result;
     }
 
-    // if the distance to the element cube is not less than the current best distance, then it's not possible
-    // for any details inside the cube to be closer so we don't need to consider them.
     QVariantMap localExtraInfo;
     float distanceToElementDetails = parabolicDistance;
     // We can precompute the world-space parabola normal and reuse it for the parabola plane intersects AABox sphere check

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -215,7 +215,7 @@ EntityItemID EntityTreeElement::findDetailedRayIntersection(const glm::vec3& ori
         float localDistance;
         BoxFace localFace;
         glm::vec3 localSurfaceNormal;
-        if (entityFrameBox.findRayIntersection(entityFrameOrigin, entityFrameDirection, localDistance,
+        if (entityFrameBox.findRayIntersection(entityFrameOrigin, entityFrameDirection, 1.0f / entityFrameDirection, localDistance,
                                                 localFace, localSurfaceNormal)) {
             if (entityFrameBox.contains(entityFrameOrigin) || localDistance < distance) {
                 // now ask the entity if we actually intersect

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -140,27 +140,17 @@ bool EntityTreeElement::bestFitBounds(const glm::vec3& minPoint, const glm::vec3
 }
 
 EntityItemID EntityTreeElement::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
-    bool& keepSearching, OctreeElementPointer& element, float& distance,
-    BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude,
-    const QVector<EntityItemID>& entityIdsToDiscard, bool visibleOnly, bool collidableOnly,
-    QVariantMap& extraInfo, bool precisionPicking) {
+    OctreeElementPointer& element, float& distance, BoxFace& face, glm::vec3& surfaceNormal,
+    const QVector<EntityItemID>& entityIdsToInclude, const QVector<EntityItemID>& entityIdsToDiscard,
+    bool visibleOnly, bool collidableOnly, QVariantMap& extraInfo, bool precisionPicking) {
 
     EntityItemID result;
-    float distanceToElementCube = std::numeric_limits<float>::max();
+    float distanceToElementCube = FLT_MAX;
     BoxFace localFace;
     glm::vec3 localSurfaceNormal;
 
-    // if the ray doesn't intersect with our cube OR the distance to element is less than current best distance
-    // we can stop searching!
-    bool hit = _cube.findRayIntersection(origin, direction, distanceToElementCube, localFace, localSurfaceNormal);
-    if (!hit || (!_cube.contains(origin) && distanceToElementCube > distance)) {
-        keepSearching = false; // no point in continuing to search
-        return result; // we did not intersect
-    }
-
-    // by default, we only allow intersections with leaves with content
     if (!canPickIntersect()) {
-        return result; // we don't intersect with non-leaves, and we keep searching
+        return result;
     }
 
     // if the distance to the element cube is not less than the current best distance, then it's not possible
@@ -289,7 +279,7 @@ bool EntityTreeElement::findSpherePenetration(const glm::vec3& center, float rad
 }
 
 EntityItemID EntityTreeElement::findParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity,
-    const glm::vec3& acceleration, bool& keepSearching, OctreeElementPointer& element, float& parabolicDistance,
+    const glm::vec3& acceleration, OctreeElementPointer& element, float& parabolicDistance,
     BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude,
     const QVector<EntityItemID>& entityIdsToDiscard, bool visibleOnly, bool collidableOnly,
     QVariantMap& extraInfo, bool precisionPicking) {
@@ -299,17 +289,8 @@ EntityItemID EntityTreeElement::findParabolaIntersection(const glm::vec3& origin
     BoxFace localFace;
     glm::vec3 localSurfaceNormal;
 
-    // if the parabola doesn't intersect with our cube OR the distance to element is less than current best distance
-    // we can stop searching!
-    bool hit = _cube.findParabolaIntersection(origin, velocity, acceleration, distanceToElementCube, localFace, localSurfaceNormal);
-    if (!hit || (!_cube.contains(origin) && distanceToElementCube > parabolicDistance)) {
-        keepSearching = false; // no point in continuing to search
-        return result; // we did not intersect
-    }
-
-    // by default, we only allow intersections with leaves with content
     if (!canPickIntersect()) {
-        return result; // we don't intersect with non-leaves, and we keep searching
+        return result;
     }
 
     // if the distance to the element cube is not less than the current best distance, then it's not possible

--- a/libraries/entities/src/EntityTreeElement.h
+++ b/libraries/entities/src/EntityTreeElement.h
@@ -136,10 +136,9 @@ public:
 
     virtual bool canPickIntersect() const override { return hasEntities(); }
     virtual EntityItemID findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
-        bool& keepSearching, OctreeElementPointer& element, float& distance,
-        BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude,
-        const QVector<EntityItemID>& entityIdsToDiscard, bool visibleOnly, bool collidableOnly,
-        QVariantMap& extraInfo, bool precisionPicking = false);
+        OctreeElementPointer& element, float& distance, BoxFace& face, glm::vec3& surfaceNormal,
+        const QVector<EntityItemID>& entityIdsToInclude, const QVector<EntityItemID>& entityIdsToDiscard,
+        bool visibleOnly, bool collidableOnly, QVariantMap& extraInfo, bool precisionPicking = false);
     virtual EntityItemID findDetailedRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
                          OctreeElementPointer& element, float& distance,
                          BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude,
@@ -149,7 +148,7 @@ public:
                         glm::vec3& penetration, void** penetratedObject) const override;
 
     virtual EntityItemID findParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity,
-        const glm::vec3& acceleration, bool& keepSearching, OctreeElementPointer& element, float& parabolicDistance,
+        const glm::vec3& acceleration, OctreeElementPointer& element, float& parabolicDistance,
         BoxFace& face, glm::vec3& surfaceNormal, const QVector<EntityItemID>& entityIdsToInclude,
         const QVector<EntityItemID>& entityIdsToDiscard, bool visibleOnly, bool collidableOnly,
         QVariantMap& extraInfo, bool precisionPicking = false);

--- a/libraries/entities/src/ShapeEntityItem.cpp
+++ b/libraries/entities/src/ShapeEntityItem.cpp
@@ -262,20 +262,18 @@ bool ShapeEntityItem::findDetailedRayIntersection(const glm::vec3& origin, const
     glm::mat4 entityToWorldMatrix = getEntityToWorldMatrix();
     glm::mat4 worldToEntityMatrix = glm::inverse(entityToWorldMatrix);
     glm::vec3 entityFrameOrigin = glm::vec3(worldToEntityMatrix * glm::vec4(origin, 1.0f));
-    glm::vec3 entityFrameDirection = glm::normalize(glm::vec3(worldToEntityMatrix * glm::vec4(direction, 0.0f)));
+    glm::vec3 entityFrameDirection = glm::vec3(worldToEntityMatrix * glm::vec4(direction, 0.0f));
 
-    float localDistance;
     // NOTE: unit sphere has center of 0,0,0 and radius of 0.5
-    if (findRaySphereIntersection(entityFrameOrigin, entityFrameDirection, glm::vec3(0.0f), 0.5f, localDistance)) {
-        // determine where on the unit sphere the hit point occured
-        glm::vec3 entityFrameHitAt = entityFrameOrigin + (entityFrameDirection * localDistance);
-        // then translate back to work coordinates
-        glm::vec3 hitAt = glm::vec3(entityToWorldMatrix * glm::vec4(entityFrameHitAt, 1.0f));
-        distance = glm::distance(origin, hitAt);
+    if (findRaySphereIntersection(entityFrameOrigin, entityFrameDirection, glm::vec3(0.0f), 0.5f, distance)) {
         bool success;
-        // FIXME: this is only correct for uniformly scaled spheres
-        surfaceNormal = glm::normalize(hitAt - getCenterPosition(success));
-        if (!success) {
+        glm::vec3 center = getCenterPosition(success);
+        if (success) {
+            // FIXME: this is only correct for uniformly scaled spheres
+            // determine where on the unit sphere the hit point occured
+            glm::vec3 hitAt = origin + (direction * distance);
+            surfaceNormal = glm::normalize(hitAt - center);
+        } else {
             return false;
         }
         return true;
@@ -297,9 +295,11 @@ bool ShapeEntityItem::findDetailedParabolaIntersection(const glm::vec3& origin, 
     // NOTE: unit sphere has center of 0,0,0 and radius of 0.5
     if (findParabolaSphereIntersection(entityFrameOrigin, entityFrameVelocity, entityFrameAcceleration, glm::vec3(0.0f), 0.5f, parabolicDistance)) {
         bool success;
-        // FIXME: this is only correct for uniformly scaled spheres
-        surfaceNormal = glm::normalize((origin + velocity * parabolicDistance + 0.5f * acceleration * parabolicDistance * parabolicDistance) - getCenterPosition(success));
-        if (!success) {
+        glm::vec3 center = getCenterPosition(success);
+        if (success) {
+            // FIXME: this is only correct for uniformly scaled spheres
+            surfaceNormal = glm::normalize((origin + velocity * parabolicDistance + 0.5f * acceleration * parabolicDistance * parabolicDistance) - center);
+        } else {
             return false;
         }
         return true;

--- a/libraries/octree/src/Octree.cpp
+++ b/libraries/octree/src/Octree.cpp
@@ -68,53 +68,10 @@ Octree::~Octree() {
     eraseAllOctreeElements(false);
 }
 
-
-// Inserts the value and key into three arrays sorted by the key array, the first array is the value,
-// the second array is a sorted key for the value, the third array is the index for the value in it original
-// non-sorted array
-// returns -1 if size exceeded
-// originalIndexArray is optional
-int insertOctreeElementIntoSortedArrays(const OctreeElementPointer& value, float key, int originalIndex,
-                                        OctreeElementPointer* valueArray, float* keyArray, int* originalIndexArray,
-                                        int currentCount, int maxCount) {
-
-    if (currentCount < maxCount) {
-        int i = 0;
-        if (currentCount > 0) {
-            while (i < currentCount && key > keyArray[i]) {
-                i++;
-            }
-            // i is our desired location
-            // shift array elements to the right
-            if (i < currentCount && i+1 < maxCount) {
-                for (int j = currentCount - 1; j > i; j--) {
-                    valueArray[j] = valueArray[j - 1];
-                    keyArray[j] = keyArray[j - 1];
-                }
-            }
-        }
-        // place new element at i
-        valueArray[i] = value;
-        keyArray[i] = key;
-        if (originalIndexArray) {
-            originalIndexArray[i] = originalIndex;
-        }
-        return currentCount + 1;
-    }
-    return -1; // error case
-}
-
-
-
 // Recurses voxel tree calling the RecurseOctreeOperation function for each element.
 // stops recursion if operation function returns false.
 void Octree::recurseTreeWithOperation(const RecurseOctreeOperation& operation, void* extraData) {
     recurseElementWithOperation(_rootElement, operation, extraData);
-}
-
-// Recurses voxel tree calling the RecurseOctreePostFixOperation function for each element in post-fix order.
-void Octree::recurseTreeWithPostOperation(const RecurseOctreeOperation& operation, void* extraData) {
-    recurseElementWithPostOperation(_rootElement, operation, extraData);
 }
 
 // Recurses voxel element with an operation function
@@ -129,71 +86,53 @@ void Octree::recurseElementWithOperation(const OctreeElementPointer& element, co
         for (int i = 0; i < NUMBER_OF_CHILDREN; i++) {
             OctreeElementPointer child = element->getChildAtIndex(i);
             if (child) {
-                recurseElementWithOperation(child, operation, extraData, recursionCount+1);
+                recurseElementWithOperation(child, operation, extraData, recursionCount + 1);
             }
         }
     }
 }
 
-// Recurses voxel element with an operation function
-void Octree::recurseElementWithPostOperation(const OctreeElementPointer& element, const RecurseOctreeOperation& operation,
-                                             void* extraData, int recursionCount) {
+void Octree::recurseTreeWithOperationSorted(const RecurseOctreeOperation& operation, const RecurseOctreeSortingOperation& sortingOperation, void* extraData) {
+    recurseElementWithOperationSorted(_rootElement, operation, sortingOperation, extraData);
+}
+
+// Recurses voxel element with an operation function, calling operation on its children in a specific order
+bool Octree::recurseElementWithOperationSorted(const OctreeElementPointer& element, const RecurseOctreeOperation& operation,
+                                               const RecurseOctreeSortingOperation& sortingOperation, void* extraData, int recursionCount) {
     if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        HIFI_FCDEBUG(octree(), "Octree::recurseElementWithPostOperation() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
-        return;
+        HIFI_FCDEBUG(octree(), "Octree::recurseElementWithOperationSorted() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
+        // If we go too deep, we want to keep searching other paths
+        return true;
     }
 
+    bool keepSearching = operation(element, extraData);
+
+    std::vector<SortedChild> sortedChildren;
     for (int i = 0; i < NUMBER_OF_CHILDREN; i++) {
         OctreeElementPointer child = element->getChildAtIndex(i);
         if (child) {
-            recurseElementWithPostOperation(child, operation, extraData, recursionCount+1);
-        }
-    }
-    operation(element, extraData);
-}
-
-// Recurses voxel tree calling the RecurseOctreeOperation function for each element.
-// stops recursion if operation function returns false.
-void Octree::recurseTreeWithOperationDistanceSorted(const RecurseOctreeOperation& operation,
-                                                       const glm::vec3& point, void* extraData) {
-
-    recurseElementWithOperationDistanceSorted(_rootElement, operation, point, extraData);
-}
-
-// Recurses voxel element with an operation function
-void Octree::recurseElementWithOperationDistanceSorted(const OctreeElementPointer& element, const RecurseOctreeOperation& operation,
-                                                       const glm::vec3& point, void* extraData, int recursionCount) {
-
-    if (recursionCount > DANGEROUSLY_DEEP_RECURSION) {
-        HIFI_FCDEBUG(octree(), "Octree::recurseElementWithOperationDistanceSorted() reached DANGEROUSLY_DEEP_RECURSION, bailing!");
-        return;
-    }
-
-    if (operation(element, extraData)) {
-        // determine the distance sorted order of our children
-        OctreeElementPointer sortedChildren[NUMBER_OF_CHILDREN] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL };
-        float distancesToChildren[NUMBER_OF_CHILDREN] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-        int indexOfChildren[NUMBER_OF_CHILDREN] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-        int currentCount = 0;
-
-        for (int i = 0; i < NUMBER_OF_CHILDREN; i++) {
-            OctreeElementPointer childElement = element->getChildAtIndex(i);
-            if (childElement) {
-                // chance to optimize, doesn't need to be actual distance!! Could be distance squared
-                float distanceSquared = childElement->distanceSquareToPoint(point);
-                currentCount = insertOctreeElementIntoSortedArrays(childElement, distanceSquared, i,
-                                                                   sortedChildren, (float*)&distancesToChildren,
-                                                                   (int*)&indexOfChildren, currentCount, NUMBER_OF_CHILDREN);
-            }
-        }
-
-        for (int i = 0; i < currentCount; i++) {
-            OctreeElementPointer childElement = sortedChildren[i];
-            if (childElement) {
-                recurseElementWithOperationDistanceSorted(childElement, operation, point, extraData);
+            float priority = sortingOperation(child, extraData);
+            if (priority < FLT_MAX) {
+                sortedChildren.emplace_back(priority, child);
             }
         }
     }
+
+    if (sortedChildren.size() > 1) {
+        static auto comparator = [](const SortedChild& left, const SortedChild& right) { return left.first > right.first; };
+        std::sort(sortedChildren.begin(), sortedChildren.end(), comparator);
+    }
+
+    for (auto it = sortedChildren.begin(); it != sortedChildren.end(); ++it) {
+        const SortedChild& sortedChild = *it;
+        // Our children were sorted, so if one hits something, we don't need to check the others
+        if (!recurseElementWithOperationSorted(sortedChild.second, operation, sortingOperation, extraData, recursionCount + 1)) {
+            return false;
+        }
+    }
+    // We checked all our children and didn't find anything.
+    // Stop if we hit something in this element.  Continue if we didn't.
+    return keepSearching;
 }
 
 void Octree::recurseTreeWithOperator(RecurseOctreeOperator* operatorObject) {

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -49,6 +49,9 @@ public:
 
 // Callback function, for recuseTreeWithOperation
 using RecurseOctreeOperation = std::function<bool(const OctreeElementPointer&, void*)>;
+// Function for sorting octree children during recursion.  If return value == FLT_MAX, child is discarded
+using RecurseOctreeSortingOperation = std::function<float(const OctreeElementPointer&, void*)>;
+using SortedChild = std::pair<float, OctreeElementPointer>;
 typedef QHash<uint, AACube> CubeList;
 
 const bool NO_EXISTS_BITS         = false;
@@ -163,16 +166,9 @@ public:
     OctreeElementPointer getOrCreateChildElementContaining(const AACube& box);
 
     void recurseTreeWithOperation(const RecurseOctreeOperation& operation, void* extraData = NULL);
-    void recurseTreeWithPostOperation(const RecurseOctreeOperation& operation, void* extraData = NULL);
-
-    /// \param operation type of operation
-    /// \param point point in world-frame (meters)
-    /// \param extraData hook for user data to be interpreted by special context
-    void recurseTreeWithOperationDistanceSorted(const RecurseOctreeOperation& operation,
-                                                const glm::vec3& point, void* extraData = NULL);
+    void recurseTreeWithOperationSorted(const RecurseOctreeOperation& operation, const RecurseOctreeSortingOperation& sortingOperation, void* extraData = NULL);
 
     void recurseTreeWithOperator(RecurseOctreeOperator* operatorObject);
-
 
     bool isDirty() const { return _isDirty; }
     void clearDirtyBit() { _isDirty = false; }
@@ -227,14 +223,8 @@ public:
 
     void recurseElementWithOperation(const OctreeElementPointer& element, const RecurseOctreeOperation& operation,
                 void* extraData, int recursionCount = 0);
-
-    /// Traverse child nodes of node applying operation in post-fix order
-    ///
-    void recurseElementWithPostOperation(const OctreeElementPointer& element, const RecurseOctreeOperation& operation,
-                void* extraData, int recursionCount = 0);
-
-    void recurseElementWithOperationDistanceSorted(const OctreeElementPointer& element, const RecurseOctreeOperation& operation,
-                const glm::vec3& point, void* extraData, int recursionCount = 0);
+    bool recurseElementWithOperationSorted(const OctreeElementPointer& element, const RecurseOctreeOperation& operation,
+        const RecurseOctreeSortingOperation& sortingOperation, void* extraData, int recursionCount = 0);
 
     bool recurseElementWithOperator(const OctreeElementPointer& element, RecurseOctreeOperator* operatorObject, int recursionCount = 0);
 

--- a/libraries/pointers/src/Pick.cpp
+++ b/libraries/pointers/src/Pick.cpp
@@ -72,11 +72,15 @@ PickResultPointer PickQuery::getPrevPickResult() const {
 void PickQuery::setIgnoreItems(const QVector<QUuid>& ignoreItems) {
     withWriteLock([&] {
         _ignoreItems = ignoreItems;
+        // We sort these items here so the PickCacheOptimizer can catch cases where two picks have the same ignoreItems in a different order
+        std::sort(_ignoreItems.begin(), _ignoreItems.end(), std::less<QUuid>());
     });
 }
 
 void PickQuery::setIncludeItems(const QVector<QUuid>& includeItems) {
     withWriteLock([&] {
         _includeItems = includeItems;
+        // We sort these items here so the PickCacheOptimizer can catch cases where two picks have the same includeItems in a different order
+        std::sort(_includeItems.begin(), _includeItems.end(), std::less<QUuid>());
     });
 }

--- a/libraries/pointers/src/PickCacheOptimizer.h
+++ b/libraries/pointers/src/PickCacheOptimizer.h
@@ -37,7 +37,7 @@ template<typename T>
 class PickCacheOptimizer {
 
 public:
-    void update(std::unordered_map<uint32_t, std::shared_ptr<PickQuery>>& picks, uint32_t& nextToUpdate, uint64_t expiry, bool shouldPickHUD);
+    QVector4D update(std::unordered_map<uint32_t, std::shared_ptr<PickQuery>>& picks, uint32_t& nextToUpdate, uint64_t expiry, bool shouldPickHUD);
 
 protected:
     typedef std::unordered_map<T, std::unordered_map<PickCacheKey, PickResultPointer>> PickCache;
@@ -67,8 +67,9 @@ void PickCacheOptimizer<T>::cacheResult(const bool intersects, const PickResultP
 }
 
 template<typename T>
-void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<PickQuery>>& picks,
+QVector4D PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<PickQuery>>& picks,
         uint32_t& nextToUpdate, uint64_t expiry, bool shouldPickHUD) {
+    QVector4D numIntersectionsComputed;
     PickCache results;
     const uint32_t INVALID_PICK_ID = 0;
     auto itr = picks.begin();
@@ -91,6 +92,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
                 PickCacheKey entityKey = { pick->getFilter().getEntityFlags(), pick->getIncludeItems(), pick->getIgnoreItems() };
                 if (!checkAndCompareCachedResults(mathematicalPick, results, res, entityKey)) {
                     PickResultPointer entityRes = pick->getEntityIntersection(mathematicalPick);
+                    numIntersectionsComputed[0]++;
                     if (entityRes) {
                         cacheResult(entityRes->doesIntersect(), entityRes, entityKey, res, mathematicalPick, results, pick);
                     }
@@ -101,6 +103,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
                 PickCacheKey overlayKey = { pick->getFilter().getOverlayFlags(), pick->getIncludeItems(), pick->getIgnoreItems() };
                 if (!checkAndCompareCachedResults(mathematicalPick, results, res, overlayKey)) {
                     PickResultPointer overlayRes = pick->getOverlayIntersection(mathematicalPick);
+                    numIntersectionsComputed[1]++;
                     if (overlayRes) {
                         cacheResult(overlayRes->doesIntersect(), overlayRes, overlayKey, res, mathematicalPick, results, pick);
                     }
@@ -111,6 +114,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
                 PickCacheKey avatarKey = { pick->getFilter().getAvatarFlags(), pick->getIncludeItems(), pick->getIgnoreItems() };
                 if (!checkAndCompareCachedResults(mathematicalPick, results, res, avatarKey)) {
                     PickResultPointer avatarRes = pick->getAvatarIntersection(mathematicalPick);
+                    numIntersectionsComputed[2]++;
                     if (avatarRes) {
                         cacheResult(avatarRes->doesIntersect(), avatarRes, avatarKey, res, mathematicalPick, results, pick);
                     }
@@ -122,6 +126,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
                 PickCacheKey hudKey = { pick->getFilter().getHUDFlags(), QVector<QUuid>(), QVector<QUuid>() };
                 if (!checkAndCompareCachedResults(mathematicalPick, results, res, hudKey)) {
                     PickResultPointer hudRes = pick->getHUDIntersection(mathematicalPick);
+                    numIntersectionsComputed[3]++;
                     if (hudRes) {
                         cacheResult(true, hudRes, hudKey, res, mathematicalPick, results, pick);
                     }
@@ -145,6 +150,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
             break;
         }
     }
+    return numIntersectionsComputed;
 }
 
 #endif // hifi_PickCacheOptimizer_h

--- a/libraries/pointers/src/PickManager.cpp
+++ b/libraries/pointers/src/PickManager.cpp
@@ -20,6 +20,7 @@ unsigned int PickManager::addPick(PickQuery::PickType type, const std::shared_pt
             id = _nextPickID++;
             _picks[type][id] = pick;
             _typeMap[id] = type;
+            _totalPickCounts[type]++;
         }
     });
     return id;
@@ -41,6 +42,7 @@ void PickManager::removePick(unsigned int uid) {
         if (type != _typeMap.end()) {
             _picks[type->second].erase(uid);
             _typeMap.erase(uid);
+            _totalPickCounts[type->second]--;
         }
     });
 }
@@ -96,12 +98,12 @@ void PickManager::update() {
     });
 
     bool shouldPickHUD = _shouldPickHUDOperator();
-    // we pass the same expiry to both updates, but the stylus updates are relatively cheap
-    // and the rayPicks updae will ALWAYS update at least one ray even when there is no budget
-    _stylusPickCacheOptimizer.update(cachedPicks[PickQuery::Stylus], _nextPickToUpdate[PickQuery::Stylus], expiry, false);
-    _rayPickCacheOptimizer.update(cachedPicks[PickQuery::Ray], _nextPickToUpdate[PickQuery::Ray], expiry, shouldPickHUD);
-    _parabolaPickCacheOptimizer.update(cachedPicks[PickQuery::Parabola], _nextPickToUpdate[PickQuery::Parabola], expiry, shouldPickHUD);
-    _collisionPickCacheOptimizer.update(cachedPicks[PickQuery::Collision], _nextPickToUpdate[PickQuery::Collision], expiry, false);
+    // FIXME: give each type its own expiry
+    // Each type will update at least one pick, regardless of the expiry
+    _updatedPickCounts[PickQuery::Stylus] = _stylusPickCacheOptimizer.update(cachedPicks[PickQuery::Stylus], _nextPickToUpdate[PickQuery::Stylus], expiry, false);
+    _updatedPickCounts[PickQuery::Ray] = _rayPickCacheOptimizer.update(cachedPicks[PickQuery::Ray], _nextPickToUpdate[PickQuery::Ray], expiry, shouldPickHUD);
+    _updatedPickCounts[PickQuery::Parabola] = _parabolaPickCacheOptimizer.update(cachedPicks[PickQuery::Parabola], _nextPickToUpdate[PickQuery::Parabola], expiry, shouldPickHUD);
+    _updatedPickCounts[PickQuery::Collision] = _collisionPickCacheOptimizer.update(cachedPicks[PickQuery::Collision], _nextPickToUpdate[PickQuery::Collision], expiry, false);
 }
 
 bool PickManager::isLeftHand(unsigned int uid) {

--- a/libraries/pointers/src/PickManager.h
+++ b/libraries/pointers/src/PickManager.h
@@ -58,10 +58,16 @@ public:
 
     bool getForceCoarsePicking() { return _forceCoarsePicking; }
 
+    const std::vector<QVector4D>& getUpdatedPickCounts() { return _updatedPickCounts; }
+    const std::vector<int>& getTotalPickCounts() { return _totalPickCounts; }
+
 public slots:
     void setForceCoarsePicking(bool forceCoarsePicking) { _forceCoarsePicking = forceCoarsePicking; }
 
 protected:
+    std::vector<QVector4D> _updatedPickCounts { PickQuery::NUM_PICK_TYPES };
+    std::vector<int> _totalPickCounts { 0, 0, 0, 0 };
+
     bool _forceCoarsePicking { false };
     std::function<bool()> _shouldPickHUDOperator;
     std::function<glm::vec2(const glm::vec3&)> _calculatePos2DFromHUDOperator;

--- a/libraries/pointers/src/PickManager.h
+++ b/libraries/pointers/src/PickManager.h
@@ -16,7 +16,10 @@
 
 #include <NumericalConstants.h>
 
-class PickManager : public Dependency, protected ReadWriteLockable {
+#include <QObject>
+
+class PickManager : public QObject, public Dependency, protected ReadWriteLockable {
+    Q_OBJECT
     SINGLETON_DEPENDENCY
 
 public:
@@ -53,7 +56,13 @@ public:
     unsigned int getPerFrameTimeBudget() const { return _perFrameTimeBudget; }
     void setPerFrameTimeBudget(unsigned int numUsecs) { _perFrameTimeBudget = numUsecs; }
 
+    bool getForceCoarsePicking() { return _forceCoarsePicking; }
+
+public slots:
+    void setForceCoarsePicking(bool forceCoarsePicking) { _forceCoarsePicking = forceCoarsePicking; }
+
 protected:
+    bool _forceCoarsePicking { false };
     std::function<bool()> _shouldPickHUDOperator;
     std::function<glm::vec2(const glm::vec3&)> _calculatePos2DFromHUDOperator;
 

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -385,9 +385,9 @@ bool Model::findRayIntersectionAgainstSubMeshes(const glm::vec3& origin, const g
         Triangle bestWorldTriangle;
         glm::vec3 bestWorldIntersectionPoint;
         glm::vec3 bestMeshIntersectionPoint;
-        int bestPartIndex;
-        int bestShapeID;
-        int bestSubMeshIndex;
+        int bestPartIndex = 0;
+        int bestShapeID = 0;
+        int bestSubMeshIndex = 0;
 
         const FBXGeometry& geometry = getFBXGeometry();
         if (!_triangleSetsValid) {
@@ -527,9 +527,9 @@ bool Model::findParabolaIntersectionAgainstSubMeshes(const glm::vec3& origin, co
         Triangle bestWorldTriangle;
         glm::vec3 bestWorldIntersectionPoint;
         glm::vec3 bestMeshIntersectionPoint;
-        int bestPartIndex;
-        int bestShapeID;
-        int bestSubMeshIndex;
+        int bestPartIndex = 0;
+        int bestShapeID = 0;
+        int bestSubMeshIndex = 0;
 
         const FBXGeometry& geometry = getFBXGeometry();
         if (!_triangleSetsValid) {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -376,7 +376,7 @@ bool Model::findRayIntersectionAgainstSubMeshes(const glm::vec3& origin, const g
 
     // we can use the AABox's intersection by mapping our origin and direction into the model frame
     // and testing intersection there.
-    if (modelFrameBox.findRayIntersection(modelFrameOrigin, modelFrameDirection, distance, face, surfaceNormal)) {
+    if (modelFrameBox.findRayIntersection(modelFrameOrigin, modelFrameDirection, 1.0f / modelFrameDirection, distance, face, surfaceNormal)) {
         QMutexLocker locker(&_mutex);
 
         float bestDistance = FLT_MAX;
@@ -400,6 +400,7 @@ bool Model::findRayIntersectionAgainstSubMeshes(const glm::vec3& origin, const g
 
         glm::vec3 meshFrameOrigin = glm::vec3(worldToMeshMatrix * glm::vec4(origin, 1.0f));
         glm::vec3 meshFrameDirection = glm::vec3(worldToMeshMatrix * glm::vec4(direction, 0.0f));
+        glm::vec3 meshFrameInvDirection = 1.0f / meshFrameDirection;
 
         int shapeID = 0;
         int subMeshIndex = 0;
@@ -415,8 +416,8 @@ bool Model::findRayIntersectionAgainstSubMeshes(const glm::vec3& origin, const g
                     float partBoundDistance = FLT_MAX;
                     BoxFace partBoundFace;
                     glm::vec3 partBoundNormal;
-                    if (partTriangleSet.getBounds().findRayIntersection(meshFrameOrigin, meshFrameDirection, partBoundDistance,
-                                                                        partBoundFace, partBoundNormal)) {
+                    if (partTriangleSet.getBounds().findRayIntersection(meshFrameOrigin, meshFrameDirection, meshFrameInvDirection,
+                                                                        partBoundDistance, partBoundFace, partBoundNormal)) {
                         priority = partBoundDistance;
                     }
                 }
@@ -444,7 +445,7 @@ bool Model::findRayIntersectionAgainstSubMeshes(const glm::vec3& origin, const g
             float triangleSetDistance = FLT_MAX;
             BoxFace triangleSetFace;
             Triangle triangleSetTriangle;
-            if (sortedTriangleSet.triangleSet->findRayIntersection(meshFrameOrigin, meshFrameDirection, triangleSetDistance, triangleSetFace,
+            if (sortedTriangleSet.triangleSet->findRayIntersection(meshFrameOrigin, meshFrameDirection, meshFrameInvDirection, triangleSetDistance, triangleSetFace,
                                                                    triangleSetTriangle, pickAgainstTriangles, allowBackface)) {
                 if (triangleSetDistance < bestDistance) {
                     bestDistance = triangleSetDistance;

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -64,6 +64,16 @@ class Model;
 using ModelPointer = std::shared_ptr<Model>;
 using ModelWeakPointer = std::weak_ptr<Model>;
 
+struct SortedTriangleSet {
+    SortedTriangleSet(float distance, TriangleSet* triangleSet, int partIndex, int shapeID, int subMeshIndex) :
+        distance(distance), triangleSet(triangleSet), partIndex(partIndex), shapeID(shapeID), subMeshIndex(subMeshIndex) {}
+
+    float distance;
+    TriangleSet* triangleSet;
+    int partIndex;
+    int shapeID;
+    int subMeshIndex;
+};
 
 /// A generic 3D model displaying geometry loaded from a URL.
 class Model : public QObject, public std::enable_shared_from_this<Model>, public scriptable::ModelProvider {

--- a/libraries/render-utils/src/PickItemsJob.cpp
+++ b/libraries/render-utils/src/PickItemsJob.cpp
@@ -33,6 +33,7 @@ void PickItemsJob::run(const render::RenderContextPointer& renderContext, const 
 render::ItemBound PickItemsJob::findNearestItem(const render::RenderContextPointer& renderContext, const render::ItemBounds& inputs, float& minIsectDistance) const {
     const glm::vec3 rayOrigin = renderContext->args->getViewFrustum().getPosition();
     const glm::vec3 rayDirection = renderContext->args->getViewFrustum().getDirection();
+    const glm::vec3 rayInvDirection = 1.0f / rayDirection;
     BoxFace face;
     glm::vec3 normal;
     float isectDistance;
@@ -42,7 +43,7 @@ render::ItemBound PickItemsJob::findNearestItem(const render::RenderContextPoint
     render::ItemKey itemKey;
 
     for (const auto& itemBound : inputs) {
-        if (!itemBound.bound.contains(rayOrigin) && itemBound.bound.findRayIntersection(rayOrigin, rayDirection, isectDistance, face, normal)) {
+        if (!itemBound.bound.contains(rayOrigin) && itemBound.bound.findRayIntersection(rayOrigin, rayDirection, rayInvDirection, isectDistance, face, normal)) {
             auto& item = renderContext->_scene->getItem(itemBound.id);
             itemKey = item.getKey();
             if (itemKey.isWorldSpace() && isectDistance>minDistance && isectDistance < minIsectDistance && isectDistance<maxDistance

--- a/libraries/shared/src/AABox.cpp
+++ b/libraries/shared/src/AABox.cpp
@@ -192,9 +192,9 @@ bool AABox::expandedIntersectsSegment(const glm::vec3& start, const glm::vec3& e
                 isWithin(start.x + axisDistance*direction.x, expandedCorner.x, expandedSize.x));
 }
 
-bool AABox::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
-                                BoxFace& face, glm::vec3& surfaceNormal) const {
-    return findRayAABoxIntersection(origin, direction, _corner, _scale, distance, face, surfaceNormal);
+bool AABox::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& invDirection,
+                                float& distance, BoxFace& face, glm::vec3& surfaceNormal) const {
+    return findRayAABoxIntersection(origin, direction, invDirection, _corner, _scale, distance, face, surfaceNormal);
 }
 
 bool AABox::findParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity, const glm::vec3& acceleration,

--- a/libraries/shared/src/AABox.h
+++ b/libraries/shared/src/AABox.h
@@ -69,7 +69,7 @@ public:
 
     bool expandedContains(const glm::vec3& point, float expansion) const;
     bool expandedIntersectsSegment(const glm::vec3& start, const glm::vec3& end, float expansion) const;
-    bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
+    bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& invDirection, float& distance,
                              BoxFace& face, glm::vec3& surfaceNormal) const;
     bool findParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity, const glm::vec3& acceleration,
                                   float& parabolicDistance, BoxFace& face, glm::vec3& surfaceNormal) const;

--- a/libraries/shared/src/AACube.cpp
+++ b/libraries/shared/src/AACube.cpp
@@ -187,9 +187,9 @@ bool AACube::expandedIntersectsSegment(const glm::vec3& start, const glm::vec3& 
                 isWithin(start.x + axisDistance*direction.x, expandedCorner.x, expandedSize.x));
 }
 
-bool AACube::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance, 
-                                    BoxFace& face, glm::vec3& surfaceNormal) const {
-    return findRayAABoxIntersection(origin, direction, _corner, glm::vec3(_scale), distance, face, surfaceNormal);
+bool AACube::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& invDirection,
+                                 float& distance, BoxFace& face, glm::vec3& surfaceNormal) const {
+    return findRayAABoxIntersection(origin, direction, invDirection, _corner, glm::vec3(_scale), distance, face, surfaceNormal);
 }
 
 bool AACube::findParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity, const glm::vec3& acceleration,

--- a/libraries/shared/src/AACube.h
+++ b/libraries/shared/src/AACube.h
@@ -56,10 +56,10 @@ public:
     bool touches(const AABox& otherBox) const;
     bool expandedContains(const glm::vec3& point, float expansion) const;
     bool expandedIntersectsSegment(const glm::vec3& start, const glm::vec3& end, float expansion) const;
-    bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
-                                BoxFace& face, glm::vec3& surfaceNormal) const;
+    bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& invDirection,
+                             float& distance, BoxFace& face, glm::vec3& surfaceNormal) const;
     bool findParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity, const glm::vec3& acceleration,
-                                float& parabolicDistance, BoxFace& face, glm::vec3& surfaceNormal) const;
+                                  float& parabolicDistance, BoxFace& face, glm::vec3& surfaceNormal) const;
     bool touchesSphere(const glm::vec3& center, float radius) const;
     bool findSpherePenetration(const glm::vec3& center, float radius, glm::vec3& penetration) const;
     bool findCapsulePenetration(const glm::vec3& start, const glm::vec3& end, float radius, glm::vec3& penetration) const;

--- a/libraries/shared/src/GeometryUtil.cpp
+++ b/libraries/shared/src/GeometryUtil.cpp
@@ -286,12 +286,13 @@ bool findRaySphereIntersection(const glm::vec3& origin, const glm::vec3& directi
         distance = 0.0f;
         return true; // starts inside the sphere
     }
-    float b = glm::dot(direction, relativeOrigin);
-    float radicand = b * b - c;
+    float b = 2.0f * glm::dot(direction, relativeOrigin);
+    float a = glm::dot(direction, direction);
+    float radicand = b * b - 4.0f * a * c;
     if (radicand < 0.0f) {
         return false; // doesn't hit the sphere
     }
-    float t = -b - sqrtf(radicand);
+    float t = 0.5f * (-b - sqrtf(radicand)) / a;
     if (t < 0.0f) {
         return false; // doesn't hit the sphere
     }

--- a/libraries/shared/src/GeometryUtil.h
+++ b/libraries/shared/src/GeometryUtil.h
@@ -76,8 +76,8 @@ glm::vec3 addPenetrations(const glm::vec3& currentPenetration, const glm::vec3& 
 
 bool findIntersection(float origin, float direction, float corner, float size, float& distance);
 bool findInsideOutIntersection(float origin, float direction, float corner, float size, float& distance);
-bool findRayAABoxIntersection(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& corner, const glm::vec3& scale, float& distance,
-                              BoxFace& face, glm::vec3& surfaceNormal);
+bool findRayAABoxIntersection(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& invDirection,
+                              const glm::vec3& corner, const glm::vec3& scale, float& distance, BoxFace& face, glm::vec3& surfaceNormal);
 
 bool findRaySphereIntersection(const glm::vec3& origin, const glm::vec3& direction,
     const glm::vec3& center, float radius, float& distance);

--- a/libraries/shared/src/TriangleSet.cpp
+++ b/libraries/shared/src/TriangleSet.cpp
@@ -176,7 +176,7 @@ void TriangleSet::TriangleTreeCell::insert(size_t triangleIndex) {
     _triangleIndices.push_back(triangleIndex);
 }
 
-bool TriangleSet::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
+bool TriangleSet::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& invDirection, float& distance,
                                       BoxFace& face, Triangle& triangle, bool precision, bool allowBackface) {
     if (!_isBalanced) {
         balanceTree();
@@ -184,7 +184,7 @@ bool TriangleSet::findRayIntersection(const glm::vec3& origin, const glm::vec3& 
 
     float localDistance = distance;
     int trianglesTouched = 0;
-    bool hit = _triangleTree.findRayIntersection(origin, direction, localDistance, face, triangle, precision, trianglesTouched, allowBackface);
+    bool hit = _triangleTree.findRayIntersection(origin, direction, invDirection, localDistance, face, triangle, precision, trianglesTouched, allowBackface);
     if (hit) {
         distance = localDistance;
     }
@@ -232,9 +232,9 @@ bool TriangleSet::TriangleTreeCell::findRayIntersectionInternal(const glm::vec3&
     return intersectedSomething;
 }
 
-bool TriangleSet::TriangleTreeCell::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, float& distance,
-                                                          BoxFace& face, Triangle& triangle, bool precision, int& trianglesTouched,
-                                                          bool allowBackface) {
+bool TriangleSet::TriangleTreeCell::findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& invDirection,
+                                                        float& distance, BoxFace& face, Triangle& triangle, bool precision, int& trianglesTouched,
+                                                        bool allowBackface) {
     if (_population < 1) {
         return false; // no triangles below here, so we can't intersect
     }
@@ -270,7 +270,7 @@ bool TriangleSet::TriangleTreeCell::findRayIntersection(const glm::vec3& origin,
                     float childBoundDistance = FLT_MAX;
                     BoxFace childBoundFace;
                     glm::vec3 childBoundNormal;
-                    if (child->getBounds().findRayIntersection(origin, direction, childBoundDistance, childBoundFace, childBoundNormal)) {
+                    if (child->getBounds().findRayIntersection(origin, direction, invDirection, childBoundDistance, childBoundFace, childBoundNormal)) {
                         // We only need to add this cell if it's closer than the local triangle set intersection (if there was one)
                         if (childBoundDistance < bestLocalDistance) {
                             priority = childBoundDistance;
@@ -301,11 +301,11 @@ bool TriangleSet::TriangleTreeCell::findRayIntersection(const glm::vec3& origin,
             if (!precision && childDistance < EPSILON) {
                 BoxFace childBoundFace;
                 glm::vec3 childBoundNormal;
-                sortedTriangleCell.second->getBounds().findRayIntersection(origin, direction, childDistance, childBoundFace, childBoundNormal);
+                sortedTriangleCell.second->getBounds().findRayIntersection(origin, direction, invDirection, childDistance, childBoundFace, childBoundNormal);
             }
             BoxFace childFace;
             Triangle childTriangle;
-            if (sortedTriangleCell.second->findRayIntersection(origin, direction, childDistance, childFace, childTriangle, precision, trianglesTouched)) {
+            if (sortedTriangleCell.second->findRayIntersection(origin, direction, invDirection, childDistance, childFace, childTriangle, precision, trianglesTouched)) {
                 if (childDistance < bestLocalDistance) {
                     bestLocalDistance = childDistance;
                     bestLocalFace = childFace;

--- a/libraries/shared/src/TriangleSet.h
+++ b/libraries/shared/src/TriangleSet.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <vector>
+#include <memory>
 
 #include "AABox.h"
 #include "GeometryUtil.h"
@@ -20,9 +21,8 @@ class TriangleSet {
 
     class TriangleOctreeCell {
     public:
-        TriangleOctreeCell(std::vector<Triangle>& allTriangles) :
-            _allTriangles(allTriangles)
-        { }
+        TriangleOctreeCell(std::vector<Triangle>& allTriangles) : _allTriangles(allTriangles) {}
+        TriangleOctreeCell(std::vector<Triangle>& allTriangles, const AABox& bounds, int depth);
 
         void insert(size_t triangleIndex);
         void reset(const AABox& bounds, int depth = 0);
@@ -40,8 +40,6 @@ class TriangleSet {
         void debugDump();
 
     protected:
-        TriangleOctreeCell(std::vector<Triangle>& allTriangles, const AABox& bounds, int depth);
-
         // checks our internal list of triangles
         bool findRayIntersectionInternal(const glm::vec3& origin, const glm::vec3& direction,
             float& distance, BoxFace& face, Triangle& triangle, bool precision, int& trianglesTouched,
@@ -50,20 +48,22 @@ class TriangleSet {
             float& parabolicDistance, BoxFace& face, Triangle& triangle, bool precision, int& trianglesTouched,
             bool allowBackface = false);
 
+        std::pair<AABox, AABox> getTriangleOctreeCellChildBounds();
+
         std::vector<Triangle>& _allTriangles;
-        std::map<AABox::OctreeChild, TriangleOctreeCell> _children;
-        int _depth{ 0 };
-        int _population{ 0 };
+        std::pair<std::shared_ptr<TriangleOctreeCell>, std::shared_ptr<TriangleOctreeCell>> _children;
+        int _depth { 0 };
+        int _population { 0 };
         AABox _bounds;
         std::vector<size_t> _triangleIndices;
 
         friend class TriangleSet;
     };
 
+    using SortedTriangleCell = std::pair<float, std::shared_ptr<TriangleOctreeCell>>;
+
 public:
-    TriangleSet() :
-        _triangleOctree(_triangles)
-    {}
+    TriangleSet() : _triangleOctree(_triangles) {}
 
     void debugDump();
 
@@ -87,8 +87,7 @@ public:
     const AABox& getBounds() const { return _bounds; }
 
 protected:
-
-    bool _isBalanced{ false };
+    bool _isBalanced { false };
     std::vector<Triangle> _triangles;
     TriangleOctreeCell _triangleOctree;
     AABox _bounds;

--- a/libraries/shared/src/TriangleSet.h
+++ b/libraries/shared/src/TriangleSet.h
@@ -19,10 +19,10 @@
 
 class TriangleSet {
 
-    class TriangleOctreeCell {
+    class TriangleTreeCell {
     public:
-        TriangleOctreeCell(std::vector<Triangle>& allTriangles) : _allTriangles(allTriangles) {}
-        TriangleOctreeCell(std::vector<Triangle>& allTriangles, const AABox& bounds, int depth);
+        TriangleTreeCell(std::vector<Triangle>& allTriangles) : _allTriangles(allTriangles) {}
+        TriangleTreeCell(std::vector<Triangle>& allTriangles, const AABox& bounds, int depth);
 
         void insert(size_t triangleIndex);
         void reset(const AABox& bounds, int depth = 0);
@@ -48,10 +48,10 @@ class TriangleSet {
             float& parabolicDistance, BoxFace& face, Triangle& triangle, bool precision, int& trianglesTouched,
             bool allowBackface = false);
 
-        std::pair<AABox, AABox> getTriangleOctreeCellChildBounds();
+        std::pair<AABox, AABox> getTriangleTreeCellChildBounds();
 
         std::vector<Triangle>& _allTriangles;
-        std::pair<std::shared_ptr<TriangleOctreeCell>, std::shared_ptr<TriangleOctreeCell>> _children;
+        std::pair<std::shared_ptr<TriangleTreeCell>, std::shared_ptr<TriangleTreeCell>> _children;
         int _depth { 0 };
         int _population { 0 };
         AABox _bounds;
@@ -60,10 +60,10 @@ class TriangleSet {
         friend class TriangleSet;
     };
 
-    using SortedTriangleCell = std::pair<float, std::shared_ptr<TriangleOctreeCell>>;
+    using SortedTriangleCell = std::pair<float, std::shared_ptr<TriangleTreeCell>>;
 
 public:
-    TriangleSet() : _triangleOctree(_triangles) {}
+    TriangleSet() : _triangleTree(_triangles) {}
 
     void debugDump();
 
@@ -74,7 +74,7 @@ public:
     bool findParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity, const glm::vec3& acceleration,
         float& parabolicDistance, BoxFace& face, Triangle& triangle, bool precision, bool allowBackface = false);
 
-    void balanceOctree();
+    void balanceTree();
 
     void reserve(size_t size) { _triangles.reserve(size); } // reserve space in the datastructure for size number of triangles
     size_t size() const { return _triangles.size(); }
@@ -89,6 +89,6 @@ public:
 protected:
     bool _isBalanced { false };
     std::vector<Triangle> _triangles;
-    TriangleOctreeCell _triangleOctree;
+    TriangleTreeCell _triangleTree;
     AABox _bounds;
 };

--- a/libraries/shared/src/TriangleSet.h
+++ b/libraries/shared/src/TriangleSet.h
@@ -28,7 +28,7 @@ class TriangleSet {
         void reset(const AABox& bounds, int depth = 0);
         void clear();
 
-        bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
+        bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& invDirection,
             float& distance, BoxFace& face, Triangle& triangle, bool precision, int& trianglesTouched,
             bool allowBackface = false);
         bool findParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity, const glm::vec3& acceleration,
@@ -69,7 +69,7 @@ public:
 
     void insert(const Triangle& t);
 
-    bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction,
+    bool findRayIntersection(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& invDirection,
         float& distance, BoxFace& face, Triangle& triangle, bool precision, bool allowBackface = false);
     bool findParabolaIntersection(const glm::vec3& origin, const glm::vec3& velocity, const glm::vec3& acceleration,
         float& parabolicDistance, BoxFace& face, Triangle& triangle, bool precision, bool allowBackface = false);


### PR DESCRIPTION
Improves picking performance in certain cases:
- Octree cells are recursed in order of bounding box distance, instead of always in the same order, so farther cells don't need to be checked
- Model TriangleSets are checked in order of bounding box distance, instead of in a random order.
- TriangleSets store triangles in a simple k-d tree, instead of an octree, for a better distribution of triangles.  Cells are always split in half along the longest dimension.  When walking the tree, the two children are sorted by bounding box distance.
- Avatars are checked in order of capsule distance, instead of always checking all of them.
- Faster triangle intersection code (Möller-Trumbore)
- https://highfidelity.manuscript.com/f/cases/17116/implement-faster-ray-box-algorithm

Adds a menu option (Developer -> Picking -> Force Coarse Picking) to force Picks to always do coarse intersection, so we can see the price of precise picking against models.

Test plan:
- Run the https://github.com/highfidelity/hifi_tests/tree/master/tests/engine/interaction/pointer tests.
- In an HMD, use far grab and teleport and verify that they work as in master.
- Go to a completely empty domain.
- Make sure you only have default scripts running and open the expanded stats.  At the bottom of the first column, you should see "Intersection calls:" and then below that, "Rays".  It should say 6/4/0/0.
- Run [this](https://gist.githubusercontent.com/SamGondelman/4a2eb74273cf19c58d8ff933db0f8e7c/raw/1f40ece4364de73259fd3efee43c1645713870b5/PickPerformanceTest.js).  You should see lots of models appear in front of you.  (If necessary, open up the LOD tools (Developer -> Render -> LOD Tools), set it to manual, and move the slider all the way to the right, so the LOD stops oscillating.)
- You should see 7/4/0/0 in that row.
- In desktop, move to each corner of the cube of models and point towards the center, so the ray from your mouse would intersect the longest line of models.  You should see a blue sphere obstructing your view and another blue sphere at the intersection point, if there is one.  Watch the pickManager time in the first column and wait for it to settle.  Record it for each corner of the cube.

Compare to https://github.com/highfidelity/hifi/pull/13876/:
- In https://github.com/highfidelity/hifi/pull/13876/, running that script, the stats should say 8/4/0/0
- Repeat the last step from above with https://github.com/highfidelity/hifi/pull/13876/.  The times should be higher in that PR, usually by a factor of about 2-3.