### PR TITLE
Don't render particles without textures

### DIFF
--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -310,7 +310,7 @@ void ParticleEffectEntityRenderer::stepSimulation() {
 }
 
 void ParticleEffectEntityRenderer::doRender(RenderArgs* args) {
-    if (!_visible) {
+    if (!_visible || !(_networkTexture && _networkTexture->isLoaded())) {
         return;
     }
 
@@ -318,11 +318,7 @@ void ParticleEffectEntityRenderer::doRender(RenderArgs* args) {
     stepSimulation();
 
     gpu::Batch& batch = *args->_batch;
-    if (_networkTexture && _networkTexture->isLoaded()) {
-        batch.setResourceTexture(0, _networkTexture->getGPUTexture());
-    } else {
-        batch.setResourceTexture(0, DependencyManager::get<TextureCache>()->getWhiteTexture());
-    }
+    batch.setResourceTexture(0, _networkTexture->getGPUTexture());
 
     Transform transform; 
     // The particles are in world space, so the transform is unused, except for the rotation, which we use


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/16337/Particle-effect-default-particle-should-not-be-square

Test plan:
- Using Create, make a particle effect.  It should render with the cloud texture.  In the particle properties, remove the texture.  It should stop rendering.  Make the URL something invalid.  It shouldn't render.  Put the first URL back.  It should render.