### PR TITLE
Disable Hand Touch when Leap Motion is running

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1055,6 +1055,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
     auto controllerScriptingInterface = DependencyManager::get<controller::ScriptingInterface>().data();
     _controllerScriptingInterface = dynamic_cast<ControllerScriptingInterface*>(controllerScriptingInterface);
+    connect(PluginManager::getInstance().data(), &PluginManager::inputDeviceRunningChanged,
+        controllerScriptingInterface, &controller::ScriptingInterface::updateRunningInputDevices);
 
     _entityClipboard->createRootElement();
 

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -179,8 +179,14 @@ namespace controller {
     }
 
     QStringList ScriptingInterface::getRunningInputDeviceNames() {
-        QMutexLocker locker(&_mutex);
+        QMutexLocker locker(&_getRunningDevicesMutex);
         return _runningInputDeviceNames;
+    }
+
+    void ScriptingInterface::updateRunningInputDevices(const QString& deviceName, bool isRunning, const QStringList& runningDevices) {
+        QMutexLocker locker(&_setRunningDevicesMutex);
+        _runningInputDeviceNames = runningDevices;
+        emit inputDeviceRunningChanged(deviceName, isRunning);
     }
 
     bool ScriptingInterface::triggerHapticPulseOnDevice(unsigned int device, float strength, float duration, controller::Hand hand) const {

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -179,12 +179,12 @@ namespace controller {
     }
 
     QStringList ScriptingInterface::getRunningInputDeviceNames() {
-        QMutexLocker locker(&_getRunningDevicesMutex);
+        QMutexLocker locker(&_runningDevicesMutex);
         return _runningInputDeviceNames;
     }
 
     void ScriptingInterface::updateRunningInputDevices(const QString& deviceName, bool isRunning, const QStringList& runningDevices) {
-        QMutexLocker locker(&_setRunningDevicesMutex);
+        QMutexLocker locker(&_runningDevicesMutex);
         _runningInputDeviceNames = runningDevices;
         emit inputDeviceRunningChanged(deviceName, isRunning);
     }

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -178,6 +178,11 @@ namespace controller {
         return inputRecorder->getSaveDirectory();
     }
 
+    QStringList ScriptingInterface::getRunningInputDeviceNames() {
+        QMutexLocker locker(&_mutex);
+        return _runningInputDeviceNames;
+    }
+
     bool ScriptingInterface::triggerHapticPulseOnDevice(unsigned int device, float strength, float duration, controller::Hand hand) const {
         return DependencyManager::get<UserInputMapper>()->triggerHapticPulseOnDevice(device, strength, duration, hand);
     }

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -626,8 +626,7 @@ namespace controller {
         std::atomic<bool> _wheelCaptured { false };
         std::atomic<bool> _actionsCaptured { false };
 
-        QMutex _setRunningDevicesMutex;
-        QMutex _getRunningDevicesMutex;
+        QMutex _runningDevicesMutex;
     };
 
 }

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -431,6 +431,13 @@ namespace controller {
          */
         Q_INVOKABLE QString getInputRecorderSaveDirectory();
 
+        /**jsdoc
+        * Get all the active and enabled (running) input devices
+        * @function Controller.getRunningInputDevices
+        * @returns {string[]} An array of strings with the names
+        */
+        Q_INVOKABLE QStringList getRunningInputDeviceNames() { return _runningInputDeviceNames; }
+
         bool isMouseCaptured() const { return _mouseCaptured; }
         bool isTouchCaptured() const { return _touchCaptured; }
         bool isWheelCaptured() const { return _wheelCaptured; }
@@ -531,6 +538,11 @@ namespace controller {
          */
         virtual void releaseActionEvents() { _actionsCaptured = false; }
 
+        void updateRunningInputDevices(const QString& deviceName, bool isRunning, const QStringList& runningDevices) { 
+            _runningInputDeviceNames = runningDevices;
+            emit inputDeviceRunningChanged(deviceName, isRunning);
+        }
+
     signals:
         /**jsdoc
          * Triggered when an action occurs.
@@ -590,6 +602,17 @@ namespace controller {
          */
         void hardwareChanged();
 
+        /**jsdoc
+        * Triggered when a device is enabled/disabled
+        * Enabling/Disabling Leapmotion on settings/controls will trigger this signal.
+        * @function Controller.deviceRunningChanged
+        * @param {string} deviceName - The name of the device that is getting enabled/disabled
+        * @param {boolean} isEnabled - Return if the device is enabled.
+        * @returns {Signal}
+        */
+        void inputDeviceRunningChanged(QString deviceName, bool isRunning);
+
+
     private:
         // Update the exposed variant maps reporting active hardware
         void updateMaps();
@@ -597,6 +620,8 @@ namespace controller {
         QVariantMap _hardware;
         QVariantMap _actions;
         QVariantMap _standard;
+
+        QStringList _runningInputDeviceNames;
 
         std::atomic<bool> _mouseCaptured{ false };
         std::atomic<bool> _touchCaptured { false };

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -539,10 +539,7 @@ namespace controller {
          */
         virtual void releaseActionEvents() { _actionsCaptured = false; }
 
-        void updateRunningInputDevices(const QString& deviceName, bool isRunning, const QStringList& runningDevices) { 
-            _runningInputDeviceNames = runningDevices;
-            emit inputDeviceRunningChanged(deviceName, isRunning);
-        }
+        void updateRunningInputDevices(const QString& deviceName, bool isRunning, const QStringList& runningDevices);
 
     signals:
         /**jsdoc
@@ -629,7 +626,8 @@ namespace controller {
         std::atomic<bool> _wheelCaptured { false };
         std::atomic<bool> _actionsCaptured { false };
 
-        QMutex _mutex;
+        QMutex _setRunningDevicesMutex;
+        QMutex _getRunningDevicesMutex;
     };
 
 }

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -26,6 +26,7 @@
 #include <QThread>
 #include <QtCore/QObject>
 #include <QtCore/QVariant>
+#include <QMutex>
 
 #include <QtQml/QJSValue>
 #include <QtScript/QScriptValue>
@@ -436,7 +437,7 @@ namespace controller {
         * @function Controller.getRunningInputDevices
         * @returns {string[]} An array of strings with the names
         */
-        Q_INVOKABLE QStringList getRunningInputDeviceNames() { return _runningInputDeviceNames; }
+        Q_INVOKABLE QStringList getRunningInputDeviceNames();
 
         bool isMouseCaptured() const { return _mouseCaptured; }
         bool isTouchCaptured() const { return _touchCaptured; }
@@ -627,6 +628,8 @@ namespace controller {
         std::atomic<bool> _touchCaptured { false };
         std::atomic<bool> _wheelCaptured { false };
         std::atomic<bool> _actionsCaptured { false };
+
+        QMutex _mutex;
     };
 
 }

--- a/libraries/plugins/src/plugins/Plugin.h
+++ b/libraries/plugins/src/plugins/Plugin.h
@@ -75,8 +75,11 @@ public:
 
     virtual void saveSettings() const {}
     virtual void loadSettings() {}
+    virtual bool isRunning() const { return _active; }
 
 signals:
+    void deviceStatusChanged(const QString& deviceName, bool isRunning) const;
+
     // These signals should be emitted when a device is first known to be available. In some cases this will
     // be in `init()`, in other cases, like Neuron, this isn't known until activation.
     // SDL2 isn't a device itself, but can have 0+ subdevices. subdeviceConnected is used in this case.
@@ -85,6 +88,7 @@ signals:
 
 protected:
     bool _active { false };
+    bool _enabled { false };
     bool _sessionStatus { false };
     PluginContainer* _container { nullptr };
     static const char* UNKNOWN_PLUGIN_ID;

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -19,6 +19,7 @@ using PluginManagerPointer = QSharedPointer<PluginManager>;
 
 class PluginManager : public QObject, public Dependency {
     SINGLETON_DEPENDENCY
+    Q_OBJECT
 
 public:
     static PluginManagerPointer getInstance();
@@ -44,6 +45,10 @@ public:
     void setInputPluginProvider(const InputPluginProvider& provider);
     void setCodecPluginProvider(const CodecPluginProvider& provider);
     void setInputPluginSettingsPersister(const InputPluginSettingsPersister& persister);
+    QStringList getRunningInputDeviceNames() const;
+
+signals:
+    void inputDeviceRunningChanged(const QString& pluginName, bool isRunning, const QStringList& runningDevices);
     
 private:
     PluginManager() = default;

--- a/plugins/hifiLeapMotion/src/LeapMotionPlugin.cpp
+++ b/plugins/hifiLeapMotion/src/LeapMotionPlugin.cpp
@@ -21,7 +21,7 @@
 Q_DECLARE_LOGGING_CATEGORY(inputplugins)
 Q_LOGGING_CATEGORY(inputplugins, "hifi.inputplugins")
 
-const char* LeapMotionPlugin::NAME = "Leap Motion";
+const char* LeapMotionPlugin::NAME = "LeapMotion";
 const char* LeapMotionPlugin::LEAPMOTION_ID_STRING = "Leap Motion";
 
 const bool DEFAULT_ENABLED = false;
@@ -203,7 +203,6 @@ static const char* getControllerJointName(controller::StandardPoseChannel i) {
     return "unknown";
 }
 
-
 void LeapMotionPlugin::pluginUpdate(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) {
     if (!_enabled) {
         return;
@@ -312,13 +311,13 @@ void LeapMotionPlugin::InputDevice::update(float deltaTime, const controller::In
 
 void LeapMotionPlugin::init() {
     loadSettings();
-
     auto preferences = DependencyManager::get<Preferences>();
     static const QString LEAPMOTION_PLUGIN { "Leap Motion" };
     {
         auto getter = [this]()->bool { return _enabled; };
         auto setter = [this](bool value) {
             _enabled = value;
+            emit deviceStatusChanged(getName(), isRunning());
             saveSettings();
             if (!_enabled) {
                 auto userInputMapper = DependencyManager::get<controller::UserInputMapper>();
@@ -406,6 +405,7 @@ void LeapMotionPlugin::loadSettings() {
     settings.beginGroup(idString);
     {
         _enabled = settings.value(SETTINGS_ENABLED_KEY, QVariant(DEFAULT_ENABLED)).toBool();
+        emit deviceStatusChanged(getName(), isRunning());
         _sensorLocation = settings.value(SETTINGS_SENSOR_LOCATION_KEY, QVariant(DEFAULT_SENSOR_LOCATION)).toString();
         _desktopHeightOffset = 
             settings.value(SETTINGS_DESKTOP_HEIGHT_OFFSET_KEY, QVariant(DEFAULT_DESKTOP_HEIGHT_OFFSET)).toFloat();

--- a/plugins/hifiLeapMotion/src/LeapMotionPlugin.h
+++ b/plugins/hifiLeapMotion/src/LeapMotionPlugin.h
@@ -30,7 +30,7 @@ public:
     // Plugin methods
     virtual const QString getName() const override { return NAME; }
     const QString getID() const override { return LEAPMOTION_ID_STRING; }
-
+    bool isRunning() const override { return _active && _enabled; }
     virtual void init() override;
 
     virtual bool activate() override;
@@ -43,8 +43,6 @@ protected:
     static const char* NAME;
     static const char* LEAPMOTION_ID_STRING;
     const float DEFAULT_DESKTOP_HEIGHT_OFFSET = 0.2f;
-
-    bool _enabled { false };
     QString _sensorLocation;
     float _desktopHeightOffset { DEFAULT_DESKTOP_HEIGHT_OFFSET };
 

--- a/plugins/hifiNeuron/src/NeuronPlugin.cpp
+++ b/plugins/hifiNeuron/src/NeuronPlugin.cpp
@@ -369,7 +369,11 @@ void NeuronPlugin::init() {
     static const QString NEURON_PLUGIN { "Perception Neuron" };
     {
         auto getter = [this]()->bool { return _enabled; };
-        auto setter = [this](bool value) { _enabled = value; saveSettings(); };
+        auto setter = [this](bool value) { 
+            _enabled = value; 
+            saveSettings(); 
+            emit deviceStatusChanged(getName(), _enabled && _active);
+        };
         auto preference = new CheckPreference(NEURON_PLUGIN, "Enabled", getter, setter);
         preferences->addPreference(preference);
     }
@@ -493,7 +497,7 @@ void NeuronPlugin::loadSettings() {
     {
         // enabled
         _enabled = settings.value("enabled", QVariant(DEFAULT_ENABLED)).toBool();
-
+        emit deviceStatusChanged(getName(), _enabled && _active);
         // serverAddress
         _serverAddress = settings.value("serverAddress", QVariant(DEFAULT_SERVER_ADDRESS)).toString();
 

--- a/plugins/hifiNeuron/src/NeuronPlugin.h
+++ b/plugins/hifiNeuron/src/NeuronPlugin.h
@@ -30,7 +30,7 @@ public:
     virtual bool isSupported() const override;
     virtual const QString getName() const override { return NAME; }
     const QString getID() const override { return NEURON_ID_STRING; }
-
+    bool isRunning() const override { return _active && _enabled; }
     virtual bool activate() override;
     virtual void deactivate() override;
 
@@ -67,7 +67,6 @@ protected:
     static const char* NAME;
     static const char* NEURON_ID_STRING;
 
-    bool _enabled;
     QString _serverAddress;
     int _serverPort;
     void* _socketRef;

--- a/plugins/hifiSdl2/src/SDL2Manager.cpp
+++ b/plugins/hifiSdl2/src/SDL2Manager.cpp
@@ -79,10 +79,11 @@ bool SDL2Manager::activate() {
         auto preferences = DependencyManager::get<Preferences>();
         static const QString SDL2_PLUGIN { "Game Controller" };
         {
-            auto getter = [this]()->bool { return _isEnabled; };
+            auto getter = [this]()->bool { return _enabled; };
             auto setter = [this](bool value) {
-                _isEnabled = value;
+                _enabled = value;
                 saveSettings();
+                emit deviceStatusChanged(getName(), isRunning());
             };
             auto preference = new CheckPreference(SDL2_PLUGIN, "Enabled", getter, setter);
             preferences->addPreference(preference);
@@ -147,7 +148,7 @@ void SDL2Manager::saveSettings() const {
     QString idString = getID();
     settings.beginGroup(idString);
     {
-        settings.setValue(QString(SETTINGS_ENABLED_KEY), _isEnabled);
+        settings.setValue(QString(SETTINGS_ENABLED_KEY), _enabled);
     }
     settings.endGroup();
 }
@@ -157,7 +158,8 @@ void SDL2Manager::loadSettings() {
     QString idString = getID();
     settings.beginGroup(idString);
     {
-        _isEnabled = settings.value(SETTINGS_ENABLED_KEY, QVariant(DEFAULT_ENABLED)).toBool();
+        _enabled = settings.value(SETTINGS_ENABLED_KEY, QVariant(DEFAULT_ENABLED)).toBool();
+        emit deviceStatusChanged(getName(), isRunning());
     }
     settings.endGroup();
 }
@@ -173,7 +175,7 @@ void SDL2Manager::pluginFocusOutEvent() {
 }
 
 void SDL2Manager::pluginUpdate(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) {
-    if (!_isEnabled) {
+    if (!_enabled) {
         return;
     }
 

--- a/plugins/hifiSdl2/src/SDL2Manager.h
+++ b/plugins/hifiSdl2/src/SDL2Manager.h
@@ -26,7 +26,7 @@ public:
     bool isSupported() const override;
     const QString getName() const override { return NAME; }
     const QString getID() const override { return SDL2_ID_STRING; }
-
+    bool isRunning() const override { return _active && _enabled; }
     QStringList getSubdeviceNames() override;
 
     void init() override;
@@ -81,7 +81,6 @@ private:
     int buttonRelease() const { return SDL_RELEASED; }
 
     QMap<SDL_JoystickID, Joystick::Pointer> _openJoysticks;
-    bool _isEnabled { false };
     bool _isInitialized { false };
     static const char* NAME;
     static const char* SDL2_ID_STRING;

--- a/scripts/system/controllers/handTouch.js
+++ b/scripts/system/controllers/handTouch.js
@@ -16,7 +16,9 @@
 
 (function () {
 
+    var LEAP_MOTION_NAME = "LeapMotion";
     var handTouchEnabled = true;
+    var leapMotionEnabled = Controller.getRunningInputDeviceNames().indexOf(LEAP_MOTION_NAME) >= 0;
     var MSECONDS_AFTER_LOAD = 2000;
     var updateFingerWithIndex = 0;
     var untouchableEntities = [];
@@ -870,6 +872,12 @@
         handTouchEnabled = !shouldDisable;
     });
 
+    Controller.inputDeviceRunningChanged.connect(function (deviceName, isEnabled) {
+        if (deviceName == LEAP_MOTION_NAME) {
+            leapMotionEnabled = isEnabled;
+        }
+    });
+
     MyAvatar.disableHandTouchForIDChanged.connect(function (entityID, disable) {
         var entityIndex = untouchableEntities.indexOf(entityID);
         if (disable) {
@@ -902,7 +910,7 @@
 
     Script.update.connect(function () {
 
-        if (!handTouchEnabled) {
+        if (!handTouchEnabled || leapMotionEnabled) {
             return;
         }
 


### PR DESCRIPTION
This PR creates a couple of API methods so a script can access which input devices are running on interface at a given moment.
The main purpose of this PR is disable Hand Touch when Leap Motion is active and enabled (running).
https://highfidelity.manuscript.com/f/cases/16843/Leap-Motion-finger-tracking-updating-conflict-with-handTouch-script