### PR TITLE
Improve keyboard raising logic for web views

### DIFF
--- a/interface/resources/html/raiseAndLowerKeyboard.js
+++ b/interface/resources/html/raiseAndLowerKeyboard.js
@@ -18,6 +18,11 @@
     window.isKeyboardRaised = false;
     window.isNumericKeyboard = false;
     window.isPasswordField = false;
+    window.lastActiveElement = null;
+
+    function getActiveElement() {
+        return document.activeElement;
+    }
 
     function shouldSetPasswordField() {
         var nodeType = document.activeElement.type;
@@ -65,10 +70,11 @@
         var keyboardRaised = shouldRaiseKeyboard();
         var numericKeyboard = shouldSetNumeric();
         var passwordField = shouldSetPasswordField();
+        var activeElement = getActiveElement();
 
         if (isWindowFocused &&
             (keyboardRaised !== window.isKeyboardRaised || numericKeyboard !== window.isNumericKeyboard
-                || passwordField !== window.isPasswordField)) {
+                || passwordField !== window.isPasswordField || activeElement !== window.lastActiveElement)) {
 
             if (typeof EventBridge !== "undefined" && EventBridge !== null) {
                 EventBridge.emitWebEvent(
@@ -90,6 +96,7 @@
             window.isKeyboardRaised = keyboardRaised;
             window.isNumericKeyboard = numericKeyboard;
             window.isPasswordField = passwordField;
+            window.lastActiveElement = activeElement;
         }
     }, POLL_FREQUENCY);
 

--- a/interface/resources/qml/controls/FlickableWebViewCore.qml
+++ b/interface/resources/qml/controls/FlickableWebViewCore.qml
@@ -34,10 +34,34 @@ Item {
         webViewCore.stop();
     }
 
+    Timer {
+        id: delayedUnfocuser
+        repeat: false
+        interval: 200
+        onTriggered: {
+
+            // The idea behind this is to delay unfocusing, so that fast lower/raise will not result actual unfocusing.
+            // Fast lower/raise happens every time keyboard is being re-raised (see the code below in OffscreenQmlSurface::setKeyboardRaised)
+            //
+            // if (raised) {
+            //    item->setProperty("keyboardRaised", QVariant(!raised));
+            // }
+            //
+            // item->setProperty("keyboardRaised", QVariant(raised));
+            //
+
+            webViewCore.runJavaScript("if (document.activeElement) document.activeElement.blur();", function(result) {
+                console.log('unfocus completed: ', result);
+            });
+        }
+    }
+
     function unfocus() {
-        webViewCore.runJavaScript("if (document.activeElement) document.activeElement.blur();", function(result) {
-            console.log('unfocus completed: ', result);
-        });
+        delayedUnfocuser.start();
+    }
+
+    function stopUnfocus() {
+        delayedUnfocuser.stop();
     }
 
     function onLoadingChanged(loadRequest) {

--- a/interface/resources/qml/controls/TabletWebScreen.qml
+++ b/interface/resources/qml/controls/TabletWebScreen.qml
@@ -13,6 +13,8 @@ Item {
     onKeyboardRaisedChanged: {
         if(!keyboardRaised) {
             webroot.unfocus();
+        } else {
+            webroot.stopUnfocus();
         }
     }
     property bool punctuationMode: false

--- a/interface/resources/qml/controls/TabletWebView.qml
+++ b/interface/resources/qml/controls/TabletWebView.qml
@@ -17,6 +17,8 @@ Item {
     onKeyboardRaisedChanged: {
         if(!keyboardRaised) {
             webroot.unfocus();
+        } else {
+            webroot.stopUnfocus();
         }
     }
     property bool punctuationMode: false

--- a/interface/resources/qml/controls/WebView.qml
+++ b/interface/resources/qml/controls/WebView.qml
@@ -15,6 +15,8 @@ Item {
     onKeyboardRaisedChanged: {
         if(!keyboardRaised) {
             webroot.unfocus();
+        } else {
+            webroot.stopUnfocus();
         }
     }
     property bool punctuationMode: false


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/12459/Keyboard-shouldn-t-lower-when-move-between-property-values-in-Create-app-in-HMD-mode

**Test plan**

1. Switch to HMD
2. Open create app
3. Create text (which should open properties tab)
4. In properties tab, ensure keyboard stays raised on switching between different text fields
5. Ensure keyboard stays raised on switching between text field and spinbox
6. Ensure 'mirror text' gets cleared on jumping between text fields and spinboxes. 