### PR TITLE
Fix MS18154: Don't snap to cards in My Purchases

### DIFF
--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -585,7 +585,7 @@ Rectangle {
             visible: purchasesModel.count !== 0;
             clip: true;
             model: purchasesModel;
-            snapMode: ListView.SnapToItem;
+            snapMode: ListView.NoSnap;
             // Anchors
             anchors.top: separator.bottom;
             anchors.left: parent.left;


### PR DESCRIPTION
Fixes [MS18154](https://highfidelity.fogbugz.com/f/cases/18154/Bottom-Item-of-My-Purchases-Obscured-by-Window-When-Scrolling-With-Mouse-Wheel) by preventing My Purchases from snapping to Purchased Item cards.