### PR TITLE
fix keyboard collapsing in VR/goto

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
@@ -105,7 +105,6 @@ StackView {
             propagateComposedEvents: true
             onPressed: {
                 parent.forceActiveFocus();
-                addressBarDialog.keyboardEnabled = false;
                 mouse.accepted = false;
             }
         }
@@ -223,7 +222,6 @@ StackView {
                     updateLocationText(text.length > 0);
                 }
                 onAccepted: {
-                    addressBarDialog.keyboardEnabled = false;
                     toggleOrGo();
                 }
 
@@ -378,7 +376,7 @@ StackView {
 
         HifiControls.Keyboard {
             id: keyboard
-            raised: parent.keyboardEnabled
+            raised: parent.keyboardEnabled && parent.keyboardRaised
             numeric: parent.punctuationMode
             anchors {
                 bottom: parent.bottom


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/18024/2-users-report-that-while-in-VR-and-in-GoTo-menu-keyboard-is-unable-to-be-minimized

**Test plan**

1. Switch to VR
2. Open goto
3. Ensure keyboard collapses using 'collapse' button
4. Ensure keyboard still raises on focusing input field and collapses on unfocusing one