### PR TITLE
Fix snapshot settings issue in HMD

### DIFF
--- a/interface/resources/qml/hifi/tablet/tabletWindows/TabletPreferencesDialog.qml
+++ b/interface/resources/qml/hifi/tablet/tabletWindows/TabletPreferencesDialog.qml
@@ -41,7 +41,15 @@ Item {
             section.saveAll();
         }
 
-        closeDialog();
+        if (HMD.active) {
+            if (gotoPreviousApp) {
+                tablet.returnToPreviousApp();
+            } else {
+                tablet.popFromStack();
+            }
+        } else {
+            closeDialog();
+        }
     }
 
     function restoreAll() {
@@ -50,7 +58,15 @@ Item {
             section.restoreAll();
         }
 
-        closeDialog();
+        if (HMD.active) {
+            if (gotoPreviousApp) {
+                tablet.returnToPreviousApp();
+            } else {
+                tablet.popFromStack();
+            }
+        } else {
+            closeDialog();
+        }
     }
 
     function closeDialog() {

--- a/interface/resources/qml/hifi/tablet/tabletWindows/TabletPreferencesDialog.qml
+++ b/interface/resources/qml/hifi/tablet/tabletWindows/TabletPreferencesDialog.qml
@@ -41,11 +41,7 @@ Item {
             section.saveAll();
         }
 
-        if (HMD.active) {
-            tablet.popFromStack();
-        } else {
-            closeDialog();
-        }
+        closeDialog();
     }
 
     function restoreAll() {
@@ -54,11 +50,7 @@ Item {
             section.restoreAll();
         }
 
-        if (HMD.active) {
-            tablet.popFromStack();
-        } else {
-            closeDialog();
-        }
+        closeDialog();
     }
 
     function closeDialog() {

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -255,7 +255,7 @@ Menu::Menu() {
     connect(action, &QAction::triggered, [] {
             auto tablet = DependencyManager::get<TabletScriptingInterface>()->getTablet("com.highfidelity.interface.tablet.system");
             auto hmd = DependencyManager::get<HMDScriptingInterface>();
-            tablet->loadQMLOnTop("hifi/tablet/ControllerSettings.qml");
+            tablet->pushOntoStack("hifi/tablet/ControllerSettings.qml");
 
             if (!hmd->getShouldShowTablet()) {
                 hmd->toggleShouldShowTablet();

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -255,7 +255,7 @@ Menu::Menu() {
     connect(action, &QAction::triggered, [] {
             auto tablet = DependencyManager::get<TabletScriptingInterface>()->getTablet("com.highfidelity.interface.tablet.system");
             auto hmd = DependencyManager::get<HMDScriptingInterface>();
-            tablet->pushOntoStack("hifi/tablet/ControllerSettings.qml");
+            tablet->loadQMLOnTop("hifi/tablet/ControllerSettings.qml");
 
             if (!hmd->getShouldShowTablet()) {
                 hmd->toggleShouldShowTablet();


### PR DESCRIPTION
This PR fix the issue described in this PR - https://highfidelity.manuscript.com/f/cases/18429/In-VR-mode-cannot-save-changes-or-cancel-after-going-to-Settings-from-the-Snap-app