### PR TITLE
Replacing cpu timing calls from gl to std::chrono

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendQuery.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendQuery.cpp
@@ -32,7 +32,8 @@ void GLBackend::do_beginQuery(const Batch& batch, size_t paramOffset) {
         PROFILE_RANGE_BEGIN(render_gpu_gl_detail, glquery->_profileRangeId, query->getName().c_str(), 0xFFFF7F00);
 
         ++_queryStage._rangeQueryDepth;
-        glGetInteger64v(GL_TIMESTAMP, (GLint64*)&glquery->_batchElapsedTime);
+        glquery->_batchElapsedTimeBegin = std::chrono::high_resolution_clock::now();
+   //     glGetInteger64v(GL_TIMESTAMP, (GLint64*)&glquery->_batchElapsedTime);
 
         if (timeElapsed) {
             if (_queryStage._rangeQueryDepth <= MAX_RANGE_QUERY_DEPTH) {
@@ -61,9 +62,10 @@ void GLBackend::do_endQuery(const Batch& batch, size_t paramOffset) {
         }
 
         --_queryStage._rangeQueryDepth;
-        GLint64 now;
-        glGetInteger64v(GL_TIMESTAMP, &now);
-        glquery->_batchElapsedTime = now - glquery->_batchElapsedTime;
+      //  GLint64 now;
+      //  glGetInteger64v(GL_TIMESTAMP, &now);
+        auto duration_ns = (std::chrono::high_resolution_clock::now() - glquery->_batchElapsedTimeBegin);
+        glquery->_batchElapsedTime = duration_ns.count();
 
         PROFILE_RANGE_END(render_gpu_gl_detail, glquery->_profileRangeId);
 

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendQuery.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendQuery.cpp
@@ -94,7 +94,7 @@ void GLBackend::do_getQuery(const Batch& batch, size_t paramOffset) {
             }
 #else 
             // gles3 is not supporting true time query returns just the batch elapsed time
-            query->triggerReturnHandler(glquery->_result, glquery->_batchElapsedTime);
+            query->triggerReturnHandler(0, glquery->_batchElapsedTime);
 #endif
             (void)CHECK_GL_ERROR();
         }

--- a/libraries/gpu-gl-common/src/gpu/gl/GLQuery.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLQuery.h
@@ -47,7 +47,7 @@ public:
 
     const GLuint& _endqo = { _id };
     const GLuint _beginqo = { 0 };
-    GLuint64 _result { (GLuint64)-1 };
+    GLuint64 _result { (GLuint64)0 };
     GLuint64 _batchElapsedTime{ (GLuint64)0 };
     std::chrono::high_resolution_clock::time_point _batchElapsedTimeBegin;
     uint64_t _profileRangeId { 0 };

--- a/libraries/gpu-gl-common/src/gpu/gl/GLQuery.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLQuery.h
@@ -48,7 +48,8 @@ public:
     const GLuint& _endqo = { _id };
     const GLuint _beginqo = { 0 };
     GLuint64 _result { (GLuint64)-1 };
-    GLuint64 _batchElapsedTime { (GLuint64) 0 };
+    GLuint64 _batchElapsedTime{ (GLuint64)0 };
+    std::chrono::high_resolution_clock::time_point _batchElapsedTimeBegin;
     uint64_t _profileRangeId { 0 };
     uint32_t _rangeQueryDepth { 0 };
 

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendBuffer.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendBuffer.cpp
@@ -52,7 +52,7 @@ GLuint GL45Backend::getBufferID(const Buffer& buffer) {
 }
 
 GLuint GL45Backend::getBufferIDUnsynced(const Buffer& buffer) {
-    return GLBuffer::getIdUnsynced<GL45Buffer>(*this, buffer);
+    return GL45Buffer::getIdUnsynced<GL45Buffer>(*this, buffer);
 }
 
 GLBuffer* GL45Backend::syncGPUObject(const Buffer& buffer) {

--- a/libraries/gpu-gl/src/gpu/gl45/GL45BackendBuffer.cpp
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45BackendBuffer.cpp
@@ -52,7 +52,7 @@ GLuint GL45Backend::getBufferID(const Buffer& buffer) {
 }
 
 GLuint GL45Backend::getBufferIDUnsynced(const Buffer& buffer) {
-    return GL45Buffer::getIdUnsynced<GL45Buffer>(*this, buffer);
+    return GLBuffer::getIdUnsynced<GL45Buffer>(*this, buffer);
 }
 
 GLBuffer* GL45Backend::syncGPUObject(const Buffer& buffer) {


### PR DESCRIPTION
The method to measure CPU batch time from a gpu::query has been changed to std::chrono instead of from using gl (glGetInteger64v(GL_TIMESTAMP, ...).
This is two less opengl calls which were actually showing up in profiles.

## TEST PLAN 
This is simply replacing one method by another to measure the Batch time so if the batch time is visible in stats as normal  then this means that it s a pass.
this should be verified on mac and pc platforms
and check that andoird build works correctly too
