### PR TITLE
Correct transparent parabola shader

### DIFF
--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -382,9 +382,8 @@ void ParabolaPointer::RenderState::ParabolaRenderItem::updateBounds() {
 
 const gpu::PipelinePointer ParabolaPointer::RenderState::ParabolaRenderItem::getParabolaPipeline() {
     if (!_parabolaPipeline || !_transparentParabolaPipeline) {
-        gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::parabola);
-
         {
+            gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::parabola);
             auto state = std::make_shared<gpu::State>();
             state->setDepthTest(true, true, gpu::LESS_EQUAL);
             state->setBlendFunction(false,
@@ -396,6 +395,7 @@ const gpu::PipelinePointer ParabolaPointer::RenderState::ParabolaRenderItem::get
         }
 
         {
+            gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::parabola_translucent);
             auto state = std::make_shared<gpu::State>();
             state->setDepthTest(true, true, gpu::LESS_EQUAL);
             state->setBlendFunction(true,

--- a/libraries/render-utils/src/parabola_translucent.slf
+++ b/libraries/render-utils/src/parabola_translucent.slf
@@ -1,0 +1,18 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  Created by Sam Gondelman on 9/10/2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include DeferredBufferWrite.slh@>
+
+layout(location=0) in vec4 _color;
+
+void main(void) {
+    packDeferredFragmentTranslucent(vec3(1.0, 0.0, 0.0), _color.a, _color.rgb, DEFAULT_FRESNEL, DEFAULT_ROUGHNESS);
+}

--- a/libraries/render-utils/src/render-utils/parabola_translucent.slp
+++ b/libraries/render-utils/src/render-utils/parabola_translucent.slp
@@ -1,0 +1,1 @@
+VERTEX parabola


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17767/Create-a-transparent-version-of-the-fragment-shader-for-teleport-parabola-on-AMD

Test plan:
- Run [this](https://gist.githubusercontent.com/SamGondelman/7bbb72ec23d3bcc1a9a2651ca5587d5c/raw/6570f92601072ad99116baaaa850f4bc3bc67cdf/ParabolaPointerTest.js).  An opaque blue parabola will shoot out of your mouse.
- Press 'u'.  The parabola will become yellow and slightly translucent.
- Verify that both parabolas render correctly on various graphics cards (NVIDIA, AMD (windows and mac)).