### PR TITLE
Don't popup login dialog in android

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2302,8 +2302,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     connect(&AndroidHelper::instance(), &AndroidHelper::enterBackground, this, &Application::enterBackground);
     connect(&AndroidHelper::instance(), &AndroidHelper::enterForeground, this, &Application::enterForeground);
     AndroidHelper::instance().notifyLoadComplete();
-#endif
-
+#else
     static int CHECK_LOGIN_TIMER = 3000;
     QTimer* checkLoginTimer = new QTimer(this);
     checkLoginTimer->setInterval(CHECK_LOGIN_TIMER);
@@ -2321,6 +2320,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     });
     Setting::Handle<bool>{"loginDialogPoppedUp", false}.set(false);
     checkLoginTimer->start();
+#endif
 }
 
 void Application::updateVerboseLogging() {


### PR DESCRIPTION
This PR is intended to revert PR 13961 on android, this is to avoid the login dialog to popup in android.

**Testing plan**
- Entering any listed domain being logged out should not popup the login dialog
- Test entering a domain that requires to be logged in: the java login should appears