### PR TITLE
Small Improvements to Anim Stats

### DIFF
--- a/interface/resources/qml/AnimStats.qml
+++ b/interface/resources/qml/AnimStats.qml
@@ -48,6 +48,9 @@ Item {
                     spacing: 4; x: 4; y: 4;
 
                     StatText {
+                        text: root.positionText
+                    }
+                    StatText {
                         text: "State Machines:---------------------------------------------------------------------------"
                     }
                     ListView {
@@ -74,9 +77,11 @@ Item {
                     spacing: 4; x: 4; y: 4;
 
                     StatText {
+                        text: root.rotationText
+                    }
+                    StatText {
                         text: "Anim Vars:--------------------------------------------------------------------------------"
                     }
-
                     ListView {
                         width: secondCol.width
                         height: root.animVars.length * 15
@@ -114,9 +119,11 @@ Item {
                     spacing: 4; x: 4; y: 4;
 
                     StatText {
+                        text: root.velocityText
+                    }
+                    StatText {
                         text: "Alpha Values:--------------------------------------------------------------------------"
                     }
-
                     ListView {
                         width: thirdCol.width
                         height: root.animAlphaValues.length * 15

--- a/interface/resources/qml/AnimStats.qml
+++ b/interface/resources/qml/AnimStats.qml
@@ -51,35 +51,6 @@ Item {
                         text: root.positionText
                     }
                     StatText {
-                        text: "State Machines:---------------------------------------------------------------------------"
-                    }
-                    ListView {
-                        width: firstCol.width
-                        height: root.animStateMachines.length * 15
-                        visible: root.animStateMchines.length > 0;
-                        model: root.animStateMachines
-                        delegate: StatText {
-                            text: {
-                                return modelData;
-                            }
-                        }
-                    }
-                }
-            }
-
-            Rectangle {
-                width: secondCol.width + 8
-                height: secondCol.height + 8
-                color: root.bgColor;
-
-                Column {
-                    id: secondCol
-                    spacing: 4; x: 4; y: 4;
-
-                    StatText {
-                        text: root.rotationText
-                    }
-                    StatText {
                         text: "Anim Vars:--------------------------------------------------------------------------------"
                     }
                     ListView {
@@ -106,6 +77,36 @@ Item {
                             }
                         }
                     }
+                }
+            }
+
+            Rectangle {
+                width: secondCol.width + 8
+                height: secondCol.height + 8
+                color: root.bgColor;
+
+                Column {
+                    id: secondCol
+                    spacing: 4; x: 4; y: 4;
+
+                    StatText {
+                        text: root.rotationText
+                    }
+                    StatText {
+                        text: "State Machines:---------------------------------------------------------------------------"
+                    }
+                    ListView {
+                        width: firstCol.width
+                        height: root.animStateMachines.length * 15
+                        visible: root.animStateMchines.length > 0;
+                        model: root.animStateMachines
+                        delegate: StatText {
+                            text: {
+                                return modelData;
+                            }
+                        }
+                    }
+
                 }
             }
 

--- a/interface/resources/qml/AnimStats.qml
+++ b/interface/resources/qml/AnimStats.qml
@@ -98,7 +98,7 @@ Item {
                     ListView {
                         width: firstCol.width
                         height: root.animStateMachines.length * 15
-                        visible: root.animStateMchines.length > 0;
+                        visible: root.animStateMachines.length > 0;
                         model: root.animStateMachines
                         delegate: StatText {
                             text: {

--- a/interface/src/ui/AnimStats.cpp
+++ b/interface/src/ui/AnimStats.cpp
@@ -42,6 +42,29 @@ void AnimStats::updateStats(bool force) {
     auto myAvatar = avatarManager->getMyAvatar();
     auto debugAlphaMap = myAvatar->getSkeletonModel()->getRig().getDebugAlphaMap();
 
+    glm::vec3 position = myAvatar->getWorldPosition();
+    glm::quat rotation = myAvatar->getWorldOrientation();
+    glm::vec3 velocity = myAvatar->getWorldVelocity();
+
+    _positionText = QString("Position: (%1, %2, %3)").
+        arg(QString::number(position.x, 'f', 2)).
+        arg(QString::number(position.y, 'f', 2)).
+        arg(QString::number(position.z, 'f', 2));
+    emit positionTextChanged();
+
+    glm::vec3 eulerRotation = safeEulerAngles(rotation);
+    _rotationText = QString("Heading: %1").
+        arg(QString::number(glm::degrees(eulerRotation.y), 'f', 2));
+    emit rotationTextChanged();
+
+    // transform velocity into rig coordinate frame. z forward.
+    glm::vec3 localVelocity = Quaternions::Y_180 * glm::inverse(rotation) * velocity;
+    _velocityText = QString("Local Vel: (%1, %2, %3)").
+        arg(QString::number(localVelocity.x, 'f', 2)).
+        arg(QString::number(localVelocity.y, 'f', 2)).
+        arg(QString::number(localVelocity.z, 'f', 2));
+    emit velocityTextChanged();
+
     // update animation debug alpha values
     QStringList newAnimAlphaValues;
     qint64 now = usecTimestampNow();

--- a/interface/src/ui/AnimStats.h
+++ b/interface/src/ui/AnimStats.h
@@ -19,6 +19,9 @@ class AnimStats : public QQuickItem {
     Q_PROPERTY(QStringList animAlphaValues READ animAlphaValues NOTIFY animAlphaValuesChanged)
     Q_PROPERTY(QStringList animVars READ animVars NOTIFY animVarsChanged)
     Q_PROPERTY(QStringList animStateMachines READ animStateMachines NOTIFY animStateMachinesChanged)
+    Q_PROPERTY(QString positionText READ positionText NOTIFY positionTextChanged)
+    Q_PROPERTY(QString rotationText READ rotationText NOTIFY rotationTextChanged)
+    Q_PROPERTY(QString velocityText READ velocityText NOTIFY velocityTextChanged)
 
 public:
     static AnimStats* getInstance();
@@ -27,9 +30,13 @@ public:
 
     void updateStats(bool force = false);
 
-    QStringList animAlphaValues() { return _animAlphaValues; }
-    QStringList animVars() { return _animVarsList; }
-    QStringList animStateMachines() { return _animStateMachines; }
+    QStringList animAlphaValues() const { return _animAlphaValues; }
+    QStringList animVars() const { return _animVarsList; }
+    QStringList animStateMachines() const { return _animStateMachines; }
+
+    QString positionText() const { return _positionText; }
+    QString rotationText() const { return _rotationText; }
+    QString velocityText() const { return _velocityText; }
 
 public slots:
     void forceUpdateStats() { updateStats(true); }
@@ -39,6 +46,9 @@ signals:
     void animAlphaValuesChanged();
     void animVarsChanged();
     void animStateMachinesChanged();
+    void positionTextChanged();
+    void rotationTextChanged();
+    void velocityTextChanged();
 
 private:
     QStringList _animAlphaValues;
@@ -50,6 +60,10 @@ private:
     std::map<QString, qint64> _animVarChangedTimers; // last time animVar value has changed.
 
     QStringList _animStateMachines;
+
+    QString _positionText;
+    QString _rotationText;
+    QString _velocityText;
 };
 
 #endif // hifi_AnimStats_h

--- a/libraries/animation/src/AnimStateMachine.cpp
+++ b/libraries/animation/src/AnimStateMachine.cpp
@@ -88,6 +88,10 @@ const AnimPoseVec& AnimStateMachine::evaluate(const AnimVariantMap& animVars, co
     processOutputJoints(triggersOut);
 
     context.addStateMachineInfo(_id, _currentState->getID(), _previousState->getID(), _duringInterp, _alpha);
+    if (_duringInterp) {
+        // hack: add previoius state to debug alpha map, with parens around it's name.
+        context.setDebugAlpha(QString("(%1)").arg(_previousState->getID()), 1.0f - _alpha, AnimNodeType::Clip);
+    }
 
     return _poses;
 }

--- a/libraries/animation/src/AnimVariant.cpp
+++ b/libraries/animation/src/AnimVariant.cpp
@@ -140,14 +140,19 @@ std::map<QString, QString> AnimVariantMap::toDebugMap() const {
             result[pair.first] = QString::number(pair.second.getFloat(), 'f', 3);
             break;
         case AnimVariant::Type::Vec3: {
+            // To prevent filling up debug stats, don't show vec3 values
+            /*
             glm::vec3 value = pair.second.getVec3();
             result[pair.first] = QString("(%1, %2, %3)").
                 arg(QString::number(value.x, 'f', 3)).
                 arg(QString::number(value.y, 'f', 3)).
                 arg(QString::number(value.z, 'f', 3));
+            */
             break;
         }
         case AnimVariant::Type::Quat: {
+            // To prevent filling up the anim stats, don't show quat values
+            /*
             glm::quat value = pair.second.getQuat();
             result[pair.first] = QString("(%1, %2, %3, %4)").
                 arg(QString::number(value.x, 'f', 3)).
@@ -155,10 +160,14 @@ std::map<QString, QString> AnimVariantMap::toDebugMap() const {
                 arg(QString::number(value.z, 'f', 3)).
                 arg(QString::number(value.w, 'f', 3));
             break;
+            */
         }
         case AnimVariant::Type::String:
+            // To prevent filling up anim stats, don't show string values
+            /*
             result[pair.first] = pair.second.getString();
             break;
+            */
         default:
             assert(("invalid AnimVariant::Type", false));
         }


### PR DESCRIPTION
* During a state machine interp the previous state now shows up in AlphaValues panel, with parentheses around the name.
* Added 3 new fields
  * Position - in world coordinate frame.
  * Heading - the facing angle in the world corrdinate frame.
  * Local Vel - the velocity of the character in the local coordinate frame. (left, forward, up).
* Removed noisy position and quaternion values from AnimVars panel.
* Swapped the AnimVars and StateMachine panels