### PR TITLE
Phase walk fix bug 17770

### DIFF
--- a/libraries/animation/src/AnimBlendLinearMove.cpp
+++ b/libraries/animation/src/AnimBlendLinearMove.cpp
@@ -139,8 +139,6 @@ void AnimBlendLinearMove::setFrameAndPhase(float dt, float alpha, int prevPoseIn
     auto nextClipNode = std::dynamic_pointer_cast<AnimClip>(_children[nextPoseIndex]);
     assert(nextClipNode);
 
-    
-
     float v0 = _characteristicSpeeds[prevPoseIndex];
     float n0 = (prevClipNode->getEndFrame() - prevClipNode->getStartFrame()) + 1.0f;
     float v1 = _characteristicSpeeds[nextPoseIndex];

--- a/libraries/animation/src/AnimBlendLinearMove.cpp
+++ b/libraries/animation/src/AnimBlendLinearMove.cpp
@@ -139,6 +139,8 @@ void AnimBlendLinearMove::setFrameAndPhase(float dt, float alpha, int prevPoseIn
     auto nextClipNode = std::dynamic_pointer_cast<AnimClip>(_children[nextPoseIndex]);
     assert(nextClipNode);
 
+    
+
     float v0 = _characteristicSpeeds[prevPoseIndex];
     float n0 = (prevClipNode->getEndFrame() - prevClipNode->getStartFrame()) + 1.0f;
     float v1 = _characteristicSpeeds[nextPoseIndex];
@@ -153,9 +155,17 @@ void AnimBlendLinearMove::setFrameAndPhase(float dt, float alpha, int prevPoseIn
     float f1 = nextClipNode->getStartFrame() + _phase * n1;
     nextClipNode->setCurrentFrame(f1);
 
+
+
     // integrate phase forward in time.
     _phase += omega * dt;
-    qCDebug(animation) << "the _phase is " << _phase;
+    
+    qCDebug(animation) << "the _phase is " << _phase << " and omega " << omega << _desiredSpeed;
+
+    if (_phase < 0.0f) {
+        _phase = 0.0f; // 1.0f + _phase;
+    }
+    
 
     // detect loop trigger events
     if (_phase >= 1.0f) {
@@ -173,7 +183,4 @@ void AnimBlendLinearMove::setCurrentFrameInternal(float frame) {
     assert(clipNode);
     const float NUM_FRAMES = (clipNode->getEndFrame() - clipNode->getStartFrame()) + 1.0f;
     _phase = fmodf(frame / NUM_FRAMES, 1.0f);
-    if (_phase < 0.0f) {
-        _phase = 0.0f; // 1.0f + _phase;
-    }
 }

--- a/libraries/animation/src/AnimBlendLinearMove.cpp
+++ b/libraries/animation/src/AnimBlendLinearMove.cpp
@@ -155,6 +155,7 @@ void AnimBlendLinearMove::setFrameAndPhase(float dt, float alpha, int prevPoseIn
 
     // integrate phase forward in time.
     _phase += omega * dt;
+    qCDebug(animation) << "the _phase is " << _phase;
 
     // detect loop trigger events
     if (_phase >= 1.0f) {
@@ -172,4 +173,7 @@ void AnimBlendLinearMove::setCurrentFrameInternal(float frame) {
     assert(clipNode);
     const float NUM_FRAMES = (clipNode->getEndFrame() - clipNode->getStartFrame()) + 1.0f;
     _phase = fmodf(frame / NUM_FRAMES, 1.0f);
+    if (_phase < 0.0f) {
+        _phase = 0.0f; // 1.0f + _phase;
+    }
 }

--- a/libraries/animation/src/AnimBlendLinearMove.cpp
+++ b/libraries/animation/src/AnimBlendLinearMove.cpp
@@ -155,18 +155,13 @@ void AnimBlendLinearMove::setFrameAndPhase(float dt, float alpha, int prevPoseIn
     float f1 = nextClipNode->getStartFrame() + _phase * n1;
     nextClipNode->setCurrentFrame(f1);
 
-
-
     // integrate phase forward in time.
     _phase += omega * dt;
-    
-    qCDebug(animation) << "the _phase is " << _phase << " and omega " << omega << _desiredSpeed;
 
     if (_phase < 0.0f) {
-        _phase = 0.0f; // 1.0f + _phase;
+        _phase = 0.0f;
     }
     
-
     // detect loop trigger events
     if (_phase >= 1.0f) {
         triggersOut.setTrigger(_id + "Loop");


### PR DESCRIPTION
This pr addresses https://highfidelity.manuscript.com/f/cases/17770/Walking-Running-animation-does-not-transition-smoothly

### **Test** Plan:
1) open interface and go into 3rd person.  
2) push up arrow and back arrow and watch the transition from forward to backward walking. 
3) expected result is less sliding.  