### PR TITLE
Fix case 18465: redirect to domain after login

### DIFF
--- a/android/app/src/main/cpp/native.cpp
+++ b/android/app/src/main/cpp/native.cpp
@@ -156,7 +156,7 @@ JNIEXPORT void Java_io_highfidelity_hifiinterface_InterfaceActivity_nativeOnCrea
     JavaVM* jvm;
     env->GetJavaVM(&jvm);
 
-    QObject::connect(&AndroidHelper::instance(), &AndroidHelper::androidActivityRequested, [jvm](const QString& a, const bool backToScene, QList<QString> args) {
+    QObject::connect(&AndroidHelper::instance(), &AndroidHelper::androidActivityRequested, [jvm](const QString& a, const bool backToScene, QMap<QString, QString> args) {
         JNIEnv* myNewEnv;
         JavaVMAttachArgs jvmArgs;
         jvmArgs.version = JNI_VERSION_1_6; // choose your JNI version
@@ -182,9 +182,11 @@ JNIEXPORT void Java_io_highfidelity_hifiinterface_InterfaceActivity_nativeOnCrea
         jmethodID mapClassConstructor =  myNewEnv->GetMethodID(hashMapClass, "<init>", "()V");
         jobject hashmap = myNewEnv->NewObject(hashMapClass, mapClassConstructor);
         jmethodID mapClassPut = myNewEnv->GetMethodID(hashMapClass, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
-        for (const QString& arg: args) {
-            QAndroidJniObject jArg = QAndroidJniObject::fromString(arg);
-            myNewEnv->CallObjectMethod(hashmap, mapClassPut, QAndroidJniObject::fromString("url").object<jstring>(), jArg.object<jstring>());
+        QMap<QString, QString>::iterator i;
+        for (i = args.begin(); i != args.end(); ++i) {
+            QAndroidJniObject jKey = QAndroidJniObject::fromString(i.key());
+            QAndroidJniObject jValue = QAndroidJniObject::fromString(i.value());
+            myNewEnv->CallObjectMethod(hashmap, mapClassPut, jKey.object<jstring>(), jValue.object<jstring>());
         }
         __interfaceActivity.callMethod<void>("openAndroidActivity", "(Ljava/lang/String;ZLjava/util/HashMap;)V", string.object<jstring>(), jBackToScene, hashmap);
         if (attachedHere) {

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/InterfaceActivity.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import io.highfidelity.hifiinterface.fragment.WebViewFragment;
 import io.highfidelity.hifiinterface.receiver.HeadsetStateReceiver;
@@ -303,14 +304,22 @@ public class InterfaceActivity extends QtActivity implements WebViewFragment.OnW
         switch (activityName) {
             case "Home":
             case "Privacy Policy":
-            case "Login": {
                 nativeBeforeEnterBackground();
                 Intent intent = new Intent(this, MainActivity.class);
                 intent.putExtra(MainActivity.EXTRA_FRAGMENT, activityName);
                 intent.putExtra(MainActivity.EXTRA_BACK_TO_SCENE, backToScene);
                 startActivity(intent);
                 break;
-            }
+            case "Login":
+                nativeBeforeEnterBackground();
+                Intent loginIntent = new Intent(this, MainActivity.class);
+                loginIntent.putExtra(MainActivity.EXTRA_FRAGMENT, activityName);
+                loginIntent.putExtra(MainActivity.EXTRA_BACK_TO_SCENE, backToScene);
+                if (args != null && args.containsKey(DOMAIN_URL)) {
+                    loginIntent.putExtra(DOMAIN_URL, (String) args.get(DOMAIN_URL));
+                }
+                startActivity(loginIntent);
+                break;
             case "WebView":
                 runOnUiThread(() -> {
                     webSlidingDrawer.setVisibility(View.VISIBLE);

--- a/android/app/src/main/java/io/highfidelity/hifiinterface/MainActivity.java
+++ b/android/app/src/main/java/io/highfidelity/hifiinterface/MainActivity.java
@@ -29,6 +29,9 @@ import android.widget.TextView;
 import com.squareup.picasso.Callback;
 import com.squareup.picasso.Picasso;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import io.highfidelity.hifiinterface.fragment.FriendsFragment;
 import io.highfidelity.hifiinterface.fragment.HomeFragment;
 import io.highfidelity.hifiinterface.fragment.LoginFragment;
@@ -45,6 +48,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     public static final String DEFAULT_FRAGMENT = "Home";
     public static final String EXTRA_FRAGMENT = "fragment";
     public static final String EXTRA_BACK_TO_SCENE = "backToScene";
+    public static final String EXTRA_BACK_TO_URL = "url";
 
     private String TAG = "HighFidelity";
 
@@ -62,6 +66,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private MenuItem mPeopleMenuItem;
 
     private boolean backToScene;
+    private String backToUrl;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -105,9 +110,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 loadFragment(DEFAULT_FRAGMENT);
             }
 
-            if (getIntent().hasExtra(EXTRA_BACK_TO_SCENE)) {
-                backToScene = getIntent().getBooleanExtra(EXTRA_BACK_TO_SCENE, false);
-            }
+            backToScene = getIntent().getBooleanExtra(EXTRA_BACK_TO_SCENE, false);
+            backToUrl = getIntent().getStringExtra(EXTRA_BACK_TO_URL);
         }
     }
 
@@ -301,7 +305,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     }
 
     private void goToLastLocation() {
-        goToDomain("");
+        goToDomain(backToUrl != null? backToUrl : "");
     }
 
     private void goToDomain(String domainUrl) {

--- a/interface/src/AndroidHelper.cpp
+++ b/interface/src/AndroidHelper.cpp
@@ -25,7 +25,7 @@ AndroidHelper::AndroidHelper() {
 AndroidHelper::~AndroidHelper() {
 }
 
-void AndroidHelper::requestActivity(const QString &activityName, const bool backToScene, QList<QString> args) {
+void AndroidHelper::requestActivity(const QString &activityName, const bool backToScene, QMap<QString, QString> args) {
     emit androidActivityRequested(activityName, backToScene, args);
 }
 
@@ -49,8 +49,10 @@ void AndroidHelper::performHapticFeedback(int duration) {
     emit hapticFeedbackRequested(duration);
 }
 
-void AndroidHelper::showLoginDialog() {
-    emit androidActivityRequested("Login", true);
+void AndroidHelper::showLoginDialog(QUrl url) {
+    QMap<QString, QString> args;
+    args["url"] = url.toString();
+    emit androidActivityRequested("Login", true, args);
 }
 
 void AndroidHelper::processURL(const QString &url) {

--- a/interface/src/AndroidHelper.h
+++ b/interface/src/AndroidHelper.h
@@ -13,6 +13,8 @@
 #define hifi_Android_Helper_h
 
 #include <QObject>
+#include <QMap>
+#include <QUrl>
 
 class AndroidHelper : public QObject {
     Q_OBJECT
@@ -21,7 +23,7 @@ public:
             static AndroidHelper instance;
             return instance;
     }
-    void requestActivity(const QString &activityName, const bool backToScene, QList<QString> args = QList<QString>());
+    void requestActivity(const QString &activityName, const bool backToScene, QMap<QString, QString> args = QMap<QString, QString>());
     void notifyLoadComplete();
     void notifyEnterForeground();
     void notifyBeforeEnterBackground();
@@ -35,10 +37,10 @@ public:
     void operator=(AndroidHelper const&) = delete;
 
 public slots:
-    void showLoginDialog();
+    void showLoginDialog(QUrl url);
 
 signals:
-    void androidActivityRequested(const QString &activityName, const bool backToScene, QList<QString> args = QList<QString>());
+    void androidActivityRequested(const QString &activityName, const bool backToScene, QMap<QString, QString> args = QMap<QString, QString>());
     void qtAppLoadComplete();
     void enterForeground();
     void beforeEnterBackground();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1236,7 +1236,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     auto dialogsManager = DependencyManager::get<DialogsManager>();
 #if defined(Q_OS_ANDROID)
     connect(accountManager.data(), &AccountManager::authRequired, this, []() {
-        AndroidHelper::instance().showLoginDialog();
+        auto addressManager = DependencyManager::get<AddressManager>();
+        AndroidHelper::instance().showLoginDialog(addressManager->currentAddress());
     });
 #else
     connect(accountManager.data(), &AccountManager::authRequired, dialogsManager.data(), &DialogsManager::showLoginDialog);

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -134,7 +134,8 @@ void WindowScriptingInterface::openUrl(const QUrl& url) {
             DependencyManager::get<AddressManager>()->handleLookupString(url.toString());
         } else {
 #if defined(Q_OS_ANDROID)
-            QList<QString> args = { url.toString() };
+            QMap<QString, QString> args;
+            args["url"] = url.toString();
             AndroidHelper::instance().requestActivity("WebView", true, args);
 #else
             // address manager did not handle - ask QDesktopServices to handle


### PR DESCRIPTION
** Manuscript case **
18465: Android - Selecting "Your Last Location" does not work for authentication-protected domains

**Overview of the issue**
Some domains require to be signed in to access them. Trying to connect to one of these domains will lead the user to the login screen. After the user is logged in the access to the domain must be achieved immediately.

Android was implementing the final redirect by using the stored last location but since [this commit](https://github.com/highfidelity/hifi/commit/8e1e93abb016a3d26441b5248074fd6f5008efa1) that url is not stored anymore if the user isn't really connected to the domain so the bug is that the user ends being redirected to the last visited and stored location.

This PR handles the real URL of the access-restricted domain to redirect the him/her back after the login process.

**Test plan**
- Entering an open domain must continue working as usual
- Entering an access-restricted domain must redirect the user to the login. After the user gets logged in it must redirect him/her to the domain.
- The redirect should also work after signing up
- The last known location must work as usual (considering that it's not stored immediately)





