### PR TITLE
Bug fix for rotation culling in AvatarData::toByteArray()

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -594,7 +594,7 @@ QByteArray AvatarData::toByteArray(AvatarDataDetail dataDetail, quint64 lastSent
                 // The dot product for larger rotations is a lower number.
                 // So if the dot() is less than the value, then the rotation is a larger angle of rotation
                 if (sendAll || last.rotationIsDefaultPose || (!cullSmallChanges && last.rotation != data.rotation)
-                    || (cullSmallChanges && glm::dot(last.rotation, data.rotation) < minRotationDOT) ) {
+                    || (cullSmallChanges && fabsf(glm::dot(last.rotation, data.rotation)) < minRotationDOT) ) {
                     validity |= (1 << validityBit);
 #ifdef WANT_DEBUG
                     rotationSentCount++;


### PR DESCRIPTION
The commit 5a0de0f103c inadvertently introduced a regression in how the AvatarMixer and clients encode AvatarData packets. When encoding packets that with the cullSmallChanges flag set to true, we only include rotations that have changed significantly from the previous packet. A bug was introduced that incorrectly preformed the comparison to detect changed rotations, this needs to handle the case when two quaternions are almost equal but have negative signs.  Previously, this was preformed with an absolute value after the 4-component dot product. In commit 5a0de0f103c, this absolute value was removed, causing the culling to happen much more frequently.

This PR re-introduces that absolute value.