### PR TITLE
Follow wallet setup referrer when autogenerating new wallet

### DIFF
--- a/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/Wallet.qml
@@ -831,6 +831,7 @@ Rectangle {
         Commerce.getWalletAuthenticatedStatus(); // before writing security image, ensures that salt/account password is set.
         Commerce.chooseSecurityImage(securityImagePath);
         Commerce.generateKeyPair();
+        followReferrer({ referrer: walletSetup.referrer });
     }
 
     function addLeadingZero(n) {

--- a/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
+++ b/interface/resources/qml/hifi/commerce/wallet/WalletSetup.qml
@@ -28,7 +28,7 @@ Item {
     property string activeView: "step_1";
     property string lastPage;
     property bool hasShownSecurityImageTip: false;
-    property string referrer;
+    property string referrer: '';
     property string keyFilePath;
     property date startingTimestamp;
     property string setupAttemptID;


### PR DESCRIPTION
This PR makes it so that if you're a new user and you go to checkout an item from the marketplace, you'll be dumped back to that item's screen after wallet creation (instead of being dumped into the wallet app, from where there's no "BACK" button).

Issue raised by Philip during a demo and raised to me by Howard.

DNM because I don't think there's even a MS ticket up for this yet, and it might not be the right solution.