### PR TITLE
Prototype improved controller mappings - D

### DIFF
--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -36,18 +36,6 @@
           "when": [ "!Application.SnapTurn" ]
         },
 
-        { "from": "Standard.RY",
-          "when": "Application.Grounded",
-          "to": "Actions.Up",
-          "filters":
-            [
-                { "type": "deadZone", "min": 0.6 },
-                "invert"
-            ]
-        },
-
-        { "from": "Standard.RY", "to": "Actions.Up", "filters": "invert"},
-
         { "from": "Standard.Back", "to": "Actions.CycleCamera" },
         { "from": "Standard.Start", "to": "Actions.ContextMenu" },
 

--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -5,7 +5,7 @@
 
         { "from": "Standard.LX",
           "when": [
-            "Application.InHMD", "!Application.AdvancedMovement",
+            "Application.InHMD",
             "Application.SnapTurn", "!Standard.RX"
           ],
           "to": "Actions.StepYaw",
@@ -17,11 +17,8 @@
                 { "type": "scale", "scale": 22.5 }
             ]
         },
-        { "from": "Standard.LX", "to": "Actions.TranslateX",
-          "when": [ "Application.AdvancedMovement" ]
-        },
         { "from": "Standard.LX", "to": "Actions.Yaw",
-          "when": [ "!Application.AdvancedMovement", "!Application.SnapTurn" ]
+          "when": [ "!Application.SnapTurn" ]
         },
 
         { "from": "Standard.RX",

--- a/interface/resources/controllers/standard.json
+++ b/interface/resources/controllers/standard.json
@@ -5,7 +5,7 @@
 
         { "from": "Standard.LX",
           "when": [
-            "Application.InHMD",
+            "Application.InHMD", "!Application.AdvancedMovement",
             "Application.SnapTurn", "!Standard.RX"
           ],
           "to": "Actions.StepYaw",
@@ -17,8 +17,11 @@
                 { "type": "scale", "scale": 22.5 }
             ]
         },
+        { "from": "Standard.LX", "to": "Actions.TranslateX",
+          "when": [ "Application.AdvancedMovement" ]
+        },
         { "from": "Standard.LX", "to": "Actions.Yaw",
-          "when": [ "!Application.SnapTurn" ]
+          "when": [ "!Application.AdvancedMovement", "!Application.SnapTurn" ]
         },
 
         { "from": "Standard.RX",

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1961,7 +1961,7 @@ void MyAvatar::updateMotors() {
 
         bool wasWaitingToFly = _isWaitingToFly;
         bool isWaitingToFly = false;
-        const quint64 WAITING_TO_FLY_TIMEOUT = 2000000; // 2s
+        const quint64 WAITING_TO_FLY_TIMEOUT = 1000000; // 1s
 
         if (qApp->isHMDMode() && getLeftHandPose().isValid()) {
             // Fly and walk per left hand orientation.

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1993,8 +1993,9 @@ void MyAvatar::updateMotors() {
                     _isPushingEnabled = false;
                 } else if (_isPushing && _isWaitingToFly && getFlyingHMDPref()) {
                     // On ground but user is stationary and waiting to fly.
-                    if (handPointedUpwardDot >= COS_MAX_START_FLYING_ANGLE && !_isWaitingToFlyCancelled) {
-                        // Hand still pointing upward so continue countdown.
+                    if (handPointedUpwardDot >= COS_MAX_START_FLYING_ANGLE && !_isWaitingToFlyCancelled
+                            && getDriveKey(TRANSLATE_Z) > 0.0f) {
+                        // Hand still pointing upward so continue countdown if joystick is forward.
                         if (usecTimestampNow() - _startedWaitingToFly >= WAITING_TO_FLY_TIMEOUT) {
                             _characterController.jump(); // Initiate flying.
                             _haveSentSecondJump = false;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -137,8 +137,8 @@ MyAvatar::MyAvatar(QThread* thread) :
     _userHeightSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "userHeight", DEFAULT_AVATAR_HEIGHT),
     _flyingHMDSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "flyingHMD", _flyingPrefHMD),
     _avatarEntityCountSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "avatarEntityData" << "size", _flyingPrefHMD),
-    _minFlyingSpeedSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "minFlyingSpeed", _minFlyingSpeed),
-    _maxFlyingSpeedSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "maxFlyingSpeed", _maxFlyingSpeed)
+    _maxFlyingSpeedSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "maxFlyingSpeed", _maxFlyingSpeed),
+    _minFlyingSpeedSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "minFlyingSpeed", _minFlyingSpeed)
 {
     _clientTraitsHandler = std::unique_ptr<ClientTraitsHandler>(new ClientTraitsHandler(this));
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -71,7 +71,10 @@ const float DEFAULT_REAL_WORLD_FIELD_OF_VIEW_DEGREES = 30.0f;
 const float YAW_SPEED_DEFAULT = 100.0f;   // degrees/sec
 const float PITCH_SPEED_DEFAULT = 75.0f; // degrees/sec
 
+// FIXME: Remove old code and associated constants if new is adopted.
+/*
 const float MAX_BOOST_SPEED = 0.5f * DEFAULT_AVATAR_MAX_WALKING_SPEED; // action motor gets additive boost below this speed
+*/
 const float MIN_AVATAR_SPEED = 0.05f;
 const float MIN_AVATAR_SPEED_SQUARED = MIN_AVATAR_SPEED * MIN_AVATAR_SPEED; // speed is set to zero below this
 

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1961,6 +1961,7 @@ void MyAvatar::updateMotors() {
 
         bool wasWaitingToFly = _isWaitingToFly;
         bool isWaitingToFly = false;
+        bool hasStartedFlying = false;
         const quint64 WAITING_TO_FLY_TIMEOUT = 1000000; // 1s
 
         if (qApp->isHMDMode() && getLeftHandPose().isValid()) {
@@ -1997,6 +1998,7 @@ void MyAvatar::updateMotors() {
                         _characterController.jump(); // Initiate flying.
                         _haveSentSecondJump = false;
                         motorRotation = cancelOutRoll(handOrientation);
+                        hasStartedFlying = true;
                     } else {
                         isWaitingToFly = true;
                         _isPushingEnabled = false;
@@ -2037,7 +2039,7 @@ void MyAvatar::updateMotors() {
                 _waitingToFlySignalEmitted = now;
             }
         } else if (wasWaitingToFly) {
-            emit waitingToFly(0.0f);
+            emit waitingToFly(hasStartedFlying ? 1.0f : 0.0f);
         }
 
         if (_isPushing || _isBraking || !_isBeingPushed) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1977,7 +1977,7 @@ void MyAvatar::updateMotors() {
                     _haveSentSecondJump = true;
                 }
                 motorRotation = cancelOutRoll(handOrientation);
-            } else if (_isPushing && !_wasPushing
+            } else if (_isPushing && !_wasPushing && getFlyingHMDPref()
                     && glm::dot(handOrientation * Vectors::UNIT_NEG_Z, Vectors::UNIT_Y) >= COS_MAX_START_FLYING_ANGLE) {
                 // On ground but user is stationary and wants to fly.
                 _characterController.jump(); // Initiate flying.

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1956,7 +1956,7 @@ void MyAvatar::updateMotors() {
         if (qApp->isHMDMode() && getLeftHandPose().isValid()) {
             // Fly and walk per left hand orientation.
             const glm::quat LEFT_HAND_ZERO_ROT(glm::quat(glm::radians(glm::vec3(90.0f, -90.0f, 0.0f))));
-            const float MAX_START_FLYING_ANGLE = 30.0f; // Max offset from vertical that hand can be pointed to start flying.
+            const float MAX_START_FLYING_ANGLE = 40.0f; // Max offset from vertical that hand can be pointed to start flying.
             const float COS_MAX_START_FLYING_ANGLE = glm::cos(glm::radians(MAX_START_FLYING_ANGLE));
             glm::quat handOrientation = getLeftPalmRotation() * LEFT_HAND_ZERO_ROT;
             if (_characterController.getState() == CharacterController::State::Hover ||

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2028,6 +2028,18 @@ void MyAvatar::updateMotors() {
         }
 
         _isWaitingToFly = isWaitingToFly;
+        if (_isWaitingToFly) {
+            const quint64 MIN_WAITING_TO_FLY_SIGNAL_INTERVAL = 25000;
+            auto now = usecTimestampNow();
+            if (now - _waitingToFlySignalEmitted >= MIN_WAITING_TO_FLY_SIGNAL_INTERVAL) {
+                float fraction = (double)(now - _startedWaitingToFly) / (double)WAITING_TO_FLY_TIMEOUT;
+                emit waitingToFly(min(fraction, 1.0f));
+                _waitingToFlySignalEmitted = now;
+            }
+        } else if (wasWaitingToFly) {
+            emit waitingToFly(0.0f);
+        }
+
         if (_isPushing || _isBraking || !_isBeingPushed) {
             _characterController.addMotor(_actionMotorVelocity, motorRotation, horizontalMotorTimescale, verticalMotorTimescale);
         } else {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -72,9 +72,7 @@ const float YAW_SPEED_DEFAULT = 100.0f;   // degrees/sec
 const float PITCH_SPEED_DEFAULT = 75.0f; // degrees/sec
 
 // FIXME: Remove old code and associated constants if new is adopted.
-/*
 const float MAX_BOOST_SPEED = 0.5f * DEFAULT_AVATAR_MAX_WALKING_SPEED; // action motor gets additive boost below this speed
-*/
 const float MIN_AVATAR_SPEED = 0.05f;
 const float MIN_AVATAR_SPEED_SQUARED = MIN_AVATAR_SPEED * MIN_AVATAR_SPEED; // speed is set to zero below this
 
@@ -2798,7 +2796,6 @@ void MyAvatar::updateActionMotor(float deltaTime) {
 
     if (state == CharacterController::State::Hover) {
         // FIXME: Remove old code and associated constants if new is adopted.
-        /*
         // we're flying --> complex acceleration curve that builds on top of current motor speed and caps at some max speed
 
         float motorSpeed = glm::length(_actionMotorVelocity);
@@ -2818,8 +2815,9 @@ void MyAvatar::updateActionMotor(float deltaTime) {
             }
         }
         _actionMotorVelocity = motorSpeed * direction;
-        */
 
+        // FIXME: Remove new code and associated settings etc. if old code is retained.
+        /*
         // we're flying --> constant speed depending on angle between direction camera and left hand is pointing.
         const glm::quat LEFT_HAND_ZERO_ROT(glm::quat(glm::radians(glm::vec3(90.0f, -90.0f, 0.0f))));
         auto handDirection = (getLeftPalmRotation() * LEFT_HAND_ZERO_ROT) * Vectors::UNIT_NEG_Z;
@@ -2837,6 +2835,7 @@ void MyAvatar::updateActionMotor(float deltaTime) {
             motorSpeed = getSensorToWorldScale() * _minFlyingSpeed;
         }
         _actionMotorVelocity = motorSpeed * direction;
+        */
     } else {
         // we're interacting with a floor --> simple horizontal speed and exponential decay
         const glm::vec2 currentVel = { direction.x, direction.z };

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2003,12 +2003,9 @@ void MyAvatar::updateMotors() {
                         isWaitingToFly = true;
                         _isPushingEnabled = false;
                     }
-                } else if (abs(handPointedUpwardDot) < COS_MAX_START_FLYING_ANGLE) {
-                    // Walk on ground per left hand orientation if not pointing upward or downward.
+                } else  {
+                    // Walk on ground per left hand orientation.
                     motorRotation = cancelOutRollAndPitch(handOrientation);
-                } else {
-                    // On ground but left hand pointing up or down so don't walk.
-                    _isPushingEnabled = false;
                 }
             }
         } else {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1615,6 +1615,11 @@ private:
     float _yawSpeed; // degrees/sec
     float _pitchSpeed; // degrees/sec
 
+    const float DEFAULT_MAX_FLYING_SPEED = 20.0f; // m/s Speed if hand pointing in same direction as camera.
+    const float DEFAULT_MIN_FLYING_SPEED = 5.0f; // m/s Speed if hand pointing at right angles to or behind camera.
+    float _maxFlyingSpeed { DEFAULT_MAX_FLYING_SPEED };
+    float _minFlyingSpeed { DEFAULT_MIN_FLYING_SPEED };
+
     glm::vec3 _thrust { 0.0f };  // impulse accumulator for outside sources
 
     glm::vec3 _actionMotorVelocity; // target local-frame velocity of avatar (default controller actions)

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1593,9 +1593,12 @@ private:
     bool _flyingPrefHMD { false };
     bool _wasPushing { false };
     bool _isPushing { false };
+    bool _isPushingEnabled { false };
     bool _isBeingPushed { false };
     bool _isBraking { false };
     bool _isAway { false };
+    bool _isWaitingToFly { false };
+    quint64 _startedWaitingToFly { 0 };
 
     float _boomLength { ZOOM_DEFAULT };
     float _yawSpeed; // degrees/sec

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1806,6 +1806,8 @@ private:
 
     bool _haveReceivedHeightLimitsFromDomain { false };
     int _disableHandTouchCount { 0 };
+
+    bool _haveSentSecondJump { false };
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1503,6 +1503,15 @@ signals:
      */
     void disableHandTouchForIDChanged(const QUuid& entityID, bool disable);
 
+    /**jsdoc
+     * Triggered when the user is waiting to fly (left hand pointed upward and left joystick forward) or has started flying.
+     * @function MyAvatar.waitingToFly
+     * @param {number} fraction - The fraction of the wait time completed, <code>0.0</code> &ndash; <code>1.0</code>. Is 
+     *     <code>0.0</code> if stopped waiting (e.g., started flying).
+     * @returns {Signal}
+     */
+    void waitingToFly(float fraction);
+
 private slots:
     void leaveDomain();
     void updateCollisionCapsuleCache();
@@ -1599,6 +1608,7 @@ private:
     bool _isAway { false };
     bool _isWaitingToFly { false };
     quint64 _startedWaitingToFly { 0 };
+    quint64 _waitingToFlySignalEmitted { 0 };
 
     float _boomLength { ZOOM_DEFAULT };
     float _yawSpeed; // degrees/sec

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1607,6 +1607,7 @@ private:
     bool _isBraking { false };
     bool _isAway { false };
     bool _isWaitingToFly { false };
+    bool _isWaitingToFlyCancelled { false };
     quint64 _startedWaitingToFly { 0 };
     quint64 _waitingToFlySignalEmitted { 0 };
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1506,8 +1506,8 @@ signals:
     /**jsdoc
      * Triggered when the user is waiting to fly (left hand pointed upward and left joystick forward) or has started flying.
      * @function MyAvatar.waitingToFly
-     * @param {number} fraction - The fraction of the wait time completed, <code>0.0</code> &ndash; <code>1.0</code>. Is 
-     *     <code>0.0</code> if stopped waiting (e.g., started flying).
+     * @param {number} fraction - The fraction of the wait time completed, <code>0.0</code> &ndash; <code>1.0</code>.  Is 
+     *     <code>0.0</code> if stopped waiting; <code>1.0</code> if completed waiting, i.e., started flying.
      * @returns {Signal}
      */
     void waitingToFly(float fraction);

--- a/scripts/defaultScripts.js
+++ b/scripts/defaultScripts.js
@@ -31,7 +31,8 @@ var DEFAULT_SCRIPTS_COMBINED = [
     "system/dialTone.js",
     "system/firstPersonHMD.js",
     "system/tablet-ui/tabletUI.js",
-    "system/emote.js"
+    "system/emote.js",
+    "system/waitingToFly.js"
 ];
 var DEFAULT_SCRIPTS_SEPARATE = [
     "system/controllers/controllerScripts.js",

--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -574,6 +574,12 @@ Script.include("/~/system/libraries/controllers.js");
         // Teleport actions.
         teleportMapping.from(Controller.Standard.LeftPrimaryThumb).peek().to(leftTeleporter.buttonPress);
         teleportMapping.from(Controller.Standard.RightPrimaryThumb).peek().to(rightTeleporter.buttonPress);
+        teleportMapping.from(Controller.Standard.RY)
+            .peek()
+            .clamp(-1, 0)
+            .invert()
+            .constrainToInteger()
+            .to(rightTeleporter.buttonPress);
     }
 
     var leftTeleporter = new Teleporter(LEFT_HAND);

--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -129,7 +129,9 @@ Script.include("/~/system/libraries/controllers.js");
         var _this = this;
         this.init = false;
         this.hand = hand;
+        this.touchValue = 0;
         this.buttonValue = 0;
+        this.teleported = false;
         this.disabled = false; // used by the 'Hifi-Teleport-Disabler' message handler
         this.active = false;
         this.state = TELEPORTER_STATES.IDLE;
@@ -299,6 +301,12 @@ Script.include("/~/system/libraries/controllers.js");
                 && (_this.axisButtonStateX !== 0 || _this.axisButtonStateY !== 0);
         };
 
+        this.beamOn = function (value) {
+            if (value === 0 || !_this.teleportLocked()) {
+                _this.touchValue = value;
+            }
+        };
+
         this.buttonPress = function (value) {
             if (value === 0 || !_this.teleportLocked()) {
                 _this.buttonValue = value;
@@ -317,9 +325,10 @@ Script.include("/~/system/libraries/controllers.js");
 
         this.isReady = function(controllerData, deltaTime) {
             var otherModule = this.getOtherModule();
-            if (!this.disabled && this.buttonValue !== 0 && !otherModule.active) {
+            if (!this.disabled && this.touchValue !== 0 && this.buttonValue === 0 && !otherModule.active) {
                 this.active = true;
                 this.enterTeleport();
+                this.teleported = false;
                 return makeRunningValues(true, [], []);
             }
             return makeRunningValues(false, [], []);
@@ -387,21 +396,23 @@ Script.include("/~/system/libraries/controllers.js");
 
         this.teleport = function(newResult, target) {
             var result = newResult;
-            if (_this.buttonValue !== 0) {
+            if (this.touchValue === 1 && this.buttonValue === 0) {
                 return makeRunningValues(true, [], []);
             }
 
-            if (target === TARGET.NONE || target === TARGET.INVALID) {
+            if (target === TARGET.NONE || target === TARGET.INVALID || this.touchValue === 0) {
                 // Do nothing
-            } else if (target === TARGET.SEAT) {
+            } else if (target === TARGET.SEAT && !this.teleported) {
                 Entities.callEntityMethod(result.objectID, 'sit');
-            } else if (target === TARGET.SURFACE || target === TARGET.DISCREPANCY) {
+                this.teleported = true;
+            } else if ((target === TARGET.SURFACE || target === TARGET.DISCREPANCY) && !this.teleported) {
                 var offset = getAvatarFootOffset();
                 result.intersection.y += offset;
                 var shouldLandSafe = target === TARGET.DISCREPANCY;
                 MyAvatar.goToLocation(result.intersection, true, HMD.orientation, false, shouldLandSafe);
                 HMD.centerUI();
                 MyAvatar.centerBody();
+                this.teleported = true;
             }
 
             this.disableLasers();
@@ -570,6 +581,11 @@ Script.include("/~/system/libraries/controllers.js");
 
         // Vive teleport button lock-out.
         registerViveTeleportMapping();
+
+        // Teleport beam.
+        teleportMapping.from(Controller.Standard.RSTouch)
+            .peek()
+            .to(rightTeleporter.beamOn);
 
         // Teleport action.
         teleportMapping.from(Controller.Standard.RY)

--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -571,9 +571,7 @@ Script.include("/~/system/libraries/controllers.js");
         // Vive teleport button lock-out.
         registerViveTeleportMapping();
 
-        // Teleport actions.
-        teleportMapping.from(Controller.Standard.LeftPrimaryThumb).peek().to(leftTeleporter.buttonPress);
-        teleportMapping.from(Controller.Standard.RightPrimaryThumb).peek().to(rightTeleporter.buttonPress);
+        // Teleport action.
         teleportMapping.from(Controller.Standard.RY)
             .peek()
             .clamp(-1, 0)

--- a/scripts/system/waitingToFly.js
+++ b/scripts/system/waitingToFly.js
@@ -1,0 +1,79 @@
+//
+//  waitingToFly.js
+//
+//  Created by David Rowe on 21 Sep 2018.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+(function () {
+
+    var overlay,
+        LOCAL_POSITION = { x: 0, y: 0.01, z: 0 },
+        LOCAL_ROTATION = Quat.fromVec3Degrees({ x: 90, y: 180, z: 0 }),
+        INNER_RADIUS = 0.05,
+        OUTER_RADIUS = 0.06,
+        FULL_CIRCLE = 360,
+        HIDE_DELAY = 200,
+        visible = false;
+
+    function onWaitingToFly(fraction) {
+        var properties;
+
+        if (fraction > 0) {
+            if (!visible) {
+                properties = {
+                    innerRadius: MyAvatar.scale * INNER_RADIUS,
+                    outerRadius: MyAvatar.scale * OUTER_RADIUS,
+                    parentID: MyAvatar.SELF_ID,
+                    parentJointIndex: MyAvatar.getJointIndex("LeftHand"),
+                    localPosition: Vec3.multiply(MyAvatar.scale, LOCAL_POSITION),
+                    localRotation: LOCAL_ROTATION,
+                    endAt: fraction * FULL_CIRCLE,
+                    visible: true
+                };
+                visible = true;
+            } else {
+                properties = {
+                    endAt: fraction * FULL_CIRCLE
+                };
+            }
+            Overlays.editOverlay(overlay, properties);
+        } else {
+            if (visible) {
+                // Leave completed circle displayed for a short time while the take-off completes.
+                Overlays.editOverlay(overlay, {
+                    endAt: FULL_CIRCLE
+                });
+                Script.setTimeout(function () {
+                    Overlays.editOverlay(overlay, {
+                        visible: false
+                    });
+                }, HIDE_DELAY);
+                visible = false;
+            }
+        }
+    }
+
+    function setUp() {
+        overlay = Overlays.addOverlay("circle3d", {
+            solid: true,
+            color: { red: 0, green: 180, blue: 239 },
+            alpha: 0.8,
+            ignorePickIntersection: true,
+            visible: false
+        });
+        MyAvatar.waitingToFly.connect(onWaitingToFly);
+    }
+
+    function tearDown() {
+        MyAvatar.waitingToFly.disconnect(onWaitingToFly);
+        Overlays.deleteOverlay(overlay);
+    }
+
+    setUp();
+    Script.scriptEnding.connect(tearDown);
+
+}());

--- a/scripts/system/waitingToFly.js
+++ b/scripts/system/waitingToFly.js
@@ -14,7 +14,7 @@
         LOCAL_POSITION = { x: 0, y: 0.01, z: 0 },
         LOCAL_ROTATION = Quat.fromVec3Degrees({ x: 90, y: 180, z: 0 }),
         INNER_RADIUS = 0.05,
-        OUTER_RADIUS = 0.06,
+        OUTER_RADIUS = 0.07,
         FULL_CIRCLE = 360,
         HIDE_DELAY = 200,
         visible = false;

--- a/scripts/system/waitingToFly.js
+++ b/scripts/system/waitingToFly.js
@@ -11,8 +11,8 @@
 (function () {
 
     var overlay,
-        LOCAL_POSITION = { x: 0, y: 0.01, z: 0 },
-        LOCAL_ROTATION = Quat.fromVec3Degrees({ x: 90, y: 180, z: 0 }),
+        LOCAL_POSITION = { x: -0.1, y: 0.1, z: 0 },
+        LOCAL_ROTATION = Quat.fromVec3Degrees({ x: 90, y: 0, z: 90 }),
         INNER_RADIUS = 0.05,
         OUTER_RADIUS = 0.07,
         FULL_CIRCLE = 360,

--- a/scripts/system/waitingToFly.js
+++ b/scripts/system/waitingToFly.js
@@ -41,17 +41,20 @@
                 };
             }
             Overlays.editOverlay(overlay, properties);
-        } else {
-            if (visible) {
+            if (fraction === 1) {
                 // Leave completed circle displayed for a short time while the take-off completes.
-                Overlays.editOverlay(overlay, {
-                    endAt: FULL_CIRCLE
-                });
                 Script.setTimeout(function () {
                     Overlays.editOverlay(overlay, {
                         visible: false
                     });
+                    visible = false;
                 }, HIDE_DELAY);
+            }
+        } else {
+            if (visible) {
+                Overlays.editOverlay(overlay, {
+                    visible: false
+                });
                 visible = false;
             }
         }


### PR DESCRIPTION
In HMD mode:
- Touch right joystick to show teleport beam. (Instead of A and X buttons.)
- Forward right joystick to teleport.
- Right joystick backward takes no action.

In HMD mode with Settings > Controls > Advanced Movement in VR plus Flying & Jumping (HMD):
- To initiate flying, while stationary point your left hand upward (within 40 degrees of vertical) and do left joystick forward, then wait for the countdown graphic displayed on your hand to complete. (Instead of right joystick forward.)
- Flying is directly up/down with left joystick forward/backward if your left hand is point upward, otherwise it is in the direction of your head.
- While flying, tilt (roll) your head left/right to turn left/right. (No change.)