### PR TITLE
Fix MS17902: Prevent case where My Purchases says Open instead of Uninstall

### DIFF
--- a/interface/src/commerce/QmlCommerce.cpp
+++ b/interface/src/commerce/QmlCommerce.cpp
@@ -40,11 +40,9 @@ QmlCommerce::QmlCommerce() {
     connect(ledger.data(), &Ledger::transferAssetToUsernameResult, this, &QmlCommerce::transferAssetToUsernameResult);
     connect(ledger.data(), &Ledger::availableUpdatesResult, this, &QmlCommerce::availableUpdatesResult);
     connect(ledger.data(), &Ledger::updateItemResult, this, &QmlCommerce::updateItemResult);
-    
+
     auto accountManager = DependencyManager::get<AccountManager>();
-    connect(accountManager.data(), &AccountManager::usernameChanged, this, [&]() {
-        setPassphrase("");
-    });
+    connect(accountManager.data(), &AccountManager::usernameChanged, this, [&]() { setPassphrase(""); });
 
     _appsPath = PathUtils::getAppDataPath() + "Apps/";
 }
@@ -105,7 +103,11 @@ void QmlCommerce::balance() {
     }
 }
 
-void QmlCommerce::inventory(const QString& editionFilter, const QString& typeFilter, const QString& titleFilter, const int& page, const int& perPage) {
+void QmlCommerce::inventory(const QString& editionFilter,
+                            const QString& typeFilter,
+                            const QString& titleFilter,
+                            const int& page,
+                            const int& perPage) {
     auto ledger = DependencyManager::get<Ledger>();
     auto wallet = DependencyManager::get<Wallet>();
     QStringList cachedPublicKeys = wallet->listPublicKeys();
@@ -166,24 +168,30 @@ void QmlCommerce::certificateInfo(const QString& certificateId) {
     ledger->certificateInfo(certificateId);
 }
 
-void QmlCommerce::transferAssetToNode(const QString& nodeID, const QString& certificateID, const int& amount, const QString& optionalMessage) {
+void QmlCommerce::transferAssetToNode(const QString& nodeID,
+                                      const QString& certificateID,
+                                      const int& amount,
+                                      const QString& optionalMessage) {
     auto ledger = DependencyManager::get<Ledger>();
     auto wallet = DependencyManager::get<Wallet>();
     QStringList keys = wallet->listPublicKeys();
     if (keys.count() == 0) {
-        QJsonObject result{ { "status", "fail" },{ "message", "Uninitialized Wallet." } };
+        QJsonObject result{ { "status", "fail" }, { "message", "Uninitialized Wallet." } };
         return emit transferAssetToNodeResult(result);
     }
     QString key = keys[0];
     ledger->transferAssetToNode(key, nodeID, certificateID, amount, optionalMessage);
 }
 
-void QmlCommerce::transferAssetToUsername(const QString& username, const QString& certificateID, const int& amount, const QString& optionalMessage) {
+void QmlCommerce::transferAssetToUsername(const QString& username,
+                                          const QString& certificateID,
+                                          const int& amount,
+                                          const QString& optionalMessage) {
     auto ledger = DependencyManager::get<Ledger>();
     auto wallet = DependencyManager::get<Wallet>();
     QStringList keys = wallet->listPublicKeys();
     if (keys.count() == 0) {
-        QJsonObject result{ { "status", "fail" },{ "message", "Uninitialized Wallet." } };
+        QJsonObject result{ { "status", "fail" }, { "message", "Uninitialized Wallet." } };
         return emit transferAssetToUsernameResult(result);
     }
     QString key = keys[0];
@@ -194,10 +202,7 @@ void QmlCommerce::replaceContentSet(const QString& itemHref, const QString& cert
     auto ledger = DependencyManager::get<Ledger>();
     ledger->updateLocation(certificateID, DependencyManager::get<AddressManager>()->getPlaceName(), true);
     qApp->replaceDomainContent(itemHref);
-    QJsonObject messageProperties = {
-        { "status", "SuccessfulRequestToReplaceContent" },
-        { "content_set_url", itemHref }
-    };
+    QJsonObject messageProperties = { { "status", "SuccessfulRequestToReplaceContent" }, { "content_set_url", itemHref } };
     UserActivityLogger::getInstance().logAction("replace_domain_content", messageProperties);
 
     emit contentSetChanged(itemHref);
@@ -214,10 +219,7 @@ QString QmlCommerce::getInstalledApps(const QString& justInstalledAppID) {
 
     QDir directory(_appsPath);
     QStringList apps = directory.entryList(QStringList("*.app.json"));
-    foreach(QString appFileName, apps) {
-        installedAppsFromMarketplace += appFileName;
-        installedAppsFromMarketplace += ",";
-
+    foreach (QString appFileName, apps) {
         // If we were supplied a "justInstalledAppID" argument, that means we're entering this function
         // to get the new list of installed apps immediately after installing an app.
         // In that case, the app we installed may not yet have its associated script running -
@@ -243,10 +245,12 @@ QString QmlCommerce::getInstalledApps(const QString& justInstalledAppID) {
             // delete the .app.json from the user's local disk.
             if (!runningScripts.contains(scriptURL)) {
                 if (!appFile.remove()) {
-                    qCWarning(commerce)
-                        << "Couldn't delete local .app.json file (app's script isn't running). App filename is:"
-                        << appFileName;
+                    qCWarning(commerce) << "Couldn't delete local .app.json file (app's script isn't running). App filename is:"
+                                        << appFileName;
                 }
+            } else {
+                installedAppsFromMarketplace += appFileName;
+                installedAppsFromMarketplace += ",";
             }
         } else {
             qCDebug(commerce) << "Couldn't open local .app.json file for reading.";
@@ -317,7 +321,9 @@ bool QmlCommerce::uninstallApp(const QString& itemHref) {
     // Read from the file to know what .js script to stop
     QFile appFile(_appsPath + "/" + appHref.fileName());
     if (!appFile.open(QIODevice::ReadOnly)) {
-        qCDebug(commerce) << "Couldn't open local .app.json file for deletion. Cannot continue with app uninstallation. App filename is:" << appHref.fileName();
+        qCDebug(commerce)
+            << "Couldn't open local .app.json file for deletion. Cannot continue with app uninstallation. App filename is:"
+            << appHref.fileName();
         return false;
     }
     QJsonDocument appFileJsonDocument = QJsonDocument::fromJson(appFile.readAll());
@@ -325,13 +331,15 @@ bool QmlCommerce::uninstallApp(const QString& itemHref) {
     QString scriptUrl = appFileJsonObject["scriptURL"].toString();
 
     if (!DependencyManager::get<ScriptEngines>()->stopScript(scriptUrl.trimmed(), false)) {
-        qCWarning(commerce) << "Couldn't stop script during app uninstall. Continuing anyway. ScriptURL is:" << scriptUrl.trimmed();
+        qCWarning(commerce) << "Couldn't stop script during app uninstall. Continuing anyway. ScriptURL is:"
+                            << scriptUrl.trimmed();
     }
 
     // Delete the .app.json from the filesystem
     // remove() closes the file first.
     if (!appFile.remove()) {
-        qCWarning(commerce) << "Couldn't delete local .app.json file during app uninstall. Continuing anyway. App filename is:" << appHref.fileName();
+        qCWarning(commerce) << "Couldn't delete local .app.json file during app uninstall. Continuing anyway. App filename is:"
+                            << appHref.fileName();
     }
 
     QFileInfo appFileInfo(appFile);
@@ -352,7 +360,8 @@ bool QmlCommerce::openApp(const QString& itemHref) {
     QJsonObject appFileJsonObject = appFileJsonDocument.object();
     QString homeUrl = appFileJsonObject["homeURL"].toString();
 
-    auto tablet = dynamic_cast<TabletProxy*>(DependencyManager::get<TabletScriptingInterface>()->getTablet("com.highfidelity.interface.tablet.system"));
+    auto tablet = dynamic_cast<TabletProxy*>(
+        DependencyManager::get<TabletScriptingInterface>()->getTablet("com.highfidelity.interface.tablet.system"));
     if (homeUrl.contains(".qml", Qt::CaseInsensitive)) {
         tablet->loadQMLSource(homeUrl);
     } else if (homeUrl.contains(".html", Qt::CaseInsensitive)) {
@@ -377,7 +386,7 @@ void QmlCommerce::updateItem(const QString& certificateId) {
     auto wallet = DependencyManager::get<Wallet>();
     QStringList keys = wallet->listPublicKeys();
     if (keys.count() == 0) {
-        QJsonObject result{ { "status", "fail" },{ "message", "Uninitialized Wallet." } };
+        QJsonObject result{ { "status", "fail" }, { "message", "Uninitialized Wallet." } };
         return emit updateItemResult(result);
     }
     QString key = keys[0];


### PR DESCRIPTION
Fixes [MS17902](https://highfidelity.manuscript.com/f/cases/17902/Killing-Spectator-Camera-script-from-Running-Scripts-shows-button-as-Open-instead-of-Install-when-visiting-My-Purchases).

Also, Clang changed the format of this file a bunch. The only non-formatting changes are inside `QmlCommerce::getInstalledApps()`.