### PR TITLE
Fix Android StateController assert

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -913,7 +913,7 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     controller::StateController::setStateVariables({ { STATE_IN_HMD, STATE_CAMERA_FULL_SCREEN_MIRROR,
                     STATE_CAMERA_FIRST_PERSON, STATE_CAMERA_THIRD_PERSON, STATE_CAMERA_ENTITY, STATE_CAMERA_INDEPENDENT,
                     STATE_SNAP_TURN, STATE_ADVANCED_MOVEMENT_CONTROLS, STATE_GROUNDED, STATE_NAV_FOCUSED,
-                    STATE_PLATFORM_WINDOWS, STATE_PLATFORM_MAC, STATE_PLATFORM_WINDOWS } });
+                    STATE_PLATFORM_WINDOWS, STATE_PLATFORM_MAC, STATE_PLATFORM_ANDROID } });
     DependencyManager::set<UserInputMapper>();
     DependencyManager::set<controller::ScriptingInterface, ControllerScriptingInterface>();
     DependencyManager::set<InterfaceParentFinder>();


### PR DESCRIPTION
Follow-up fix to assert caused by https://github.com/highfidelity/hifi/pull/13888/

Test Plan:

- Enter Interface in desktop mode on PC and open Create app
- Verify the following keyboard shortcuts work as expected:
Delete = Delete selected entities
Ctrl + D on PC and Cmd + D on Mac = Deselect selected entities
T = Toggle between world and local space edit handles
F = Enter edit camera or focus on any selected entities
G = Align grid to bottom of selected entities (requires grid set to visible on Grid tab)
- Enter Interface on Mac and open Create app
- Verify the above keyboard shortcuts work as expected
- Run smoke test on Android to verify no issues