### PR TITLE
Fixing double loginFailed

### DIFF
--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -538,7 +538,6 @@ void AccountManager::requestAccessToken(const QString& login, const QString& pas
 
     QNetworkReply* requestReply = networkAccessManager.post(request, postData);
     connect(requestReply, &QNetworkReply::finished, this, &AccountManager::requestAccessTokenFinished);
-    connect(requestReply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(requestAccessTokenError(QNetworkReply::NetworkError)));
 }
 
 void AccountManager::requestAccessTokenWithSteam(QByteArray authSessionTicket) {
@@ -631,12 +630,6 @@ void AccountManager::requestAccessTokenFinished() {
         qCDebug(networking) <<  "Error in response for password grant -" << rootObject["error_description"].toString();
         emit loginFailed();
     }
-}
-
-void AccountManager::requestAccessTokenError(QNetworkReply::NetworkError error) {
-    // TODO: error handling
-    qCDebug(networking) << "AccountManager: failed to fetch access token - " << error;
-    emit loginFailed();
 }
 
 void AccountManager::refreshAccessTokenFinished() {

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -106,7 +106,6 @@ public slots:
     void requestAccessTokenFinished();
     void refreshAccessTokenFinished();
     void requestProfileFinished();
-    void requestAccessTokenError(QNetworkReply::NetworkError error);
     void refreshAccessTokenError(QNetworkReply::NetworkError error);
     void requestProfileError(QNetworkReply::NetworkError error);
     void logout();


### PR DESCRIPTION
- Sending one loginFailed action when logging in (Related to #13989)
- Fix for MS#[18453](https://highfidelity.manuscript.com/f/cases/18453/AccountManager-loginFailed-signal-gets-sent-twice-when-login-fails)

## Test Plan
- Launch Interface
- If logged in, log out
- Click `Settings > Developer Menu`
- Click `Developer > Log`
- Click `File > Log In/Sign Up`
- Log in with a bad username/password combination
- You should only see ` [DEBUG] [qml] [LinkAccountBody.qml] Login Failed` once in the developer log for each time this occurs