### PR TITLE
Avatar App: stop reloading existing selected bookmarks on app relaunch (master)

### DIFF
--- a/interface/resources/qml/hifi/AvatarApp.qml
+++ b/interface/resources/qml/hifi/AvatarApp.qml
@@ -175,7 +175,14 @@ Rectangle {
             displayNameInput.text = getAvatarsData.displayName;
             currentAvatarSettings = getAvatarsData.currentAvatarSettings;
 
-            updateCurrentAvatarInBookmarks(currentAvatar);
+            var bookmarkAvatarIndex = allAvatars.findAvatarIndexByValue(currentAvatar);
+            if (bookmarkAvatarIndex === -1) {
+                currentAvatar.name = '';
+            } else {
+                currentAvatar.name = allAvatars.get(bookmarkAvatarIndex).name;
+                allAvatars.move(bookmarkAvatarIndex, 0, 1);
+            }
+            view.setPage(0);
         } else if (message.method === 'updateAvatarInBookmarks') {
             updateCurrentAvatarInBookmarks(currentAvatar);
         } else if (message.method === 'selectAvatarEntity') {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17982/Avatar-App-reloads-existing-selected-bookmark-on-app-relaunch

**Test plan**

Ensure AvatarApp still can detect whether current avatar is bookmarked and highlight it. 