### PR TITLE
Ensure a web overlay doesn't access an invalid tabletScriptingInterface

### DIFF
--- a/interface/src/ui/overlays/Web3DOverlay.cpp
+++ b/interface/src/ui/overlays/Web3DOverlay.cpp
@@ -132,7 +132,9 @@ void Web3DOverlay::destroyWebSurface() {
 
     if (rootItem && rootItem->objectName() == "tabletRoot") {
         auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
-        tabletScriptingInterface->setQmlTabletRoot("com.highfidelity.interface.tablet.system", nullptr);
+        if (tabletScriptingInterface) {
+            tabletScriptingInterface->setQmlTabletRoot("com.highfidelity.interface.tablet.system", nullptr);
+        }
     }
 
     // Fix for crash in QtWebEngineCore when rapidly switching domains


### PR DESCRIPTION
Fix for [FB18149](https://highfidelity.manuscript.com/f/cases/18149/Backtrace-Big-increase-in-crashes-related-to-destroying-web-overlays)

## Testing

The bug lists no specific repro case.  Based on light investigation, it seems likely this may have to do with having the tablet open on shutdown.  Attempt to startup and shutdown interface with the tablet open.  