### PR TITLE
Only call selectEntity once triggered when using edit handles

### DIFF
--- a/scripts/system/controllers/controllerModules/inEditMode.js
+++ b/scripts/system/controllers/controllerModules/inEditMode.js
@@ -73,20 +73,21 @@ Script.include("/~/system/libraries/utils.js");
                             method: "clearSelection",
                             hand: hand
                         }));
+                    } else {
+                        if (this.selectedTarget.type === Picks.INTERSECTED_ENTITY) {
+                            Messages.sendLocalMessage("entityToolUpdates", JSON.stringify({
+                                method: "selectEntity",
+                                entityID: this.selectedTarget.objectID,
+                                hand: hand
+                            }));
+                        } else if (this.selectedTarget.type === Picks.INTERSECTED_OVERLAY) {
+                            Messages.sendLocalMessage("entityToolUpdates", JSON.stringify({
+                                method: "selectOverlay",
+                                overlayID: this.selectedTarget.objectID,
+                                hand: hand
+                            }));
+                        }
                     }
-                }
-                if (this.selectedTarget.type === Picks.INTERSECTED_ENTITY) {
-                    Messages.sendLocalMessage("entityToolUpdates", JSON.stringify({
-                        method: "selectEntity",
-                        entityID: this.selectedTarget.objectID,
-                        hand: hand
-                    }));
-                } else if (this.selectedTarget.type === Picks.INTERSECTED_OVERLAY) {
-                    Messages.sendLocalMessage("entityToolUpdates", JSON.stringify({
-                        method: "selectOverlay",
-                        overlayID: this.selectedTarget.objectID,
-                        hand: hand
-                    }));
                 }
 
                 this.triggerClicked = true;


### PR DESCRIPTION
Previously the selectEntity/selectOverlay messages could continually be sent from the inEditMode controller when triggering in HMD. This can eventually lead to the possible constant iteration over all entities in EntityIconOverlayManager.updatePositions (from SelectionManager setSelections -> _update -> listeners callback) causing the edit performance spikes seen in the bug below. Instead, we only need to send the messages once when first triggered.

Fixes: https://highfidelity.manuscript.com/f/cases/18554

Test Plan:
- Enter Interface in HMD mode into your sandbox
- Apply the islandExport2.json at the bottom of the above bug to your content set for your sandbox
- Go to localhost/414,161,515
- Open Create app and create a Shape entity
- Verify you can trigger your laser onto nothing to clear selection and then trigger it on the new Shape entity to reselect it
- Verify that when using all edit handles, but especially when using the center scale cube, that they perform as expected besides a small amount of performance hit as seen in the first gif in the above bug (not fully smooth updates)
- Also verify triggering on the entity itself for translating it along the XZ plane behaves as expected with the same performance experienced
- Continue to stress test selecting different entities with the laser (including light and particle entities) and using their edit handles
- Remove all entities from your sandbox, create a new Shape entity, and verify edit handle performance on it is now fully smooth