### PR TITLE
Prototype improved controller mappings - A

### DIFF
--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -39,18 +39,6 @@
           "when": [ "!Application.SnapTurn" ]
         },
 
-        { "from": "Standard.RY",
-          "when": "Application.Grounded",
-          "to": "Actions.Up",
-          "filters":
-            [
-                { "type": "deadZone", "min": 0.6 },
-                "invert"
-            ]
-        },
-
-        { "from": "Standard.RY", "to": "Actions.Up", "filters": "invert"},
-
         { "from": "Standard.Back", "to": "Actions.CycleCamera" },
         { "from": "Standard.Start", "to": "Actions.ContextMenu" },
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1964,15 +1964,8 @@ void MyAvatar::updateMotors() {
             // Fly in direction of left hand.
             motorRotation = cancelOutRoll(handOrientation);
         } else {
-            // non-hovering = walking: follow camera twist about vertical but not lift
-            // we decompose camera's rotation and store the twist part in motorRotation
-            // however, we need to perform the decomposition in the avatar-frame
-            // using the local UP axis and then transform back into world-frame
-            glm::quat orientation = getWorldOrientation();
-            glm::quat headOrientation = glm::inverse(orientation) * getMyHead()->getHeadOrientation(); // avatar-frame
-            glm::quat liftRotation;
-            swingTwistDecomposition(headOrientation, Vectors::UNIT_Y, liftRotation, motorRotation);
-            motorRotation = orientation * motorRotation;
+            // Walk in direction of left hand in x-z plane.
+            motorRotation = cancelOutRollAndPitch(handOrientation);
         }
 
         if (_isPushing || _isBraking || !_isBeingPushed) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1956,10 +1956,13 @@ void MyAvatar::updateMotors() {
         verticalMotorTimescale = INVALID_MOTOR_TIMESCALE;
     }
 
+    const glm::quat LEFT_HAND_ZERO_ROT(glm::quat(glm::radians(glm::vec3(90.0f, -90.0f, 0.0f))));
     if (_motionBehaviors & AVATAR_MOTION_ACTION_MOTOR_ENABLED) {
+        glm::quat handOrientation = getLeftPalmRotation() * LEFT_HAND_ZERO_ROT;
         if (_characterController.getState() == CharacterController::State::Hover ||
                 _characterController.computeCollisionGroup() == BULLET_COLLISION_GROUP_COLLISIONLESS) {
-            motorRotation = getMyHead()->getHeadOrientation();
+            // Fly in direction of left hand.
+            motorRotation = cancelOutRoll(handOrientation);
         } else {
             // non-hovering = walking: follow camera twist about vertical but not lift
             // we decompose camera's rotation and store the twist part in motorRotation

--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -574,6 +574,12 @@ Script.include("/~/system/libraries/controllers.js");
         // Teleport actions.
         teleportMapping.from(Controller.Standard.LeftPrimaryThumb).peek().to(leftTeleporter.buttonPress);
         teleportMapping.from(Controller.Standard.RightPrimaryThumb).peek().to(rightTeleporter.buttonPress);
+        teleportMapping.from(Controller.Standard.RY)
+            .peek()
+            .clamp(-1, 0)
+            .invert()
+            .constrainToInteger()
+            .to(rightTeleporter.buttonPress);
     }
 
     var leftTeleporter = new Teleporter(LEFT_HAND);


### PR DESCRIPTION
With Settings > Controls > Advanced Movement in VR:
- Walking on the ground is in the direction your left hand is pointing (instead of your head).
- To initiate flying, point your left hand upward and do left joystick forward (instead of right joystick forward).
- Flying is in the direction your left hand is pointing (instead of your head).
- While flying, tilt (roll) your head left/right to turn left/right. (No change.)

Right joystick forward initiates the teleport beam.

Right joystick backward takes no action.