### PR TITLE
Fix models with 1^3 dimensions never being resized

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -210,7 +210,8 @@ void RenderableModelEntityItem::updateModelBounds() {
     }
 
     if (model->getScaleToFitDimensions() != getScaledDimensions() ||
-            model->getRegistrationPoint() != getRegistrationPoint()) {
+            model->getRegistrationPoint() != getRegistrationPoint() ||
+            !model->getIsScaledToFit()) {
         // The machinery for updateModelBounds will give existing models the opportunity to fix their
         // translation/rotation/scale/registration.  The first two are straightforward, but the latter two
         // have guards to make sure they don't happen after they've already been set.  Here we reset those guards.


### PR DESCRIPTION
Models with a dimension of 1x1x1 would rendered and treated physically as if it were at its natural dimensions. This happened because the default scaled dimensions for a model are 1x1x1, so a reload will never be triggered.

https://highfidelity.fogbugz.com/f/cases/11210/Model-Entities-cause-problems-with-extreme-high-naturalDimensions-dimensions-not-set