### PR TITLE
Prevent thread issues with PickResults modified by Pointers

### DIFF
--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -35,6 +35,11 @@ void LaserPointer::editRenderStatePath(const std::string& state, const QVariant&
     }
 }
 
+PickResultPointer LaserPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
+    auto rayPickResult = std::static_pointer_cast<RayPickResult>(pickResult);
+    return std::make_shared<RayPickResult>(*rayPickResult.get());
+}
+
 QVariantMap LaserPointer::toVariantMap() const {
     QVariantMap qVariantMap;
 

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -38,7 +38,7 @@ void LaserPointer::editRenderStatePath(const std::string& state, const QVariant&
 PickResultPointer LaserPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
     auto rayPickResult = std::dynamic_pointer_cast<RayPickResult>(pickResult);
     if (!rayPickResult) {
-        std::make_shared<RayPickResult>();
+        return std::make_shared<RayPickResult>();
     }
     return std::make_shared<RayPickResult>(*rayPickResult.get());
 }

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -36,10 +36,10 @@ void LaserPointer::editRenderStatePath(const std::string& state, const QVariant&
 }
 
 PickResultPointer LaserPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
-    if (!pickResult) {
+    auto rayPickResult = std::dynamic_pointer_cast<RayPickResult>(pickResult);
+    if (!rayPickResult) {
         std::make_shared<RayPickResult>();
     }
-    auto rayPickResult = std::static_pointer_cast<RayPickResult>(pickResult);
     return std::make_shared<RayPickResult>(*rayPickResult.get());
 }
 

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -36,6 +36,9 @@ void LaserPointer::editRenderStatePath(const std::string& state, const QVariant&
 }
 
 PickResultPointer LaserPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
+    if (!pickResult) {
+        std::make_shared<RayPickResult>();
+    }
     auto rayPickResult = std::static_pointer_cast<RayPickResult>(pickResult);
     return std::make_shared<RayPickResult>(*rayPickResult.get());
 }

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -47,6 +47,8 @@ public:
     static std::shared_ptr<StartEndRenderState> buildRenderState(const QVariantMap& propMap);
 
 protected:
+    PickResultPointer getPickResultCopy(const PickResultPointer& pickResult) const override;
+
     void editRenderStatePath(const std::string& state, const QVariant& pathProps) override;
 
     glm::vec3 getPickOrigin(const PickResultPointer& pickResult) const override;

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -33,7 +33,7 @@ ParabolaPointer::ParabolaPointer(const QVariant& rayProps, const RenderStateMap&
 PickResultPointer ParabolaPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
     auto parabolaPickResult = std::dynamic_pointer_cast<ParabolaPickResult>(pickResult);
     if (!parabolaPickResult) {
-        std::make_shared<ParabolaPickResult>();
+        return std::make_shared<ParabolaPickResult>();
     }
     return std::make_shared<ParabolaPickResult>(*parabolaPickResult.get());
 }

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -31,11 +31,11 @@ ParabolaPointer::ParabolaPointer(const QVariant& rayProps, const RenderStateMap&
 }
 
 PickResultPointer ParabolaPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
-    if (!pickResult) {
+    auto parabolaPickResult = std::dynamic_pointer_cast<ParabolaPickResult>(pickResult);
+    if (!parabolaPickResult) {
         std::make_shared<ParabolaPickResult>();
     }
-    auto stylusPickResult = std::static_pointer_cast<ParabolaPickResult>(pickResult);
-    return std::make_shared<ParabolaPickResult>(*stylusPickResult.get());
+    return std::make_shared<ParabolaPickResult>(*parabolaPickResult.get());
 }
 
 void ParabolaPointer::editRenderStatePath(const std::string& state, const QVariant& pathProps) {

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -30,6 +30,11 @@ ParabolaPointer::ParabolaPointer(const QVariant& rayProps, const RenderStateMap&
 {
 }
 
+PickResultPointer ParabolaPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
+    auto stylusPickResult = std::static_pointer_cast<ParabolaPickResult>(pickResult);
+    return std::make_shared<ParabolaPickResult>(*stylusPickResult.get());
+}
+
 void ParabolaPointer::editRenderStatePath(const std::string& state, const QVariant& pathProps) {
     auto renderState = std::static_pointer_cast<RenderState>(_renderStates[state]);
     if (renderState) {

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -31,6 +31,9 @@ ParabolaPointer::ParabolaPointer(const QVariant& rayProps, const RenderStateMap&
 }
 
 PickResultPointer ParabolaPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
+    if (!pickResult) {
+        std::make_shared<ParabolaPickResult>();
+    }
     auto stylusPickResult = std::static_pointer_cast<ParabolaPickResult>(pickResult);
     return std::make_shared<ParabolaPickResult>(*stylusPickResult.get());
 }

--- a/interface/src/raypick/ParabolaPointer.h
+++ b/interface/src/raypick/ParabolaPointer.h
@@ -102,6 +102,8 @@ public:
     static std::shared_ptr<StartEndRenderState> buildRenderState(const QVariantMap& propMap);
 
 protected:
+    virtual PickResultPointer getPickResultCopy(const PickResultPointer& pickResult) const override;
+
     void editRenderStatePath(const std::string& state, const QVariant& pathProps) override;
 
     glm::vec3 getPickOrigin(const PickResultPointer& pickResult) const override;

--- a/interface/src/raypick/StylusPointer.cpp
+++ b/interface/src/raypick/StylusPointer.cpp
@@ -150,7 +150,7 @@ bool StylusPointer::shouldTrigger(const PickResultPointer& pickResult) {
 PickResultPointer StylusPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
     auto stylusPickResult = std::dynamic_pointer_cast<StylusPickResult>(pickResult);
     if (!stylusPickResult) {
-        std::make_shared<StylusPickResult>();
+        return std::make_shared<StylusPickResult>();
     }
     return std::make_shared<StylusPickResult>(*stylusPickResult.get());
 }

--- a/interface/src/raypick/StylusPointer.cpp
+++ b/interface/src/raypick/StylusPointer.cpp
@@ -148,10 +148,10 @@ bool StylusPointer::shouldTrigger(const PickResultPointer& pickResult) {
 }
 
 PickResultPointer StylusPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
-    if (!pickResult) {
+    auto stylusPickResult = std::dynamic_pointer_cast<StylusPickResult>(pickResult);
+    if (!stylusPickResult) {
         std::make_shared<StylusPickResult>();
     }
-    auto stylusPickResult = std::static_pointer_cast<StylusPickResult>(pickResult);
     return std::make_shared<StylusPickResult>(*stylusPickResult.get());
 }
 

--- a/interface/src/raypick/StylusPointer.cpp
+++ b/interface/src/raypick/StylusPointer.cpp
@@ -148,6 +148,9 @@ bool StylusPointer::shouldTrigger(const PickResultPointer& pickResult) {
 }
 
 PickResultPointer StylusPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
+    if (!pickResult) {
+        std::make_shared<StylusPickResult>();
+    }
     auto stylusPickResult = std::static_pointer_cast<StylusPickResult>(pickResult);
     return std::make_shared<StylusPickResult>(*stylusPickResult.get());
 }

--- a/interface/src/raypick/StylusPointer.cpp
+++ b/interface/src/raypick/StylusPointer.cpp
@@ -147,6 +147,11 @@ bool StylusPointer::shouldTrigger(const PickResultPointer& pickResult) {
     return false;
 }
 
+PickResultPointer StylusPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
+    auto stylusPickResult = std::static_pointer_cast<StylusPickResult>(pickResult);
+    return std::make_shared<StylusPickResult>(*stylusPickResult.get());
+}
+
 Pointer::PickedObject StylusPointer::getHoveredObject(const PickResultPointer& pickResult) {
     auto stylusPickResult = std::static_pointer_cast<const StylusPickResult>(pickResult);
     if (!stylusPickResult) {

--- a/interface/src/raypick/StylusPointer.h
+++ b/interface/src/raypick/StylusPointer.h
@@ -42,6 +42,7 @@ protected:
     Buttons getPressedButtons(const PickResultPointer& pickResult) override;
     bool shouldHover(const PickResultPointer& pickResult) override;
     bool shouldTrigger(const PickResultPointer& pickResult) override;
+    virtual PickResultPointer getPickResultCopy(const PickResultPointer& pickResult) const override;
 
     PointerEvent buildPointerEvent(const PickedObject& target, const PickResultPointer& pickResult, const std::string& button = "", bool hover = true) override;
 

--- a/libraries/pointers/src/Pointer.cpp
+++ b/libraries/pointers/src/Pointer.cpp
@@ -68,6 +68,7 @@ void Pointer::update(unsigned int pointerID) {
     // This only needs to be a read lock because update won't change any of the properties that can be modified from scripts
     withReadLock([&] {
         auto pickResult = getPrevPickResult();
+        // Pointer needs its own PickResult object so it doesn't modify the cached pick result
         auto visualPickResult = getVisualPickResult(std::make_shared<PickResult>(*pickResult.get()));
         updateVisuals(visualPickResult);
         generatePointerEvents(pointerID, visualPickResult);

--- a/libraries/pointers/src/Pointer.cpp
+++ b/libraries/pointers/src/Pointer.cpp
@@ -69,7 +69,7 @@ void Pointer::update(unsigned int pointerID) {
     withReadLock([&] {
         auto pickResult = getPrevPickResult();
         // Pointer needs its own PickResult object so it doesn't modify the cached pick result
-        auto visualPickResult = getVisualPickResult(std::make_shared<PickResult>(*pickResult.get()));
+        auto visualPickResult = getVisualPickResult(getPickResultCopy(pickResult));
         updateVisuals(visualPickResult);
         generatePointerEvents(pointerID, visualPickResult);
     });

--- a/libraries/pointers/src/Pointer.cpp
+++ b/libraries/pointers/src/Pointer.cpp
@@ -68,7 +68,7 @@ void Pointer::update(unsigned int pointerID) {
     // This only needs to be a read lock because update won't change any of the properties that can be modified from scripts
     withReadLock([&] {
         auto pickResult = getPrevPickResult();
-        auto visualPickResult = getVisualPickResult(pickResult);
+        auto visualPickResult = getVisualPickResult(std::make_shared<PickResult>(*pickResult.get()));
         updateVisuals(visualPickResult);
         generatePointerEvents(pointerID, visualPickResult);
     });

--- a/libraries/pointers/src/Pointer.h
+++ b/libraries/pointers/src/Pointer.h
@@ -91,6 +91,7 @@ protected:
 
     virtual bool shouldHover(const PickResultPointer& pickResult) { return true; }
     virtual bool shouldTrigger(const PickResultPointer& pickResult) { return true; }
+    virtual PickResultPointer getPickResultCopy(const PickResultPointer& pickResult) const = 0;
     virtual PickResultPointer getVisualPickResult(const PickResultPointer& pickResult) { return pickResult; };
 
     static const float POINTER_MOVE_DELAY;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/18506/RayPickResult-RayPickResult-bb1a07c73108db9911271cd4551f56eaddaef1a21fff1b8a7f0ecd0ccddb3469

This PR addresses a common crash involving PickResults. It makes the PickResult used by Pointers a separate copy so it can properly use it for its own calculations. I could not reproduce the crash, but was able to produce a similar crash by making the script engine process a lot of LaserPointers and PickResults, which will be used during this test.

## TEST PLAN
**Prerequisites**
- Have access to Backtrace, and have [this Backtrace page](https://highfidelity.sp.backtrace.io/dashboard/highfidelity/project/Interface/group/ddd602e3c1a920c656b6835eaecef986a54e0d0b9820db0af2089d483710f9bb) open to refresh/reference later.
- Have a way to know if your interface client was responsible for a crash on Backtrace, such as being logged in to a specific account.
- Have a program open to monitor the amount of memory Interface is using such as Task Manager. The test script will cause Interface to use a lot of memory, which is unrelated to the crash but may impede testing.
- Be in desktop mode, on a domain, with at least one small (<2 meter dimensions) entity near (within 50 meters) your avatar. You can verify it's an entity by going into the Create menu, selecting the object, and going into the properties menu and seeing a bunch of properties such as the type, model name, position, etc. It is not required for the object to be editable in any way, just that it exists.

**Test Steps**

Run these steps 30 times in master and this PR, or however many times it takes to get 3 repros on master if that is smaller. For both builds, record the number of crashes that match [this Backtrace page](https://highfidelity.sp.backtrace.io/dashboard/highfidelity/project/Interface/group/ddd602e3c1a920c656b6835eaecef986a54e0d0b9820db0af2089d483710f9bb), which shows a list of occurences of the crash the test script can reproduce.
1. In an appropriate domain and location, copy, paste, and enter the following script into the console: [laser-pointer-lock_stress-test.js](https://gist.github.com/sabrina-shanman/cd537e43939c40c63e987bff0d0dfc76). Do not run this script from "Running Scripts" because it will not unload unless interface settings are reset. The console can be accessed by enabling Settings>Developer Menu and clicking on Developer>Console.
1. Wait until Interface crashes. Monitor the memory usage by Interface on occasion. If Interface takes up too much memory (OS memory usage above 80%), just close interface and count that as a run.
1. Refresh the backtrace page and see if there is a new crash which matches your interface client. If so, record it in the repro count.

This test should pass if the crash repros on master three times but does not repro in this PR after the same number of runs.