### PR TITLE
Fix crash on shutdown in domain with material

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1841,6 +1841,10 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     });
 
     EntityTree::setAddMaterialToEntityOperator([this](const QUuid& entityID, graphics::MaterialLayer material, const std::string& parentMaterialName) {
+        if (_aboutToQuit) {
+            return false;
+        }
+
         // try to find the renderable
         auto renderable = getEntities()->renderableForEntityId(entityID);
         if (renderable) {
@@ -1856,6 +1860,10 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         return false;
     });
     EntityTree::setRemoveMaterialFromEntityOperator([this](const QUuid& entityID, graphics::MaterialPointer material, const std::string& parentMaterialName) {
+        if (_aboutToQuit) {
+            return false;
+        }
+
         // try to find the renderable
         auto renderable = getEntities()->renderableForEntityId(entityID);
         if (renderable) {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17851/Crash-on-shutdown-if-there-s-a-material-in-the-domain

Test plan:
- Go to engine-dev.  Close interface.  You shouldn't crash.
- Go to any domain where you have edit rights.  Make a cube and a material entity with this URL: https://hifi-content.s3.amazonaws.com/samuel/TestMaterialRelative.json.  Set the cube as the parent to the material.  Close interface.  You shouldn't crash.