### PR TITLE
Edit mode controller mapping using new platform state variables

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -726,6 +726,9 @@ static const QString STATE_SNAP_TURN = "SnapTurn";
 static const QString STATE_ADVANCED_MOVEMENT_CONTROLS = "AdvancedMovement";
 static const QString STATE_GROUNDED = "Grounded";
 static const QString STATE_NAV_FOCUSED = "NavigationFocused";
+static const QString STATE_PLATFORM_WINDOWS = "PlatformWindows";
+static const QString STATE_PLATFORM_MAC = "PlatformMac";
+static const QString STATE_PLATFORM_ANDROID = "PlatformAndroid";
 
 // Statically provided display and input plugins
 extern DisplayPluginList getDisplayPlugins();
@@ -909,7 +912,8 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     DependencyManager::set<MessagesClient>();
     controller::StateController::setStateVariables({ { STATE_IN_HMD, STATE_CAMERA_FULL_SCREEN_MIRROR,
                     STATE_CAMERA_FIRST_PERSON, STATE_CAMERA_THIRD_PERSON, STATE_CAMERA_ENTITY, STATE_CAMERA_INDEPENDENT,
-                    STATE_SNAP_TURN, STATE_ADVANCED_MOVEMENT_CONTROLS, STATE_GROUNDED, STATE_NAV_FOCUSED } });
+                    STATE_SNAP_TURN, STATE_ADVANCED_MOVEMENT_CONTROLS, STATE_GROUNDED, STATE_NAV_FOCUSED,
+                    STATE_PLATFORM_WINDOWS, STATE_PLATFORM_MAC, STATE_PLATFORM_WINDOWS } });
     DependencyManager::set<UserInputMapper>();
     DependencyManager::set<controller::ScriptingInterface, ControllerScriptingInterface>();
     DependencyManager::set<InterfaceParentFinder>();
@@ -1682,6 +1686,27 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     });
     _applicationStateDevice->setInputVariant(STATE_NAV_FOCUSED, []() -> float {
         return DependencyManager::get<OffscreenUi>()->navigationFocused() ? 1 : 0;
+    });
+    _applicationStateDevice->setInputVariant(STATE_PLATFORM_WINDOWS, []() -> float {
+#if defined(Q_OS_WIN) 
+        return 1;
+#else
+        return 0;
+#endif
+    });
+    _applicationStateDevice->setInputVariant(STATE_PLATFORM_MAC, []() -> float {
+#if defined(Q_OS_MAC) 
+        return 1;
+#else
+        return 0;
+#endif
+    });
+    _applicationStateDevice->setInputVariant(STATE_PLATFORM_ANDROID, []() -> float {
+#if defined(Q_OS_ANDROID) 
+        return 1;
+#else
+        return 0;
+#endif
     });
 
     // Setup the _keyboardMouseDevice, _touchscreenDevice, _touchscreenVirtualPadDevice and the user input mapper with the default bindings

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
@@ -302,6 +302,8 @@ controller::Input::NamedVector KeyboardMouseDevice::InputDevice::getAvailableInp
         availableInputs.append(Input::NamedPair(makeInput(Qt::Key_PageDown), QKeySequence(Qt::Key_PageDown).toString()));
         availableInputs.append(Input::NamedPair(makeInput(Qt::Key_Tab), QKeySequence(Qt::Key_Tab).toString()));
         availableInputs.append(Input::NamedPair(makeInput(Qt::Key_Control), "Control"));
+        availableInputs.append(Input::NamedPair(makeInput(Qt::Key_Delete), "Delete"));
+        availableInputs.append(Input::NamedPair(makeInput(Qt::Key_Backspace), QKeySequence(Qt::Key_Backspace).toString()));
 
         availableInputs.append(Input::NamedPair(makeInput(Qt::LeftButton), "LeftMouseButton"));
         availableInputs.append(Input::NamedPair(makeInput(Qt::MiddleButton), "MiddleMouseButton"));

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
@@ -304,6 +304,8 @@ controller::Input::NamedVector KeyboardMouseDevice::InputDevice::getAvailableInp
         availableInputs.append(Input::NamedPair(makeInput(Qt::Key_Control), "Control"));
         availableInputs.append(Input::NamedPair(makeInput(Qt::Key_Delete), "Delete"));
         availableInputs.append(Input::NamedPair(makeInput(Qt::Key_Backspace), QKeySequence(Qt::Key_Backspace).toString()));
+        availableInputs.append(Input::NamedPair(makeInput(Qt::Key_BracketLeft), "BracketLeft"));
+        availableInputs.append(Input::NamedPair(makeInput(Qt::Key_BracketRight), "BracketRight"));
 
         availableInputs.append(Input::NamedPair(makeInput(Qt::LeftButton), "LeftMouseButton"));
         availableInputs.append(Input::NamedPair(makeInput(Qt::MiddleButton), "MiddleMouseButton"));

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
@@ -304,8 +304,6 @@ controller::Input::NamedVector KeyboardMouseDevice::InputDevice::getAvailableInp
         availableInputs.append(Input::NamedPair(makeInput(Qt::Key_Control), "Control"));
         availableInputs.append(Input::NamedPair(makeInput(Qt::Key_Delete), "Delete"));
         availableInputs.append(Input::NamedPair(makeInput(Qt::Key_Backspace), QKeySequence(Qt::Key_Backspace).toString()));
-        availableInputs.append(Input::NamedPair(makeInput(Qt::Key_BracketLeft), "BracketLeft"));
-        availableInputs.append(Input::NamedPair(makeInput(Qt::Key_BracketRight), "BracketRight"));
 
         availableInputs.append(Input::NamedPair(makeInput(Qt::LeftButton), "LeftMouseButton"));
         availableInputs.append(Input::NamedPair(makeInput(Qt::MiddleButton), "MiddleMouseButton"));

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1912,7 +1912,7 @@ function gridKey(value) {
     }
 }
 var mapping = Controller.newMapping(CONTROLLER_MAPPING_NAME);
-mapping.from([Controller.Hardware.Keyboard.Delete]).when([Controller.Hardware.Application.PlatformWindows]).to(deleteKey);
+mapping.from([Controller.Hardware.Keyboard.Delete]).when([!Controller.Hardware.Application.PlatformMac]).to(deleteKey);
 mapping.from([Controller.Hardware.Keyboard.Backspace]).when([Controller.Hardware.Application.PlatformMac]).to(deleteKey);
 mapping.from([Controller.Hardware.Keyboard.D]).when([Controller.Hardware.Keyboard.Control]).to(deselectKey);
 mapping.from([Controller.Hardware.Keyboard.T]).to(toggleKey);

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1892,8 +1892,10 @@ function toggleKey(value) {
 function focusKey(value) {
     if (value === 0) { // on release
         cameraManager.enable();
-        cameraManager.focus(selectionManager.worldPosition, selectionManager.worldDimensions, 
-                            Menu.isOptionChecked(MENU_EASE_ON_FOCUS));
+        if (selectionManager.hasSelection()) {
+            cameraManager.focus(selectionManager.worldPosition, selectionManager.worldDimensions, 
+                                Menu.isOptionChecked(MENU_EASE_ON_FOCUS));
+        }
     }
 }
 function gridKey(value) {

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1863,28 +1863,7 @@ var keyReleaseEvent = function (event) {
         cameraManager.keyReleaseEvent(event);
     }
     // since sometimes our menu shortcut keys don't work, trap our menu items here also and fire the appropriate menu items
-    if (event.text === 'd' && event.isControl) {
-        selectionManager.clearSelections();
-    } else if (event.text === "t") {
-        selectionDisplay.toggleSpaceMode();
-    } else if (event.text === "f") {
-        if (isActive) {
-            if (selectionManager.hasSelection()) {
-                cameraManager.enable();
-                cameraManager.focus(selectionManager.worldPosition,
-                    selectionManager.worldDimensions,
-                    Menu.isOptionChecked(MENU_EASE_ON_FOCUS));
-            }
-        }
-    } else if (event.text === '[') {
-        if (isActive) {
-            cameraManager.enable();
-        }
-    } else if (event.text === 'g') {
-        if (isActive && selectionManager.hasSelection()) {
-            grid.moveToSelection();
-        }
-    } else if (event.key === KEY_P && event.isControl && !event.isAutoRepeat ) {
+    if (event.key === KEY_P && event.isControl && !event.isAutoRepeat) {
         if (event.isShifted) {
             unparentSelectedEntities();
         } else {
@@ -1900,9 +1879,46 @@ function deleteKey(value) {
         deleteSelectedEntities();
     }
 }
+function deselectKey(value) {
+    if (value === 0) { // on release
+        selectionManager.clearSelections();
+    }
+}
+function toggleKey(value) {
+    if (value === 0) { // on release
+        selectionDisplay.toggleSpaceMode();
+    }
+}
+function focusKey(value) {
+    if (value === 0) { // on release
+        if (selectionManager.hasSelection()) {
+            cameraManager.enable();
+            cameraManager.focus(selectionManager.worldPosition, 
+                                selectionManager.worldDimensions, 
+                                Menu.isOptionChecked(MENU_EASE_ON_FOCUS));
+        }
+    }
+}
+function cameraKey(value) {
+    if (value === 0) { // on release
+        cameraManager.enable();
+    }
+}
+function gridKey(value) {
+    if (value === 0) { // on release
+        if (selectionManager.hasSelection()) {
+            grid.moveToSelection();
+        }
+    }
+}
 var mapping = Controller.newMapping(CONTROLLER_MAPPING_NAME);
-mapping.from([Controller.Hardware.Keyboard.Delete]).when([Controller.Hardware.Application.PlatformWindows]).peek().to(deleteKey);
-mapping.from([Controller.Hardware.Keyboard.Backspace]).when([Controller.Hardware.Application.PlatformMac]).peek().to(deleteKey);
+mapping.from([Controller.Hardware.Keyboard.Delete]).when([Controller.Hardware.Application.PlatformWindows]).to(deleteKey);
+mapping.from([Controller.Hardware.Keyboard.Backspace]).when([Controller.Hardware.Application.PlatformMac]).to(deleteKey);
+mapping.from([Controller.Hardware.Keyboard.D]).when([Controller.Hardware.Keyboard.Control]).to(deselectKey);
+mapping.from([Controller.Hardware.Keyboard.T]).to(toggleKey);
+mapping.from([Controller.Hardware.Keyboard.F]).to(focusKey);
+mapping.from([Controller.Hardware.Keyboard.BracketLeft]).to(cameraKey);
+mapping.from([Controller.Hardware.Keyboard.G]).to(gridKey);
 
 function recursiveAdd(newParentID, parentData) {
     if (parentData.children !== undefined) {

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -20,6 +20,8 @@
 
 var EDIT_TOGGLE_BUTTON = "com.highfidelity.interface.system.editButton";
 
+var CONTROLLER_MAPPING_NAME = "com.highfidelity.editMode";
+
 Script.include([
     "libraries/stringHelpers.js",
     "libraries/dataViewHelpers.js",
@@ -860,6 +862,7 @@ var toolBar = (function () {
             cameraManager.disable();
             selectionDisplay.triggerMapping.disable();
             tablet.landscape = false;
+            Controller.disableMapping(CONTROLLER_MAPPING_NAME);
         } else {
             if (shouldUseEditTabletApp()) {
                 tablet.loadQMLSource("hifi/tablet/Edit.qml", true);
@@ -876,6 +879,7 @@ var toolBar = (function () {
             selectionDisplay.triggerMapping.enable();
             print("starting tablet in landscape mode");
             tablet.landscape = true;
+            Controller.enableMapping(CONTROLLER_MAPPING_NAME);
             // Not sure what the following was meant to accomplish, but it currently causes
             // everybody else to think that Interface has lost focus overall. fogbugzid:558
             // Window.setFocus();
@@ -1859,9 +1863,7 @@ var keyReleaseEvent = function (event) {
         cameraManager.keyReleaseEvent(event);
     }
     // since sometimes our menu shortcut keys don't work, trap our menu items here also and fire the appropriate menu items
-    if (event.text === "DELETE") {
-        deleteSelectedEntities();
-    } else if (event.text === 'd' && event.isControl) {
+    if (event.text === 'd' && event.isControl) {
         selectionManager.clearSelections();
     } else if (event.text === "t") {
         selectionDisplay.toggleSpaceMode();
@@ -1892,6 +1894,15 @@ var keyReleaseEvent = function (event) {
 };
 Controller.keyReleaseEvent.connect(keyReleaseEvent);
 Controller.keyPressEvent.connect(keyPressEvent);
+
+function deleteKey(value) {
+    if (value === 0) { // on release
+        deleteSelectedEntities();
+    }
+}
+var mapping = Controller.newMapping(CONTROLLER_MAPPING_NAME);
+mapping.from([Controller.Hardware.Keyboard.Delete]).when([Controller.Hardware.Application.PlatformWindows]).peek().to(deleteKey);
+mapping.from([Controller.Hardware.Keyboard.Backspace]).when([Controller.Hardware.Application.PlatformMac]).peek().to(deleteKey);
 
 function recursiveAdd(newParentID, parentData) {
     if (parentData.children !== undefined) {

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1891,17 +1891,9 @@ function toggleKey(value) {
 }
 function focusKey(value) {
     if (value === 0) { // on release
-        if (selectionManager.hasSelection()) {
-            cameraManager.enable();
-            cameraManager.focus(selectionManager.worldPosition, 
-                                selectionManager.worldDimensions, 
-                                Menu.isOptionChecked(MENU_EASE_ON_FOCUS));
-        }
-    }
-}
-function cameraKey(value) {
-    if (value === 0) { // on release
         cameraManager.enable();
+        cameraManager.focus(selectionManager.worldPosition, selectionManager.worldDimensions, 
+                            Menu.isOptionChecked(MENU_EASE_ON_FOCUS));
     }
 }
 function gridKey(value) {
@@ -1917,7 +1909,6 @@ mapping.from([Controller.Hardware.Keyboard.Backspace]).when([Controller.Hardware
 mapping.from([Controller.Hardware.Keyboard.D]).when([Controller.Hardware.Keyboard.Control]).to(deselectKey);
 mapping.from([Controller.Hardware.Keyboard.T]).to(toggleKey);
 mapping.from([Controller.Hardware.Keyboard.F]).to(focusKey);
-mapping.from([Controller.Hardware.Keyboard.BracketLeft]).to(cameraKey);
 mapping.from([Controller.Hardware.Keyboard.G]).to(gridKey);
 
 function recursiveAdd(newParentID, parentData) {


### PR DESCRIPTION
Add a controller mapping for edit mode keyboard shortcuts using new platform-specific state variables in Application to allow for separating the delete selected entities shortcut to be the actual Delete key on PC (next to End) and the Backspace key on Mac.

Also remove the '[' keyboard shortcut for entering edit camera, and allow 'F' key to enter edit camera without any selected entities to focus on.

Fixes: https://highfidelity.manuscript.com/f/cases/6395

Test Plan:
- Enter Interface in desktop mode on PC and open Create app
- Verify the following keyboard shortcuts work as expected:
Delete key = Delete selected entities
Ctrl + D on PC and Cmd + D on Mac = Deselect selected entities
T = Toggle between world and local space edit handles
F = Enter edit camera or focus on any selected entities
G = Align grid to bottom of selected entities (requires grid set to visible on Grid tab)
- Enter Interface on Mac and open Create app
- Verify the above keyboard shortcuts work as expected