### PR TITLE
Prototype improved controller mappings - B

### DIFF
--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -36,18 +36,6 @@
           "when": [ "!Application.SnapTurn" ]
         },
 
-        { "from": "Standard.RY",
-          "when": "Application.Grounded",
-          "to": "Actions.Up",
-          "filters":
-            [
-                { "type": "deadZone", "min": 0.6 },
-                "invert"
-            ]
-        },
-
-        { "from": "Standard.RY", "to": "Actions.Up", "filters": "invert"},
-
         { "from": "Standard.Back", "to": "Actions.CycleCamera" },
         { "from": "Standard.Start", "to": "Actions.ContextMenu" },
 

--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -5,7 +5,7 @@
 
         { "from": "Standard.LX",
           "when": [
-            "Application.InHMD", "!Application.AdvancedMovement",
+            "Application.InHMD",
             "Application.SnapTurn", "!Standard.RX"
           ],
           "to": "Actions.StepYaw",
@@ -17,11 +17,8 @@
                 { "type": "scale", "scale": 22.5 }
             ]
         },
-        { "from": "Standard.LX", "to": "Actions.TranslateX",
-          "when": [ "Application.AdvancedMovement" ]
-        },
         { "from": "Standard.LX", "to": "Actions.Yaw",
-          "when": [ "!Application.AdvancedMovement", "!Application.SnapTurn" ]
+          "when": [ "!Application.SnapTurn" ]
         },
 
         { "from": "Standard.RX",

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1961,7 +1961,7 @@ void MyAvatar::updateMotors() {
 
         bool wasWaitingToFly = _isWaitingToFly;
         bool isWaitingToFly = false;
-        const quint64 WAITING_TO_FLY_TIMEOUT = 2000000; // 2s
+        const quint64 WAITING_TO_FLY_TIMEOUT = 1000000; // 1s
 
         if (qApp->isHMDMode() && getLeftHandPose().isValid()) {
             // Fly and walk per left hand orientation.

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -71,7 +71,10 @@ const float DEFAULT_REAL_WORLD_FIELD_OF_VIEW_DEGREES = 30.0f;
 const float YAW_SPEED_DEFAULT = 100.0f;   // degrees/sec
 const float PITCH_SPEED_DEFAULT = 75.0f; // degrees/sec
 
+// FIXME: Remove old code and associated constants if new is adopted.
+/*
 const float MAX_BOOST_SPEED = 0.5f * DEFAULT_AVATAR_MAX_WALKING_SPEED; // action motor gets additive boost below this speed
+*/
 const float MIN_AVATAR_SPEED = 0.05f;
 const float MIN_AVATAR_SPEED_SQUARED = MIN_AVATAR_SPEED * MIN_AVATAR_SPEED; // speed is set to zero below this
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1961,6 +1961,7 @@ void MyAvatar::updateMotors() {
 
         bool wasWaitingToFly = _isWaitingToFly;
         bool isWaitingToFly = false;
+        bool hasStartedFlying = false;
         const quint64 WAITING_TO_FLY_TIMEOUT = 1000000; // 1s
 
         if (qApp->isHMDMode() && getLeftHandPose().isValid()) {
@@ -1997,6 +1998,7 @@ void MyAvatar::updateMotors() {
                         _characterController.jump(); // Initiate flying.
                         _haveSentSecondJump = false;
                         motorRotation = cancelOutRoll(handOrientation);
+                        hasStartedFlying = true;
                     } else {
                         isWaitingToFly = true;
                         _isPushingEnabled = false;
@@ -2037,7 +2039,7 @@ void MyAvatar::updateMotors() {
                 _waitingToFlySignalEmitted = now;
             }
         } else if (wasWaitingToFly) {
-            emit waitingToFly(0.0f);
+            emit waitingToFly(hasStartedFlying ? 1.0f : 0.0f);
         }
 
         if (_isPushing || _isBraking || !_isBeingPushed) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1977,7 +1977,7 @@ void MyAvatar::updateMotors() {
                     _haveSentSecondJump = true;
                 }
                 motorRotation = cancelOutRoll(handOrientation);
-            } else if (_isPushing && !_wasPushing
+            } else if (_isPushing && !_wasPushing && getFlyingHMDPref()
                     && glm::dot(handOrientation * Vectors::UNIT_NEG_Z, Vectors::UNIT_Y) >= COS_MAX_START_FLYING_ANGLE) {
                 // On ground but user is stationary and wants to fly.
                 _characterController.jump(); // Initiate flying.

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2028,6 +2028,18 @@ void MyAvatar::updateMotors() {
         }
 
         _isWaitingToFly = isWaitingToFly;
+        if (_isWaitingToFly) {
+            const quint64 MIN_WAITING_TO_FLY_SIGNAL_INTERVAL = 25000;
+            auto now = usecTimestampNow();
+            if (now - _waitingToFlySignalEmitted >= MIN_WAITING_TO_FLY_SIGNAL_INTERVAL) {
+                float fraction = (double)(now - _startedWaitingToFly) / (double)WAITING_TO_FLY_TIMEOUT;
+                emit waitingToFly(min(fraction, 1.0f));
+                _waitingToFlySignalEmitted = now;
+            }
+        } else if (wasWaitingToFly) {
+            emit waitingToFly(0.0f);
+        }
+
         if (_isPushing || _isBraking || !_isBeingPushed) {
             _characterController.addMotor(_actionMotorVelocity, motorRotation, horizontalMotorTimescale, verticalMotorTimescale);
         } else {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2003,12 +2003,9 @@ void MyAvatar::updateMotors() {
                         isWaitingToFly = true;
                         _isPushingEnabled = false;
                     }
-                } else if (abs(handPointedUpwardDot) < COS_MAX_START_FLYING_ANGLE) {
-                    // Walk on ground per left hand orientation if not pointing upward or downward.
+                } else  {
+                    // Walk on ground per left hand orientation.
                     motorRotation = cancelOutRollAndPitch(handOrientation);
-                } else {
-                    // On ground but left hand pointing up or down so don't walk.
-                    _isPushingEnabled = false;
                 }
             }
         } else {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1615,6 +1615,11 @@ private:
     float _yawSpeed; // degrees/sec
     float _pitchSpeed; // degrees/sec
 
+    const float DEFAULT_MAX_FLYING_SPEED = 20.0f; // m/s Speed if hand pointing in same direction as camera.
+    const float DEFAULT_MIN_FLYING_SPEED = 5.0f; // m/s Speed if hand pointing at right angles to or behind camera.
+    float _maxFlyingSpeed { DEFAULT_MAX_FLYING_SPEED };
+    float _minFlyingSpeed { DEFAULT_MIN_FLYING_SPEED };
+
     glm::vec3 _thrust { 0.0f };  // impulse accumulator for outside sources
 
     glm::vec3 _actionMotorVelocity; // target local-frame velocity of avatar (default controller actions)

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1593,9 +1593,12 @@ private:
     bool _flyingPrefHMD { false };
     bool _wasPushing { false };
     bool _isPushing { false };
+    bool _isPushingEnabled { false };
     bool _isBeingPushed { false };
     bool _isBraking { false };
     bool _isAway { false };
+    bool _isWaitingToFly { false };
+    quint64 _startedWaitingToFly { 0 };
 
     float _boomLength { ZOOM_DEFAULT };
     float _yawSpeed; // degrees/sec

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1806,6 +1806,8 @@ private:
 
     bool _haveReceivedHeightLimitsFromDomain { false };
     int _disableHandTouchCount { 0 };
+
+    bool _haveSentSecondJump { false };
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1503,6 +1503,15 @@ signals:
      */
     void disableHandTouchForIDChanged(const QUuid& entityID, bool disable);
 
+    /**jsdoc
+     * Triggered when the user is waiting to fly (left hand pointed upward and left joystick forward) or has started flying.
+     * @function MyAvatar.waitingToFly
+     * @param {number} fraction - The fraction of the wait time completed, <code>0.0</code> &ndash; <code>1.0</code>. Is 
+     *     <code>0.0</code> if stopped waiting (e.g., started flying).
+     * @returns {Signal}
+     */
+    void waitingToFly(float fraction);
+
 private slots:
     void leaveDomain();
     void updateCollisionCapsuleCache();
@@ -1599,6 +1608,7 @@ private:
     bool _isAway { false };
     bool _isWaitingToFly { false };
     quint64 _startedWaitingToFly { 0 };
+    quint64 _waitingToFlySignalEmitted { 0 };
 
     float _boomLength { ZOOM_DEFAULT };
     float _yawSpeed; // degrees/sec

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1607,6 +1607,7 @@ private:
     bool _isBraking { false };
     bool _isAway { false };
     bool _isWaitingToFly { false };
+    bool _isWaitingToFlyCancelled { false };
     quint64 _startedWaitingToFly { 0 };
     quint64 _waitingToFlySignalEmitted { 0 };
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1506,8 +1506,8 @@ signals:
     /**jsdoc
      * Triggered when the user is waiting to fly (left hand pointed upward and left joystick forward) or has started flying.
      * @function MyAvatar.waitingToFly
-     * @param {number} fraction - The fraction of the wait time completed, <code>0.0</code> &ndash; <code>1.0</code>. Is 
-     *     <code>0.0</code> if stopped waiting (e.g., started flying).
+     * @param {number} fraction - The fraction of the wait time completed, <code>0.0</code> &ndash; <code>1.0</code>.  Is 
+     *     <code>0.0</code> if stopped waiting; <code>1.0</code> if completed waiting, i.e., started flying.
      * @returns {Signal}
      */
     void waitingToFly(float fraction);

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -31,7 +31,8 @@ var DEFAULT_SCRIPTS_COMBINED = [
     "system/dialTone.js",
     "system/firstPersonHMD.js",
     "system/tablet-ui/tabletUI.js",
-    "system/emote.js"
+    "system/emote.js",
+    "system/waitingToFly.js"
 ];
 var DEFAULT_SCRIPTS_SEPARATE = [
     "system/controllers/controllerScripts.js",

--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -574,6 +574,12 @@ Script.include("/~/system/libraries/controllers.js");
         // Teleport actions.
         teleportMapping.from(Controller.Standard.LeftPrimaryThumb).peek().to(leftTeleporter.buttonPress);
         teleportMapping.from(Controller.Standard.RightPrimaryThumb).peek().to(rightTeleporter.buttonPress);
+        teleportMapping.from(Controller.Standard.RY)
+            .peek()
+            .clamp(-1, 0)
+            .invert()
+            .constrainToInteger()
+            .to(rightTeleporter.buttonPress);
     }
 
     var leftTeleporter = new Teleporter(LEFT_HAND);

--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -571,9 +571,7 @@ Script.include("/~/system/libraries/controllers.js");
         // Vive teleport button lock-out.
         registerViveTeleportMapping();
 
-        // Teleport actions.
-        teleportMapping.from(Controller.Standard.LeftPrimaryThumb).peek().to(leftTeleporter.buttonPress);
-        teleportMapping.from(Controller.Standard.RightPrimaryThumb).peek().to(rightTeleporter.buttonPress);
+        // Teleport action.
         teleportMapping.from(Controller.Standard.RY)
             .peek()
             .clamp(-1, 0)

--- a/scripts/system/waitingToFly.js
+++ b/scripts/system/waitingToFly.js
@@ -1,0 +1,79 @@
+//
+//  waitingToFly.js
+//
+//  Created by David Rowe on 21 Sep 2018.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+(function () {
+
+    var overlay,
+        LOCAL_POSITION = { x: 0, y: 0.01, z: 0 },
+        LOCAL_ROTATION = Quat.fromVec3Degrees({ x: 90, y: 180, z: 0 }),
+        INNER_RADIUS = 0.05,
+        OUTER_RADIUS = 0.06,
+        FULL_CIRCLE = 360,
+        HIDE_DELAY = 200,
+        visible = false;
+
+    function onWaitingToFly(fraction) {
+        var properties;
+
+        if (fraction > 0) {
+            if (!visible) {
+                properties = {
+                    innerRadius: MyAvatar.scale * INNER_RADIUS,
+                    outerRadius: MyAvatar.scale * OUTER_RADIUS,
+                    parentID: MyAvatar.SELF_ID,
+                    parentJointIndex: MyAvatar.getJointIndex("LeftHand"),
+                    localPosition: Vec3.multiply(MyAvatar.scale, LOCAL_POSITION),
+                    localRotation: LOCAL_ROTATION,
+                    endAt: fraction * FULL_CIRCLE,
+                    visible: true
+                };
+                visible = true;
+            } else {
+                properties = {
+                    endAt: fraction * FULL_CIRCLE
+                };
+            }
+            Overlays.editOverlay(overlay, properties);
+        } else {
+            if (visible) {
+                // Leave completed circle displayed for a short time while the take-off completes.
+                Overlays.editOverlay(overlay, {
+                    endAt: FULL_CIRCLE
+                });
+                Script.setTimeout(function () {
+                    Overlays.editOverlay(overlay, {
+                        visible: false
+                    });
+                }, HIDE_DELAY);
+                visible = false;
+            }
+        }
+    }
+
+    function setUp() {
+        overlay = Overlays.addOverlay("circle3d", {
+            solid: true,
+            color: { red: 0, green: 180, blue: 239 },
+            alpha: 0.8,
+            ignorePickIntersection: true,
+            visible: false
+        });
+        MyAvatar.waitingToFly.connect(onWaitingToFly);
+    }
+
+    function tearDown() {
+        MyAvatar.waitingToFly.disconnect(onWaitingToFly);
+        Overlays.deleteOverlay(overlay);
+    }
+
+    setUp();
+    Script.scriptEnding.connect(tearDown);
+
+}());

--- a/scripts/system/waitingToFly.js
+++ b/scripts/system/waitingToFly.js
@@ -14,7 +14,7 @@
         LOCAL_POSITION = { x: 0, y: 0.01, z: 0 },
         LOCAL_ROTATION = Quat.fromVec3Degrees({ x: 90, y: 180, z: 0 }),
         INNER_RADIUS = 0.05,
-        OUTER_RADIUS = 0.06,
+        OUTER_RADIUS = 0.07,
         FULL_CIRCLE = 360,
         HIDE_DELAY = 200,
         visible = false;

--- a/scripts/system/waitingToFly.js
+++ b/scripts/system/waitingToFly.js
@@ -41,17 +41,20 @@
                 };
             }
             Overlays.editOverlay(overlay, properties);
-        } else {
-            if (visible) {
+            if (fraction === 1) {
                 // Leave completed circle displayed for a short time while the take-off completes.
-                Overlays.editOverlay(overlay, {
-                    endAt: FULL_CIRCLE
-                });
                 Script.setTimeout(function () {
                     Overlays.editOverlay(overlay, {
                         visible: false
                     });
+                    visible = false;
                 }, HIDE_DELAY);
+            }
+        } else {
+            if (visible) {
+                Overlays.editOverlay(overlay, {
+                    visible: false
+                });
                 visible = false;
             }
         }


### PR DESCRIPTION
In HMD mode:
- Left joystick left/right turns. (Instead of strafing.)
- Right joystick forward initiates the teleport beam. (Instead of A and X buttons.)
- Right joystick backward takes no action.

In HMD mode with Settings > Controls > Advanced Movement in VR:
- Walking on the ground is in the direction your left hand is pointing. (Instead of your head.)

In HMD mode with Settings > Controls > Advanced Movement in VR plus Flying & Jumping (HMD):
- To initiate flying, while stationary point your left hand upward and do left joystick forward, then wait for the countdown graphic displayed on your hand to complete. (Instead of right joystick forward.)
- Flying is in the direction your left hand is pointing. (Instead of your head.)
- While flying, tilt (roll) your head left/right to turn left/right. (No change.)
- Flying is at a constant speed (not accelerating) depending on the angle between hand and camera: min speed if hand pointing behind or at right angles to camera; max speed if hand pointing in same direction of camera.
- Min and max speed values added as Settings so that different value can be tried:
    "Avatar/maxFlyingSpeed": 20,
    "Avatar/minFlyingSpeed": 5,
