### PR TITLE
Toggle going to 404 redirect domain

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3498,13 +3498,14 @@ bool Application::isServerlessMode() const {
 }
 
 void Application::setIsInterstitialMode(bool interstitialMode) {
-    Settings settings;
-    bool enableInterstitial = settings.value("enableIntersitialMode", false).toBool();
-    if (_interstitialMode != interstitialMode && enableInterstitial) {
-        _interstitialMode = interstitialMode;
+    bool enableInterstitial = DependencyManager::get<NodeList>()->getDomainHandler().getInterstitialModeEnabled();
+    if (enableInterstitial) {
+        if (_interstitialMode != interstitialMode) {
+            _interstitialMode = interstitialMode;
 
-        DependencyManager::get<AudioClient>()->setAudioPaused(_interstitialMode);
-        DependencyManager::get<AvatarManager>()->setMyAvatarDataPacketsPaused(_interstitialMode);
+            DependencyManager::get<AudioClient>()->setAudioPaused(_interstitialMode);
+            DependencyManager::get<AvatarManager>()->setMyAvatarDataPacketsPaused(_interstitialMode);
+        }
     }
 }
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -432,7 +432,7 @@ public slots:
 
     void setIsServerlessMode(bool serverlessDomain);
     void loadServerlessDomain(QUrl domainURL, bool errorDomain = false);
-    void setIsInterstitialMode(bool interstialMode);
+    void setIsInterstitialMode(bool interstitialMode);
 
     void updateVerboseLogging();
 

--- a/interface/src/ConnectionMonitor.cpp
+++ b/interface/src/ConnectionMonitor.cpp
@@ -18,7 +18,6 @@
 #include <DomainHandler.h>
 #include <AddressManager.h>
 #include <NodeList.h>
-#include <SettingHandle.h>
 
 // Because the connection monitor is created at startup, the time we wait on initial load
 // should be longer to allow the application to initialize.
@@ -40,8 +39,7 @@ void ConnectionMonitor::init() {
 
     _timer.setSingleShot(true);
     if (!domainHandler.isConnected()) {
-        Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
-        if (enableInterstitialMode.get()) {
+        if (_enableInterstitialMode.get()) {
             _timer.start(ON_INITIAL_LOAD_REDIRECT_AFTER_DISCONNECTED_FOR_X_MS);
         } else {
             _timer.start(ON_INITIAL_LOAD_DISPLAY_AFTER_DISCONNECTED_FOR_X_MS);
@@ -50,8 +48,7 @@ void ConnectionMonitor::init() {
 
     connect(&_timer, &QTimer::timeout, this, [this]() {
         // set in a timeout error
-        Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
-        if (enableInterstitialMode.get()) {
+        if (_enableInterstitialMode.get()) {
             qDebug() << "ConnectionMonitor: Redirecting to 404 error domain";
             emit setRedirectErrorState(REDIRECT_HIFI_ADDRESS, 5);
         } else {
@@ -62,8 +59,7 @@ void ConnectionMonitor::init() {
 }
 
 void ConnectionMonitor::startTimer() {
-    Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
-    if (enableInterstitialMode.get()) {
+    if (_enableInterstitialMode.get()) {
         _timer.start(REDIRECT_AFTER_DISCONNECTED_FOR_X_MS);
     } else {
         _timer.start(DISPLAY_AFTER_DISCONNECTED_FOR_X_MS);
@@ -72,8 +68,7 @@ void ConnectionMonitor::startTimer() {
 
 void ConnectionMonitor::stopTimer() {
     _timer.stop();
-    Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
-    if (!enableInterstitialMode.get()) {
+    if (!_enableInterstitialMode.get()) {
         DependencyManager::get<DialogsManager>()->setDomainConnectionFailureVisibility(false);
     }
 }

--- a/interface/src/ConnectionMonitor.cpp
+++ b/interface/src/ConnectionMonitor.cpp
@@ -23,8 +23,6 @@
 // should be longer to allow the application to initialize.
 static const int ON_INITIAL_LOAD_REDIRECT_AFTER_DISCONNECTED_FOR_X_MS = 10000;
 static const int REDIRECT_AFTER_DISCONNECTED_FOR_X_MS = 5000;
-static const int ON_INITIAL_LOAD_DISPLAY_AFTER_DISCONNECTED_FOR_X_MS = 10000;
-static const int DISPLAY_AFTER_DISCONNECTED_FOR_X_MS = 5000;
 
 void ConnectionMonitor::init() {
     // Connect to domain disconnected message
@@ -39,18 +37,15 @@ void ConnectionMonitor::init() {
 
     _timer.setSingleShot(true);
     if (!domainHandler.isConnected()) {
-        if (_enableInterstitialMode.get()) {
-            _timer.start(ON_INITIAL_LOAD_REDIRECT_AFTER_DISCONNECTED_FOR_X_MS);
-        } else {
-            _timer.start(ON_INITIAL_LOAD_DISPLAY_AFTER_DISCONNECTED_FOR_X_MS);
-        }
+        _timer.start(ON_INITIAL_LOAD_REDIRECT_AFTER_DISCONNECTED_FOR_X_MS);
     }
 
     connect(&_timer, &QTimer::timeout, this, [this]() {
         // set in a timeout error
-        if (_enableInterstitialMode.get()) {
+        bool enableInterstitial = DependencyManager::get<NodeList>()->getDomainHandler().getInterstitialModeEnabled();
+        if (enableInterstitial) {
             qDebug() << "ConnectionMonitor: Redirecting to 404 error domain";
-            emit setRedirectErrorState(REDIRECT_HIFI_ADDRESS, 5);
+            emit setRedirectErrorState(REDIRECT_HIFI_ADDRESS, "", 5);
         } else {
             qDebug() << "ConnectionMonitor: Showing connection failure window";
             DependencyManager::get<DialogsManager>()->setDomainConnectionFailureVisibility(true);
@@ -59,16 +54,13 @@ void ConnectionMonitor::init() {
 }
 
 void ConnectionMonitor::startTimer() {
-    if (_enableInterstitialMode.get()) {
-        _timer.start(REDIRECT_AFTER_DISCONNECTED_FOR_X_MS);
-    } else {
-        _timer.start(DISPLAY_AFTER_DISCONNECTED_FOR_X_MS);
-    }
+    _timer.start(REDIRECT_AFTER_DISCONNECTED_FOR_X_MS);
 }
 
 void ConnectionMonitor::stopTimer() {
     _timer.stop();
-    if (!_enableInterstitialMode.get()) {
+    bool enableInterstitial = DependencyManager::get<NodeList>()->getDomainHandler().getInterstitialModeEnabled();
+    if (!enableInterstitial) {
         DependencyManager::get<DialogsManager>()->setDomainConnectionFailureVisibility(false);
     }
 }

--- a/interface/src/ConnectionMonitor.cpp
+++ b/interface/src/ConnectionMonitor.cpp
@@ -26,7 +26,6 @@ static const int ON_INITIAL_LOAD_REDIRECT_AFTER_DISCONNECTED_FOR_X_MS = 10000;
 static const int REDIRECT_AFTER_DISCONNECTED_FOR_X_MS = 5000;
 static const int ON_INITIAL_LOAD_DISPLAY_AFTER_DISCONNECTED_FOR_X_MS = 10000;
 static const int DISPLAY_AFTER_DISCONNECTED_FOR_X_MS = 5000;
-Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
 
 void ConnectionMonitor::init() {
     // Connect to domain disconnected message
@@ -41,6 +40,7 @@ void ConnectionMonitor::init() {
 
     _timer.setSingleShot(true);
     if (!domainHandler.isConnected()) {
+        Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
         if (enableInterstitialMode.get()) {
             _timer.start(ON_INITIAL_LOAD_REDIRECT_AFTER_DISCONNECTED_FOR_X_MS);
         } else {
@@ -50,6 +50,7 @@ void ConnectionMonitor::init() {
 
     connect(&_timer, &QTimer::timeout, this, [this]() {
         // set in a timeout error
+        Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
         if (enableInterstitialMode.get()) {
             qDebug() << "ConnectionMonitor: Redirecting to 404 error domain";
             emit setRedirectErrorState(REDIRECT_HIFI_ADDRESS, 5);
@@ -61,6 +62,7 @@ void ConnectionMonitor::init() {
 }
 
 void ConnectionMonitor::startTimer() {
+    Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
     if (enableInterstitialMode.get()) {
         _timer.start(REDIRECT_AFTER_DISCONNECTED_FOR_X_MS);
     } else {
@@ -70,6 +72,7 @@ void ConnectionMonitor::startTimer() {
 
 void ConnectionMonitor::stopTimer() {
     _timer.stop();
+    Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
     if (!enableInterstitialMode.get()) {
         DependencyManager::get<DialogsManager>()->setDomainConnectionFailureVisibility(false);
     }

--- a/interface/src/ConnectionMonitor.h
+++ b/interface/src/ConnectionMonitor.h
@@ -15,8 +15,6 @@
 #include <QObject>
 #include <QTimer>
 
-#include <SettingHandle.h>
-
 class QUrl;
 class QString;
 
@@ -26,7 +24,7 @@ public:
     void init();
 
 signals:
-    void setRedirectErrorState(QUrl errorURL, int reasonCode);
+    void setRedirectErrorState(QUrl errorURL, QString reasonMessage = "", int reasonCode = -1, const QString& extraInfo = "");
 
 private slots:
     void startTimer();
@@ -34,7 +32,6 @@ private slots:
 
 private:
     QTimer _timer;
-    Setting::Handle<bool> _enableInterstitialMode{ "enableInterstitialMode", false };
 };
 
 #endif // hifi_ConnectionMonitor_h

--- a/interface/src/ConnectionMonitor.h
+++ b/interface/src/ConnectionMonitor.h
@@ -15,6 +15,8 @@
 #include <QObject>
 #include <QTimer>
 
+#include <SettingHandle.h>
+
 class QUrl;
 class QString;
 
@@ -32,6 +34,7 @@ private slots:
 
 private:
     QTimer _timer;
+    Setting::Handle<bool> _enableInterstitialMode{ "enableInterstitialMode", false };
 };
 
 #endif // hifi_ConnectionMonitor_h

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -180,6 +180,14 @@ void WindowScriptingInterface::setPreviousBrowseAssetLocation(const QString& loc
     Setting::Handle<QVariant>(LAST_BROWSE_ASSETS_LOCATION_SETTING).set(location);
 }
 
+bool WindowScriptingInterface::getInterstitialModeEnabled() const {
+    return DependencyManager::get<NodeList>()->getDomainHandler().getInterstitialModeEnabled();
+}
+
+void WindowScriptingInterface::setInterstitialModeEnabled(bool enableInterstitialMode) {
+    DependencyManager::get<NodeList>()->getDomainHandler().setInterstitialModeEnabled(enableInterstitialMode);
+}
+
 bool  WindowScriptingInterface::isPointOnDesktopWindow(QVariant point) {
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     return offscreenUi->isPointOnDesktopWindow(point);

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -49,6 +49,7 @@ class WindowScriptingInterface : public QObject, public Dependency {
     Q_PROPERTY(int innerHeight READ getInnerHeight)
     Q_PROPERTY(int x READ getX)
     Q_PROPERTY(int y READ getY)
+    Q_PROPERTY(bool interstitialModeEnabled READ getInterstitialModeEnabled WRITE setInterstitialModeEnabled)
 
 public:
     WindowScriptingInterface();
@@ -757,6 +758,9 @@ private:
 
     QString getPreviousBrowseAssetLocation() const;
     void setPreviousBrowseAssetLocation(const QString& location);
+
+    bool getInterstitialModeEnabled() const;
+    void setInterstitialModeEnabled(bool enableInterstitialMode);
 
     void ensureReticleVisible() const;
 

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -140,8 +140,7 @@ public:
      * </table>
      * @typedef {number} location.LookupTrigger
      */
-    enum LookupTrigger
-    {
+    enum LookupTrigger {
         UserInput,
         Back,
         Forward,
@@ -207,9 +206,8 @@ public slots:
     // functions and signals that should be exposed are moved to a scripting interface class.
     //
     // we currently expect this to be called from NodeList once handleLookupString has been called with a path
-    bool goToViewpointForPath(const QString& viewpointString, const QString& pathString) {
-        return handleViewpoint(viewpointString, false, DomainPathResponse, false, pathString);
-    }
+    bool goToViewpointForPath(const QString& viewpointString, const QString& pathString)
+        { return handleViewpoint(viewpointString, false, DomainPathResponse, false, pathString); }
 
     /**jsdoc
      * Go back to the previous location in your navigation history, if there is one.
@@ -231,8 +229,7 @@ public slots:
      *     location history is correctly maintained.
      */
     void goToLocalSandbox(QString path = "", LookupTrigger trigger = LookupTrigger::StartupFromSettings) {
-        handleUrl(SANDBOX_HIFI_ADDRESS + path, trigger);
-    }
+        handleUrl(SANDBOX_HIFI_ADDRESS + path, trigger); }
 
     /**jsdoc
      * Go to the default "welcome" metaverse address.
@@ -364,8 +361,7 @@ signals:
      * location.locationChangeRequired.connect(onLocationChangeRequired);
      */
     void locationChangeRequired(const glm::vec3& newPosition,
-                                bool hasOrientationChange,
-                                const glm::quat& newOrientation,
+                                bool hasOrientationChange, const glm::quat& newOrientation,
                                 bool shouldFaceLocation);
 
     /**jsdoc
@@ -448,11 +444,8 @@ private:
 
     bool handleNetworkAddress(const QString& lookupString, LookupTrigger trigger, bool& hostChanged);
     void handlePath(const QString& path, LookupTrigger trigger, bool wasPathOnly = false);
-    bool handleViewpoint(const QString& viewpointString,
-                         bool shouldFace,
-                         LookupTrigger trigger,
-                         bool definitelyPathOnly = false,
-                         const QString& pathString = QString());
+    bool handleViewpoint(const QString& viewpointString, bool shouldFace, LookupTrigger trigger,
+                         bool definitelyPathOnly = false, const QString& pathString = QString());
     bool handleUsername(const QString& lookupString);
     bool handleDomainID(const QString& host);
 

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -15,6 +15,10 @@
 
 #include <PathUtils.h>
 
+#include <shared/QtHelpers.h>
+
+#include <QThread>
+
 #include <QtCore/QJsonDocument>
 #include <QtCore/QDataStream>
 
@@ -132,6 +136,18 @@ void DomainHandler::hardReset() {
 
     // clear any pending path we may have wanted to ask the previous DS about
     _pendingPath.clear();
+}
+
+bool DomainHandler::getInterstitialModeEnabled() const {
+    return _interstitialModeSettingLock.resultWithReadLock<bool>([&] {
+        return _enableInterstitialMode.get();
+    });
+}
+
+void DomainHandler::setInterstitialModeEnabled(bool enableInterstitialMode) {
+    _interstitialModeSettingLock.withWriteLock([&] {
+        _enableInterstitialMode.set(enableInterstitialMode);
+    });
 }
 
 void DomainHandler::setErrorDomainURL(const QUrl& url) {
@@ -340,11 +356,15 @@ void DomainHandler::loadedErrorDomain(std::map<QString, QString> namedPaths) {
     DependencyManager::get<AddressManager>()->goToViewpointForPath(viewpoint, QString());
 }
 
-void DomainHandler::setRedirectErrorState(QUrl errorUrl, int reasonCode) {
-    _errorDomainURL = errorUrl;
+void DomainHandler::setRedirectErrorState(QUrl errorUrl, QString reasonMessage, int reasonCode, const QString& extraInfo) {
     _lastDomainConnectionError = reasonCode;
-    _isInErrorState = true;
-    emit redirectToErrorDomainURL(_errorDomainURL);
+    if (getInterstitialModeEnabled()) {
+        _errorDomainURL = errorUrl;
+        _isInErrorState = true;
+        emit redirectToErrorDomainURL(_errorDomainURL);
+    } else {
+        emit domainConnectionRefused(reasonMessage, reasonCode, extraInfo);
+    }
 }
 
 void DomainHandler::requestDomainSettings() {
@@ -486,18 +506,9 @@ void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<Rec
         emit domainConnectionRefused(reasonMessage, (int)reasonCode, extraInfo);
 #else
 
-        if (_enableInterstitialMode.get()) {
-            if (reasonCode == ConnectionRefusedReason::ProtocolMismatch || reasonCode == ConnectionRefusedReason::NotAuthorized) {
-                // ingest the error - this is a "hard" connection refusal.
-                setRedirectErrorState(_errorDomainURL, (int)reasonCode);
-            } else {
-                emit domainConnectionRefused(reasonMessage, (int)reasonCode, extraInfo);
-            }
-            _lastDomainConnectionError = (int)reasonCode;
-        } else {
-            emit domainConnectionRefused(reasonMessage, (int)reasonCode, extraInfo);
-        }
-       #endif
+        // ingest the error - this is a "hard" connection refusal.
+        setRedirectErrorState(_errorDomainURL, reasonMessage, (int)reasonCode, extraInfo);
+#endif
     }
 
     auto accountManager = DependencyManager::get<AccountManager>();

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -14,7 +14,6 @@
 #include <math.h>
 
 #include <PathUtils.h>
-#include <SettingHandle.h>
 
 #include <QtCore/QJsonDocument>
 #include <QtCore/QDataStream>
@@ -486,9 +485,8 @@ void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<Rec
 #if defined(Q_OS_ANDROID)
         emit domainConnectionRefused(reasonMessage, (int)reasonCode, extraInfo);
 #else
-        Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
 
-        if (enableInterstitialMode.get()) {
+        if (_enableInterstitialMode.get()) {
             if (reasonCode == ConnectionRefusedReason::ProtocolMismatch || reasonCode == ConnectionRefusedReason::NotAuthorized) {
                 // ingest the error - this is a "hard" connection refusal.
                 setRedirectErrorState(_errorDomainURL, (int)reasonCode);
@@ -496,8 +494,7 @@ void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<Rec
                 emit domainConnectionRefused(reasonMessage, (int)reasonCode, extraInfo);
             }
             _lastDomainConnectionError = (int)reasonCode;
-        }
-        else {
+        } else {
             emit domainConnectionRefused(reasonMessage, (int)reasonCode, extraInfo);
         }
        #endif

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -14,6 +14,7 @@
 #include <math.h>
 
 #include <PathUtils.h>
+#include <SettingHandle.h>
 
 #include <QtCore/QJsonDocument>
 #include <QtCore/QDataStream>
@@ -28,6 +29,8 @@
 #include "SharedUtil.h"
 #include "UserActivityLogger.h"
 #include "NetworkLogging.h"
+
+Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
 
 DomainHandler::DomainHandler(QObject* parent) :
     QObject(parent),
@@ -485,14 +488,19 @@ void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<Rec
 #if defined(Q_OS_ANDROID)
         emit domainConnectionRefused(reasonMessage, (int)reasonCode, extraInfo);
 #else
-        if (reasonCode == ConnectionRefusedReason::ProtocolMismatch || reasonCode == ConnectionRefusedReason::NotAuthorized) {
-            // ingest the error - this is a "hard" connection refusal.
-            setRedirectErrorState(_errorDomainURL, (int)reasonCode);
-        } else {
+        if (enableInterstitialMode.get()) {
+            if (reasonCode == ConnectionRefusedReason::ProtocolMismatch || reasonCode == ConnectionRefusedReason::NotAuthorized) {
+                // ingest the error - this is a "hard" connection refusal.
+                setRedirectErrorState(_errorDomainURL, (int)reasonCode);
+            } else {
+                emit domainConnectionRefused(reasonMessage, (int)reasonCode, extraInfo);
+            }
+            _lastDomainConnectionError = (int)reasonCode;
+        }
+        else {
             emit domainConnectionRefused(reasonMessage, (int)reasonCode, extraInfo);
         }
-        _lastDomainConnectionError = (int)reasonCode;
-#endif
+       #endif
     }
 
     auto accountManager = DependencyManager::get<AccountManager>();

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -30,8 +30,6 @@
 #include "UserActivityLogger.h"
 #include "NetworkLogging.h"
 
-Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
-
 DomainHandler::DomainHandler(QObject* parent) :
     QObject(parent),
     _sockAddr(HifiSockAddr(QHostAddress::Null, DEFAULT_DOMAIN_SERVER_PORT)),
@@ -488,6 +486,8 @@ void DomainHandler::processDomainServerConnectionDeniedPacket(QSharedPointer<Rec
 #if defined(Q_OS_ANDROID)
         emit domainConnectionRefused(reasonMessage, (int)reasonCode, extraInfo);
 #else
+        Setting::Handle<bool> enableInterstitialMode{ "enableInterstitialMode", false };
+
         if (enableInterstitialMode.get()) {
             if (reasonCode == ConnectionRefusedReason::ProtocolMismatch || reasonCode == ConnectionRefusedReason::NotAuthorized) {
                 // ingest the error - this is a "hard" connection refusal.

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -19,6 +19,7 @@
 #include <QtCore/QUrl>
 #include <QtNetwork/QHostInfo>
 
+#include <shared/ReadWriteLockable.h>
 #include <SettingHandle.h>
 
 #include "HifiSockAddr.h"
@@ -85,6 +86,8 @@ public:
     bool isConnected() const { return _isConnected; }
     void setIsConnected(bool isConnected);
     bool isServerless() const { return _domainURL.scheme() != URL_SCHEME_HIFI; }
+    bool getInterstitialModeEnabled() const;
+    void setInterstitialModeEnabled(bool enableInterstitialMode);
 
     void connectedToServerless(std::map<QString, QString> namedPaths);
 
@@ -173,7 +176,7 @@ public slots:
     void processDomainServerConnectionDeniedPacket(QSharedPointer<ReceivedMessage> message);
 
     // sets domain handler in error state.
-    void setRedirectErrorState(QUrl errorUrl, int reasonCode);
+    void setRedirectErrorState(QUrl errorUrl, QString reasonMessage = "", int reason = -1, const QString& extraInfo = "");
 
     bool isInErrorState() { return _isInErrorState; }
 
@@ -223,10 +226,11 @@ private:
     NetworkPeer _icePeer;
     bool _isConnected { false };
     bool _isInErrorState { false };
-    Setting::Handle<bool> _enableInterstitialMode{ "enableInterstitialMode", false };
     QJsonObject _settingsObject;
     QString _pendingPath;
     QTimer _settingsTimer;
+    mutable ReadWriteLockable _interstitialModeSettingLock;
+    Setting::Handle<bool> _enableInterstitialMode{ "enableInterstitialMode", false };
 
     QSet<QString> _domainConnectionRefusals;
     bool _hasCheckedForAccessToken { false };

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -19,6 +19,8 @@
 #include <QtCore/QUrl>
 #include <QtNetwork/QHostInfo>
 
+#include <SettingHandle.h>
+
 #include "HifiSockAddr.h"
 #include "NetworkPeer.h"
 #include "NLPacket.h"
@@ -221,6 +223,7 @@ private:
     NetworkPeer _icePeer;
     bool _isConnected { false };
     bool _isInErrorState { false };
+    Setting::Handle<bool> _enableInterstitialMode{ "enableInterstitialMode", false };
     QJsonObject _settingsObject;
     QString _pendingPath;
     QTimer _settingsTimer;


### PR DESCRIPTION
- Fix for MS#[18555](https://highfidelity.manuscript.com/f/cases/18555) and #[18689](https://highfidelity.manuscript.com/f/cases/18689)

This PR defaults the behavior of getting redirected to the 404 domain to be disabled.  Enabling it would be by opening the `Developer > Console` after enabling the developer menu via `Settings > Developer Menu`, and setting the mode through `Settings.setValue("enableInterstitialMode", true);`

## TEST PLAN
- Launch Interface
- Enable developer menu in `Settings > Developer Menu`
- Open `Developer > Console` or `CTRL+ALT+J`
- In console, toggle on interstitial mode by using `Window.interstitialModeEnabled = true`
- Press `CTRL+R`
- Navigate to a domain using `GOTO` app
- While going to domain, interstitial page should pop up
- Navigate to a domain that would trigger a timeout, protocol mismatch, or not authorized error
- Interstitial page should pop up, then land you in the 404 redirect domain
## 
- In console, toggle off interstitial mode by using `Window.interstitialModeEnabled = false`
- Press `CTRL+R` to reload all scripts and reload content
- Navigate to a domain using `GOTO` app
- While going to domain, interstitial page should not come up
- Navigate to a domain that would trigger a timeout, protocol mismatch, or not authorized error
- Interstitial page should not come up, then you should see a pop up dialog with the error you triggered
## 
- Try these a couple of times, also with closing/reopening the interface with differing settings from different sessions

Test case:
https://highfidelity.testrail.net/index.php?/cases/view/27807