### PR TITLE
Collision Pick Parenting

### DIFF
--- a/interface/src/avatar/MyAvatarHeadTransformNode.cpp
+++ b/interface/src/avatar/MyAvatarHeadTransformNode.cpp
@@ -1,0 +1,23 @@
+//
+//  Created by Sabrina Shanman 8/14/2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "MyAvatarHeadTransformNode.h"
+
+#include "DependencyManager.h"
+#include "AvatarManager.h"
+#include "MyAvatar.h"
+
+Transform MyAvatarHeadTransformNode::getTransform() {
+    auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+
+    glm::vec3 pos = myAvatar->getHeadPosition();
+    glm::quat headOri = myAvatar->getHeadOrientation();
+    glm::quat ori = headOri * glm::angleAxis(-PI / 2.0f, Vectors::RIGHT);
+
+    return Transform(ori, myAvatar->scaleForChildren(), pos);
+}

--- a/interface/src/avatar/MyAvatarHeadTransformNode.cpp
+++ b/interface/src/avatar/MyAvatarHeadTransformNode.cpp
@@ -19,5 +19,5 @@ Transform MyAvatarHeadTransformNode::getTransform() {
     glm::quat headOri = myAvatar->getHeadOrientation();
     glm::quat ori = headOri * glm::angleAxis(-PI / 2.0f, Vectors::RIGHT);
 
-    return Transform(ori, myAvatar->scaleForChildren(), pos);
+    return Transform(ori, glm::vec3(1.0f), pos);
 }

--- a/interface/src/avatar/MyAvatarHeadTransformNode.h
+++ b/interface/src/avatar/MyAvatarHeadTransformNode.h
@@ -1,0 +1,19 @@
+//
+//  Created by Sabrina Shanman 8/14/2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#ifndef hifi_MyAvatarHeadTransformNode_h
+#define hifi_MyAvatarHeadTransformNode_h
+
+#include "TransformNode.h"
+
+class MyAvatarHeadTransformNode : public TransformNode {
+public:
+    MyAvatarHeadTransformNode() { }
+    Transform getTransform() override;
+};
+
+#endif // hifi_MyAvatarHeadTransformNode_h

--- a/interface/src/raypick/CollisionPick.cpp
+++ b/interface/src/raypick/CollisionPick.cpp
@@ -356,9 +356,7 @@ CollisionPick::CollisionPick(const PickFilter& filter, float maxDistance, bool e
 
 CollisionRegion CollisionPick::getMathematicalPick() const {
     CollisionRegion mathPick = _mathPick;
-    if (!mathPick.loaded) {
-        mathPick.loaded = isLoaded();
-    }
+    mathPick.loaded = isLoaded();
     if (!parentTransform) {
         return mathPick;
     } else {

--- a/interface/src/raypick/CollisionPick.cpp
+++ b/interface/src/raypick/CollisionPick.cpp
@@ -421,7 +421,5 @@ PickResultPointer CollisionPick::getHUDIntersection(const CollisionRegion& pick)
 }
 
 Transform CollisionPick::getResultTransform() const {
-    Transform transform;
-    transform.setTranslation(getMathematicalPick().transform.getTranslation());
-    return transform;
+    return Transform(getMathematicalPick().transform);
 }

--- a/interface/src/raypick/CollisionPick.cpp
+++ b/interface/src/raypick/CollisionPick.cpp
@@ -94,8 +94,7 @@ bool CollisionPick::getShapeInfoReady() {
         }
 
         return false;
-    }
-    else {
+    } else {
         computeShapeInfoDimensionsOnly(_mathPick, *_mathPick.shapeInfo, _cachedResource);
         return true;
     }

--- a/interface/src/raypick/CollisionPick.cpp
+++ b/interface/src/raypick/CollisionPick.cpp
@@ -423,11 +423,6 @@ PickResultPointer CollisionPick::getHUDIntersection(const CollisionRegion& pick)
 }
 
 Transform CollisionPick::getResultTransform() const {
-    PickResultPointer result = getPrevPickResult();
-    if (!result) {
-        return Transform();
-    }
-
     Transform transform;
     transform.setTranslation(getMathematicalPick().transform.getTranslation());
     return transform;

--- a/interface/src/raypick/CollisionPick.cpp
+++ b/interface/src/raypick/CollisionPick.cpp
@@ -391,7 +391,7 @@ PickResultPointer CollisionPick::getEntityIntersection(const CollisionRegion& pi
         return std::make_shared<CollisionPickResult>(pick.toVariantMap(), CollisionPickResult::LOAD_STATE_NOT_LOADED, std::vector<ContactTestResult>(), std::vector<ContactTestResult>());
     }
     
-    auto entityIntersections = _physicsEngine->contactTest(USER_COLLISION_MASK_ENTITIES, *pick.shapeInfo, pick.transform);
+    auto entityIntersections = _physicsEngine->contactTest(USER_COLLISION_MASK_ENTITIES, *pick.shapeInfo, pick.transform, USER_COLLISION_GROUP_DYNAMIC, pick.threshold);
     filterIntersections(entityIntersections);
     return std::make_shared<CollisionPickResult>(pick, CollisionPickResult::LOAD_STATE_LOADED, entityIntersections, std::vector<ContactTestResult>());
 }
@@ -406,7 +406,7 @@ PickResultPointer CollisionPick::getAvatarIntersection(const CollisionRegion& pi
         return std::make_shared<CollisionPickResult>(pick, CollisionPickResult::LOAD_STATE_NOT_LOADED, std::vector<ContactTestResult>(), std::vector<ContactTestResult>());
     }
     
-    auto avatarIntersections = _physicsEngine->contactTest(USER_COLLISION_MASK_AVATARS, *pick.shapeInfo, pick.transform);
+    auto avatarIntersections = _physicsEngine->contactTest(USER_COLLISION_MASK_AVATARS, *pick.shapeInfo, pick.transform, USER_COLLISION_GROUP_DYNAMIC, pick.threshold);
     filterIntersections(avatarIntersections);
     return std::make_shared<CollisionPickResult>(pick, CollisionPickResult::LOAD_STATE_LOADED, std::vector<ContactTestResult>(), avatarIntersections);
 }

--- a/interface/src/raypick/CollisionPick.h
+++ b/interface/src/raypick/CollisionPick.h
@@ -16,18 +16,11 @@
 
 class CollisionPickResult : public PickResult {
 public:
-    enum LoadState {
-        LOAD_STATE_UNKNOWN,
-        LOAD_STATE_NOT_LOADED,
-        LOAD_STATE_LOADED
-    };
-
     CollisionPickResult() {}
     CollisionPickResult(const QVariantMap& pickVariant) : PickResult(pickVariant) {}
 
-    CollisionPickResult(const CollisionRegion& searchRegion, LoadState loadState, const std::vector<ContactTestResult>& entityIntersections, const std::vector<ContactTestResult>& avatarIntersections) :
+    CollisionPickResult(const CollisionRegion& searchRegion, const std::vector<ContactTestResult>& entityIntersections, const std::vector<ContactTestResult>& avatarIntersections) :
         PickResult(searchRegion.toVariantMap()),
-        loadState(loadState),
         intersects(entityIntersections.size() || avatarIntersections.size()),
         entityIntersections(entityIntersections),
         avatarIntersections(avatarIntersections)
@@ -38,10 +31,8 @@ public:
         avatarIntersections = collisionPickResult.avatarIntersections;
         entityIntersections = collisionPickResult.entityIntersections;
         intersects = collisionPickResult.intersects;
-        loadState = collisionPickResult.loadState;
     }
 
-    LoadState loadState { LOAD_STATE_UNKNOWN };
     bool intersects { false };
     std::vector<ContactTestResult> entityIntersections;
     std::vector<ContactTestResult> avatarIntersections;
@@ -61,7 +52,7 @@ public:
 
     CollisionRegion getMathematicalPick() const override;
     PickResultPointer getDefaultResult(const QVariantMap& pickVariant) const override {
-        return std::make_shared<CollisionPickResult>(pickVariant, CollisionPickResult::LOAD_STATE_UNKNOWN, std::vector<ContactTestResult>(), std::vector<ContactTestResult>());
+        return std::make_shared<CollisionPickResult>(pickVariant, std::vector<ContactTestResult>(), std::vector<ContactTestResult>());
     }
     PickResultPointer getEntityIntersection(const CollisionRegion& pick) override;
     PickResultPointer getOverlayIntersection(const CollisionRegion& pick) override;
@@ -69,7 +60,9 @@ public:
     PickResultPointer getHUDIntersection(const CollisionRegion& pick) override;
     Transform getResultTransform() const override;
 protected:
-    // Returns true if pick.shapeInfo is valid. Otherwise, attempts to get the shapeInfo ready for use.
+    // Returns true if the resource for _mathPick.shapeInfo is loaded or if a resource is not needed.
+    bool isLoaded() const;
+    // Returns true if _mathPick.shapeInfo is valid. Otherwise, attempts to get the _mathPick ready for use.
     bool getShapeInfoReady();
     void computeShapeInfo(CollisionRegion& pick, ShapeInfo& shapeInfo, QSharedPointer<GeometryResource> resource);
     void computeShapeInfoDimensionsOnly(CollisionRegion& pick, ShapeInfo& shapeInfo, QSharedPointer<GeometryResource> resource);

--- a/interface/src/raypick/CollisionPick.h
+++ b/interface/src/raypick/CollisionPick.h
@@ -53,6 +53,7 @@ public:
     QVariantMap toVariantMap() const override;
 
     bool doesIntersect() const override { return intersects; }
+    bool needsToCompareResults() const override { return true; }
     bool checkOrFilterAgainstMaxDistance(float maxDistance) override { return true; }
 
     PickResultPointer compareAndProcessNewResult(const PickResultPointer& newRes) override;

--- a/interface/src/raypick/CollisionPick.h
+++ b/interface/src/raypick/CollisionPick.h
@@ -11,6 +11,7 @@
 #include <PhysicsEngine.h>
 #include <model-networking/ModelCache.h>
 #include <RegisteredMetaTypes.h>
+#include <TransformNode.h>
 #include <Pick.h>
 
 class CollisionPickResult : public PickResult {
@@ -24,12 +25,17 @@ public:
     CollisionPickResult() {}
     CollisionPickResult(const QVariantMap& pickVariant) : PickResult(pickVariant) {}
 
-    CollisionPickResult(const CollisionRegion& searchRegion, LoadState loadState, const std::vector<ContactTestResult>& entityIntersections, const std::vector<ContactTestResult>& avatarIntersections) :
+    CollisionPickResult(const CollisionRegion& searchRegion,
+        LoadState loadState,
+        const std::vector<ContactTestResult>& entityIntersections,
+        const std::vector<ContactTestResult>& avatarIntersections
+    ) :
         PickResult(searchRegion.toVariantMap()),
         loadState(loadState),
         intersects(entityIntersections.size() || avatarIntersections.size()),
         entityIntersections(entityIntersections),
-        avatarIntersections(avatarIntersections) {
+        avatarIntersections(avatarIntersections)
+    {
     }
 
     CollisionPickResult(const CollisionPickResult& collisionPickResult) : PickResult(collisionPickResult.pickVariant) {
@@ -54,14 +60,7 @@ public:
 
 class CollisionPick : public Pick<CollisionRegion> {
 public:
-    CollisionPick(const PickFilter& filter, float maxDistance, bool enabled, CollisionRegion collisionRegion, PhysicsEnginePointer physicsEngine) :
-        Pick(filter, maxDistance, enabled),
-        _mathPick(collisionRegion),
-        _physicsEngine(physicsEngine) {
-        if (collisionRegion.shouldComputeShapeInfo()) {
-            _cachedResource = DependencyManager::get<ModelCache>()->getCollisionGeometryResource(collisionRegion.modelURL);
-        }
-    }
+    CollisionPick(const PickFilter& filter, float maxDistance, bool enabled, CollisionRegion collisionRegion, PhysicsEnginePointer physicsEngine);
 
     CollisionRegion getMathematicalPick() const override;
     PickResultPointer getDefaultResult(const QVariantMap& pickVariant) const override {
@@ -71,11 +70,12 @@ public:
     PickResultPointer getOverlayIntersection(const CollisionRegion& pick) override;
     PickResultPointer getAvatarIntersection(const CollisionRegion& pick) override;
     PickResultPointer getHUDIntersection(const CollisionRegion& pick) override;
-
+    Transform getResultTransform() const override;
 protected:
     // Returns true if pick.shapeInfo is valid. Otherwise, attempts to get the shapeInfo ready for use.
-    bool isShapeInfoReady();
+    bool getShapeInfoReady();
     void computeShapeInfo(CollisionRegion& pick, ShapeInfo& shapeInfo, QSharedPointer<GeometryResource> resource);
+    void computeShapeInfoDimensionsOnly(CollisionRegion& pick, ShapeInfo& shapeInfo, QSharedPointer<GeometryResource> resource);
     void filterIntersections(std::vector<ContactTestResult>& intersections) const;
 
     CollisionRegion _mathPick;

--- a/interface/src/raypick/CollisionPick.h
+++ b/interface/src/raypick/CollisionPick.h
@@ -25,11 +25,7 @@ public:
     CollisionPickResult() {}
     CollisionPickResult(const QVariantMap& pickVariant) : PickResult(pickVariant) {}
 
-    CollisionPickResult(const CollisionRegion& searchRegion,
-        LoadState loadState,
-        const std::vector<ContactTestResult>& entityIntersections,
-        const std::vector<ContactTestResult>& avatarIntersections
-    ) :
+    CollisionPickResult(const CollisionRegion& searchRegion, LoadState loadState, const std::vector<ContactTestResult>& entityIntersections, const std::vector<ContactTestResult>& avatarIntersections) :
         PickResult(searchRegion.toVariantMap()),
         loadState(loadState),
         intersects(entityIntersections.size() || avatarIntersections.size()),

--- a/interface/src/raypick/CollisionPick.h
+++ b/interface/src/raypick/CollisionPick.h
@@ -40,7 +40,6 @@ public:
     QVariantMap toVariantMap() const override;
 
     bool doesIntersect() const override { return intersects; }
-    bool needsToCompareResults() const override { return true; }
     bool checkOrFilterAgainstMaxDistance(float maxDistance) override { return true; }
 
     PickResultPointer compareAndProcessNewResult(const PickResultPointer& newRes) override;

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -35,6 +35,39 @@ void LaserPointer::editRenderStatePath(const std::string& state, const QVariant&
     }
 }
 
+QVariantMap LaserPointer::toVariantMap() const {
+    QVariantMap qVariantMap;
+
+    QVariantList qRenderStates;
+    for (auto iter = _renderStates.cbegin(); iter != _renderStates.cend(); iter++) {
+        auto renderState = iter->second;
+        QVariantMap qRenderState;
+        qRenderState["name"] = iter->first.c_str();
+        qRenderState["start"] = renderState->getStartID();
+        qRenderState["path"] = std::static_pointer_cast<RenderState>(renderState)->getPathID();
+        qRenderState["end"] = renderState->getEndID();
+        qRenderStates.append(qRenderState);
+    }
+    qVariantMap["renderStates"] = qRenderStates;
+
+    QVariantList qDefaultRenderStates;
+    for (auto iter = _defaultRenderStates.cbegin(); iter != _defaultRenderStates.cend(); iter++) {
+        float distance = iter->second.first;
+        auto defaultRenderState = iter->second.second;
+        QVariantMap qDefaultRenderState;
+
+        qDefaultRenderState["name"] = iter->first.c_str();
+        qDefaultRenderState["distance"] = distance;
+        qDefaultRenderState["start"] = defaultRenderState->getStartID();
+        qDefaultRenderState["path"] = std::static_pointer_cast<RenderState>(defaultRenderState)->getPathID();
+        qDefaultRenderState["end"] = defaultRenderState->getEndID();
+        qDefaultRenderStates.append(qDefaultRenderState);
+    }
+    qVariantMap["defaultRenderStates"] = qDefaultRenderStates;
+
+    return qVariantMap;
+}
+
 glm::vec3 LaserPointer::getPickOrigin(const PickResultPointer& pickResult) const {
     auto rayPickResult = std::static_pointer_cast<RayPickResult>(pickResult);
     return (rayPickResult ? vec3FromVariant(rayPickResult->pickVariant["origin"]) : glm::vec3(0.0f));

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -38,30 +38,28 @@ void LaserPointer::editRenderStatePath(const std::string& state, const QVariant&
 QVariantMap LaserPointer::toVariantMap() const {
     QVariantMap qVariantMap;
 
-    QVariantList qRenderStates;
+    QVariantMap qRenderStates;
     for (auto iter = _renderStates.cbegin(); iter != _renderStates.cend(); iter++) {
         auto renderState = iter->second;
         QVariantMap qRenderState;
-        qRenderState["name"] = iter->first.c_str();
         qRenderState["start"] = renderState->getStartID();
         qRenderState["path"] = std::static_pointer_cast<RenderState>(renderState)->getPathID();
         qRenderState["end"] = renderState->getEndID();
-        qRenderStates.append(qRenderState);
+        qRenderStates[iter->first.c_str()] = qRenderState;
     }
     qVariantMap["renderStates"] = qRenderStates;
 
-    QVariantList qDefaultRenderStates;
+    QVariantMap qDefaultRenderStates;
     for (auto iter = _defaultRenderStates.cbegin(); iter != _defaultRenderStates.cend(); iter++) {
         float distance = iter->second.first;
         auto defaultRenderState = iter->second.second;
         QVariantMap qDefaultRenderState;
 
-        qDefaultRenderState["name"] = iter->first.c_str();
         qDefaultRenderState["distance"] = distance;
         qDefaultRenderState["start"] = defaultRenderState->getStartID();
         qDefaultRenderState["path"] = std::static_pointer_cast<RenderState>(defaultRenderState)->getPathID();
         qDefaultRenderState["end"] = defaultRenderState->getEndID();
-        qDefaultRenderStates.append(qDefaultRenderState);
+        qDefaultRenderStates[iter->first.c_str()] = qDefaultRenderState;
     }
     qVariantMap["defaultRenderStates"] = qDefaultRenderStates;
 

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -42,6 +42,8 @@ public:
     LaserPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates, bool hover, const PointerTriggers& triggers,
         bool faceAvatar, bool followNormal, float followNormalStrength, bool centerEndY, bool lockEnd, bool distanceScaleEnd, bool scaleWithAvatar, bool enabled);
 
+    QVariantMap toVariantMap() const override;
+
     static std::shared_ptr<StartEndRenderState> buildRenderState(const QVariantMap& propMap);
 
 protected:

--- a/interface/src/raypick/MouseTransformNode.cpp
+++ b/interface/src/raypick/MouseTransformNode.cpp
@@ -1,0 +1,43 @@
+//
+//  Created by Sabrina Shanman 8/14/2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "MouseTransformNode.h"
+
+#include "DependencyManager.h"
+#include "PickManager.h"
+#include "MouseRayPick.h"
+
+const PickFilter MOUSE_TRANSFORM_NODE_PICK_FILTER(
+    1 << PickFilter::PICK_ENTITIES |
+    1 << PickFilter::PICK_AVATARS |
+    1 << PickFilter::PICK_INCLUDE_NONCOLLIDABLE
+);
+const float MOUSE_TRANSFORM_NODE_MAX_DISTANCE = 1000.0f;
+
+MouseTransformNode::MouseTransformNode() {
+    _parentMouseRayPick = DependencyManager::get<PickManager>()->addPick(PickQuery::Ray,
+        std::make_shared<MouseRayPick>(MOUSE_TRANSFORM_NODE_PICK_FILTER, MOUSE_TRANSFORM_NODE_MAX_DISTANCE, true));
+}
+
+MouseTransformNode::~MouseTransformNode() {
+    if (DependencyManager::isSet<PickManager>()) {
+        auto pickManager = DependencyManager::get<PickManager>();
+        if (pickManager) {
+            pickManager->removePick(_parentMouseRayPick);
+        }
+    }
+}
+
+Transform MouseTransformNode::getTransform() {
+    Transform transform;
+    std::shared_ptr<RayPickResult> rayPickResult = DependencyManager::get<PickManager>()->getPrevPickResultTyped<RayPickResult>(_parentMouseRayPick);
+    if (rayPickResult) {
+        transform.setTranslation(rayPickResult->intersection);
+    }
+    return transform;
+}

--- a/interface/src/raypick/MouseTransformNode.h
+++ b/interface/src/raypick/MouseTransformNode.h
@@ -12,12 +12,7 @@
 
 class MouseTransformNode : public TransformNode {
 public:
-    MouseTransformNode();
-    ~MouseTransformNode();
     Transform getTransform() override;
-
-protected:
-    unsigned int _parentMouseRayPick = 0;
 };
 
 #endif // hifi_MouseTransformNode_h

--- a/interface/src/raypick/MouseTransformNode.h
+++ b/interface/src/raypick/MouseTransformNode.h
@@ -1,0 +1,23 @@
+//
+//  Created by Sabrina Shanman 8/14/2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#ifndef hifi_MouseTransformNode_h
+#define hifi_MouseTransformNode_h
+
+#include "TransformNode.h"
+
+class MouseTransformNode : public TransformNode {
+public:
+    MouseTransformNode();
+    ~MouseTransformNode();
+    Transform getTransform() override;
+
+protected:
+    unsigned int _parentMouseRayPick = 0;
+};
+
+#endif // hifi_MouseTransformNode_h

--- a/interface/src/raypick/ParabolaPick.cpp
+++ b/interface/src/raypick/ParabolaPick.cpp
@@ -68,3 +68,15 @@ glm::vec3 ParabolaPick::getAcceleration() const {
     }
     return scale * _accelerationAxis;
 }
+
+Transform ParabolaPick::getResultTransform() const {
+    PickResultPointer result = getPrevPickResult();
+    if (!result) {
+        return Transform();
+    }
+
+    auto parabolaResult = std::static_pointer_cast<ParabolaPickResult>(result);
+    Transform transform;
+    transform.setTranslation(parabolaResult->intersection);
+    return transform;
+}

--- a/interface/src/raypick/ParabolaPick.h
+++ b/interface/src/raypick/ParabolaPick.h
@@ -83,6 +83,7 @@ public:
     PickResultPointer getOverlayIntersection(const PickParabola& pick) override;
     PickResultPointer getAvatarIntersection(const PickParabola& pick) override;
     PickResultPointer getHUDIntersection(const PickParabola& pick) override;
+    Transform getResultTransform() const override;
 
 protected:
     float _speed;

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -60,6 +60,37 @@ void ParabolaPointer::editRenderStatePath(const std::string& state, const QVaria
     }
 }
 
+QVariantMap ParabolaPointer::toVariantMap() const {
+    QVariantMap qVariantMap;
+
+    QVariantList qRenderStates;
+    for (auto iter = _renderStates.cbegin(); iter != _renderStates.cend(); iter++) {
+        auto renderState = iter->second;
+        QVariantMap qRenderState;
+        qRenderState["name"] = iter->first.c_str();
+        qRenderState["start"] = renderState->getStartID();
+        qRenderState["end"] = renderState->getEndID();
+        qRenderStates.append(qRenderState);
+    }
+    qVariantMap["renderStates"] = qRenderStates;
+
+    QVariantList qDefaultRenderStates;
+    for (auto iter = _defaultRenderStates.cbegin(); iter != _defaultRenderStates.cend(); iter++) {
+        float distance = iter->second.first;
+        auto defaultRenderState = iter->second.second;
+        QVariantMap qDefaultRenderState;
+
+        qDefaultRenderState["name"] = iter->first.c_str();
+        qDefaultRenderState["distance"] = distance;
+        qDefaultRenderState["start"] = defaultRenderState->getStartID();
+        qDefaultRenderState["end"] = defaultRenderState->getEndID();
+        qDefaultRenderStates.append(qDefaultRenderState);
+    }
+    qVariantMap["defaultRenderStates"] = qDefaultRenderStates;
+
+    return qVariantMap;
+}
+
 glm::vec3 ParabolaPointer::getPickOrigin(const PickResultPointer& pickResult) const {
     auto parabolaPickResult = std::static_pointer_cast<ParabolaPickResult>(pickResult);
     return (parabolaPickResult ? vec3FromVariant(parabolaPickResult->pickVariant["origin"]) : glm::vec3(0.0f));

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -63,28 +63,26 @@ void ParabolaPointer::editRenderStatePath(const std::string& state, const QVaria
 QVariantMap ParabolaPointer::toVariantMap() const {
     QVariantMap qVariantMap;
 
-    QVariantList qRenderStates;
+    QVariantMap qRenderStates;
     for (auto iter = _renderStates.cbegin(); iter != _renderStates.cend(); iter++) {
         auto renderState = iter->second;
         QVariantMap qRenderState;
-        qRenderState["name"] = iter->first.c_str();
         qRenderState["start"] = renderState->getStartID();
         qRenderState["end"] = renderState->getEndID();
-        qRenderStates.append(qRenderState);
+        qRenderStates[iter->first.c_str()] = qRenderState;
     }
     qVariantMap["renderStates"] = qRenderStates;
 
-    QVariantList qDefaultRenderStates;
+    QVariantMap qDefaultRenderStates;
     for (auto iter = _defaultRenderStates.cbegin(); iter != _defaultRenderStates.cend(); iter++) {
         float distance = iter->second.first;
         auto defaultRenderState = iter->second.second;
         QVariantMap qDefaultRenderState;
 
-        qDefaultRenderState["name"] = iter->first.c_str();
         qDefaultRenderState["distance"] = distance;
         qDefaultRenderState["start"] = defaultRenderState->getStartID();
         qDefaultRenderState["end"] = defaultRenderState->getEndID();
-        qDefaultRenderStates.append(qDefaultRenderState);
+        qDefaultRenderStates[iter->first.c_str()] = qDefaultRenderState;
     }
     qVariantMap["defaultRenderStates"] = qDefaultRenderStates;
 

--- a/interface/src/raypick/ParabolaPointer.h
+++ b/interface/src/raypick/ParabolaPointer.h
@@ -97,6 +97,8 @@ public:
     ParabolaPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates, bool hover, const PointerTriggers& triggers,
         bool faceAvatar, bool followNormal, float followNormalStrength, bool centerEndY, bool lockEnd, bool distanceScaleEnd, bool scaleWithAvatar, bool enabled);
 
+    QVariantMap toVariantMap() const override;
+
     static std::shared_ptr<StartEndRenderState> buildRenderState(const QVariantMap& propMap);
 
 protected:

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -23,6 +23,13 @@
 #include "MouseParabolaPick.h"
 #include "CollisionPick.h"
 
+#include "SpatialParentFinder.h"
+#include "NestableTransformNode.h"
+#include "PickTransformNode.h"
+#include "MouseTransformNode.h"
+#include "avatar/MyAvatarHeadTransformNode.h"
+#include "avatar/AvatarManager.h"
+
 #include <ScriptEngine.h>
 
 unsigned int PickScriptingInterface::createPick(const PickQuery::PickType type, const QVariant& properties) {
@@ -276,8 +283,10 @@ unsigned int PickScriptingInterface::createCollisionPick(const QVariant& propert
     }
 
     CollisionRegion collisionRegion(propMap);
+    auto collisionPick = std::make_shared<CollisionPick>(filter, maxDistance, enabled, collisionRegion, qApp->getPhysicsEngine());
+    collisionPick->parentTransform = createTransformNode(propMap);
 
-    return DependencyManager::get<PickManager>()->addPick(PickQuery::Collision, std::make_shared<CollisionPick>(filter, maxDistance, enabled, collisionRegion, qApp->getPhysicsEngine()));
+    return DependencyManager::get<PickManager>()->addPick(PickQuery::Collision, collisionPick);
 }
 
 void PickScriptingInterface::enablePick(unsigned int uid) {
@@ -350,4 +359,43 @@ unsigned int PickScriptingInterface::getPerFrameTimeBudget() const {
 
 void PickScriptingInterface::setPerFrameTimeBudget(unsigned int numUsecs) {
     DependencyManager::get<PickManager>()->setPerFrameTimeBudget(numUsecs);
+}
+
+std::shared_ptr<TransformNode> PickScriptingInterface::createTransformNode(const QVariantMap& propMap) {
+    if (propMap["parentID"].isValid()) {
+        QUuid parentUuid = propMap["parentID"].toUuid();
+        if (!parentUuid.isNull()) {
+            // Infer object type from parentID
+            // For now, assume a QUuuid is a SpatiallyNestable. This should change when picks are converted over to QUuids.
+            bool success;
+            std::weak_ptr<SpatiallyNestable> nestablePointer = DependencyManager::get<SpatialParentFinder>()->find(parentUuid, success, nullptr);
+            int parentJointIndex = 0;
+            if (propMap["parentJointIndex"].isValid()) {
+                parentJointIndex = propMap["parentJointIndex"].toInt();
+            }
+            if (success && !nestablePointer.expired()) {
+                return std::make_shared<NestableTransformNode>(nestablePointer, parentJointIndex);
+            }
+        }
+
+        unsigned int pickID = propMap["parentID"].toUInt();
+        if (pickID != 0) {
+            return std::make_shared<PickTransformNode>(pickID);
+        }
+    }
+    
+    if (propMap["joint"].isValid()) {
+        QString joint = propMap["joint"].toString();
+        if (joint == "Mouse") {
+            return std::make_shared<MouseTransformNode>();
+        } else if (joint == "Avatar") {
+            return std::make_shared<MyAvatarHeadTransformNode>();
+        } else if (!joint.isNull()) {
+            auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+            int jointIndex = myAvatar->getJointIndex(joint);
+            return std::make_shared<NestableTransformNode>(myAvatar, jointIndex);
+        }
+    }
+
+    return std::shared_ptr<TransformNode>();
 }

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -373,7 +373,8 @@ std::shared_ptr<TransformNode> PickScriptingInterface::createTransformNode(const
             if (propMap["parentJointIndex"].isValid()) {
                 parentJointIndex = propMap["parentJointIndex"].toInt();
             }
-            if (success && !nestablePointer.expired()) {
+            auto sharedNestablePointer = nestablePointer.lock();
+            if (success && sharedNestablePointer) {
                 return std::make_shared<NestableTransformNode>(nestablePointer, parentJointIndex);
             }
         }

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -320,6 +320,9 @@ public slots:
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_HUD() { return IntersectionType::HUD; }
+
+protected:
+    static std::shared_ptr<TransformNode> createTransformNode(const QVariantMap& propMap);
 };
 
 #endif // hifi_PickScriptingInterface_h

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -152,9 +152,6 @@ public:
      * @property {CollisionRegion} collisionRegion The CollisionRegion that was used. Valid even if there was no intersection.
      */
 
-    // TODO: Add this to the CollisionPickResult jsdoc once model collision picks are working
-    //* @property {boolean} loaded If the CollisionRegion was successfully loaded (may be false if a model was used)
-
     /**jsdoc
     * Information about the Collision Pick's intersection with an object
     *

--- a/interface/src/raypick/PointerScriptingInterface.cpp
+++ b/interface/src/raypick/PointerScriptingInterface.cpp
@@ -79,7 +79,7 @@ unsigned int PointerScriptingInterface::createStylus(const QVariant& properties)
  * A set of properties which define the visual aspect of a Ray Pointer in the case that the Pointer is intersecting something.
  *
  * @typedef {object} Pointers.RayPointerRenderState
- * @property {string} name The name of this render state, used by {@link Pointers.setRenderState} and {@link Pointers.editRenderState}
+ * @property {string} name When using {@link Pointers.createPointer}, the name of this render state, used by {@link Pointers.setRenderState} and {@link Pointers.editRenderState}
  * @property {Overlays.OverlayProperties|QUuid} [start] When using {@link Pointers.createPointer}, an optionally defined overlay to represent the beginning of the Ray Pointer,
  * using the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field).
  * When returned from {@link Pointers.getPointerProperties}, the ID of the created overlay if it exists, or a null ID otherwise.
@@ -102,8 +102,12 @@ unsigned int PointerScriptingInterface::createStylus(const QVariant& properties)
  * @property {number} [followNormalStrength=0.0] The strength of the interpolation between the real normal and the visual normal if followNormal is true. <code>0-1</code>.  If 0 or 1,
  * the normal will follow exactly.
  * @property {boolean} [enabled=false]
- * @property {Pointers.RayPointerRenderState[]} [renderStates] A list of different visual states to switch between.
- * @property {Pointers.DefaultRayPointerRenderState[]} [defaultRenderStates] A list of different visual states to use if there is no intersection.
+ * @property {Pointers.RayPointerRenderState[]|Object.<string, Pointers.RayPointerRenderState>} [renderStates] A collection of different visual states to switch between.
+ * When using {@link Pointers.createPointer}, a list of RayPointerRenderStates.
+ * When returned from {@link Pointers.getPointerProperties}, a map between render state names and RayPointRenderStates.
+ * @property {Pointers.DefaultRayPointerRenderState[]|Object.<string, Pointers.DefaultRayPointerRenderState>} [defaultRenderStates] A collection of different visual states to use if there is no intersection.
+ * When using {@link Pointers.createPointer}, a list of DefaultRayPointerRenderStates.
+ * When returned from {@link Pointers.getPointerProperties}, a map between render state names and DefaultRayPointRenderStates.
  * @property {boolean} [hover=false] If this Pointer should generate hover events.
  * @property {Pointers.Trigger[]} [triggers] A list of different triggers mechanisms that control this Pointer's click event generation.
  */
@@ -227,7 +231,7 @@ unsigned int PointerScriptingInterface::createLaserPointer(const QVariant& prope
 * A set of properties used to define the visual aspect of a Parabola Pointer in the case that the Pointer is intersecting something.
 *
 * @typedef {object} Pointers.ParabolaPointerRenderState
-* @property {string} name The name of this render state, used by {@link Pointers.setRenderState} and {@link Pointers.editRenderState}
+* @property {string} name When using {@link Pointers.createPointer}, the name of this render state, used by {@link Pointers.setRenderState} and {@link Pointers.editRenderState}
 * @property {Overlays.OverlayProperties|QUuid} [start] When using {@link Pointers.createPointer}, an optionally defined overlay to represent the beginning of the Parabola Pointer,
 * using the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field).
 * When returned from {@link Pointers.getPointerProperties}, the ID of the created overlay if it exists, or a null ID otherwise.
@@ -249,8 +253,12 @@ unsigned int PointerScriptingInterface::createLaserPointer(const QVariant& prope
 * @property {number} [followNormalStrength=0.0] The strength of the interpolation between the real normal and the visual normal if followNormal is true. <code>0-1</code>.  If 0 or 1,
 * the normal will follow exactly.
 * @property {boolean} [enabled=false]
-* @property {Pointers.ParabolaPointerRenderState[]} [renderStates] A list of different visual states to switch between.
-* @property {Pointers.DefaultParabolaPointerRenderState[]} [defaultRenderStates] A list of different visual states to use if there is no intersection.
+* @property {Pointers.ParabolaPointerRenderState[]|Object.<string, Pointers.ParabolaPointerRenderState>} [renderStates] A collection of different visual states to switch between.
+* When using {@link Pointers.createPointer}, a list of ParabolaPointerRenderStates.
+* When returned from {@link Pointers.getPointerProperties}, a map between render state names and ParabolaPointerRenderStates.
+* @property {Pointers.DefaultParabolaPointerRenderState[]|Object.<string, Pointers.DefaultParabolaPointerRenderState>} [defaultRenderStates] A collection of different visual states to use if there is no intersection.
+* When using {@link Pointers.createPointer}, a list of DefaultParabolaPointerRenderStates.
+* When returned from {@link Pointers.getPointerProperties}, a map between render state names and DefaultParabolaPointerRenderStates.
 * @property {boolean} [hover=false] If this Pointer should generate hover events.
 * @property {Pointers.Trigger[]} [triggers] A list of different triggers mechanisms that control this Pointer's click event generation.
 */

--- a/interface/src/raypick/PointerScriptingInterface.cpp
+++ b/interface/src/raypick/PointerScriptingInterface.cpp
@@ -76,16 +76,19 @@ unsigned int PointerScriptingInterface::createStylus(const QVariant& properties)
  * @property {number} distance The distance at which to render the end of this Ray Pointer, if one is defined.
  */
 /**jsdoc
- * A set of properties used to define the visual aspect of a Ray Pointer in the case that the Pointer is intersecting something.
+ * A set of properties which define the visual aspect of a Ray Pointer in the case that the Pointer is intersecting something.
  *
  * @typedef {object} Pointers.RayPointerRenderState
  * @property {string} name The name of this render state, used by {@link Pointers.setRenderState} and {@link Pointers.editRenderState}
- * @property {Overlays.OverlayProperties} [start] All of the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field).
- * An overlay to represent the beginning of the Ray Pointer, if desired.
- * @property {Overlays.OverlayProperties} [path] All of the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field), which <b>must</b> be <code>"line3d"</code>.
- * An overlay to represent the path of the Ray Pointer, if desired.
- * @property {Overlays.OverlayProperties} [end] All of the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field).
- * An overlay to represent the end of the Ray Pointer, if desired.
+ * @property {Overlays.OverlayProperties|QUuid} [start] When using {@link Pointers.createPointer}, an optionally defined overlay to represent the beginning of the Ray Pointer,
+ * using the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field).
+ * When returned from {@link Pointers.getPointerProperties}, the ID of the created overlay if it exists, or a null ID otherwise.
+ * @property {Overlays.OverlayProperties|QUuid} [path] When using {@link Pointers.createPointer}, an optionally defined overlay to represent the path of the Ray Pointer,
+ * using the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field), which <b>must</b> be <code>"line3d"</code>.
+ * When returned from {@link Pointers.getPointerProperties}, the ID of the created overlay if it exists, or a null ID otherwise.
+ * @property {Overlays.OverlayProperties|QUuid} [end] When using {@link Pointers.createPointer}, an optionally defined overlay to represent the end of the Ray Pointer,
+ * using the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field).
+ * When returned from {@link Pointers.getPointerProperties}, the ID of the created overlay if it exists, or a null ID otherwise.
  */
 /**jsdoc
  * A set of properties that can be passed to {@link Pointers.createPointer} to create a new Pointer. Contains the relevant {@link Picks.PickProperties} to define the underlying Pick.
@@ -225,11 +228,14 @@ unsigned int PointerScriptingInterface::createLaserPointer(const QVariant& prope
 *
 * @typedef {object} Pointers.ParabolaPointerRenderState
 * @property {string} name The name of this render state, used by {@link Pointers.setRenderState} and {@link Pointers.editRenderState}
-* @property {Overlays.OverlayProperties} [start] All of the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field).
-* An overlay to represent the beginning of the Parabola Pointer, if desired.
-* @property {Pointers.ParabolaProperties} [path] The rendering properties of the parabolic path defined by the Parabola Pointer.
-* @property {Overlays.OverlayProperties} [end] All of the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field).
-* An overlay to represent the end of the Parabola Pointer, if desired.
+* @property {Overlays.OverlayProperties|QUuid} [start] When using {@link Pointers.createPointer}, an optionally defined overlay to represent the beginning of the Parabola Pointer,
+* using the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field).
+* When returned from {@link Pointers.getPointerProperties}, the ID of the created overlay if it exists, or a null ID otherwise.
+* @property {Pointers.ParabolaProperties} [path]  When using {@link Pointers.createPointer}, the optionally defined rendering properties of the parabolic path defined by the Parabola Pointer.
+* Not defined in {@link Pointers.getPointerProperties}.
+* @property {Overlays.OverlayProperties|QUuid} [end] When using {@link Pointers.createPointer}, an optionally defined overlay to represent the end of the Parabola Pointer,
+* using the properties you would normally pass to {@link Overlays.addOverlay}, plus the type (as a <code>type</code> field).
+* When returned from {@link Pointers.getPointerProperties}, the ID of the created overlay if it exists, or a null ID otherwise.
 */
 /**jsdoc
 * A set of properties that can be passed to {@link Pointers.createPointer} to create a new Pointer. Contains the relevant {@link Picks.PickProperties} to define the underlying Pick.
@@ -375,4 +381,8 @@ QVariantMap PointerScriptingInterface::getPrevPickResult(unsigned int uid) const
         result = pickResult->toVariantMap();
     }
     return result;
+}
+
+QVariantMap PointerScriptingInterface::getPointerProperties(unsigned int uid) const {
+    return DependencyManager::get<PointerManager>()->getPointerProperties(uid);
 }

--- a/interface/src/raypick/PointerScriptingInterface.h
+++ b/interface/src/raypick/PointerScriptingInterface.h
@@ -203,6 +203,14 @@ public:
      */
     Q_INVOKABLE bool isMouse(unsigned int uid) { return DependencyManager::get<PointerManager>()->isMouse(uid); }
 
+    /**jsdoc
+     * Returns information about an existing Pointer
+     * @function Pointers.getPointerState
+     * @param {number} uid The ID of the Pointer, as returned by {@link Pointers.createPointer}.
+     * @returns {Pointers.LaserPointerProperties|Pointers.StylusPointerProperties|Pointers.ParabolaPointerProperties} The information about the Pointer.
+     * Currently only includes renderStates and defaultRenderStates with associated overlay IDs.
+     */
+    Q_INVOKABLE QVariantMap getPointerProperties(unsigned int uid) const;
 };
 
 #endif // hifi_PointerScriptingInterface_h

--- a/interface/src/raypick/RayPick.cpp
+++ b/interface/src/raypick/RayPick.cpp
@@ -50,6 +50,18 @@ PickResultPointer RayPick::getHUDIntersection(const PickRay& pick) {
     return std::make_shared<RayPickResult>(IntersectionType::HUD, QUuid(), glm::distance(pick.origin, hudRes), hudRes, pick);
 }
 
+Transform RayPick::getResultTransform() const {
+    PickResultPointer result = getPrevPickResult();
+    if (!result) {
+        return Transform();
+    }
+
+    auto rayResult = std::static_pointer_cast<RayPickResult>(result);
+    Transform transform;
+    transform.setTranslation(rayResult->intersection);
+    return transform;
+}
+
 glm::vec3 RayPick::intersectRayWithXYPlane(const glm::vec3& origin, const glm::vec3& direction, const glm::vec3& point, const glm::quat& rotation, const glm::vec3& registration) {
     // TODO: take into account registration
     glm::vec3 n = rotation * Vectors::FRONT;

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -77,6 +77,7 @@ public:
     PickResultPointer getOverlayIntersection(const PickRay& pick) override;
     PickResultPointer getAvatarIntersection(const PickRay& pick) override;
     PickResultPointer getHUDIntersection(const PickRay& pick) override;
+    Transform getResultTransform() const override;
 
     // These are helper functions for projecting and intersecting rays
     static glm::vec3 intersectRayWithEntityXYPlane(const QUuid& entityID, const glm::vec3& origin, const glm::vec3& direction);

--- a/interface/src/raypick/StylusPick.cpp
+++ b/interface/src/raypick/StylusPick.cpp
@@ -226,3 +226,15 @@ PickResultPointer StylusPick::getAvatarIntersection(const StylusTip& pick) {
 PickResultPointer StylusPick::getHUDIntersection(const StylusTip& pick) {
     return std::make_shared<StylusPickResult>(pick.toVariantMap());
 }
+
+Transform StylusPick::getResultTransform() const {
+    PickResultPointer result = getPrevPickResult();
+    if (!result) {
+        return Transform();
+    }
+
+    auto stylusResult = std::static_pointer_cast<StylusPickResult>(result);
+    Transform transform;
+    transform.setTranslation(stylusResult->intersection);
+    return transform;
+}

--- a/interface/src/raypick/StylusPick.h
+++ b/interface/src/raypick/StylusPick.h
@@ -66,6 +66,7 @@ public:
     PickResultPointer getOverlayIntersection(const StylusTip& pick) override;
     PickResultPointer getAvatarIntersection(const StylusTip& pick) override;
     PickResultPointer getHUDIntersection(const StylusTip& pick) override;
+    Transform getResultTransform() const override;
 
     bool isLeftHand() const override { return _side == Side::Left; }
     bool isRightHand() const override { return _side == Side::Right; }

--- a/interface/src/raypick/StylusPointer.cpp
+++ b/interface/src/raypick/StylusPointer.cpp
@@ -203,6 +203,10 @@ void StylusPointer::setRenderState(const std::string& state) {
     }
 }
 
+QVariantMap StylusPointer::toVariantMap() const {
+    return QVariantMap();
+}
+
 glm::vec3 StylusPointer::findIntersection(const PickedObject& pickedObject, const glm::vec3& origin, const glm::vec3& direction) {
     switch (pickedObject.type) {
         case ENTITY:

--- a/interface/src/raypick/StylusPointer.h
+++ b/interface/src/raypick/StylusPointer.h
@@ -33,6 +33,8 @@ public:
     void setRenderState(const std::string& state) override;
     void editRenderState(const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps) override {}
 
+    QVariantMap toVariantMap() const override;
+
     static OverlayID buildStylusOverlay(const QVariantMap& properties);
 
 protected:

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -142,7 +142,7 @@ public:
 
     // Function for getting colliding objects in the world of specified type
     // See PhysicsCollisionGroups.h for mask flags.
-    std::vector<ContactTestResult> contactTest(uint16_t mask, const ShapeInfo& regionShapeInfo, const Transform& regionTransform, uint16_t group = USER_COLLISION_GROUP_DYNAMIC) const;
+    std::vector<ContactTestResult> contactTest(uint16_t mask, const ShapeInfo& regionShapeInfo, const Transform& regionTransform, uint16_t group = USER_COLLISION_GROUP_DYNAMIC, float threshold = 0.0f) const;
 
 private:
     QList<EntityDynamicPointer> removeDynamicsForBody(btRigidBody* body);

--- a/libraries/pointers/src/Pick.h
+++ b/libraries/pointers/src/Pick.h
@@ -17,7 +17,7 @@
 #include <QVariant>
 
 #include <shared/ReadWriteLockable.h>
-#include <Transform.h>
+#include <TransformNode.h>
 
 enum IntersectionType {
     NONE = 0,
@@ -213,6 +213,10 @@ public:
     virtual bool isLeftHand() const { return false; }
     virtual bool isRightHand() const { return false; }
     virtual bool isMouse() const { return false; }
+
+    virtual Transform getResultTransform() const = 0;
+
+    std::shared_ptr<TransformNode> parentTransform;
 
 private:
     PickFilter _filter;

--- a/libraries/pointers/src/Pick.h
+++ b/libraries/pointers/src/Pick.h
@@ -115,7 +115,6 @@ public:
     }
 
     virtual bool doesIntersect() const = 0;
-    virtual bool needsToCompareResults() const { return doesIntersect(); }
 
     // for example: if we want the closest result, compare based on distance
     // if we want all results, combine them

--- a/libraries/pointers/src/Pick.h
+++ b/libraries/pointers/src/Pick.h
@@ -17,6 +17,7 @@
 #include <QVariant>
 
 #include <shared/ReadWriteLockable.h>
+#include <Transform.h>
 
 enum IntersectionType {
     NONE = 0,

--- a/libraries/pointers/src/Pick.h
+++ b/libraries/pointers/src/Pick.h
@@ -115,6 +115,7 @@ public:
     }
 
     virtual bool doesIntersect() const = 0;
+    virtual bool needsToCompareResults() const { return doesIntersect(); }
 
     // for example: if we want the closest result, compare based on distance
     // if we want all results, combine them

--- a/libraries/pointers/src/PickCacheOptimizer.h
+++ b/libraries/pointers/src/PickCacheOptimizer.h
@@ -92,7 +92,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
                 if (!checkAndCompareCachedResults(mathematicalPick, results, res, entityKey)) {
                     PickResultPointer entityRes = pick->getEntityIntersection(mathematicalPick);
                     if (entityRes) {
-                        cacheResult(entityRes->needsToCompareResults(), entityRes, entityKey, res, mathematicalPick, results, pick);
+                        cacheResult(entityRes->doesIntersect(), entityRes, entityKey, res, mathematicalPick, results, pick);
                     }
                 }
             }
@@ -102,7 +102,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
                 if (!checkAndCompareCachedResults(mathematicalPick, results, res, overlayKey)) {
                     PickResultPointer overlayRes = pick->getOverlayIntersection(mathematicalPick);
                     if (overlayRes) {
-                        cacheResult(overlayRes->needsToCompareResults(), overlayRes, overlayKey, res, mathematicalPick, results, pick);
+                        cacheResult(overlayRes->doesIntersect(), overlayRes, overlayKey, res, mathematicalPick, results, pick);
                     }
                 }
             }
@@ -112,7 +112,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
                 if (!checkAndCompareCachedResults(mathematicalPick, results, res, avatarKey)) {
                     PickResultPointer avatarRes = pick->getAvatarIntersection(mathematicalPick);
                     if (avatarRes) {
-                        cacheResult(avatarRes->needsToCompareResults(), avatarRes, avatarKey, res, mathematicalPick, results, pick);
+                        cacheResult(avatarRes->doesIntersect(), avatarRes, avatarKey, res, mathematicalPick, results, pick);
                     }
                 }
             }

--- a/libraries/pointers/src/PickCacheOptimizer.h
+++ b/libraries/pointers/src/PickCacheOptimizer.h
@@ -57,8 +57,8 @@ bool PickCacheOptimizer<T>::checkAndCompareCachedResults(T& pick, PickCache& cac
 }
 
 template<typename T>
-void PickCacheOptimizer<T>::cacheResult(const bool intersects, const PickResultPointer& resTemp, const PickCacheKey& key, PickResultPointer& res, T& mathPick, PickCache& cache, const std::shared_ptr<Pick<T>> pick) {
-    if (intersects) {
+void PickCacheOptimizer<T>::cacheResult(const bool needToCompareResults, const PickResultPointer& resTemp, const PickCacheKey& key, PickResultPointer& res, T& mathPick, PickCache& cache, const std::shared_ptr<Pick<T>> pick) {
+    if (needToCompareResults) {
         cache[mathPick][key] = resTemp;
         res = res->compareAndProcessNewResult(resTemp);
     } else {
@@ -92,7 +92,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
                 if (!checkAndCompareCachedResults(mathematicalPick, results, res, entityKey)) {
                     PickResultPointer entityRes = pick->getEntityIntersection(mathematicalPick);
                     if (entityRes) {
-                        cacheResult(entityRes->doesIntersect(), entityRes, entityKey, res, mathematicalPick, results, pick);
+                        cacheResult(entityRes->needsToCompareResults(), entityRes, entityKey, res, mathematicalPick, results, pick);
                     }
                 }
             }
@@ -102,7 +102,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
                 if (!checkAndCompareCachedResults(mathematicalPick, results, res, overlayKey)) {
                     PickResultPointer overlayRes = pick->getOverlayIntersection(mathematicalPick);
                     if (overlayRes) {
-                        cacheResult(overlayRes->doesIntersect(), overlayRes, overlayKey, res, mathematicalPick, results, pick);
+                        cacheResult(overlayRes->needsToCompareResults(), overlayRes, overlayKey, res, mathematicalPick, results, pick);
                     }
                 }
             }
@@ -112,7 +112,7 @@ void PickCacheOptimizer<T>::update(std::unordered_map<uint32_t, std::shared_ptr<
                 if (!checkAndCompareCachedResults(mathematicalPick, results, res, avatarKey)) {
                     PickResultPointer avatarRes = pick->getAvatarIntersection(mathematicalPick);
                     if (avatarRes) {
-                        cacheResult(avatarRes->doesIntersect(), avatarRes, avatarKey, res, mathematicalPick, results, pick);
+                        cacheResult(avatarRes->needsToCompareResults(), avatarRes, avatarKey, res, mathematicalPick, results, pick);
                     }
                 }
             }

--- a/libraries/pointers/src/PickManager.cpp
+++ b/libraries/pointers/src/PickManager.cpp
@@ -88,6 +88,14 @@ void PickManager::setIncludeItems(unsigned int uid, const QVector<QUuid>& includ
     }
 }
 
+Transform PickManager::getResultTransform(unsigned int uid) const {
+    auto pick = findPick(uid);
+    if (pick) {
+        return pick->getResultTransform();
+    }
+    return Transform();
+}
+
 void PickManager::update() {
     uint64_t expiry = usecTimestampNow() + _perFrameTimeBudget;
     std::unordered_map<PickQuery::PickType, std::unordered_map<unsigned int, std::shared_ptr<PickQuery>>> cachedPicks;

--- a/libraries/pointers/src/PickManager.h
+++ b/libraries/pointers/src/PickManager.h
@@ -40,6 +40,8 @@ public:
     void setIgnoreItems(unsigned int uid, const QVector<QUuid>& ignore) const;
     void setIncludeItems(unsigned int uid, const QVector<QUuid>& include) const;
 
+    Transform getResultTransform(unsigned int uid) const;
+
     bool isLeftHand(unsigned int uid);
     bool isRightHand(unsigned int uid);
     bool isMouse(unsigned int uid);

--- a/libraries/pointers/src/PickTransformNode.cpp
+++ b/libraries/pointers/src/PickTransformNode.cpp
@@ -1,0 +1,26 @@
+//
+//  Created by Sabrina Shanman 8/22/2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "PickTransformNode.h"
+
+#include "DependencyManager.h"
+#include "PickManager.h"
+
+PickTransformNode::PickTransformNode(unsigned int uid) :
+    _uid(uid)
+{
+}
+
+Transform PickTransformNode::getTransform() {
+    auto pickManager = DependencyManager::get<PickManager>();
+    if (!pickManager) {
+        return Transform();
+    }
+
+    return pickManager->getResultTransform(_uid);
+}

--- a/libraries/pointers/src/PickTransformNode.h
+++ b/libraries/pointers/src/PickTransformNode.h
@@ -10,6 +10,7 @@
 
 #include "TransformNode.h"
 
+// TODO: Remove this class when Picks are converted to SpatiallyNestables
 class PickTransformNode : public TransformNode {
 public:
     PickTransformNode(unsigned int uid);

--- a/libraries/pointers/src/PickTransformNode.h
+++ b/libraries/pointers/src/PickTransformNode.h
@@ -1,0 +1,22 @@
+//
+//  Created by Sabrina Shanman 8/22/2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#ifndef hifi_PickTransformNode_h
+#define hifi_PickTransformNode_h
+
+#include "TransformNode.h"
+
+class PickTransformNode : public TransformNode {
+public:
+    PickTransformNode(unsigned int uid);
+    Transform getTransform() override;
+
+protected:
+    unsigned int _uid;
+};
+
+#endif // hifi_PickTransformNode_h

--- a/libraries/pointers/src/Pointer.h
+++ b/libraries/pointers/src/Pointer.h
@@ -50,6 +50,8 @@ public:
     virtual void setRenderState(const std::string& state) = 0;
     virtual void editRenderState(const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps) = 0;
     
+    virtual QVariantMap toVariantMap() const = 0;
+
     virtual void setPrecisionPicking(bool precisionPicking);
     virtual void setIgnoreItems(const QVector<QUuid>& ignoreItems) const;
     virtual void setIncludeItems(const QVector<QUuid>& includeItems) const;

--- a/libraries/pointers/src/PointerManager.cpp
+++ b/libraries/pointers/src/PointerManager.cpp
@@ -77,6 +77,15 @@ PickResultPointer PointerManager::getPrevPickResult(unsigned int uid) const {
     return result;
 }
 
+QVariantMap PointerManager::getPointerProperties(unsigned int uid) const {
+    auto pointer = find(uid);
+    if (pointer) {
+        return pointer->toVariantMap();
+    } else {
+        return QVariantMap();
+    }
+}
+
 void PointerManager::update() {
     auto cachedPointers = resultWithReadLock<std::unordered_map<unsigned int, std::shared_ptr<Pointer>>>([&] {
         return _pointers;

--- a/libraries/pointers/src/PointerManager.h
+++ b/libraries/pointers/src/PointerManager.h
@@ -30,6 +30,7 @@ public:
     void setRenderState(unsigned int uid, const std::string& renderState) const;
     void editRenderState(unsigned int uid, const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps) const;
     PickResultPointer getPrevPickResult(unsigned int uid) const;
+    QVariantMap getPointerProperties(unsigned int uid) const;
 
     void setPrecisionPicking(unsigned int uid, bool precisionPicking) const;
     void setIgnoreItems(unsigned int uid, const QVector<QUuid>& ignoreEntities) const;

--- a/libraries/shared/src/NestableTransformNode.cpp
+++ b/libraries/shared/src/NestableTransformNode.cpp
@@ -21,7 +21,7 @@ Transform NestableTransformNode::getTransform() {
     }
 
     bool success;
-    Transform jointWorldTransform = nestable->getTransform(_jointIndex, success, 30);
+    Transform jointWorldTransform = nestable->getTransform(_jointIndex, success);
 
     if (success) {
         return jointWorldTransform;

--- a/libraries/shared/src/NestableTransformNode.cpp
+++ b/libraries/shared/src/NestableTransformNode.cpp
@@ -1,0 +1,31 @@
+//
+//  Created by Sabrina Shanman 8/14/2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "NestableTransformNode.h"
+
+NestableTransformNode::NestableTransformNode(SpatiallyNestableWeakPointer spatiallyNestable, int jointIndex) :
+    _spatiallyNestable(spatiallyNestable),
+    _jointIndex(jointIndex)
+{
+}
+
+Transform NestableTransformNode::getTransform() {
+    auto nestable = _spatiallyNestable.lock();
+    if (!nestable) {
+        return Transform();
+    }
+
+    bool success;
+    Transform jointWorldTransform = nestable->getTransform(_jointIndex, success, 30);
+
+    if (success) {
+        return jointWorldTransform;
+    } else {
+        return Transform();
+    }
+}

--- a/libraries/shared/src/NestableTransformNode.h
+++ b/libraries/shared/src/NestableTransformNode.h
@@ -1,0 +1,25 @@
+//
+//  Created by Sabrina Shanman 8/14/2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#ifndef hifi_NestableTransformNode_h
+#define hifi_NestableTransformNode_h
+
+#include "TransformNode.h"
+
+#include "SpatiallyNestable.h"
+
+class NestableTransformNode : public TransformNode {
+public:
+    NestableTransformNode(SpatiallyNestableWeakPointer spatiallyNestable, int jointIndex);
+    Transform getTransform() override;
+
+protected:
+    SpatiallyNestableWeakPointer _spatiallyNestable;
+    int _jointIndex;
+};
+
+#endif // hifi_NestableTransformNode_h

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -271,10 +271,7 @@ public:
     CollisionRegion(const CollisionRegion& collisionRegion) :
         modelURL(collisionRegion.modelURL),
         shapeInfo(std::make_shared<ShapeInfo>()),
-        transform(collisionRegion.transform),
-        parentID(collisionRegion.parentID),
-        parentJointIndex(collisionRegion.parentJointIndex),
-        joint(collisionRegion.joint)
+        transform(collisionRegion.transform)
     {
         shapeInfo->setParams(collisionRegion.shapeInfo->getType(), collisionRegion.shapeInfo->getHalfExtents(), collisionRegion.modelURL.toString());
     }
@@ -308,15 +305,6 @@ public:
         if (pickVariant["orientation"].isValid()) {
             transform.setRotation(quatFromVariant(pickVariant["orientation"]));
         }
-        if (pickVariant["parentID"].isValid()) {
-            parentID = pickVariant["parentID"].toString();
-        }
-        if (pickVariant["parentJointIndex"].isValid()) {
-            parentJointIndex = pickVariant["parentJointIndex"].toInt();
-        }
-        if (pickVariant["joint"].isValid()) {
-            joint = pickVariant["joint"].toString();
-        }
     }
 
     QVariantMap toVariantMap() const override {
@@ -331,14 +319,6 @@ public:
 
         collisionRegion["position"] = vec3toVariant(transform.getTranslation());
         collisionRegion["orientation"] = quatToVariant(transform.getRotation());
-
-        if (!parentID.isNull()) {
-            collisionRegion["parentID"] = parentID;
-        }
-        collisionRegion["parentJointIndex"] = parentJointIndex;
-        if (!joint.isNull()) {
-            collisionRegion["joint"] = joint;
-        }
 
         return collisionRegion;
     }
@@ -374,11 +354,6 @@ public:
     // We can't compute the shapeInfo here without loading the model first, so we delegate that responsibility to the owning CollisionPick
     std::shared_ptr<ShapeInfo> shapeInfo = std::make_shared<ShapeInfo>();
     Transform transform;
-
-    // Parenting information
-    QUuid parentID;
-    int parentJointIndex = 0;
-    QString joint; 
 };
 
 namespace std {

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -365,7 +365,7 @@ public:
     }
 
     // We can't load the model here because it would create a circular dependency, so we delegate that responsibility to the owning CollisionPick
-    bool loaded = false;
+    bool loaded { false };
     QUrl modelURL;
 
     // We can't compute the shapeInfo here without loading the model first, so we delegate that responsibility to the owning CollisionPick

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -270,10 +270,10 @@ public:
     CollisionRegion() { }
 
     CollisionRegion(const CollisionRegion& collisionRegion) :
-        threshold(collisionRegion.threshold),
         modelURL(collisionRegion.modelURL),
         shapeInfo(std::make_shared<ShapeInfo>()),
-        transform(collisionRegion.transform)
+        transform(collisionRegion.transform),
+        threshold(collisionRegion.threshold)
     {
         shapeInfo->setParams(collisionRegion.shapeInfo->getType(), collisionRegion.shapeInfo->getHalfExtents(), collisionRegion.modelURL.toString());
     }

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -258,8 +258,11 @@ public:
 
 * @typedef {object} CollisionPick
 * @property {Shape} shape - The information about the collision region's size and shape.
-* @property {Vec3} position - The position of the collision region.
-* @property {Quat} orientation - The orientation of the collision region.
+* @property {Vec3} position - The position of the collision region, relative to a parent if defined.
+* @property {Quat} orientation - The orientation of the collision region, relative to a parent if defined.
+* @property {Uuid} parentID - The ID of the parent, either an avatar, an entity, or an overlay.
+* @property {number} parentJointIndex - The joint of the parent to parent to, for example, the joints on the model of an avatar. (default = 0, no joint)
+* @property {string} joint - If "Mouse," parents the pick to the mouse. If "Head," parents the pick to MyAvatar's head. Otherwise, parents to the joint of the given name on MyAvatar.
 */
 class CollisionRegion : public MathPick {
 public:
@@ -305,6 +308,15 @@ public:
         if (pickVariant["orientation"].isValid()) {
             transform.setRotation(quatFromVariant(pickVariant["orientation"]));
         }
+        if (pickVariant["parentID"].isValid()) {
+            parentID = pickVariant["parentID"].toString();
+        }
+        if (pickVariant["parentJointIndex"].isValid()) {
+            parentJointIndex = pickVariant["parentJointIndex"].toInt();
+        }
+        if (pickVariant["joint"].isValid()) {
+            joint = pickVariant["joint"].toString();
+        }
     }
 
     QVariantMap toVariantMap() const override {
@@ -319,6 +331,14 @@ public:
 
         collisionRegion["position"] = vec3toVariant(transform.getTranslation());
         collisionRegion["orientation"] = quatToVariant(transform.getRotation());
+
+        if (!parentID.isNull()) {
+            collisionRegion["parentID"] = parentID;
+        }
+        collisionRegion["parentJointIndex"] = parentJointIndex;
+        if (!joint.isNull()) {
+            collisionRegion["joint"] = joint;
+        }
 
         return collisionRegion;
     }
@@ -354,6 +374,11 @@ public:
     // We can't compute the shapeInfo here without loading the model first, so we delegate that responsibility to the owning CollisionPick
     std::shared_ptr<ShapeInfo> shapeInfo = std::make_shared<ShapeInfo>();
     Transform transform;
+
+    // Parenting information
+    QUuid parentID;
+    int parentJointIndex = 0;
+    QString joint; 
 };
 
 namespace std {

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -264,6 +264,18 @@ public:
 class CollisionRegion : public MathPick {
 public:
     CollisionRegion() { }
+
+    CollisionRegion(const CollisionRegion& collisionRegion) :
+        modelURL(collisionRegion.modelURL),
+        shapeInfo(std::make_shared<ShapeInfo>()),
+        transform(collisionRegion.transform),
+        parentID(collisionRegion.parentID),
+        parentJointIndex(collisionRegion.parentJointIndex),
+        joint(collisionRegion.joint)
+    {
+        shapeInfo->setParams(collisionRegion.shapeInfo->getType(), collisionRegion.shapeInfo->getHalfExtents(), collisionRegion.modelURL.toString());
+    }
+
     CollisionRegion(const QVariantMap& pickVariant) {
         if (pickVariant["shape"].isValid()) {
             auto shape = pickVariant["shape"].toMap();

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -263,7 +263,7 @@ public:
 * @property {float} threshold - The approximate minimum penetration depth for a test object to be considered in contact with the collision region.
 * @property {Uuid} parentID - The ID of the parent, either an avatar, an entity, or an overlay.
 * @property {number} parentJointIndex - The joint of the parent to parent to, for example, the joints on the model of an avatar. (default = 0, no joint)
-* @property {string} joint - If "Mouse," parents the pick to the mouse. If "Head," parents the pick to MyAvatar's head. Otherwise, parents to the joint of the given name on MyAvatar.
+* @property {string} joint - If "Mouse," parents the pick to the mouse. If "Avatar," parents the pick to MyAvatar's head. Otherwise, parents to the joint of the given name on MyAvatar.
 */
 class CollisionRegion : public MathPick {
 public:

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -253,6 +253,8 @@ public:
     }
 };
 
+// TODO: Add "loaded" to CollisionRegion jsdoc once model collision picks are supported.
+
 /**jsdoc
 * A CollisionRegion defines a volume for checking collisions in the physics simulation.
 
@@ -270,6 +272,7 @@ public:
     CollisionRegion() { }
 
     CollisionRegion(const CollisionRegion& collisionRegion) :
+        loaded(collisionRegion.loaded),
         modelURL(collisionRegion.modelURL),
         shapeInfo(std::make_shared<ShapeInfo>()),
         transform(collisionRegion.transform),
@@ -279,6 +282,7 @@ public:
     }
 
     CollisionRegion(const QVariantMap& pickVariant) {
+        // "loaded" is not deserialized here because there is no way to know if the shape is actually loaded
         if (pickVariant["shape"].isValid()) {
             auto shape = pickVariant["shape"].toMap();
             if (!shape.empty()) {
@@ -322,6 +326,7 @@ public:
         shape["dimensions"] = vec3toVariant(transform.getScale());
 
         collisionRegion["shape"] = shape;
+        collisionRegion["loaded"] = loaded;
 
         collisionRegion["threshold"] = threshold;
 
@@ -339,7 +344,8 @@ public:
     }
 
     bool operator==(const CollisionRegion& other) const {
-        return threshold == other.threshold &&
+        return loaded == other.loaded &&
+            threshold == other.threshold &&
             glm::all(glm::equal(transform.getTranslation(), other.transform.getTranslation())) &&
             glm::all(glm::equal(transform.getRotation(), other.transform.getRotation())) &&
             glm::all(glm::equal(transform.getScale(), other.transform.getScale())) &&
@@ -359,6 +365,7 @@ public:
     }
 
     // We can't load the model here because it would create a circular dependency, so we delegate that responsibility to the owning CollisionPick
+    bool loaded = false;
     QUrl modelURL;
 
     // We can't compute the shapeInfo here without loading the model first, so we delegate that responsibility to the owning CollisionPick

--- a/libraries/shared/src/TransformNode.h
+++ b/libraries/shared/src/TransformNode.h
@@ -1,0 +1,18 @@
+//
+//  Created by Sabrina Shanman 8/14/2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#ifndef hifi_TransformNode_h
+#define hifi_TransformNode_h
+
+#include "Transform.h"
+
+class TransformNode {
+public:
+    virtual Transform getTransform() = 0;
+};
+
+#endif // hifi_TransformNode_h


### PR DESCRIPTION
This PR is a follow-up to https://github.com/highfidelity/hifi/pull/13714. It implements the upcoming parenting system for Collision Picks, which are needed for the teleportation safety improvement.

## TEST PLAN
- Run the manual test at https://github.com/sabrina-shanman/hifi_tests/tree/safe-teleport-target/tests/engine/interaction/pick/collision/parenting_on_server
- Run all the tests in https://github.com/sabrina-shanman/hifi_tests/tree/safe-teleport-target/tests/engine/interaction/pointer