### PR TITLE
fix a crash related to setting an overlay's name

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -240,7 +240,7 @@ QVariant Base3DOverlay::getProperty(const QString& property) {
     if (property == "name") {
         return _nameLock.resultWithReadLock<QString>([&] {
             return _name;
-        }
+        });
     }
     if (property == "position" || property == "start" || property == "p1" || property == "point") {
         return vec3toVariant(getWorldPosition());

--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -351,7 +351,7 @@ void Base3DOverlay::setVisible(bool visible) {
 QString Base3DOverlay::getName() const {
     return _nameLock.resultWithReadLock<QString>([&] {
         return QString("Overlay:") + _name;
-    }
+    });
 }
 
 void Base3DOverlay::setName(QString name) {

--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -238,7 +238,9 @@ void Base3DOverlay::setProperties(const QVariantMap& originalProperties) {
  */
 QVariant Base3DOverlay::getProperty(const QString& property) {
     if (property == "name") {
-        return _name;
+        return _nameLock.resultWithReadLock<QString>([&] {
+            return _name;
+        }
     }
     if (property == "position" || property == "start" || property == "p1" || property == "point") {
         return vec3toVariant(getWorldPosition());
@@ -345,6 +347,20 @@ void Base3DOverlay::setVisible(bool visible) {
     Parent::setVisible(visible);
     notifyRenderVariableChange();
 }
+
+QString Base3DOverlay::getName() const {
+    return _nameLock.resultWithReadLock<QString>([&] {
+        return QString("Overlay:") + _name;
+    }
+}
+
+void Base3DOverlay::setName(QString name) {
+    _nameLock.withWriteLock([&] {
+        _name = name;
+    });
+}
+
+
 
 render::ItemKey Base3DOverlay::getKey() {
     auto builder = render::ItemKey::Builder(Overlay::getKey());

--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -29,8 +29,8 @@ public:
     virtual OverlayID getOverlayID() const override { return OverlayID(getID().toString()); }
     void setOverlayID(OverlayID overlayID) override { setID(overlayID); }
 
-    virtual QString getName() const override { return QString("Overlay:") + _name; }
-    void setName(QString name) { _name = name; }
+    virtual QString getName() const override;
+    void setName(QString name);
 
     // getters
     virtual bool is3D() const override { return true; }
@@ -107,6 +107,7 @@ protected:
     mutable bool _renderVariableDirty { true };
 
     QString _name;
+    mutable ReadWriteLockable _nameLock;
 };
 
 #endif // hifi_Base3DOverlay_h


### PR DESCRIPTION
- protect Base3DOverlay::_name with a mutex


https://highfidelity.fogbugz.com/f/cases/18117/Overlays-setName-isn-t-thread-safe
