### PR TITLE
Fix a missing std::chrono::duration_cast

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackendQuery.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackendQuery.cpp
@@ -63,7 +63,7 @@ void GLBackend::do_endQuery(const Batch& batch, size_t paramOffset) {
 #endif
 
         --_queryStage._rangeQueryDepth;
-        auto duration_ns = (std::chrono::high_resolution_clock::now() - glquery->_batchElapsedTimeBegin);
+        auto duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - glquery->_batchElapsedTimeBegin);
         glquery->_batchElapsedTime = duration_ns.count();
 
         PROFILE_RANGE_END(render_gpu_gl_detail, glquery->_profileRangeId);


### PR DESCRIPTION
No difference to the previous pr #13972 just use the std::chrono duration the way it should be.

## TEST PLAN
The batch stat time should be correct