### PR TITLE
fix a bug that broke Entities.setVoxel().  Fix polyvox textures

### DIFF
--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -291,7 +291,7 @@ QByteArray RenderablePolyVoxEntityItem::volDataToArray(quint16 voxelXSize, quint
     withReadLock([&] {
         if (isEdged()) {
             low += 1;
-            voxelSize += 1;
+            voxelSize += 2;
         }
 
         loop3(low, voxelSize, [&](const ivec3& v){


### PR DESCRIPTION
- fix a bug that broke Entities.setVoxel().

https://github.com/highfidelity/hifi/issues/13882
https://highfidelity.fogbugz.com/f/cases/20014/Entities-setVoxel-is-broken

