### PR TITLE
RC72: force NL reset if the domain changes session ID or local ID

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -463,19 +463,15 @@ SharedNodePointer DomainGatekeeper::processAgentConnectRequest(const NodeConnect
     limitedNodeList->eachNodeBreakable([nodeConnection, username, &existingNodeID](const SharedNodePointer& node){
 
         if (node->getPublicSocket() == nodeConnection.publicSockAddr && node->getLocalSocket() == nodeConnection.localSockAddr) {
-            // we have a node that already has these exact sockets - this can occur if a node
-            // is failing to connect to the domain
-
-            // we'll re-use the existing node ID
-            // as long as the user hasn't changed their username (by logging in or logging out)
-            auto existingNodeData = static_cast<DomainServerNodeData*>(node->getLinkedData());
-
-            if (existingNodeData->getUsername() == username) {
-                qDebug() << "Deleting existing connection from same sockaddr: " << node->getUUID();
-                existingNodeID = node->getUUID();
-                return false;
-            }
+            // we have a node that already has these exact sockets
+            // this can occur if a node is failing to connect to the domain
+            
+            // remove the old node before adding the new node
+            qDebug() << "Deleting existing connection from same sockaddr: " << node->getUUID();
+            existingNodeID = node->getUUID();
+            return false;
         }
+
         return true;
     });
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -656,7 +656,13 @@ void NodeList::processDomainServerList(QSharedPointer<ReceivedMessage> message) 
         ((currentLocalID != Node::NULL_LOCAL_ID && newLocalID != currentLocalID) ||
         (!currentSessionID.isNull() && newUUID != currentSessionID))) {
             qCDebug(networking) << "Local ID or Session ID changed while connected to domain - forcing NodeList reset";
+
+            // reset the nodelist, but don't do a domain handler reset since we're about to process a good domain list
             reset(true);
+
+            // tell the domain handler that we're no longer connected so that below
+            // it can re-perform actions as if we just connected
+            _domainHandler.setIsConnected(false);
     }
 
     setSessionLocalID(newLocalID);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17817/Client-session-ID-and-local-ID-can-change-without-resetting-any-of-the-connections-to-nodes