### PR TITLE
Fix application uninstall in marketplace item tester

### DIFF
--- a/interface/resources/qml/hifi/commerce/marketplaceItemTester/MarketplaceItemTester.qml
+++ b/interface/resources/qml/hifi/commerce/marketplaceItemTester/MarketplaceItemTester.qml
@@ -131,7 +131,7 @@ Rectangle {
                             print("Marketplace item tester unsupported assetType " + assetType);
                     }
                 },
-                "trash": function(){
+                "trash": function(resource, assetType){
                     if ("application" === assetType) {
                         Commerce.uninstallApp(resource);
                     }


### PR DESCRIPTION
Previously, in response to a click of a trash icon associated with an application in the marketplace item tester, the application would not uninstall from commerce due to an erroneous function signature. This PR corrects the function signature, providing the originally intended behavior of uninstalling the application from commerce.

https://highfidelity.manuscript.com/f/cases/18505/Markertplace-tester-MVP