### PR TITLE
Improve thread safety for QVariantMaps in pick results

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2280,7 +2280,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
                 entityResult.distance = pickResult->distance;
                 entityResult.surfaceNormal = pickResult->surfaceNormal;
                 entityResult.entityID = pickResult->objectID;
-                entityResult.extraInfo = pickResult->extraInfo;
+                entityResult.extraInfo = pickResult->getExtraInfo();
             }
         }
         return entityResult;

--- a/interface/src/raypick/CollisionPick.cpp
+++ b/interface/src/raypick/CollisionPick.cpp
@@ -78,7 +78,7 @@ QVariantMap CollisionPickResult::toVariantMap() const {
     }
 
     variantMap["intersectingObjects"] = qIntersectingObjects;
-    variantMap["collisionRegion"] = pickVariant;
+    variantMap["collisionRegion"] = PickResult::toVariantMap();
 
     return variantMap;
 }

--- a/interface/src/raypick/CollisionPick.h
+++ b/interface/src/raypick/CollisionPick.h
@@ -27,7 +27,7 @@ public:
     {
     }
 
-    CollisionPickResult(const CollisionPickResult& collisionPickResult) : PickResult(collisionPickResult.pickVariant) {
+    CollisionPickResult(const CollisionPickResult& collisionPickResult) : PickResult(collisionPickResult) {
         avatarIntersections = collisionPickResult.avatarIntersections;
         entityIntersections = collisionPickResult.entityIntersections;
         intersects = collisionPickResult.intersects;

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -68,7 +68,7 @@ QVariantMap LaserPointer::toVariantMap() const {
 
 glm::vec3 LaserPointer::getPickOrigin(const PickResultPointer& pickResult) const {
     auto rayPickResult = std::static_pointer_cast<RayPickResult>(pickResult);
-    return (rayPickResult ? vec3FromVariant(rayPickResult->pickVariant["origin"]) : glm::vec3(0.0f));
+    return (rayPickResult ? vec3FromVariant(rayPickResult->getPickVariant()["origin"]) : glm::vec3(0.0f));
 }
 
 glm::vec3 LaserPointer::getPickEnd(const PickResultPointer& pickResult, float distance) const {
@@ -77,7 +77,7 @@ glm::vec3 LaserPointer::getPickEnd(const PickResultPointer& pickResult, float di
         return glm::vec3(0.0f);
     }
     if (distance > 0.0f) {
-        PickRay pick = PickRay(rayPickResult->pickVariant);
+        PickRay pick = PickRay(rayPickResult->getPickVariant());
         return pick.origin + distance * pick.direction;
     } else {
         return rayPickResult->intersection;
@@ -108,7 +108,9 @@ void LaserPointer::setVisualPickResultInternal(PickResultPointer pickResult, Int
         rayPickResult->intersection = intersection;
         rayPickResult->distance = distance;
         rayPickResult->surfaceNormal = surfaceNormal;
-        rayPickResult->pickVariant["direction"] = vec3toVariant(-surfaceNormal);
+        QVariantMap adjustedPickVariant = rayPickResult->getPickVariant();
+        adjustedPickVariant["direction"] = vec3toVariant(-surfaceNormal);
+        rayPickResult->setPickVariant(adjustedPickVariant);
     }
 }
 
@@ -194,7 +196,7 @@ PointerEvent LaserPointer::buildPointerEvent(const PickedObject& target, const P
     if (rayPickResult) {
         intersection = rayPickResult->intersection;
         surfaceNormal = rayPickResult->surfaceNormal;
-        const QVariantMap& searchRay = rayPickResult->pickVariant;
+        const QVariantMap& searchRay = rayPickResult->getPickVariant();
         direction = vec3FromVariant(searchRay["direction"]);
         origin = vec3FromVariant(searchRay["origin"]);
         pickedID = rayPickResult->objectID;

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -91,7 +91,7 @@ QVariantMap ParabolaPointer::toVariantMap() const {
 
 glm::vec3 ParabolaPointer::getPickOrigin(const PickResultPointer& pickResult) const {
     auto parabolaPickResult = std::static_pointer_cast<ParabolaPickResult>(pickResult);
-    return (parabolaPickResult ? vec3FromVariant(parabolaPickResult->pickVariant["origin"]) : glm::vec3(0.0f));
+    return (parabolaPickResult ? vec3FromVariant(parabolaPickResult->getPickVariant()["origin"]) : glm::vec3(0.0f));
 }
 
 glm::vec3 ParabolaPointer::getPickEnd(const PickResultPointer& pickResult, float distance) const {
@@ -100,7 +100,7 @@ glm::vec3 ParabolaPointer::getPickEnd(const PickResultPointer& pickResult, float
         return glm::vec3(0.0f);
     }
     if (distance > 0.0f) {
-        PickParabola pick = PickParabola(parabolaPickResult->pickVariant);
+        PickParabola pick = PickParabola(parabolaPickResult->getPickVariant());
         return pick.origin + pick.velocity * distance + 0.5f * pick.acceleration * distance * distance;
     } else {
         return parabolaPickResult->intersection;
@@ -131,9 +131,11 @@ void ParabolaPointer::setVisualPickResultInternal(PickResultPointer pickResult, 
         parabolaPickResult->intersection = intersection;
         parabolaPickResult->distance = distance;
         parabolaPickResult->surfaceNormal = surfaceNormal;
-        PickParabola parabola = PickParabola(parabolaPickResult->pickVariant);
-        parabolaPickResult->pickVariant["velocity"] = vec3toVariant((intersection - parabola.origin -
+        QVariantMap parabolaPickVariant = parabolaPickResult->getPickVariant();
+        PickParabola parabola = PickParabola(parabolaPickVariant);
+        parabolaPickVariant["velocity"] = vec3toVariant((intersection - parabola.origin -
             0.5f * parabola.acceleration * parabolaPickResult->parabolicDistance * parabolaPickResult->parabolicDistance) / parabolaPickResult->parabolicDistance);
+        parabolaPickResult->setPickVariant(parabolaPickVariant);
     }
 }
 
@@ -198,7 +200,7 @@ void ParabolaPointer::RenderState::update(const glm::vec3& origin, const glm::ve
         render::Transaction transaction;
         auto scene = qApp->getMain3DScene();
 
-        PickParabola parabola = PickParabola(parabolaPickResult->pickVariant);
+        PickParabola parabola = PickParabola(parabolaPickResult->getPickVariant());
         glm::vec3 velocity = parabola.velocity;
         glm::vec3 acceleration = parabola.acceleration;
         float parabolicDistance = distance > 0.0f ? distance : parabolaPickResult->parabolicDistance;
@@ -271,7 +273,7 @@ PointerEvent ParabolaPointer::buildPointerEvent(const PickedObject& target, cons
     if (parabolaPickResult) {
         intersection = parabolaPickResult->intersection;
         surfaceNormal = parabolaPickResult->surfaceNormal;
-        const QVariantMap& parabola = parabolaPickResult->pickVariant;
+        const QVariantMap& parabola = parabolaPickResult->getPickVariant();
         origin = vec3FromVariant(parabola["origin"]);
         velocity = vec3FromVariant(parabola["velocity"]);
         acceleration = vec3FromVariant(parabola["acceleration"]);

--- a/interface/src/raypick/StylusPick.h
+++ b/interface/src/raypick/StylusPick.h
@@ -22,7 +22,7 @@ public:
         PickResult(stylusTip.toVariantMap()), type(type), intersects(type != NONE), objectID(objectID), distance(distance), intersection(intersection), surfaceNormal(surfaceNormal) {
     }
 
-    StylusPickResult(const StylusPickResult& stylusPickResult) : PickResult(stylusPickResult.pickVariant) {
+    StylusPickResult(const StylusPickResult& stylusPickResult) : PickResult(stylusPickResult) {
         type = stylusPickResult.type;
         intersects = stylusPickResult.intersects;
         objectID = stylusPickResult.objectID;

--- a/interface/src/raypick/StylusPointer.cpp
+++ b/interface/src/raypick/StylusPointer.cpp
@@ -58,7 +58,7 @@ void StylusPointer::updateVisuals(const PickResultPointer& pickResult) {
     auto stylusPickResult = std::static_pointer_cast<const StylusPickResult>(pickResult);
 
     if (_enabled && !qApp->getPreferAvatarFingerOverStylus() && _renderState != DISABLED && stylusPickResult) {
-        StylusTip tip(stylusPickResult->pickVariant);
+        StylusTip tip(stylusPickResult->getPickVariant());
         if (tip.side != bilateral::Side::Invalid) {
             show(tip);
             return;
@@ -118,7 +118,7 @@ bool StylusPointer::shouldTrigger(const PickResultPointer& pickResult) {
         float distance = stylusPickResult->distance;
 
         // If we're triggering on an object, recalculate the distance instead of using the pickResult
-        glm::vec3 origin = vec3FromVariant(stylusPickResult->pickVariant["position"]);
+        glm::vec3 origin = vec3FromVariant(stylusPickResult->getPickVariant()["position"]);
         glm::vec3 direction = _state.triggering ? -_state.surfaceNormal : -stylusPickResult->surfaceNormal;
         if ((_state.triggering || _state.wasTriggering) && stylusPickResult->objectID != _state.triggeredObject.objectID) {
             distance = glm::dot(findIntersection(_state.triggeredObject, origin, direction) - origin, direction);
@@ -169,7 +169,7 @@ PointerEvent StylusPointer::buildPointerEvent(const PickedObject& target, const 
     if (stylusPickResult) {
         intersection = stylusPickResult->intersection;
         surfaceNormal = hover ? stylusPickResult->surfaceNormal : _state.surfaceNormal;
-        const QVariantMap& stylusTip = stylusPickResult->pickVariant;
+        const QVariantMap& stylusTip = stylusPickResult->getPickVariant();
         origin = vec3FromVariant(stylusTip["position"]);
         direction = -surfaceNormal;
         pos2D = findPos2D(target, origin);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/18506/RayPickResult-RayPickResult-bb1a07c73108db9911271cd4551f56eaddaef1a21fff1b8a7f0ecd0ccddb3469

This PR adds locking to pick results so that getting the stored QVariantMaps requires a lock, in an attempt to fix the destructor crash described above. I have been unable to reproduce the crash, but from the dump files, my inspection of the code, and some research into Qt, the copying of QVariantMap seems the most likely cause.

This PR brings to my attention that the way Pointers handles pick results is not ideal, but that's out of scope for this PR as this is a high-priority fix.

## TEST PLAN
- Do the tests in https://github.com/highfidelity/hifi_tests/tree/master/tests/engine/interaction/pointer
- Do the tests in https://github.com/highfidelity/hifi_tests/tree/master/tests/engine/interaction/pick/collision with the exception of capsule_on_server. parenting_on_server is a manual test. Collision contact point visualizations may vary in size for that test. This is an acceptable bug with the test script since collision contact points have no notion of scale.
- If, for whatever reason, this PR crashes frequently, do the tests on master, and if the crashes do not exist on master, fail this PR.