### PR TITLE
call saveRecordingToAsset callback on correct thread

### DIFF
--- a/libraries/script-engine/src/RecordingScriptingInterface.cpp
+++ b/libraries/script-engine/src/RecordingScriptingInterface.cpp
@@ -243,7 +243,8 @@ bool RecordingScriptingInterface::saveRecordingToAsset(QScriptValue getClipAtpUr
     }
 
     if (auto upload = DependencyManager::get<AssetClient>()->createUpload(recording::Clip::toBuffer(_lastClip))) {
-        QObject::connect(upload, &AssetUpload::finished, this, [=](AssetUpload* upload, const QString& hash) mutable {
+        QObject::connect(upload, &AssetUpload::finished,
+                         getClipAtpUrl.engine(), [=](AssetUpload* upload, const QString& hash) mutable {
             QString clip_atp_url = "";
 
             if (upload->getError() == AssetUpload::NoError) {


### PR DESCRIPTION
- fix crash when uploading an avatar recording to asset-server


https://highfidelity.manuscript.com/f/cases/18292/QTJSC-Interpreter-privateExecute-QTJSC-Interpreter-ExecutionFlag-QTJSC-RegisterFile-QTJSC-24f4fb23f21492f0cd539046397
