### PR TITLE
Fix avatars transit on domain enter

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -275,7 +275,11 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
             if (inView && avatar->hasNewJointData()) {
                 numAvatarsUpdated++;
             }
-            avatar->_transit.update(deltaTime, avatar->_globalPosition, _transitConfig);
+            auto transitStatus = avatar->_transit.update(deltaTime, avatar->_globalPosition, _transitConfig);
+            if (avatar->getIsNewAvatar() && transitStatus == AvatarTransit::Status::START_TRANSIT) {
+                avatar->_transit.reset();
+                avatar->setIsNewAvatar(false);
+            }
             avatar->simulate(deltaTime, inView);
             avatar->updateRenderItem(renderTransaction);
             avatar->updateSpaceProxy(workloadTransaction);

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -276,7 +276,7 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
                 numAvatarsUpdated++;
             }
             auto transitStatus = avatar->_transit.update(deltaTime, avatar->_globalPosition, _transitConfig);
-            if (avatar->getIsNewAvatar() && transitStatus == AvatarTransit::Status::START_TRANSIT) {
+            if (avatar->getIsNewAvatar() && (transitStatus == AvatarTransit::Status::START_TRANSIT || transitStatus == AvatarTransit::Status::ABORT_TRANSIT)) {
                 avatar->_transit.reset();
                 avatar->setIsNewAvatar(false);
             }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -126,6 +126,11 @@ AvatarTransit::Status AvatarTransit::update(float deltaTime, const glm::vec3& av
     return _status;
 }
 
+void AvatarTransit::reset() {
+    _lastPosition = _endPosition;
+    _currentPosition = _endPosition;
+    _isTransiting = false;
+}
 void AvatarTransit::start(float deltaTime, const glm::vec3& startPosition, const glm::vec3& endPosition, const AvatarTransit::TransitConfig& config) {
     _startPosition = startPosition;
     _endPosition = endPosition;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -118,8 +118,13 @@ AvatarTransit::Status AvatarTransit::update(float deltaTime, const glm::vec3& av
     float oneFrameDistance = glm::length(currentPosition - _lastPosition);
     const float MAX_TRANSIT_DISTANCE = 30.0f;
     float scaledMaxTransitDistance = MAX_TRANSIT_DISTANCE * _scale;
-    if (oneFrameDistance > config._triggerDistance && oneFrameDistance < scaledMaxTransitDistance && !_isTransiting) {
-        start(deltaTime, _lastPosition, currentPosition, config);
+    if (oneFrameDistance > config._triggerDistance && !_isTransiting) {
+        if (oneFrameDistance < scaledMaxTransitDistance) {
+            start(deltaTime, _lastPosition, currentPosition, config);
+        } else {
+            _lastPosition = currentPosition;
+            return Status::ABORT_TRANSIT;
+        }        
     }
     _lastPosition = currentPosition;
     _status = updatePosition(deltaTime);

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -84,6 +84,7 @@ public:
     glm::vec3 getEndPosition() { return _endPosition; }
     float getTransitTime() { return _totalTime; }
     void setScale(float scale) { _scale = scale; }
+    void reset();
 
 private:
     Status updatePosition(float deltaTime);

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -56,7 +56,8 @@ public:
         IDLE = 0,
         START_TRANSIT,
         TRANSITING,
-        END_TRANSIT
+        END_TRANSIT,
+        ABORT_TRANSIT
     };
 
     enum EaseType {

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1190,6 +1190,9 @@ public:
     void setReplicaIndex(int replicaIndex) { _replicaIndex = replicaIndex; }
     int getReplicaIndex() { return _replicaIndex; }
 
+    void setIsNewAvatar(bool isNewAvatar) { _isNewAvatar = isNewAvatar; }
+    bool getIsNewAvatar() { return _isNewAvatar; }
+
 signals:
 
     /**jsdoc
@@ -1452,6 +1455,7 @@ protected:
     bool _hasProcessedFirstIdentity { false };
     float _density;
     int _replicaIndex { 0 };
+    bool _isNewAvatar { true };
 
     // null unless MyAvatar or ScriptableAvatar sending traits data to mixer
     std::unique_ptr<ClientTraitsHandler> _clientTraitsHandler;

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -259,18 +259,20 @@ AvatarSharedPointer AvatarHashMap::parseAvatarData(QSharedPointer<ReceivedMessag
         if (isNewAvatar) {
             QWriteLocker locker(&_hashLock);
             _pendingAvatars.insert(sessionUUID, { std::chrono::steady_clock::now(), 0, avatar });
+            avatar->setIsNewAvatar(true);
             auto replicaIDs = _replicas.getReplicaIDs(sessionUUID);
             for (auto replicaID : replicaIDs) {
                 auto replicaAvatar = addAvatar(replicaID, sendingNode);
+                replicaAvatar->setIsNewAvatar(true);
                 _replicas.addReplica(sessionUUID, replicaAvatar);
             }
         } 
-
-
+        
         // have the matching (or new) avatar parse the data from the packet
         int bytesRead = avatar->parseDataFromBuffer(byteArray);
         message->seek(positionBeforeRead + bytesRead);
         _replicas.parseDataFromBuffer(sessionUUID, byteArray);
+        
 
         return avatar;
     } else {


### PR DESCRIPTION
Fix for this PR:
https://github.com/highfidelity/hifi/pull/14079
This PR avoid triggering the avatar transit effect on other avatars that are located at a distance less than 30 meters from the domain origin, when entering a new domain
