### PR TITLE
Android settings (AEC)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="true"/>
     <uses-feature android:name="android.hardware.sensor.gyroscope" android:required="true"/>
 
@@ -75,6 +76,15 @@
             android:enabled="true"
             android:exported="false"
             android:process=":breakpad_uploader"/>
+
+        <receiver
+            android:name=".receiver.HeadsetStateReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.HEADSET_PLUG" />
+            </intent-filter>
+        </receiver>
     </application>
 
     <uses-feature android:name="android.software.vr.mode" android:required="true"/>

--- a/android/app/src/main/cpp/native.cpp
+++ b/android/app/src/main/cpp/native.cpp
@@ -355,5 +355,51 @@ JNIEXPORT void Java_io_highfidelity_hifiinterface_WebViewActivity_nativeProcessU
     AndroidHelper::instance().processURL(QString::fromUtf8(nativeString));
 }
 
+JNIEXPORT void JNICALL
+Java_io_highfidelity_hifiinterface_fragment_SettingsFragment_updateHifiSetting(JNIEnv *env,
+                                                                               jobject instance,
+                                                                               jstring group_,
+                                                                               jstring key_,
+                                                                               jboolean value_) {
+    const char *c_group = env->GetStringUTFChars(group_, 0);
+    const char *c_key = env->GetStringUTFChars(key_, 0);
+
+    const QString group = QString::fromUtf8(c_group);
+    const QString key = QString::fromUtf8(c_key);
+
+    env->ReleaseStringUTFChars(group_, c_group);
+    env->ReleaseStringUTFChars(key_, c_key);
+
+    bool value = value_;
+
+    Setting::Handle<bool> setting { QStringList() << group << key , !value };
+    setting.set(value);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_io_highfidelity_hifiinterface_fragment_SettingsFragment_getHifiSettingBoolean(JNIEnv *env,
+                                                                                   jobject instance,
+                                                                                   jstring group_,
+                                                                                   jstring key_,
+                                                                                   jboolean defaultValue) {
+    const char *c_group = env->GetStringUTFChars(group_, 0);
+    const char *c_key = env->GetStringUTFChars(key_, 0);
+
+    const QString group = QString::fromUtf8(c_group);
+    const QString key = QString::fromUtf8(c_key);
+
+    env->ReleaseStringUTFChars(group_, c_group);
+    env->ReleaseStringUTFChars(key_, c_key);
+
+    Setting::Handle<bool> setting { QStringList() << group << key , defaultValue};
+    return setting.get();
+}
+
+JNIEXPORT void JNICALL
+Java_io_highfidelity_hifiinterface_receiver_HeadsetStateReceiver_notifyHeadsetOn(JNIEnv *env,
+                                                                                 jobject instance,
+                                                                                 jboolean pluggedIn) {
+    AndroidHelper::instance().notifyHeadsetOn(pluggedIn);
+}
 
 }

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
@@ -13,6 +13,7 @@ package io.highfidelity.hifiinterface;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -40,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import io.highfidelity.hifiinterface.fragment.WebViewFragment;
+import io.highfidelity.hifiinterface.receiver.HeadsetStateReceiver;
 
 /*import com.google.vr.cardboard.DisplaySynchronizer;
 import com.google.vr.cardboard.DisplayUtils;
@@ -55,6 +57,7 @@ public class InterfaceActivity extends QtActivity implements WebViewFragment.OnW
     private static final int NORMAL_DPI = 160;
 
     private Vibrator mVibrator;
+    private HeadsetStateReceiver headsetStateReceiver;
 
     //public static native void handleHifiURL(String hifiURLString);
     private native long nativeOnCreate(InterfaceActivity instance, AssetManager assetManager);
@@ -151,6 +154,8 @@ public class InterfaceActivity extends QtActivity implements WebViewFragment.OnW
         layoutParams.resolveLayoutDirection(View.LAYOUT_DIRECTION_RTL);
         qtLayout.addView(webSlidingDrawer, layoutParams);
         webSlidingDrawer.setVisibility(View.GONE);
+
+        headsetStateReceiver = new HeadsetStateReceiver();
     }
 
     @Override
@@ -161,6 +166,7 @@ public class InterfaceActivity extends QtActivity implements WebViewFragment.OnW
         } else {
             nativeEnterBackground();
         }
+        unregisterReceiver(headsetStateReceiver);
         //gvrApi.pauseTracking();
     }
 
@@ -183,6 +189,7 @@ public class InterfaceActivity extends QtActivity implements WebViewFragment.OnW
         nativeEnterForeground();
         surfacesWorkaround();
         keepInterfaceRunning = false;
+        registerReceiver(headsetStateReceiver, new IntentFilter(Intent.ACTION_HEADSET_PLUG));
         //gvrApi.resumeTracking();
     }
 

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/MainActivity.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/MainActivity.java
@@ -33,6 +33,7 @@ import io.highfidelity.hifiinterface.fragment.FriendsFragment;
 import io.highfidelity.hifiinterface.fragment.HomeFragment;
 import io.highfidelity.hifiinterface.fragment.LoginFragment;
 import io.highfidelity.hifiinterface.fragment.PolicyFragment;
+import io.highfidelity.hifiinterface.fragment.SettingsFragment;
 import io.highfidelity.hifiinterface.task.DownloadProfileImageTask;
 
 public class MainActivity extends AppCompatActivity implements NavigationView.OnNavigationItemSelectedListener,
@@ -80,6 +81,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
         mPeopleMenuItem = mNavigationView.getMenu().findItem(R.id.action_people);
 
+        updateDebugMenu(mNavigationView.getMenu());
+
         Toolbar toolbar = findViewById(R.id.toolbar);
         toolbar.setTitleTextAppearance(this, R.style.HomeActionBarTitleStyle);
         setSupportActionBar(toolbar);
@@ -104,6 +107,16 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
             if (getIntent().hasExtra(EXTRA_BACK_TO_SCENE)) {
                 backToScene = getIntent().getBooleanExtra(EXTRA_BACK_TO_SCENE, false);
+            }
+        }
+    }
+
+    private void updateDebugMenu(Menu menu) {
+        if (BuildConfig.DEBUG) {
+            for (int i=0; i < menu.size(); i++) {
+                if (menu.getItem(i).getItemId() == R.id.action_debug_settings) {
+                    menu.getItem(i).setVisible(true);
+                }
             }
         }
     }
@@ -150,6 +163,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
         loadFragment(fragment, getString(R.string.people), getString(R.string.tagFragmentPeople), true);
     }
+
+    private void loadSettingsFragment() {
+        SettingsFragment fragment = SettingsFragment.newInstance();
+
+        loadFragment(fragment, getString(R.string.settings), getString(R.string.tagSettings), true);
+    }
+
 
     private void loadFragment(Fragment fragment, String title, String tag, boolean addToBackStack) {
         FragmentManager fragmentManager = getFragmentManager();
@@ -240,6 +260,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 return true;
             case R.id.action_people:
                 loadPeopleFragment();
+                return true;
+            case R.id.action_debug_settings:
+                loadSettingsFragment();
                 return true;
         }
         return false;

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/fragment/SettingsFragment.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/fragment/SettingsFragment.java
@@ -1,0 +1,63 @@
+package io.highfidelity.hifiinterface.fragment;
+
+import android.content.SharedPreferences;
+import android.media.audiofx.AcousticEchoCanceler;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceFragment;
+import android.support.annotation.Nullable;
+
+import io.highfidelity.hifiinterface.R;
+
+public class SettingsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    public native void updateHifiSetting(String group, String key, boolean value);
+    public native boolean getHifiSettingBoolean(String group, String key, boolean defaultValue);
+
+    private final String HIFI_SETTINGS_ANDROID_GROUP = "Android";
+    private final String HIFI_SETTINGS_AEC_KEY = "aec";
+    private final String PREFERENCE_KEY_AEC = "aec";
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.settings);
+
+        if (!AcousticEchoCanceler.isAvailable()) {
+            getPreferenceScreen().getPreferenceManager().findPreference("aec").setEnabled(false);
+        }
+
+        getPreferenceScreen().getSharedPreferences().edit().putBoolean(PREFERENCE_KEY_AEC,
+                getHifiSettingBoolean(HIFI_SETTINGS_ANDROID_GROUP, HIFI_SETTINGS_AEC_KEY, false));
+    }
+
+    public static SettingsFragment newInstance() {
+        SettingsFragment fragment = new SettingsFragment();
+        return fragment;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        getPreferenceScreen().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
+
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        Preference pref = findPreference(key);
+        switch (key) {
+            case "aec":
+                updateHifiSetting(HIFI_SETTINGS_ANDROID_GROUP, HIFI_SETTINGS_AEC_KEY, sharedPreferences.getBoolean(key, false));
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/receiver/HeadsetStateReceiver.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/receiver/HeadsetStateReceiver.java
@@ -13,8 +13,6 @@ public class HeadsetStateReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
-
-        Log.d("[HEADSET] " , "BR - Wired headset on:" +  audioManager.isWiredHeadsetOn());
         notifyHeadsetOn(audioManager.isWiredHeadsetOn());
     }
 }

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/receiver/HeadsetStateReceiver.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/receiver/HeadsetStateReceiver.java
@@ -1,0 +1,20 @@
+package io.highfidelity.hifiinterface.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.media.AudioManager;
+import android.util.Log;
+
+public class HeadsetStateReceiver extends BroadcastReceiver {
+
+    private native void notifyHeadsetOn(boolean pluggedIn);
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+
+        Log.d("[HEADSET] " , "BR - Wired headset on:" +  audioManager.isWiredHeadsetOn());
+        notifyHeadsetOn(audioManager.isWiredHeadsetOn());
+    }
+}

--- a/android/app/src/main/res/menu/menu_navigation.xml
+++ b/android/app/src/main/res/menu/menu_navigation.xml
@@ -9,4 +9,9 @@
         android:id="@+id/action_people"
         android:title="@string/people"
         />
+    <item
+        android:id="@+id/action_debug_settings"
+        android:title="@string/settings"
+        android:visible="false"
+    />
 </menu>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -29,4 +29,9 @@
     <string name="tagFragmentLogin">tagFragmentLogin</string>
     <string name="tagFragmentPolicy">tagFragmentPolicy</string>
     <string name="tagFragmentPeople">tagFragmentPeople</string>
+    <string name="tagSettings">tagSettings</string>
+    <string name="settings">Settings</string>
+    <string name="AEC">AEC</string>
+    <string name="acoustic_echo_cancellation">Acoustic Echo Cancellation</string>
+    <string name="settings_developer">Developer</string>
 </resources>

--- a/android/app/src/main/res/xml/settings.xml
+++ b/android/app/src/main/res/xml/settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory
+        android:title="@string/settings_developer"
+        android:key="pref_key_developer">
+        <SwitchPreference
+            android:key="aec"
+            android:title="@string/AEC"
+            android:summary="@string/acoustic_echo_cancellation" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,9 +72,9 @@ def jniFolder = new File(appDir, 'src/main/jniLibs/arm64-v8a')
 def baseUrl = 'https://hifi-public.s3.amazonaws.com/dependencies/android/'
 def breakpadDumpSymsDir = new File("${appDir}/build/tmp/breakpadDumpSyms")
 
-def qtFile='qt-5.11.1_linux_armv8-libcpp_openssl.tgz'
-def qtChecksum='bf9e734d9c4e77c4807a38c93515e25c'
-def qtVersionId='Qt3rvI0O7l5gLkacia2vA6KAchTgFkFf'
+def qtFile='qt-5.11.1_linux_armv8-libcpp_openssl_patched.tgz'
+def qtChecksum='aa449d4bfa963f3bc9a9dfe558ba29df'
+def qtVersionId='3S97HBM5G5Xw9EfE52sikmgdN3t6C2MN'
 if (Os.isFamily(Os.FAMILY_MAC)) {
     qtFile = 'qt-5.11.1_osx_armv8-libcpp_openssl_patched.tgz'
     qtChecksum='c83cc477c08a892e00c71764dca051a0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -78,7 +78,7 @@ def qtVersionId='3S97HBM5G5Xw9EfE52sikmgdN3t6C2MN'
 if (Os.isFamily(Os.FAMILY_MAC)) {
     qtFile = 'qt-5.11.1_osx_armv8-libcpp_openssl_patched.tgz'
     qtChecksum='c83cc477c08a892e00c71764dca051a0'
-    qtVersionId='QNa.lwNJaPc0eGuIL.xZ8ebeTuLL7rh8'
+    qtVersionId='OxBD7iKINv1HbyOXmAmDrBb8AF3N.Kup'
 } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     qtFile = 'qt-5.11.1_win_armv8-libcpp_openssl_patched.tgz'
     qtChecksum='0582191cc55431aa4f660848a542883e'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -77,8 +77,8 @@ def qtChecksum='bf9e734d9c4e77c4807a38c93515e25c'
 def qtVersionId='Qt3rvI0O7l5gLkacia2vA6KAchTgFkFf'
 if (Os.isFamily(Os.FAMILY_MAC)) {
     qtFile = 'qt-5.11.1_osx_armv8-libcpp_openssl_patched.tgz'
-    qtChecksum='5f12fd4fb25efe648c2fd161fd44998a'
-    qtVersionId='XXJ7ii1.xYzgFdWPnU.8mXnCj.q6y0Q5'
+    qtChecksum='c83cc477c08a892e00c71764dca051a0'
+    qtVersionId='QNa.lwNJaPc0eGuIL.xZ8ebeTuLL7rh8'
 } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     qtFile = 'qt-5.11.1_win_armv8-libcpp_openssl_patched.tgz'
     qtChecksum='0582191cc55431aa4f660848a542883e'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,16 +73,16 @@ def baseUrl = 'https://hifi-public.s3.amazonaws.com/dependencies/android/'
 def breakpadDumpSymsDir = new File("${appDir}/build/tmp/breakpadDumpSyms")
 
 def qtFile='qt-5.11.1_linux_armv8-libcpp_openssl.tgz'
-def qtChecksum='f312c47cd8b8dbca824c32af4eec5e66'
-def qtVersionId='nyCGcb91S4QbYeJhUkawO5x1lrLdSNB_'
+def qtChecksum='bf9e734d9c4e77c4807a38c93515e25c'
+def qtVersionId='Qt3rvI0O7l5gLkacia2vA6KAchTgFkFf'
 if (Os.isFamily(Os.FAMILY_MAC)) {
-    qtFile = 'qt-5.11.1_osx_armv8-libcpp_openssl.tgz'
-    qtChecksum='a0c8b394aec5b0fcd46714ca3a53278a'
-    qtVersionId='QNa.lwNJaPc0eGuIL.xZ8ebeTuLL7rh8'
+    qtFile = 'qt-5.11.1_osx_armv8-libcpp_openssl_patched.tgz'
+    qtChecksum='5f12fd4fb25efe648c2fd161fd44998a'
+    qtVersionId='XXJ7ii1.xYzgFdWPnU.8mXnCj.q6y0Q5'
 } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-    qtFile = 'qt-5.11.1_win_armv8-libcpp_openssl.tgz'
-    qtChecksum='d80aed4233ce9e222aae8376e7a94bf9'
-    qtVersionId='iDVXu0i3WEXRFIxQCtzcJ2XuKrE8RIqB'
+    qtFile = 'qt-5.11.1_win_armv8-libcpp_openssl_patched.tgz'
+    qtChecksum='0582191cc55431aa4f660848a542883e'
+    qtVersionId='JfWM0P_Mz5Qp0LwpzhrsRwN3fqlLSFeT'
 }
 
 def packages = [

--- a/interface/src/AndroidHelper.cpp
+++ b/interface/src/AndroidHelper.cpp
@@ -63,13 +63,7 @@ void AndroidHelper::notifyHeadsetOn(bool pluggedIn) {
 #if defined (Q_OS_ANDROID)
     auto audioClient = DependencyManager::get<AudioClient>();
     if (audioClient) {
-        QAudioDeviceInfo activeDev =  audioClient->getActiveAudioDevice(QAudio::AudioInput);
-        Setting::Handle<bool> enableAEC(QStringList() << ANDROID_SETTINGS_GROUP << SETTING_AEC_KEY, false);
-        if ((pluggedIn || !enableAEC.get()) && !activeDev.isNull() && activeDev.deviceName() != VOICE_RECOGNITION) {
-            QMetaObject::invokeMethod(audioClient.get(), "switchAudioDevice", Q_ARG(QAudio::Mode, QAudio::AudioInput), Q_ARG(QString, VOICE_RECOGNITION));
-        } else if ( (!pluggedIn && enableAEC.get()) && !activeDev.isNull() && activeDev.deviceName() != VOICE_COMMUNICATION) {
-            QMetaObject::invokeMethod(audioClient.get(), "switchAudioDevice", Q_ARG(QAudio::Mode, QAudio::AudioInput), Q_ARG(QString, VOICE_COMMUNICATION));
-        }
+        QMetaObject::invokeMethod(audioClient.data(), "setHeadsetPluggedIn", Q_ARG(bool, pluggedIn));
     }
 #endif
 }

--- a/interface/src/AndroidHelper.h
+++ b/interface/src/AndroidHelper.h
@@ -29,6 +29,7 @@ public:
 
     void performHapticFeedback(int duration);
     void processURL(const QString &url);
+    void notifyHeadsetOn(bool pluggedIn);
 
     AndroidHelper(AndroidHelper const&)  = delete;
     void operator=(AndroidHelper const&) = delete;

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -53,7 +53,6 @@
 #include "AudioHelpers.h"
 
 #if defined(Q_OS_ANDROID)
-#define VOICE_RECOGNITION "voicerecognition"
 #include <QtAndroidExtras/QAndroidJniObject>
 #endif
 
@@ -451,9 +450,12 @@ QAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode) {
 
 #if defined (Q_OS_ANDROID)
     if (mode == QAudio::AudioInput) {
+        Setting::Handle<bool> enableAEC(QStringList() << ANDROID_SETTINGS_GROUP << SETTING_AEC_KEY, false);
+        bool aecEnabled = enableAEC.get();
         auto inputDevices = QAudioDeviceInfo::availableDevices(QAudio::AudioInput);
         for (auto inputDevice : inputDevices) {
-            if (inputDevice.deviceName() == VOICE_RECOGNITION) {
+            if ((aecEnabled && inputDevice.deviceName() == VOICE_COMMUNICATION) ||
+                    (!aecEnabled && inputDevice.deviceName() == VOICE_RECOGNITION)) {
                 return inputDevice;
             }
         }

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -454,7 +454,7 @@ QAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode) {
         Setting::Handle<bool> enableAEC(SETTING_AEC_KEY, false);
         bool aecEnabled = enableAEC.get();
         auto audioClient = DependencyManager::get<AudioClient>();
-        bool headsetOn = audioClient? audioClient->isHeadsetPluggedIn() : false ;
+        bool headsetOn = audioClient? audioClient->isHeadsetPluggedIn() : false;
         auto inputDevices = QAudioDeviceInfo::availableDevices(QAudio::AudioInput);
         for (auto inputDevice : inputDevices) {
             if (((headsetOn || !aecEnabled) && inputDevice.deviceName() == VOICE_RECOGNITION) ||

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -64,6 +64,14 @@
 #pragma warning( pop )
 #endif
 
+#if defined (Q_OS_ANDROID)
+#define VOICE_RECOGNITION "voicerecognition"
+#define VOICE_COMMUNICATION "voicecommunication"
+
+#define ANDROID_SETTINGS_GROUP "Android"
+#define SETTING_AEC_KEY "aec"
+#endif
+
 class QAudioInput;
 class QAudioOutput;
 class QIODevice;

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -68,8 +68,7 @@
 #define VOICE_RECOGNITION "voicerecognition"
 #define VOICE_COMMUNICATION "voicecommunication"
 
-#define ANDROID_SETTINGS_GROUP "Android"
-#define SETTING_AEC_KEY "aec"
+#define SETTING_AEC_KEY "Android/aec"
 #endif
 
 class QAudioInput;
@@ -176,6 +175,10 @@ public:
     static QString getWinDeviceName(wchar_t* guid);
 #endif
 
+#if defined(Q_OS_ANDROID)
+    bool isHeadsetPluggedIn() { return _isHeadsetPluggedIn; }
+#endif
+
 public slots:
     void start();
     void stop();
@@ -223,6 +226,9 @@ public slots:
     // calling with a null QAudioDevice will use the system default
     bool switchAudioDevice(QAudio::Mode mode, const QAudioDeviceInfo& deviceInfo = QAudioDeviceInfo());
     bool switchAudioDevice(QAudio::Mode mode, const QString& deviceName);
+
+    // Qt opensles plugin is not able to detect when the headset is plugged in
+    void setHeadsetPluggedIn(bool pluggedIn);
 
     float getInputVolume() const { return (_audioInput) ? (float)_audioInput->volume() : 0.0f; }
     void setInputVolume(float volume, bool emitSignal = true);
@@ -285,6 +291,7 @@ private:
 #ifdef Q_OS_ANDROID
     QTimer _checkInputTimer;
     long _inputReadsSinceLastCheck = 0l;
+    bool _isHeadsetPluggedIn;
 #endif
 
     class Gate {


### PR DESCRIPTION
This PR adds android application a settings screen (Menu > Settings) **only in debug builds**.
The only setting by the moment is Acoustic Echo Cancellation: it's a feature present in some android phones like Google Pixel 2, Samsung S8, Samsung S9. Other devices like Huawei Mate 9 pro don't support it.

AEC must be disabled by default (we want to test its performance before turning it on by default). The user has to enable it through Menu > Settings > AEC
AEC must be disabled when a headset is plugged in (1)

Test plan
=======
- Check that AEC setting is disabled by default
- Check audio quality with regards to master
- Try starting HighFidelity app in both condition: plugged and unplugged headset
- Switch AEC setting and check that the right input device is used each time
- Plug/unplug the headset and check that that the right input device is used each time
- Check that echo cancelation is enabled (2)
- Check that AEC option only appears in debug builds (not in release ones)

(1) You can check input device switching in logcat, simply filter by "[hifi.audioclient] switchInputToAudioDevice". **voicerecognition** is an opensl es preset that uses the audio input with minimum or no processing (without AEC). **voicecommunication** is a preset that uses AEC and, if supported, noise reduction too.
(2) Echo cancelation performance depends on the device implementation. It may cancel echo at max volume or not. In all cases you can appreciate a difference between AEC enabled and disabled (voicecommunication and voicerecognition).