### PR TITLE
Added a Controller gate to the emote app

### DIFF
--- a/scripts/system/emote.js
+++ b/scripts/system/emote.js
@@ -133,7 +133,7 @@ function restoreAnimation(event) {
     // Make sure animation is not restored while:
     // - Unmuting / Muting Self
     // - Cameraing Around using inspect scripts:
-    if(event.isShifted || event.isMeta || event.isControl || event.isAlt){
+    if(event.isMeta || event.isControl || event.isAlt){
         return;
     }
     MyAvatar.restoreAnimation();

--- a/scripts/system/emote.js
+++ b/scripts/system/emote.js
@@ -129,9 +129,14 @@ function onWebEventReceived(event) {
 }
 
 // Restore the navigation animation states (idle, walk, run)
-function restoreAnimation() {
+function restoreAnimation(event) {
+    // Make sure animation is not restored while:
+    // - Unmuting / Muting Self
+    // - Cameraing Around using inspect scripts:
+    if(event.isShifted || event.isMeta || event.isControl || event.isAlt){
+        return;
+    }
     MyAvatar.restoreAnimation();
-    
     // Make sure the input is disconnected after animations are restored so it doesn't affect any emotes other than sit
     Controller.keyPressEvent.disconnect(restoreAnimation);
     Controller.disableMapping(eventMappingName);


### PR DESCRIPTION
This make sure that the emote app does not restore animations when
one unmutes / mutes self while seated, or if one uses inspect scripts that use alt/meta/control meta buttons to move the camera around, or to do something specific.