### PR TITLE
Fixing user activity logging for encourage login

### DIFF
--- a/interface/resources/qml/LoginDialog/LinkAccountBody.qml
+++ b/interface/resources/qml/LoginDialog/LinkAccountBody.qml
@@ -346,12 +346,14 @@ Item {
         target: loginDialog
         onHandleLoginCompleted: {
             console.log("Login Succeeded, linking steam account")
-
-            if (Settings.getValue("loginDialogPoppedUp", false)) {
+            var poppedUp = Settings.getValue("loginDialogPoppedUp", false);
+            if (poppedUp) {
+                console.log("[ENCOURAGELOGINDIALOG]: logging in")
                 var data = {
                     "action": "user logged in"
                 };
                 UserActivityLogger.logAction("encourageLoginDialog", data);
+                Settings.setValue("loginDialogPoppedUp", false);
             }
             if (loginDialog.isSteamRunning()) {
                 loginDialog.linkSteam()
@@ -363,11 +365,14 @@ Item {
         }
         onHandleLoginFailed: {
             console.log("Login Failed")
-            if (Settings.getValue("loginDialogPoppedUp", false)) {
+            var poppedUp = Settings.getValue("loginDialogPoppedUp", false);
+            if (poppedUp) {
+                console.log("[ENCOURAGELOGINDIALOG]: failed logging in")
                 var data = {
                     "action": "user failed logging in"
                 };
                 UserActivityLogger.logAction("encourageLoginDialog", data);
+                Settings.setValue("loginDialogPoppedUp", false);
             }
             mainTextContainer.visible = true
             toggleLoading(false)

--- a/interface/resources/qml/LoginDialog/LinkAccountBody.qml
+++ b/interface/resources/qml/LoginDialog/LinkAccountBody.qml
@@ -347,6 +347,12 @@ Item {
         onHandleLoginCompleted: {
             console.log("Login Succeeded, linking steam account")
 
+            if (Settings.getValue("loginDialogPoppedUp", false)) {
+                var data = {
+                    "action": "user logged in"
+                };
+                UserActivityLogger.logAction("encourageLoginDialog", data);
+            }
             if (loginDialog.isSteamRunning()) {
                 loginDialog.linkSteam()
             } else {
@@ -354,23 +360,17 @@ Item {
                 bodyLoader.item.width = root.pane.width
                 bodyLoader.item.height = root.pane.height
             }
-            if (Settings.getValue("loginDialogPoppedUp", false)) {
-                var data = {
-                    "action": "user logged in"
-                };
-                UserActivityLogger.logAction("encourageLoginDialog", data);
-            }
         }
         onHandleLoginFailed: {
             console.log("Login Failed")
-            mainTextContainer.visible = true
-            toggleLoading(false)
             if (Settings.getValue("loginDialogPoppedUp", false)) {
                 var data = {
                     "action": "user failed logging in"
                 };
                 UserActivityLogger.logAction("encourageLoginDialog", data);
             }
+            mainTextContainer.visible = true
+            toggleLoading(false)
         }
         onHandleLinkCompleted: {
             console.log("Link Succeeded")


### PR DESCRIPTION
- Fix for allowing logging for login success or failure

### TEST PLAN

**Testing log in success**
- Launch interface
- Wait 3 seconds - allow login dialog to pop up
- Log in successfully
- In Metabase, see that "encourageLoginDialog" user activity has logged your login action of {"action": "user logged in"}

**Testing log in failure**
- Launch interface
- Wait 3 seconds - allow login dialog to pop up
- Fail at logging in (i.e. using a bad password or username combination)
- In Metabase, see that "encourageLoginDialog" user activity has logged your login action of {"action": "user failed logged in"}