### PR TITLE
Fix for blendshapes playing back in recordings at 2x their proper values

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -391,8 +391,18 @@ void Agent::executeScript() {
             if (recordingInterface->getPlayFromCurrentLocation()) {
                 scriptedAvatar->setRecordingBasis();
             }
+
+            // these procedural movements are included in the recordings
+            scriptedAvatar->setHasProceduralEyeFaceMovement(false);
+            scriptedAvatar->setHasProceduralBlinkFaceMovement(false);
+            scriptedAvatar->setHasAudioEnabledFaceMovement(false);
         } else {
             scriptedAvatar->clearRecordingBasis();
+
+            // restore procedural blendshape movement
+            scriptedAvatar->setHasProceduralEyeFaceMovement(true);
+            scriptedAvatar->setHasProceduralBlinkFaceMovement(true);
+            scriptedAvatar->setHasAudioEnabledFaceMovement(true);
         }
     });
 

--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -145,3 +145,15 @@ void ScriptableAvatar::update(float deltatime) {
 
     _clientTraitsHandler->sendChangedTraitsToMixer();
 }
+
+void ScriptableAvatar::setHasProceduralBlinkFaceMovement(bool hasProceduralBlinkFaceMovement) {
+    _headData->setHasProceduralBlinkFaceMovement(hasProceduralBlinkFaceMovement);
+}
+
+void ScriptableAvatar::setHasProceduralEyeFaceMovement(bool hasProceduralEyeFaceMovement) {
+    _headData->setHasProceduralEyeFaceMovement(hasProceduralEyeFaceMovement);
+}
+
+void ScriptableAvatar::setHasAudioEnabledFaceMovement(bool hasAudioEnabledFaceMovement) {
+    _headData->setHasAudioEnabledFaceMovement(hasAudioEnabledFaceMovement);
+}

--- a/assignment-client/src/avatars/ScriptableAvatar.h
+++ b/assignment-client/src/avatars/ScriptableAvatar.h
@@ -157,9 +157,16 @@ public:
 
     virtual QByteArray toByteArrayStateful(AvatarDataDetail dataDetail, bool dropFaceTracking = false) override;
 
+    void setHasProceduralBlinkFaceMovement(bool hasProceduralBlinkFaceMovement);
+    bool getHasProceduralBlinkFaceMovement() const override { return _headData->getHasProceduralBlinkFaceMovement(); }
+    void setHasProceduralEyeFaceMovement(bool hasProceduralEyeFaceMovement);
+    bool getHasProceduralEyeFaceMovement() const override { return _headData->getHasProceduralEyeFaceMovement(); }
+    void setHasAudioEnabledFaceMovement(bool hasAudioEnabledFaceMovement);
+    bool getHasAudioEnabledFaceMovement() const override { return _headData->getHasAudioEnabledFaceMovement(); }
+
 private slots:
     void update(float deltatime);
-    
+
 private:
     AnimationPointer _animation;
     AnimationDetails _animationDetails;


### PR DESCRIPTION
This is fixed by having the Agent disable procedural blendshape generation on the client end by calling, setHasProceduralEyeFaceMovement(), setHasProceduralBlinkFaceMovement(), setHasAudioEnabledFaceMovement()