### PR TITLE
make extracted from resources avatarbookmarks.json writable

### DIFF
--- a/interface/src/AvatarBookmarks.cpp
+++ b/interface/src/AvatarBookmarks.cpp
@@ -108,6 +108,9 @@ AvatarBookmarks::AvatarBookmarks() {
 
         if (!QFile::copy(defaultBookmarksFilename, _bookmarksFilename)) {
             qDebug() << "failed to copy" << defaultBookmarksFilename << "to" << _bookmarksFilename;
+        } else {
+            QFile bookmarksFile(_bookmarksFilename);
+            bookmarksFile.setPermissions(bookmarksFile.permissions() | QFile::WriteUser);
         }
     }
     readFromFile();


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/17835/On-clean-installs-default-avatarbookmarks-json-file-is-read-only-bookmarks-reset-every-launch-until-replaced-or-unmarked

**Test plan**

1) Clean install interface
2) Start interface
3) Open Avatar
4) Change your avatar's scale, or pick a different avatar using the tutorial
5) Save current avatar as a favorite
6) Click Manage and delete one of the existing favorites
7) Restart interface
8) Open Avatar
9) Ensure changes applied to avatarbookmarks persist

Bonus: 
On Windows, ensure avatarbookmarks.json *doesn't* have 'ReadOnly' checked

![image](https://user-images.githubusercontent.com/23638/45872627-23055c80-bd99-11e8-93d5-11e81b1f473a.png)
