### PR TITLE
volume slider on individual users in PAL remembers setting now

### DIFF
--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -530,9 +530,7 @@ Item {
         maximumValue: 20.0
         stepSize: 5
         updateValueWhileDragging: true
-        Component.onCompleted: {
-            value = Users.getAvatarGain(uuid);
-        }
+        value: Users.getAvatarGain(uuid)
         onValueChanged: {
             updateGainFromQML(uuid, value, false);
         }


### PR DESCRIPTION
Seems onCompleted is fired before the NameCard knows the uuid, so lets not set the gain in onCompleted any more.