### PR TITLE
After PR13898, joints list in Avatar app's Joint dropdown menu do not match actual joints

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
+++ b/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
@@ -298,8 +298,10 @@ Rectangle {
 
                 function notifyJointChanged() {
                     modified = true;
+                    var jointIndex = jointsModel.get(jointsCombobox.currentIndex).jointIndex;
+
                     var properties = {
-                        parentJointIndex: currentIndex,
+                        parentJointIndex: jointIndex,
                         localPosition: {
                             x: positionVector.xvalue,
                             y: positionVector.yvalue,
@@ -312,7 +314,7 @@ Rectangle {
                         }
                     };
 
-                    wearableUpdated(getCurrentWearable().id, jointsModel.get(jointsCombobox.currentIndex).jointIndex, properties);
+                    wearableUpdated(getCurrentWearable().id, jointIndex, properties);
                 }
 
                 onCurrentIndexChanged: {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17981/After-PR13898-joints-list-in-Avatar-app-s-Joint-dropdown-menu-do-not-match-actual-joints

**Test plan**

1. Launch avatarapp, select avatar with joints, select wearable
2. Ensure joints from combobox match actual joints.  