### PR TITLE
Fix crash when teleporting into avatars with bubble active

### DIFF
--- a/libraries/physics/src/PhysicsEngine.cpp
+++ b/libraries/physics/src/PhysicsEngine.cpp
@@ -286,6 +286,7 @@ void PhysicsEngine::reinsertObject(ObjectMotionState* object) {
 void PhysicsEngine::processTransaction(PhysicsEngine::Transaction& transaction) {
     // removes
     for (auto object : transaction.objectsToRemove) {
+        bumpAndPruneContacts(object);
         btRigidBody* body = object->getRigidBody();
         if (body) {
             removeDynamicsForBody(body);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/18365/Crash-while-teleporting-close-to-another-avatar-when-the-personal-space-bubble-is-active

The crash was caused by invalid collision events of an avatar that was just removed from the client due to the bubble. This PR fixes the crash by clearing the events the moment the avatar is removed.

## TEST PLAN
- In master, find a domain with avatars. Turn the bubble on, enter HMD mode, and teleport into the center of an avatar. Interface should crash within a few attempts.
- In this PR, do the same thing, teleporting directly into avatars with the bubble on. Interface should not crash.