### PR TITLE
Fix blendshapes crash one last time, one last time

### DIFF
--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -102,7 +102,7 @@ void CauterizedModel::createRenderItemSet() {
     }
 }
 
-void CauterizedModel::updateClusterMatrices(bool triggerBlendshapes) {
+void CauterizedModel::updateClusterMatrices() {
     PerformanceTimer perfTimer("CauterizedModel::updateClusterMatrices");
 
     if (!_needsUpdateClusterMatrices || !isLoaded()) {
@@ -175,7 +175,7 @@ void CauterizedModel::updateClusterMatrices(bool triggerBlendshapes) {
 
     // post the blender if we're not currently waiting for one to finish
     auto modelBlender = DependencyManager::get<ModelBlender>();
-    if (triggerBlendshapes && modelBlender->shouldComputeBlendshapes() && geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
+    if (_blendedVertexBuffersInitialized && modelBlender->shouldComputeBlendshapes() && geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
         _blendedBlendshapeCoefficients = _blendshapeCoefficients;
         modelBlender->noteRequiresBlend(getThisPointer());
     }

--- a/libraries/render-utils/src/CauterizedModel.h
+++ b/libraries/render-utils/src/CauterizedModel.h
@@ -33,7 +33,7 @@ public:
 
     void createRenderItemSet() override;
     
-    virtual void updateClusterMatrices(bool triggerBlendshapes = true) override;
+    virtual void updateClusterMatrices() override;
     void updateRenderItems() override;
 
     const Model::MeshState& getCauterizeMeshState(int index) const;

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -159,7 +159,7 @@ public:
     bool getSnapModelToRegistrationPoint() { return _snapModelToRegistrationPoint; }
 
     virtual void simulate(float deltaTime, bool fullUpdate = true);
-    virtual void updateClusterMatrices(bool triggerBlendshapes = true);
+    virtual void updateClusterMatrices();
 
     /// Returns a reference to the shared geometry.
     const Geometry::Pointer& getGeometry() const { return _renderGeometry; }
@@ -345,6 +345,8 @@ public:
     void addMaterial(graphics::MaterialLayer material, const std::string& parentMaterialName);
     void removeMaterial(graphics::MaterialPointer material, const std::string& parentMaterialName);
 
+    bool areBlendedVertexBuffersInitialized(int index) { return _blendedVertexBuffersInitialized; }
+
 public slots:
     void loadURLFinished(bool success);
 
@@ -424,8 +426,9 @@ protected:
     QUrl _url;
 
     std::unordered_map<int, gpu::BufferPointer> _blendedVertexBuffers;
+    bool _blendedVertexBuffersInitialized { false };
 
-    QVector<QVector<QSharedPointer<Texture> > > _dilatedTextures;
+    QVector<QVector<QSharedPointer<Texture>>> _dilatedTextures;
 
     QVector<float> _blendedBlendshapeCoefficients;
     int _blendNumber;

--- a/libraries/render-utils/src/SoftAttachmentModel.cpp
+++ b/libraries/render-utils/src/SoftAttachmentModel.cpp
@@ -31,7 +31,7 @@ int SoftAttachmentModel::getJointIndexOverride(int i) const {
 
 // virtual
 // use the _rigOverride matrices instead of the Model::_rig
-void SoftAttachmentModel::updateClusterMatrices(bool triggerBlendshapes) {
+void SoftAttachmentModel::updateClusterMatrices() {
     if (!_needsUpdateClusterMatrices) {
         return;
     }
@@ -78,7 +78,7 @@ void SoftAttachmentModel::updateClusterMatrices(bool triggerBlendshapes) {
 
     // post the blender if we're not currently waiting for one to finish
     auto modelBlender = DependencyManager::get<ModelBlender>();
-    if (triggerBlendshapes && modelBlender->shouldComputeBlendshapes() && geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
+    if (_blendedVertexBuffersInitialized && modelBlender->shouldComputeBlendshapes() && geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
         _blendedBlendshapeCoefficients = _blendshapeCoefficients;
         modelBlender->noteRequiresBlend(getThisPointer());
     }

--- a/libraries/render-utils/src/SoftAttachmentModel.h
+++ b/libraries/render-utils/src/SoftAttachmentModel.h
@@ -27,7 +27,7 @@ public:
     ~SoftAttachmentModel();
 
     void updateRig(float deltaTime, glm::mat4 parentTransform) override;
-    void updateClusterMatrices(bool triggerBlendshapes = true) override;
+    void updateClusterMatrices() override;
 
 protected:
     int getJointIndexOverride(int i) const;


### PR DESCRIPTION
Test plan:

- The crash doesn't repro all the time because the timing is tricky. The easiest thing to do: go to engine-dev. There are a lot of avatars there. Spin around as they load, reload content, leave the domain and come back. Each time wait until the avatars all load. Their faces should render correctly, as should your own. You shouldn't crash.
- Try a lot.