### PR TITLE
Do not have active buy button on invalidated items

### DIFF
--- a/scripts/system/html/js/marketplacesInject.js
+++ b/scripts/system/html/js/marketplacesInject.js
@@ -316,12 +316,16 @@
             if ($this.text() === buyString || $this.text() === getString) {
                 return;
             }
+            if ($this.text() === 'invalidated') {
+                return;
+            }
             $this.data('initialHtml', $this.html());
 
             var cost = $(this).parent().siblings().text();
             if (parseInt(cost) > 0) {
                 $this.text(buyString);
-            } else {
+            }
+            if (parseInt(cost) == 0) {
                 $this.text(getString);
             }
         });
@@ -333,6 +337,9 @@
 
 
         $('.grid-item').find('#price-or-edit').find('a').on('click', function () {
+            if ($(this).closest('.grid-item').find('.price').text() === 'invalidated') {
+                return false;
+            }
             buyButtonClicked($(this).closest('.grid-item').attr('data-item-id'),
                 $(this).closest('.grid-item').find('.item-title').text(),
                 $(this).closest('.grid-item').find('.creator').find('.value').text(),


### PR DESCRIPTION
In a perfect world, invalidated items would never appear in searches on marketplace.  However, it is possible that one was invalidated and edited to not be not for sale (pardon the double negative).  Then, they will.  So just in case, this makes it the buy button on the search page do nothing.  If you are on the item page it already does nothing.

fix for https://highfidelity.manuscript.com/f/cases/18147