### PR TITLE
revert avatar entity XORing, perform avatar entity cleanup in handleRemovedAvatar

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -443,6 +443,11 @@ void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar
     avatar->die();
     queuePhysicsChange(avatar);
 
+    // remove this avatar's entities from the tree now, if we wait (as we did previously) for this Avatar's destructor
+    // it might not fire until after we create a new instance for the same remote avatar, which creates a race
+    // on the creation of entities for that avatar instance and the deletion of entities for this instance
+    avatar->removeAvatarEntitiesFromTree();
+
     if (removalReason == KillAvatarReason::TheirAvatarEnteredYourBubble) {
         emit DependencyManager::get<UsersScriptingInterface>()->enteredIgnoreRadius();
     } else if (removalReason == KillAvatarReason::AvatarDisconnected) {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -141,6 +141,7 @@ Avatar::~Avatar() {
             }
         });
     }
+
     auto geometryCache = DependencyManager::get<GeometryCache>();
     if (geometryCache) {
         geometryCache->releaseID(_nameRectGeometryID);

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -131,17 +131,6 @@ Avatar::Avatar(QThread* thread) :
 }
 
 Avatar::~Avatar() {
-    auto treeRenderer = DependencyManager::get<EntityTreeRenderer>();
-    EntityTreePointer entityTree = treeRenderer ? treeRenderer->getTree() : nullptr;
-    if (entityTree) {
-        entityTree->withWriteLock([&] {
-            AvatarEntityMap avatarEntities = getAvatarEntityData();
-            for (auto entityID : avatarEntities.keys()) {
-                entityTree->deleteEntity(entityID, true, true);
-            }
-        });
-    }
-
     auto geometryCache = DependencyManager::get<GeometryCache>();
     if (geometryCache) {
         geometryCache->releaseID(_nameRectGeometryID);
@@ -384,6 +373,19 @@ void Avatar::updateAvatarEntities() {
     });
 
     setAvatarEntityDataChanged(false);
+}
+
+void Avatar::removeAvatarEntitiesFromTree() {
+    auto treeRenderer = DependencyManager::get<EntityTreeRenderer>();
+    EntityTreePointer entityTree = treeRenderer ? treeRenderer->getTree() : nullptr;
+    if (entityTree) {
+        entityTree->withWriteLock([&] {
+            AvatarEntityMap avatarEntities = getAvatarEntityData();
+            for (auto entityID : avatarEntities.keys()) {
+                entityTree->deleteEntity(entityID, true, true);
+            }
+        });
+    }
 }
 
 void Avatar::relayJointDataToChildren() {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -73,6 +73,7 @@ public:
 
     void init();
     void updateAvatarEntities();
+    void removeAvatarEntitiesFromTree();
     void simulate(float deltaTime, bool inView);
     virtual void simulateAttachments(float deltaTime);
 

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1861,9 +1861,7 @@ qint64 AvatarData::packTrait(AvatarTraits::TraitType traitType, ExtendedIODevice
 }
 
 qint64 AvatarData::packTraitInstance(AvatarTraits::TraitType traitType, AvatarTraits::TraitInstanceID traitInstanceID,
-                                     ExtendedIODevice& destination, AvatarTraits::TraitVersion traitVersion,
-                                     AvatarTraits::TraitInstanceID wireInstanceID) {
-
+                                   ExtendedIODevice& destination, AvatarTraits::TraitVersion traitVersion) {
     qint64 bytesWritten = 0;
 
     bytesWritten += destination.writePrimitive(traitType);
@@ -1872,11 +1870,7 @@ qint64 AvatarData::packTraitInstance(AvatarTraits::TraitType traitType, AvatarTr
         bytesWritten += destination.writePrimitive(traitVersion);
     }
 
-    if (!wireInstanceID.isNull()) {
-        bytesWritten += destination.write(wireInstanceID.toRfc4122());
-    } else {
-        bytesWritten += destination.write(traitInstanceID.toRfc4122());
-    }
+    bytesWritten += destination.write(traitInstanceID.toRfc4122());
 
     if (traitType == AvatarTraits::AvatarEntity) {
         // grab a read lock on the avatar entities and check for entity data for the given ID

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1193,9 +1193,6 @@ public:
     void setReplicaIndex(int replicaIndex) { _replicaIndex = replicaIndex; }
     int getReplicaIndex() { return _replicaIndex; }
 
-    const AvatarTraits::TraitInstanceID getTraitInstanceXORID() const { return _traitInstanceXORID; }
-    void cycleTraitInstanceXORID() { _traitInstanceXORID = QUuid::createUuid(); }
-
 signals:
 
     /**jsdoc
@@ -1502,8 +1499,6 @@ private:
     // privatize the copy constructor and assignment operator so they cannot be called
     AvatarData(const AvatarData&);
     AvatarData& operator= (const AvatarData&);
-
-    AvatarTraits::TraitInstanceID _traitInstanceXORID { QUuid::createUuid() };
 };
 Q_DECLARE_METATYPE(AvatarData*)
 

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -962,8 +962,7 @@ public:
     qint64 packTrait(AvatarTraits::TraitType traitType, ExtendedIODevice& destination,
                      AvatarTraits::TraitVersion traitVersion = AvatarTraits::NULL_TRAIT_VERSION);
     qint64 packTraitInstance(AvatarTraits::TraitType traitType, AvatarTraits::TraitInstanceID instanceID,
-                             ExtendedIODevice& destination, AvatarTraits::TraitVersion traitVersion = AvatarTraits::NULL_TRAIT_VERSION,
-                             AvatarTraits::TraitInstanceID wireInstanceID = AvatarTraits::TraitInstanceID());
+                             ExtendedIODevice& destination, AvatarTraits::TraitVersion traitVersion = AvatarTraits::NULL_TRAIT_VERSION);
 
     void prepareResetTraitInstances();
 

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -86,8 +86,7 @@ void AvatarReplicas::processDeletedTraitInstance(const QUuid& parentID, AvatarTr
     if (_replicasMap.find(parentID) != _replicasMap.end()) {
         auto &replicas = _replicasMap[parentID];
         for (auto avatar : replicas) {
-            avatar->processDeletedTraitInstance(traitType,
-                                                AvatarTraits::xoredInstanceID(instanceID, avatar->getTraitInstanceXORID()));
+            avatar->processDeletedTraitInstance(traitType, instanceID);
         }
     }
 }
@@ -96,9 +95,7 @@ void AvatarReplicas::processTraitInstance(const QUuid& parentID, AvatarTraits::T
     if (_replicasMap.find(parentID) != _replicasMap.end()) {
         auto &replicas = _replicasMap[parentID];
         for (auto avatar : replicas) {
-            avatar->processTraitInstance(traitType,
-                                         AvatarTraits::xoredInstanceID(instanceID, avatar->getTraitInstanceXORID()),
-                                         traitBinaryData);
+            avatar->processTraitInstance(traitType, instanceID, traitBinaryData);
         }
     }
 }
@@ -364,11 +361,11 @@ void AvatarHashMap::processBulkAvatarTraits(QSharedPointer<ReceivedMessage> mess
                     // in order to handle re-connections to the avatar mixer when the other
                     if (traitBinarySize == AvatarTraits::DELETED_TRAIT_SIZE) {
                         avatar->processDeletedTraitInstance(traitType, xoredInstanceID);
-                        _replicas.processDeletedTraitInstance(avatarID, traitType, traitInstanceID);
+                        _replicas.processDeletedTraitInstance(avatarID, traitType, xoredInstanceID);
                     } else {
                         auto traitData = message->read(traitBinarySize);
                         avatar->processTraitInstance(traitType, xoredInstanceID, traitData);
-                        _replicas.processTraitInstance(avatarID, traitType, traitInstanceID, traitData);
+                        _replicas.processTraitInstance(avatarID, traitType, xoredInstanceID, traitData);
                     }
                     processedInstanceVersion = packetTraitVersion;
                 } else {

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -343,29 +343,17 @@ void AvatarHashMap::processBulkAvatarTraits(QSharedPointer<ReceivedMessage> mess
                 AvatarTraits::TraitInstanceID traitInstanceID =
                     QUuid::fromRfc4122(message->readWithoutCopy(NUM_BYTES_RFC4122_UUID));
 
-                // XOR the incoming trait instance ID with this avatar object's personal XOR ID
-
-                // this ensures that we have separate entity instances in the local tree
-                // if we briefly end up with two Avatar objects for this node
-
-                // (which can occur if the shared pointer for the
-                // previous instance of an avatar hasn't yet gone out of scope before the
-                // new instance is created)
-
-                auto xoredInstanceID = AvatarTraits::xoredInstanceID(traitInstanceID, avatar->getTraitInstanceXORID());
-
                 message->readPrimitive(&traitBinarySize);
 
                 auto& processedInstanceVersion = lastProcessedVersions.getInstanceValueRef(traitType, traitInstanceID);
                 if (packetTraitVersion > processedInstanceVersion) {
-                    // in order to handle re-connections to the avatar mixer when the other
                     if (traitBinarySize == AvatarTraits::DELETED_TRAIT_SIZE) {
-                        avatar->processDeletedTraitInstance(traitType, xoredInstanceID);
-                        _replicas.processDeletedTraitInstance(avatarID, traitType, xoredInstanceID);
+                        avatar->processDeletedTraitInstance(traitType, traitInstanceID);
+                        _replicas.processDeletedTraitInstance(avatarID, traitType, traitInstanceID);
                     } else {
                         auto traitData = message->read(traitBinarySize);
-                        avatar->processTraitInstance(traitType, xoredInstanceID, traitData);
-                        _replicas.processTraitInstance(avatarID, traitType, xoredInstanceID, traitData);
+                        avatar->processTraitInstance(traitType, traitInstanceID, traitData);
+                        _replicas.processTraitInstance(avatarID, traitType, traitInstanceID, traitData);
                     }
                     processedInstanceVersion = packetTraitVersion;
                 } else {

--- a/libraries/avatars/src/AvatarTraits.h
+++ b/libraries/avatars/src/AvatarTraits.h
@@ -41,8 +41,7 @@ namespace AvatarTraits {
     const TraitWireSize DELETED_TRAIT_SIZE = -1;
 
     inline qint64 packInstancedTraitDelete(TraitType traitType, TraitInstanceID instanceID, ExtendedIODevice& destination,
-                                           TraitVersion traitVersion = NULL_TRAIT_VERSION,
-                                           TraitInstanceID xoredInstanceID = TraitInstanceID()) {
+                                           TraitVersion traitVersion = NULL_TRAIT_VERSION) {
         qint64 bytesWritten = 0;
 
         bytesWritten += destination.writePrimitive(traitType);
@@ -51,27 +50,11 @@ namespace AvatarTraits {
             bytesWritten += destination.writePrimitive(traitVersion);
         }
 
-        if (xoredInstanceID.isNull()) {
-            bytesWritten += destination.write(instanceID.toRfc4122());
-        } else {
-            bytesWritten += destination.write(xoredInstanceID.toRfc4122());
-        }
+        bytesWritten += destination.write(instanceID.toRfc4122());
 
         bytesWritten += destination.writePrimitive(DELETED_TRAIT_SIZE);
 
         return bytesWritten;
-    }
-
-    inline TraitInstanceID xoredInstanceID(TraitInstanceID localInstanceID, TraitInstanceID xorKeyID) {
-        QByteArray xoredInstanceID { NUM_BYTES_RFC4122_UUID, 0 };
-        auto xorKeyIDBytes = xorKeyID.toRfc4122();
-        auto localInstanceIDBytes = localInstanceID.toRfc4122();
-
-        for (auto i = 0; i < localInstanceIDBytes.size(); ++i) {
-            xoredInstanceID[i] = localInstanceIDBytes[i] ^ xorKeyIDBytes[i];
-        }
-
-        return QUuid::fromRfc4122(xoredInstanceID);
     }
 };
 

--- a/libraries/avatars/src/AvatarTraits.h
+++ b/libraries/avatars/src/AvatarTraits.h
@@ -41,7 +41,7 @@ namespace AvatarTraits {
     const TraitWireSize DELETED_TRAIT_SIZE = -1;
 
     inline qint64 packInstancedTraitDelete(TraitType traitType, TraitInstanceID instanceID, ExtendedIODevice& destination,
-                                           TraitVersion traitVersion = NULL_TRAIT_VERSION) {
+                                         TraitVersion traitVersion = NULL_TRAIT_VERSION) {
         qint64 bytesWritten = 0;
 
         bytesWritten += destination.writePrimitive(traitType);

--- a/libraries/avatars/src/ClientTraitsHandler.cpp
+++ b/libraries/avatars/src/ClientTraitsHandler.cpp
@@ -43,9 +43,6 @@ void ClientTraitsHandler::resetForNewMixer() {
 
     // pre-fill the instanced statuses that we will need to send next frame
     _owningAvatar->prepareResetTraitInstances();
-
-    // reset the trait XOR ID since we're resetting for a new avatar mixer
-    _sessionXORID = QUuid::createUuid().toRfc4122();
 }
 
 void ClientTraitsHandler::sendChangedTraitsToMixer() {
@@ -96,11 +93,7 @@ void ClientTraitsHandler::sendChangedTraitsToMixer() {
                     || instanceIDValuePair.value == Updated) {
                     // this is a changed trait we need to send or we haven't send out trait information yet
                     // ask the owning avatar to pack it
-
-                    // since this is going to the mixer, use the XORed instance ID (to anonymize trait instance IDs
-                    // that would typically persist across sessions)
-                    _owningAvatar->packTraitInstance(instancedIt->traitType, instanceIDValuePair.id, *traitsPacketList,
-                                                     AvatarTraits::NULL_TRAIT_VERSION, xorInstanceID(instanceIDValuePair.id));
+                    _owningAvatar->packTraitInstance(instancedIt->traitType, instanceIDValuePair.id, *traitsPacketList);
                 } else if (!_shouldPerformInitialSend && instanceIDValuePair.value == Deleted) {
                     // pack delete for this trait instance
                     AvatarTraits::packInstancedTraitDelete(instancedIt->traitType, instanceIDValuePair.id,
@@ -116,17 +109,6 @@ void ClientTraitsHandler::sendChangedTraitsToMixer() {
         // if this was an initial send of all traits, consider it completed
         _shouldPerformInitialSend = false;
     }
-}
-
-AvatarTraits::TraitInstanceID ClientTraitsHandler::xorInstanceID(AvatarTraits::TraitInstanceID localInstanceID) {
-    QByteArray xorInstanceID { NUM_BYTES_RFC4122_UUID, 0 };
-    auto localInstanceIDBytes = localInstanceID.toRfc4122();
-
-    for (auto i = 0; i < localInstanceIDBytes.size(); ++i) {
-        xorInstanceID[i] = localInstanceIDBytes[i] ^ _sessionXORID[i];
-    }
-
-    return QUuid::fromRfc4122(xorInstanceID);
 }
 
 void ClientTraitsHandler::processTraitOverride(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode) {

--- a/libraries/avatars/src/ClientTraitsHandler.h
+++ b/libraries/avatars/src/ClientTraitsHandler.h
@@ -37,6 +37,8 @@ public:
 
     void resetForNewMixer();
 
+    AvatarTraits::TraitInstanceID xorInstanceID(AvatarTraits::TraitInstanceID localInstanceID);
+
 public slots:
     void processTraitOverride(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
 
@@ -53,6 +55,8 @@ private:
     AvatarTraits::TraitVersion _currentTraitVersion { AvatarTraits::DEFAULT_TRAIT_VERSION };
 
     AvatarTraits::TraitVersion _currentSkeletonVersion { AvatarTraits::NULL_TRAIT_VERSION };
+
+    QByteArray _sessionXORID { NUM_BYTES_RFC4122_UUID, 0};
     
     bool _shouldPerformInitialSend { false };
     bool _hasChangedTraits { false };

--- a/libraries/avatars/src/ClientTraitsHandler.h
+++ b/libraries/avatars/src/ClientTraitsHandler.h
@@ -30,14 +30,12 @@ public:
 
     void markTraitUpdated(AvatarTraits::TraitType updatedTrait)
         { _traitStatuses[updatedTrait] = Updated; _hasChangedTraits = true; }
-    void markInstancedTraitUpdated(AvatarTraits::TraitType traitType, AvatarTraits::TraitInstanceID updatedInstanceID)
+    void markInstancedTraitUpdated(AvatarTraits::TraitType traitType, QUuid updatedInstanceID)
         { _traitStatuses.instanceInsert(traitType, updatedInstanceID, Updated); _hasChangedTraits = true; }
-    void markInstancedTraitDeleted(AvatarTraits::TraitType traitType, AvatarTraits::TraitInstanceID deleteInstanceID)
+    void markInstancedTraitDeleted(AvatarTraits::TraitType traitType, QUuid deleteInstanceID)
         { _traitStatuses.instanceInsert(traitType, deleteInstanceID, Deleted); _hasChangedTraits = true; }
 
     void resetForNewMixer();
-
-    AvatarTraits::TraitInstanceID xorInstanceID(AvatarTraits::TraitInstanceID localInstanceID);
 
 public slots:
     void processTraitOverride(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
@@ -55,8 +53,6 @@ private:
     AvatarTraits::TraitVersion _currentTraitVersion { AvatarTraits::DEFAULT_TRAIT_VERSION };
 
     AvatarTraits::TraitVersion _currentSkeletonVersion { AvatarTraits::NULL_TRAIT_VERSION };
-
-    QByteArray _sessionXORID { NUM_BYTES_RFC4122_UUID, 0};
     
     bool _shouldPerformInitialSend { false };
     bool _hasChangedTraits { false };


### PR DESCRIPTION
The avatar entity XORing was originally added to provide anonymity on avatar entity IDs between domains. We discovered that issue while digging into a bug where an avatar's entities would appear and quickly disappear if you reconnected to the domain.

That was a race caused by Avatar shared pointers and the removal of avatar entities in the destructor. I've decided to delay a true fix for the anonymity issue and instead remove the race on the avatar entity removal.