### PR TITLE
MS18269: Fix Reloading Scripts with Create open crashes system

### DIFF
--- a/scripts/system/modules/createWindow.js
+++ b/scripts/system/modules/createWindow.js
@@ -125,6 +125,9 @@ module.exports = (function() {
 
             Script.scriptEnding.connect(this, function() {
                 this.window.close();
+                // FIXME: temp solution for reload crash (MS18269),
+                // we should decide on proper object ownership strategy for InteractiveWindow API
+                this.window = null;
             });
         },
         setVisible: function(visible) {


### PR DESCRIPTION
Temporary fix for reload crash https://highfidelity.fogbugz.com/f/cases/18269/Reloading-Scripts-with-Create-open-crashes-system

## QA Test
1) Open Interface in desktop mode
2) Open the Create App (Both windows `Create Tools` and `Entity List` should appear)
4) While the windows are up use the Reload Script option ` Edit -> Running Scripts -> Reload Scripts`
5) Open Create App again  (Both windows `Create Tools` and `Entity List` should appear again)
