### PR TITLE
Fix for glitch when entering in-air state from takeoff.

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -926,7 +926,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
 
             // compute blend based on velocity
             const float JUMP_SPEED = 3.5f;
-            float alpha = glm::clamp(-_lastVelocity.y / JUMP_SPEED, -1.0f, 1.0f) + 1.0f;
+            float alpha = glm::clamp(-workingVelocity.y / JUMP_SPEED, -1.0f, 1.0f) + 1.0f;
             _animVars.set("inAirAlpha", alpha);
         }
 


### PR DESCRIPTION
This was due to a frame lag of blend factor used for in-air blending.  So the first frame the upward velocity would be 0, followed by 3.5 m/s the next frame.

This is fixed by using the workingVelocity instead of _lastVelocity to drive the blend.