### PR TITLE
Fix avatar highlighting

### DIFF
--- a/libraries/render-utils/src/HighlightEffect.cpp
+++ b/libraries/render-utils/src/HighlightEffect.cpp
@@ -37,6 +37,8 @@ namespace gr {
 
 #define OUTLINE_STENCIL_MASK    1
 
+extern void initZPassPipelines(ShapePlumber& plumber, gpu::StatePointer state);
+
 HighlightRessources::HighlightRessources() {
 }
 
@@ -180,6 +182,7 @@ void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, c
 
             auto maskPipeline = _shapePlumber->pickPipeline(args, defaultKeyBuilder);
             auto maskSkinnedPipeline = _shapePlumber->pickPipeline(args, defaultKeyBuilder.withSkinned());
+            auto maskSkinnedDQPipeline = _shapePlumber->pickPipeline(args, defaultKeyBuilder.withSkinned().withDualQuatSkinned());
 
             // Setup camera, projection and viewport for all items
             batch.setViewportTransform(args->_viewport);
@@ -187,14 +190,17 @@ void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, c
             batch.setProjectionJitter(jitter.x, jitter.y);
             batch.setViewTransform(viewMat);
 
-            std::vector<ShapeKey> skinnedShapeKeys{};
+            std::vector<ShapeKey> skinnedShapeKeys;
+            std::vector<ShapeKey> skinnedDQShapeKeys;
 
             // Iterate through all inShapes and render the unskinned
             args->_shapePipeline = maskPipeline;
             batch.setPipeline(maskPipeline->pipeline);
             for (const auto& items : inShapes) {
                 itemBounds.insert(itemBounds.end(), items.second.begin(), items.second.end());
-                if (items.first.isSkinned()) {
+                if (items.first.isSkinned() && items.first.isDualQuatSkinned()) {
+                    skinnedDQShapeKeys.push_back(items.first);
+                } else if (items.first.isSkinned()) {
                     skinnedShapeKeys.push_back(items.first);
                 } else {
                     renderItems(renderContext, items.second);
@@ -202,10 +208,21 @@ void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, c
             }
 
             // Reiterate to render the skinned
-            args->_shapePipeline = maskSkinnedPipeline;
-            batch.setPipeline(maskSkinnedPipeline->pipeline);
-            for (const auto& key : skinnedShapeKeys) {
-                renderItems(renderContext, inShapes.at(key));
+            if (skinnedShapeKeys.size() > 0) {
+                args->_shapePipeline = maskSkinnedPipeline;
+                batch.setPipeline(maskSkinnedPipeline->pipeline);
+                for (const auto& key : skinnedShapeKeys) {
+                    renderItems(renderContext, inShapes.at(key));
+                }
+            }
+
+            // Reiterate to render the DQ skinned
+            if (skinnedDQShapeKeys.size() > 0) {
+                args->_shapePipeline = maskSkinnedDQPipeline;
+                batch.setPipeline(maskSkinnedDQPipeline->pipeline);
+                for (const auto& key : skinnedDQShapeKeys) {
+                    renderItems(renderContext, inShapes.at(key));
+                }
             }
 
             args->_shapePipeline = nullptr;
@@ -488,7 +505,7 @@ void DrawHighlightTask::build(JobModel& task, const render::Varying& inputs, ren
         state->setDepthTest(true, true, gpu::LESS_EQUAL);
         state->setColorWriteMask(false, false, false, false);
 
-        initMaskPipelines(*shapePlumber, state);
+        initZPassPipelines(*shapePlumber, state);
     }
     auto sharedParameters = std::make_shared<HighlightSharedParameters>();
 
@@ -548,16 +565,4 @@ const render::Varying DrawHighlightTask::addSelectItemJobs(JobModel& task, const
     const auto selectedMetasAndOpaques = task.addJob<SelectItems>("OpaqueSelection", selectMetaAndOpaqueInput);
     const auto selectItemInput = SelectItems::Inputs(transparents, selectedMetasAndOpaques, selectionName).asVarying();
     return task.addJob<SelectItems>("TransparentSelection", selectItemInput);
-}
-
-void DrawHighlightTask::initMaskPipelines(render::ShapePlumber& shapePlumber, gpu::StatePointer state) {
-    gpu::ShaderPointer modelProgram = gpu::Shader::createProgram(shader::render_utils::program::model_shadow);
-    shapePlumber.addPipeline(
-        ShapeKey::Filter::Builder().withoutSkinned(),
-        modelProgram, state);
-
-    gpu::ShaderPointer skinProgram = gpu::Shader::createProgram(shader::render_utils::program::skin_model_shadow);
-    shapePlumber.addPipeline(
-        ShapeKey::Filter::Builder().withSkinned(),
-        skinProgram, state);
 }

--- a/libraries/render-utils/src/HighlightEffect.h
+++ b/libraries/render-utils/src/HighlightEffect.h
@@ -208,8 +208,6 @@ public:
     void build(JobModel& task, const render::Varying& inputs, render::Varying& outputs);
 
 private:
-
-    static void initMaskPipelines(render::ShapePlumber& plumber, gpu::StatePointer state);
     static const render::Varying addSelectItemJobs(JobModel& task, const render::Varying& selectionName, const RenderFetchCullSortTask::BucketList& items);
 
 };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/18749/Highlight-on-avatars-broken

Test plan:
- Run this from the console:
```
var style = {        
    outlineUnoccludedColor: { red: 0, green: 255, blue: 250 },
    outlineOccludedColor: { red: 0, green: 255, blue: 250 },
    fillUnoccludedColor: { red: 255, green: 0, blue: 0 },
    fillOccludedColor: { red: 255, green: 0, blue: 0 },

    outlineUnoccludedAlpha: 1.0,
    outlineOccludedAlpha: 1.0,
    fillUnoccludedAlpha: 1.0,
    fillOccludedAlpha: 1.0,
                
    outlineWidth: 5,
    isOutlineSmooth: true
}
Selection.enableListHighlight("test", style)
Selection.addToSelectedItemsList("test", "avatar", "{00000000-0000-0000-0000-000000000001}")
```
- Your avatar should be highlighted correctly.