### PR TITLE
use current wearable index, not joint index!

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
+++ b/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
@@ -314,7 +314,7 @@ Rectangle {
                         }
                     };
 
-                    wearableUpdated(getCurrentWearable().id, jointIndex, properties);
+                    wearableUpdated(getCurrentWearable().id, wearablesCombobox.currentIndex, properties);
                 }
 
                 onCurrentIndexChanged: {


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/18061/Avatar-favorites-cannot-be-moved-to-a-different-joint-At-Save-the-wearable-jumps-to-the-original-joint

**Test plan**

1.  Open High Fidelity
2.  Select Last Legends: Male as avatar
3.  Click Avatar on the toolbar/tab
4.  Click the Wearables 'hat' icon
5.  On the Adjust Wearables dialog select the Fedora.fbx from the Wearable list
6.  On the Joint list, select LeftHandMiddle4 (Or standard/common joint).
7.  Click the SAVE button
8.  Ensure joint change was applied