### PR TITLE
Fix blendshape crash

### DIFF
--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -86,9 +86,8 @@ void CauterizedModel::createRenderItemSet() {
             // Create the render payloads
             int numParts = (int)mesh->getNumParts();
             for (int partIndex = 0; partIndex < numParts; partIndex++) {
-                if (!fbxGeometry.meshes[i].blendshapes.empty() && !_blendedVertexBuffers[i]) {
-                    _blendedVertexBuffers[i] = std::make_shared<gpu::Buffer>();
-                    _blendedVertexBuffers[i]->resize(fbxGeometry.meshes[i].vertices.size() * (sizeof(glm::vec3) + 2 * sizeof(NormalType)));
+                if (!fbxGeometry.meshes[i].blendshapes.empty()) {
+                    initializeBlendshapes(fbxGeometry.meshes[i], i);
                 }
                 auto ptr = std::make_shared<CauterizedMeshPartPayload>(shared_from_this(), i, partIndex, shapeID, transform, offset);
                 _modelMeshRenderItems << std::static_pointer_cast<ModelMeshPartPayload>(ptr);

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -482,6 +482,8 @@ protected:
 
     bool shouldInvalidatePayloadShapeKey(int meshIndex);
 
+    void initializeBlendshapes(const FBXMesh& mesh, int index);
+
 private:
     float _loadingPriority { 0.0f };
 


### PR DESCRIPTION
Fixes a crash related to the order of mesh part creation, initial model simulation, and Blender thread timing.

Test plan:
- The crash doesn't repro all the time because the timing is tricky.  The easiest thing to do: go to engine-dev.  There are a lot of avatars there.  Spin around as they load, reload content, leave the domain and come back.  Each time wait until the avatars all load.  Their faces should render correctly, as should your own.  You shouldn't crash.