### PR TITLE
Fix particle acceleration spread

### DIFF
--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -187,12 +187,10 @@ ParticleEffectEntityRenderer::CpuParticle ParticleEffectEntityRenderer::createPa
     particle.basePosition = baseTransform.getTranslation();
 
     // Position, velocity, and acceleration
+    glm::vec3 emitDirection;
     if (polarStart == 0.0f && polarFinish == 0.0f && emitDimensions.z == 0.0f) {
         // Emit along z-axis from position
-
-        particle.velocity = (emitSpeed + randFloatInRange(-1.0f, 1.0f) * speedSpread) * (emitOrientation * Vectors::UNIT_Z);
-        particle.acceleration = emitAcceleration + randFloatInRange(-1.0f, 1.0f) * accelerationSpread;
-
+        emitDirection = Vectors::UNIT_Z;
     } else {
         // Emit around point or from ellipsoid
         // - Distribute directions evenly around point
@@ -210,7 +208,6 @@ ParticleEffectEntityRenderer::CpuParticle ParticleEffectEntityRenderer::createPa
             azimuth = azimuthStart + (TWO_PI + azimuthFinish - azimuthStart) * randFloat();
         }
 
-        glm::vec3 emitDirection;
         if (emitDimensions == Vectors::ZERO) {
             // Point
             emitDirection = glm::quat(glm::vec3(PI_OVER_TWO - elevation, 0.0f, azimuth)) * Vectors::UNIT_Z;
@@ -235,10 +232,10 @@ ParticleEffectEntityRenderer::CpuParticle ParticleEffectEntityRenderer::createPa
             ));
             particle.relativePosition += emitOrientation * emitPosition;
         }
-
-        particle.velocity = (emitSpeed + randFloatInRange(-1.0f, 1.0f) * speedSpread) * (emitOrientation * emitDirection);
-        particle.acceleration = emitAcceleration + randFloatInRange(-1.0f, 1.0f) * accelerationSpread;
     }
+    particle.velocity = (emitSpeed + randFloatInRange(-1.0f, 1.0f) * speedSpread) * (emitOrientation * emitDirection);
+    particle.acceleration = emitAcceleration +
+        glm::vec3(randFloatInRange(-1.0f, 1.0f), randFloatInRange(-1.0f, 1.0f), randFloatInRange(-1.0f, 1.0f)) * accelerationSpread;
 
     return particle;
 }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/18050/Particle-Effect-Acceleration-Spread-scales-all-axes-the-same-amount-instead-of-individually

Acceleration Spread was not being used correctly.

Test plan:
- Create a particle entity.  Give it emitSpeed = 0, speedSpread = 0, emitAcceleration = 0.  Set two of the axes for accelerationSpread to a non-zero number.  In master, the particles would extend along a line.  In this PR, they should extend along a plane, as expected.  If you increase maxParticles, decrease lifespan, and increase emitRate, this becomes more obvious.