### PR TITLE
Fix MS 17828: Explore Desktop Text Visible

### DIFF
--- a/cmake/externals/serverless-content/CMakeLists.txt
+++ b/cmake/externals/serverless-content/CMakeLists.txt
@@ -4,8 +4,8 @@ set(EXTERNAL_NAME serverless-content)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC72.zip
-  URL_MD5 b1d8faf9266bfbff88274a484911eb99
+  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC73.zip
+  URL_MD5 0c5edfb63cafb042311d3cf25261fbf2
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""


### PR DESCRIPTION
This should fix Manuscript case 17828 where the 'Explore' station text is visible by default and makes getting HMD instructions have z-fighting issues. 

Test plan: Run tutorial test plan in HMD and Desktop mode, focusing on the Explore station text and instructional boxes. 

Also note audio levels in the Bubble station to confirm that changes made in #13839 still are applied here. 