### PR TITLE
Fix MS17877: Persist Connections table sort choice

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -780,6 +780,12 @@ Rectangle {
             headerVisible: true;
             sortIndicatorColumn: settings.connectionsSortIndicatorColumn;
             sortIndicatorOrder: settings.connectionsSortIndicatorOrder;
+            onSortIndicatorColumnChanged: {
+                settings.connectionsSortIndicatorColumn = sortIndicatorColumn;
+            }
+            onSortIndicatorOrderChanged: {
+                settings.connectionsSortIndicatorOrder = sortIndicatorOrder;
+            }
 
             TableViewColumn {
                 id: connectionsUserNameHeader;


### PR DESCRIPTION
Fixes [MS17877](https://highfidelity.manuscript.com/f/cases/17877/PAL-connections-does-retain-sort-column-or-direction).

Both "Nearby" and "Connections" tables now sort based on a modifiable value stored in `Interface.json` Settings. (Nearby always did; Connections did until the below change.)

The behavior of persisting sort order was changed for Connections only [here](https://github.com/highfidelity/hifi/pull/13307/files#diff-4e895f972c905648b8c5e80fd44e6939L750). Perhaps an oversight?