### PR TITLE
Fix avatar thumbnails

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/+android/TransparencyMask.qml
+++ b/interface/resources/qml/hifi/avatarapp/+android/TransparencyMask.qml
@@ -24,20 +24,19 @@ Item {
 
         fragmentShader: {
 "
-#version 410
-in vec2 qt_TexCoord0;
-out vec4 color;
-uniform sampler2D source;
-uniform sampler2D mask;
-void main()
-{
-    vec4 maskColor = texture(mask, vec2(qt_TexCoord0.x, qt_TexCoord0.y));
-    vec4 sourceColor = texture(source, vec2(qt_TexCoord0.x, qt_TexCoord0.y));
-    if (maskColor.a > 0.0)
-        color = sourceColor;
-    else
-        color = maskColor;
-}
+            varying highp vec2 qt_TexCoord0;
+            uniform lowp sampler2D source;
+            uniform lowp sampler2D mask;
+            void main() {
+
+                highp vec4 maskColor = texture2D(mask, vec2(qt_TexCoord0.x, qt_TexCoord0.y));
+                highp vec4 sourceColor = texture2D(source, vec2(qt_TexCoord0.x, qt_TexCoord0.y));
+
+                if (maskColor.a > 0.0)
+                    gl_FragColor = sourceColor;
+                else
+                    gl_FragColor = maskColor;
+            }
 "
         }
     }


### PR DESCRIPTION
Fix for [19088](https://highfidelity.manuscript.com/f/cases/19088). May also fix [17161](https://highfidelity.fogbugz.com/f/cases/17161/Avatar-App-Not-Populating-Thumbnails)

A recent change to fix some rendering issues on the mac had an unintended side effect of breaking avatar thumbnails on some GPUs on PC.  I was unable to reproduce the bug as my AMD driver accepted the shader even though it was technically invalid, but the attached log file included the OpenGL shader error produced on the machine that was demonstrating the problem.

This PR attempts to address the issue by updating the shader used for the transparency mask to a GLSL 410 shader, which should function on all our desktop platforms, and also adds a version that matches the old shader that should function on Android or other OpenGL ES platforms (I'm uncertain if the Android app uses the same Avatar selection UI, so it may be superfluous).

## Testing 

Users should test the rendering of Avatar thumbnails on Mac, and on PC using both AMD and nVidia GPUs.  

