### PR TITLE
Fix avatar warp into floor when navigating to a saved bookmark

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -529,7 +529,8 @@ void MyAvatar::update(float deltaTime) {
     }
     if (_goToFeetAjustment && _skeletonModelLoaded) {
         auto feetAjustment = getWorldPosition() - getWorldFeetPosition();
-        goToLocation(getWorldPosition() + feetAjustment);
+        _goToPosition = getWorldPosition() + feetAjustment;
+        setWorldPosition(_goToPosition);
         _goToFeetAjustment = false;
     }
     if (_physicsSafetyPending && qApp->isPhysicsEnabled() && _characterController.isEnabledAndReady()) {


### PR DESCRIPTION
This PR corrects a bug introduced by a previous one https://github.com/highfidelity/hifi/pull/14084
Now saved bookmarks can be access without warping into the floor

https://highfidelity.manuscript.com/f/cases/18890/Bookmark-Location-can-warp-into-floor