### PR TITLE
Fix AMD highlighting effect

### DIFF
--- a/libraries/gpu-gl/src/gpu/gl41/GL41BackendShader.cpp
+++ b/libraries/gpu-gl/src/gpu/gl41/GL41BackendShader.cpp
@@ -57,7 +57,7 @@ void GL41Backend::postLinkProgram(ShaderObject& programObject, const Shader& pro
         const auto resourceBufferUniforms = ::gl::Uniform::loadByName(glprogram, program.getResourceBuffers().getNames());
         for (const auto& resourceBuffer : resourceBufferUniforms) {
             const auto& targetBinding = expectedResourceBuffers.at(resourceBuffer.name);
-            glProgramUniform1i(glprogram, resourceBuffer.binding, targetBinding);
+            glProgramUniform1i(glprogram, resourceBuffer.binding, targetBinding + GL41Backend::RESOURCE_BUFFER_SLOT0_TEX_UNIT);
         }
     }
 

--- a/libraries/render-utils/src/Highlight.slh
+++ b/libraries/render-utils/src/Highlight.slh
@@ -15,7 +15,7 @@
 
 <@include Highlight_shared.slh@>
 
-layout(binding=RENDER_UTILS_BUFFER_HIGHLIGHT_PARAMS) uniform highlightParamsBuffer {
+layout(std140, binding=RENDER_UTILS_BUFFER_HIGHLIGHT_PARAMS) uniform highlightParamsBuffer {
     HighlightParameters params;
 };
 

--- a/libraries/render-utils/src/Highlight_aabox.slv
+++ b/libraries/render-utils/src/Highlight_aabox.slv
@@ -45,7 +45,7 @@ struct HighlightParameters {
     vec2 outlineWidth;
 };
 
-layout(binding=0) uniform parametersBuffer {
+layout(std140, binding=0) uniform parametersBuffer {
     HighlightParameters _parameters;
 };
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/15367

I identified a number of issues in this PR.  First, a number of uniform buffers haven't been marked `std140`, meaning that their layouts aren't really reliable without querying OpenGL (something we don't do).  nVidia seems to treat all uniform buffers as std140 by default, but AMD does not.  Hence, the buffer we populated on the C++ side and pushed to the final highlighting shader was corrupt from the perspective of the shader. 

Additionally, the logic for assigning binding points to storage textures in OpenGL 4.1 (the equivalent of SSBOs in GL 4.5) wasn't assigning the correct slot.  

Having fixed these issues, highlighting functionality (the only non-debug shader that currently uses gpu resource buffers) should now function properly on Windows AMD machines as well as all Mac systems.  


## Testing

See Manuscript case for reproduce instructions.  Requires testing on AMD & nVidia on both Mac and PC.

