### PR TITLE
Fix bloom on edges

### DIFF
--- a/libraries/render-utils/src/DeferredFramebuffer.cpp
+++ b/libraries/render-utils/src/DeferredFramebuffer.cpp
@@ -73,7 +73,7 @@ void DeferredFramebuffer::allocate() {
     _deferredFramebufferDepthColor->setDepthStencilBuffer(_primaryDepthTexture, depthFormat);
 
 
-    auto smoothSampler = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT);
+    auto smoothSampler = gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_LINEAR_MIP_POINT, gpu::Sampler::WRAP_CLAMP);
 
     _lightingTexture = gpu::Texture::createRenderBuffer(gpu::Element(gpu::SCALAR, gpu::FLOAT, gpu::R11G11B10), width, height, gpu::Texture::SINGLE_MIP, smoothSampler);
     _lightingFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("lighting"));


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/18152/Bloom-wraps-around-edges

Test plan:
- Make a zone with bloom.
- Find something bright that is creating bloom.  Position your view so that it's on the edge of the screen.  In master, you would see the bloom wrapping around to the other side of the image.  In this PR, you shouldn't see that.
- Verify that other lighting effects (mainly local lights) still look correct on the edge of the screen.