### PR TITLE
Fix some Mac rendering issues

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/TransparencyMask.qml
+++ b/interface/resources/qml/hifi/avatarapp/TransparencyMask.qml
@@ -24,6 +24,7 @@ Item {
 
         fragmentShader: {
 "
+#version 150 core
             varying highp vec2 qt_TexCoord0;
             uniform lowp sampler2D source;
             uniform lowp sampler2D mask;

--- a/libraries/qml/src/qml/impl/SharedObject.cpp
+++ b/libraries/qml/src/qml/impl/SharedObject.cpp
@@ -19,6 +19,7 @@
 #include <NumericalConstants.h>
 #include <shared/NsightHelpers.h>
 #include <gl/QOpenGLContextWrapper.h>
+#include <gl/GLHelpers.h>
 
 #include "../OffscreenSurface.h"
 #include "../Logging.h"
@@ -67,6 +68,7 @@ SharedObject::SharedObject() {
     //       so we wait until after its ctor to move object/context to this thread.
     QQuickWindow::setDefaultAlphaBuffer(true);
     _quickWindow = new QQuickWindow(_renderControl);
+    _quickWindow->setFormat(getDefaultOpenGLSurfaceFormat());
     _quickWindow->setColor(QColor(255, 255, 255, 0));
     _quickWindow->setClearBeforeRendering(true);
 


### PR DESCRIPTION
Qt has internal logic to switch between various versions of shaders depending on whether the OpenGL profile is core or compatibility.  Some of that logic depends on looking directly at the current GL context, but some of it depends on querying the owning window for the QML item, and asking for it's GL profile.  Previously we have not been setting the profile in the QQuickWindow created for offscreen QML surfaces.  

This corrects that.  

https://highfidelity.fogbugz.com/f/cases/9357/Mac-Texture-displays-incorrectly-for-Recent-activity-on-Wallet-app-home-page-and-audio-meter-overlay

## Testing

Run Interface on a mac.  Note the Mic audio bar meter color.  In this PR it should match the color in the PC version.  In the Master build it will be a magenta color.

