### PR TITLE
Text tuning for wallet setup call to action

### DIFF
--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -113,7 +113,7 @@
 
             var span = document.createElement('span');
             span.style = "margin:10px 5px;color:#1b6420;font-size:15px;";
-            span.innerHTML = "<a href='#' onclick='emitWalletSetupEvent(); return false;'>Setup your Wallet</a> to get money and shop in Marketplace.";
+            span.innerHTML = "<a href='#' onclick='emitWalletSetupEvent(); return false;'>Activate your Wallet</a> to get money and shop in Marketplace.";
 
             var xButton = document.createElement('a');
             xButton.id = "xButton";

--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -564,7 +564,7 @@
     }
 
     function walletNotSetup() {
-        createNotification("Your wallet isn't set up. Open the WALLET app.", NotificationType.WALLET);
+        createNotification("Your wallet isn't activated yet. Open the WALLET app.", NotificationType.WALLET);
     }
 
     function connectionAdded(connectionName) {


### PR DESCRIPTION
tiny punch-list item from account-managed wallet demo.

test plan:

Be logged out.
Try to log in and sign up for a new account instead of using an existing one.
Open Marketplace. You should get told to "activate" your wallet instead of "set up".
Click the button. It should tell you that you are all set.
Go back to the marketplace and get something free. It should work.

This PR does not cover the case where you do _not_ heed the call-to-action to activate your wallet, and try to buy something anyway. (That works, but it takes you away from the marketplace items, which is not ideal.) That case will be addressed for a later release.