### PR TITLE
HMD Edit Handles - add highlighting and fix center scale cube

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -860,7 +860,7 @@ var toolBar = (function () {
             propertiesTool.setVisible(false);
             selectionManager.clearSelections();
             cameraManager.disable();
-            selectionDisplay.triggerMapping.disable();
+            selectionDisplay.disableTriggerMapping();
             tablet.landscape = false;
             Controller.disableMapping(CONTROLLER_MAPPING_NAME);
         } else {
@@ -876,7 +876,7 @@ var toolBar = (function () {
             gridTool.setVisible(true);
             grid.setEnabled(true);
             propertiesTool.setVisible(true);
-            selectionDisplay.triggerMapping.enable();
+            selectionDisplay.enableTriggerMapping();
             print("starting tablet in landscape mode");
             tablet.landscape = true;
             Controller.enableMapping(CONTROLLER_MAPPING_NAME);

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -2083,6 +2083,7 @@ SelectionDisplay = (function() {
         var rotation = null;
         var previousPickRay = null;
         var beginMouseEvent = null;
+        var beginControllerPick = null;
 
         var onBegin = function(event, pickRay, pickResult) {     
             var proportional = directionEnum === STRETCH_DIRECTION.ALL;     
@@ -2218,6 +2219,7 @@ SelectionDisplay = (function() {
             
             previousPickRay = pickRay;
             beginMouseEvent = event;
+            beginControllerPick = pickRay.origin;
         };
 
         var onEnd = function(event, reason) {    
@@ -2286,12 +2288,21 @@ SelectionDisplay = (function() {
             var newDimensions;
             if (proportional) {
                 var viewportDimensions = Controller.getViewportDimensions();
-                var mouseXDifference = (event.x - beginMouseEvent.x) / viewportDimensions.x;
-                var mouseYDifference = (beginMouseEvent.y - event.y) / viewportDimensions.y;
-                var mouseDifference = mouseXDifference + mouseYDifference;
                 var toCameraDistance = getDistanceToCamera(position);   
                 var dimensionsMultiple = toCameraDistance * STRETCH_DIRECTION_ALL_CAMERA_DISTANCE_MULTIPLE; 
-                var dimensionChange = mouseDifference * dimensionsMultiple;
+                
+                var dimensionChange;
+                if (HMD.active) {
+                    var vecPickDifference = Vec3.subtract(pickRay.origin, beginControllerPick);
+                    var pickDifference = vecPickDifference.x + vecPickDifference.y + vecPickDifference.z;
+                    dimensionChange = pickDifference * dimensionsMultiple;
+                } else {
+                    var mouseXDifference = (event.x - beginMouseEvent.x) / viewportDimensions.x;
+                    var mouseYDifference = (beginMouseEvent.y - event.y) / viewportDimensions.y;
+                    var mouseDifference = mouseXDifference + mouseYDifference;
+                    dimensionChange = mouseDifference * dimensionsMultiple;
+                }
+ 
                 var averageInitialDimension = (initialDimensions.x + initialDimensions.y + initialDimensions.z) / 3;
                 percentChange = dimensionChange / averageInitialDimension;
                 percentChange += 1.0;

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1178,7 +1178,7 @@ SelectionDisplay = (function() {
         return controllerComputePickRay() || Camera.computePickRay(x, y);
     }
     
-    function getControllerAvatarFramePosition(pickRay) {
+    function getControllerAvatarFramePositionFromPickRay(pickRay) {
         var controllerPosition = Vec3.subtract(pickRay.origin, MyAvatar.position);
         controllerPosition = Vec3.multiplyQbyV(Quat.inverse(MyAvatar.orientation), controllerPosition);
         return controllerPosition;
@@ -2255,7 +2255,7 @@ SelectionDisplay = (function() {
             previousPickRay = pickRay;
             beginMouseEvent = event;
             if (that.triggered()) {
-                beginControllerPosition = getControllerAvatarFramePosition(pickRay);
+                beginControllerPosition = getControllerAvatarFramePositionFromPickRay(pickRay);
             }
         };
 
@@ -2332,7 +2332,7 @@ SelectionDisplay = (function() {
                 
                 var dimensionChange;
                 if (controllerTrigger) {
-                    var controllerPosition = getControllerAvatarFramePosition(pickRay);
+                    var controllerPosition = getControllerAvatarFramePositionFromPickRay(pickRay);
                     var vecControllerDifference = Vec3.subtract(controllerPosition, beginControllerPosition);
                     var controllerDifference = vecControllerDifference.x + vecControllerDifference.y + 
                                                vecControllerDifference.z;

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -1177,6 +1177,12 @@ SelectionDisplay = (function() {
     function generalComputePickRay(x, y) {
         return controllerComputePickRay() || Camera.computePickRay(x, y);
     }
+    
+    function getControllerAvatarFramePosition(pickRay) {
+        var controllerPosition = Vec3.subtract(pickRay.origin, MyAvatar.position);
+        controllerPosition = Vec3.multiplyQbyV(Quat.inverse(MyAvatar.orientation), controllerPosition);
+        return controllerPosition;
+    }
 
     function getDistanceToCamera(position) {
         var cameraPosition = Camera.getPosition();
@@ -2248,10 +2254,8 @@ SelectionDisplay = (function() {
             
             previousPickRay = pickRay;
             beginMouseEvent = event;
-            
             if (that.triggered()) {
-                beginControllerPosition = that.triggeredHand === Controller.Standard.LeftHand ? 
-                                          MyAvatar.getLeftHandPosition() :  MyAvatar.getRightHandPosition();
+                beginControllerPosition = getControllerAvatarFramePosition(pickRay);
             }
         };
 
@@ -2328,8 +2332,7 @@ SelectionDisplay = (function() {
                 
                 var dimensionChange;
                 if (controllerTrigger) {
-                    var controllerPosition = that.triggeredHand === Controller.Standard.LeftHand ? 
-                                             MyAvatar.getLeftHandPosition() :  MyAvatar.getRightHandPosition();
+                    var controllerPosition = getControllerAvatarFramePosition(pickRay);
                     var vecControllerDifference = Vec3.subtract(controllerPosition, beginControllerPosition);
                     var controllerDifference = vecControllerDifference.x + vecControllerDifference.y + 
                                                vecControllerDifference.z;

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -14,7 +14,7 @@
 //
 
 /* global SelectionManager, SelectionDisplay, grid, rayPlaneIntersection, rayPlaneIntersection2, pushCommandForSelections,
-   getMainTabletIDs, getControllerWorldLocation */
+   getMainTabletIDs, getControllerWorldLocation, TRIGGER_ON_VALUE */
 
 var SPACE_LOCAL = "local";
 var SPACE_WORLD = "world";
@@ -22,6 +22,7 @@ var HIGHLIGHT_LIST_NAME = "editHandleHighlightList";
 
 Script.include([
     "./controllers.js",
+    "./controllerDispatcherUtils.js",
     "./utils.js"
 ]);
 
@@ -448,6 +449,8 @@ SelectionDisplay = (function() {
     var CTRL_KEY_CODE = 16777249;
 
     var RAIL_AXIS_LENGTH = 10000;
+        
+    var NO_HAND = -1;
 
     var TRANSLATE_DIRECTION = {
         X: 0,
@@ -478,8 +481,6 @@ SelectionDisplay = (function() {
         YAW: 1,
         ROLL: 2
     };
-    
-    var NO_TRIGGER_HAND = -1;
 
     var spaceMode = SPACE_LOCAL;
     var overlayNames = [];
@@ -802,11 +803,21 @@ SelectionDisplay = (function() {
 
     // We get mouseMoveEvents from the handControllers, via handControllerPointer.
     // But we dont' get mousePressEvents.
-    that.triggerMapping = Controller.newMapping(Script.resolvePath('') + '-click');
-    Script.scriptEnding.connect(that.triggerMapping.disable);
-    that.triggeredHand = NO_TRIGGER_HAND;
+    that.triggerClickMapping = Controller.newMapping(Script.resolvePath('') + '-click');
+    that.triggerPressMapping = Controller.newMapping(Script.resolvePath('') + '-press');
+    that.triggeredHand = NO_HAND;
+    that.pressedHand = NO_HAND;
     that.triggered = function() {
-        return that.triggeredHand !== NO_TRIGGER_HAND;
+        return that.triggeredHand !== NO_HAND;
+    }
+    function pointingAtDesktopWindowOrTablet(hand) {
+        var pointingAtDesktopWindow = (hand === Controller.Standard.RightHand && 
+                                       SelectionManager.pointingAtDesktopWindowRight) ||
+                                      (hand === Controller.Standard.LeftHand && 
+                                       SelectionManager.pointingAtDesktopWindowLeft);
+        var pointingAtTablet = (hand === Controller.Standard.RightHand && SelectionManager.pointingAtTabletRight) ||
+                               (hand === Controller.Standard.LeftHand && SelectionManager.pointingAtTabletLeft);
+        return pointingAtDesktopWindow || pointingAtTablet;
     }
     function makeClickHandler(hand) {
         return function (clicked) {
@@ -814,26 +825,39 @@ SelectionDisplay = (function() {
             if (that.triggered() && hand !== that.triggeredHand) {
                 return;
             }
-            if (!that.triggered() && clicked) {
-                var pointingAtDesktopWindow = (hand === Controller.Standard.RightHand && 
-                                               SelectionManager.pointingAtDesktopWindowRight) ||
-                                              (hand === Controller.Standard.LeftHand && 
-                                               SelectionManager.pointingAtDesktopWindowLeft);
-                var pointingAtTablet = (hand === Controller.Standard.RightHand && SelectionManager.pointingAtTabletRight) ||
-                                       (hand === Controller.Standard.LeftHand && SelectionManager.pointingAtTabletLeft);
-                if (pointingAtDesktopWindow || pointingAtTablet) {
-                    return;
-                }
+            if (!that.triggered() && clicked && !pointingAtDesktopWindowOrTablet(hand)) {
                 that.triggeredHand = hand;
                 that.mousePressEvent({});
             } else if (that.triggered() && !clicked) {
-                that.triggeredHand = NO_TRIGGER_HAND;
+                that.triggeredHand = NO_HAND;
                 that.mouseReleaseEvent({});
             }
         };
     }
-    that.triggerMapping.from(Controller.Standard.RTClick).peek().to(makeClickHandler(Controller.Standard.RightHand));
-    that.triggerMapping.from(Controller.Standard.LTClick).peek().to(makeClickHandler(Controller.Standard.LeftHand));
+    function makePressHandler(hand) {
+        return function (value) {
+            if (value >= TRIGGER_ON_VALUE && !that.triggered() && !pointingAtDesktopWindowOrTablet(hand)) {
+                that.pressedHand = hand;
+                that.updateHighlight({});
+            } else {
+                that.pressedHand = NO_HAND;
+                that.resetPreviousHandleColor();
+            }
+        }
+    }
+    that.triggerClickMapping.from(Controller.Standard.RTClick).peek().to(makeClickHandler(Controller.Standard.RightHand));
+    that.triggerClickMapping.from(Controller.Standard.LTClick).peek().to(makeClickHandler(Controller.Standard.LeftHand));
+    that.triggerPressMapping.from(Controller.Standard.RT).peek().to(makePressHandler(Controller.Standard.RightHand));
+    that.triggerPressMapping.from(Controller.Standard.LT).peek().to(makePressHandler(Controller.Standard.LeftHand));
+    that.enableTriggerMapping = function() {
+        that.triggerClickMapping.enable();
+        that.triggerPressMapping.enable();
+    };
+    that.disableTriggerMapping = function() {
+        that.triggerClickMapping.disable();
+        that.triggerPressMapping.disable();
+    }
+    Script.scriptEnding.connect(that.disableTriggerMapping);
 
     // FUNCTION DEF(s): Intersection Check Helpers
     function testRayIntersect(queryRay, overlayIncludes, overlayExcludes) {
@@ -960,35 +984,18 @@ SelectionDisplay = (function() {
         }
         return Uuid.NULL;
     };
-
-    // FUNCTION: MOUSE MOVE EVENT
-    var lastMouseEvent = null;
-    that.mouseMoveEvent = function(event) {
-        var wantDebug = false;
-        if (wantDebug) {
-            print("=============== eST::MouseMoveEvent BEG =======================");
-        }
-        lastMouseEvent = event;
-        if (activeTool) {
-            if (wantDebug) {
-                print("    Trigger ActiveTool(" + activeTool.mode + ")'s onMove");
-            }
-            activeTool.onMove(event);
-
-            if (wantDebug) {
-                print("    Trigger SelectionManager::update");
-            }
-            SelectionManager._update();
-
-            if (wantDebug) {
-                print("=============== eST::MouseMoveEvent END =======================");
-            }
-            // EARLY EXIT--(Move handled via active tool)
-            return true;
-        }
-
+    
+    that.updateHighlight = function(event) {
         // if no tool is active, then just look for handles to highlight...
         var pickRay = generalComputePickRay(event.x, event.y);
+        
+        var interactiveOverlays = getMainTabletIDs();
+        for (var key in handleTools) {
+            if (handleTools.hasOwnProperty(key)) {
+                interactiveOverlays.push(key);
+            }
+        }
+        
         var result = Overlays.findRayIntersection(pickRay);
         var pickedColor;
         var highlightNeeded = false;
@@ -1039,7 +1046,36 @@ SelectionDisplay = (function() {
         } else {
             that.resetPreviousHandleColor();
         }
+    };
 
+    // FUNCTION: MOUSE MOVE EVENT
+    var lastMouseEvent = null;
+    that.mouseMoveEvent = function(event) {
+        var wantDebug = false;
+        if (wantDebug) {
+            print("=============== eST::MouseMoveEvent BEG =======================");
+        }
+        lastMouseEvent = event;
+        if (activeTool) {
+            if (wantDebug) {
+                print("    Trigger ActiveTool(" + activeTool.mode + ")'s onMove");
+            }
+            activeTool.onMove(event);
+
+            if (wantDebug) {
+                print("    Trigger SelectionManager::update");
+            }
+            SelectionManager._update();
+
+            if (wantDebug) {
+                print("=============== eST::MouseMoveEvent END =======================");
+            }
+            // EARLY EXIT--(Move handled via active tool)
+            return true;
+        }
+
+        that.updateHighlight(event);
+        
         if (wantDebug) {
             print("=============== eST::MouseMoveEvent END =======================");
         }
@@ -1135,9 +1171,10 @@ SelectionDisplay = (function() {
         }
     };
 
-    function controllerComputePickRay() {
-        var controllerPose = getControllerWorldLocation(that.triggeredHand, true);
-        if (controllerPose.valid && that.triggered()) {
+    function controllerComputePickRay(hand) {
+        var hand = that.triggered() ? that.triggeredHand : that.pressedHand;
+        var controllerPose = getControllerWorldLocation(hand, true);
+        if (controllerPose.valid) {
             var controllerPosition = controllerPose.translation;
             // This gets point direction right, but if you want general quaternion it would be more complicated:
             var controllerDirection = Quat.getUp(controllerPose.rotation);
@@ -2083,7 +2120,7 @@ SelectionDisplay = (function() {
         var rotation = null;
         var previousPickRay = null;
         var beginMouseEvent = null;
-        var beginControllerPick = null;
+        var beginControllerPosition = null;
 
         var onBegin = function(event, pickRay, pickResult) {     
             var proportional = directionEnum === STRETCH_DIRECTION.ALL;     
@@ -2219,7 +2256,11 @@ SelectionDisplay = (function() {
             
             previousPickRay = pickRay;
             beginMouseEvent = event;
-            beginControllerPick = pickRay.origin;
+            
+            if (that.triggered()) {
+                beginControllerPosition = that.triggeredHand === Controller.Standard.LeftHand ? 
+                                          MyAvatar.getLeftHandPosition() :  MyAvatar.getRightHandPosition();
+            }
         };
 
         var onEnd = function(event, reason) {    
@@ -2258,13 +2299,15 @@ SelectionDisplay = (function() {
             if (usePreviousPickRay(pickRay.direction, previousPickRay.direction, planeNormal)) {
                 pickRay = previousPickRay;
             }
+            
+            var controllerPose = getControllerWorldLocation(that.triggeredHand, true);
+            var controllerTrigger = HMD.isHMDAvailable() && HMD.isHandControllerAvailable() && 
+                                    controllerPose.valid && that.triggered();
 
             // Are we using handControllers or Mouse - only relevant for 3D tools
-            var controllerPose = getControllerWorldLocation(that.triggeredHand, true);
             var vector = null;
             var newPick = null;
-            if (HMD.isHMDAvailable() && HMD.isHandControllerAvailable() && 
-                    controllerPose.valid && that.triggered() && directionFor3DStretch) {
+            if (controllerTrigger && directionFor3DStretch) {
                 localDeltaPivot = deltaPivot3D;
                 newPick = pickRay.origin;
                 vector = Vec3.subtract(newPick, lastPick3D);
@@ -2292,8 +2335,10 @@ SelectionDisplay = (function() {
                 var dimensionsMultiple = toCameraDistance * STRETCH_DIRECTION_ALL_CAMERA_DISTANCE_MULTIPLE; 
                 
                 var dimensionChange;
-                if (HMD.active) {
-                    var vecPickDifference = Vec3.subtract(pickRay.origin, beginControllerPick);
+                if (controllerTrigger) {
+                    var controllerPosition = that.triggeredHand === Controller.Standard.LeftHand ? 
+                                             MyAvatar.getLeftHandPosition() :  MyAvatar.getRightHandPosition();
+                    var vecPickDifference = Vec3.subtract(controllerPosition, beginControllerPosition);
                     var pickDifference = vecPickDifference.x + vecPickDifference.y + vecPickDifference.z;
                     dimensionChange = pickDifference * dimensionsMultiple;
                 } else {

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -987,15 +987,7 @@ SelectionDisplay = (function() {
     
     that.updateHighlight = function(event) {
         // if no tool is active, then just look for handles to highlight...
-        var pickRay = generalComputePickRay(event.x, event.y);
-        
-        var interactiveOverlays = getMainTabletIDs();
-        for (var key in handleTools) {
-            if (handleTools.hasOwnProperty(key)) {
-                interactiveOverlays.push(key);
-            }
-        }
-        
+        var pickRay = generalComputePickRay(event.x, event.y);        
         var result = Overlays.findRayIntersection(pickRay);
         var pickedColor;
         var highlightNeeded = false;
@@ -2338,9 +2330,10 @@ SelectionDisplay = (function() {
                 if (controllerTrigger) {
                     var controllerPosition = that.triggeredHand === Controller.Standard.LeftHand ? 
                                              MyAvatar.getLeftHandPosition() :  MyAvatar.getRightHandPosition();
-                    var vecPickDifference = Vec3.subtract(controllerPosition, beginControllerPosition);
-                    var pickDifference = vecPickDifference.x + vecPickDifference.y + vecPickDifference.z;
-                    dimensionChange = pickDifference * dimensionsMultiple;
+                    var vecControllerDifference = Vec3.subtract(controllerPosition, beginControllerPosition);
+                    var controllerDifference = vecControllerDifference.x + vecControllerDifference.y + 
+                                               vecControllerDifference.z;
+                    dimensionChange = controllerDifference * dimensionsMultiple;
                 } else {
                     var mouseXDifference = (event.x - beginMouseEvent.x) / viewportDimensions.x;
                     var mouseYDifference = (beginMouseEvent.y - event.y) / viewportDimensions.y;


### PR DESCRIPTION
Highlight edit handles like in desktop mode when hovering over them with blue laser in HMD.

Fix center scale cube not scaling in HMD.

Fixes: https://highfidelity.manuscript.com/f/cases/18355

Test Plan:
- Enter Interface in desktop mode
- Re-run test plan from https://github.com/highfidelity/hifi/pull/13390
- Re-run test plan from https://github.com/highfidelity/hifi/pull/13865
- Verify the other edit handles (translation arrows and rotation rings) work as expected in desktop mode
- Verify when hovering over edit handles with your mouse that they highlight white and then unhighlight when unhovering or when clicking an edit handle to start it's action
- Switch to HMD
- Verify the new edit handle cube at the center of the entity performs proportional scaling when dragged in HMD:
-- rightward, upward, or inward (towards you) movement proportionally scales the entity upward
-- leftward, downward, or outward (away from you) movement will scale it downward
-- scaling downward passed minimum dimensions will invert and start scaling upward again
- Verify the above scaling with the edit handle cube performs the same (especially in terms of which directional movement causes upward scaling vs downward scaling) when viewing the entity from different sides
- Verify the other edit handles (translation arrows, rotation rings, and axis-based stretch cubes) work as expected in HMD mode
- Verify when hovering over edit handles with your blue laser that they highlight white and then unhighlight when unhovering, releasing the trigger to hide the laser, or when triggering on an edit handle to start it's action