### PR TITLE
FB18673 - Last line of GOTO desktop notification text cropped off on …

### DIFF
--- a/scripts/system/notifications.js
+++ b/scripts/system/notifications.js
@@ -343,6 +343,7 @@
     }
 
     var CLOSE_NOTIFICATION_ICON = Script.resolvePath("assets/images/close-small-light.svg");
+    var TEXT_OVERLAY_FONT_SIZE_IN_PIXELS = 18.0; // taken from TextOverlay::textSize
 
     //  This function creates and sizes the overlays
     function createNotification(text, notificationType, imageProperties) {
@@ -362,7 +363,7 @@
         if (text.length >= breakPoint) {
             breaks = count;
         }
-        extraLine = breaks * 16.0;
+        extraLine = breaks * TEXT_OVERLAY_FONT_SIZE_IN_PIXELS;
         for (i = 0; i < heights.length; i += 1) {
             stack = stack + heights[i];
         }


### PR DESCRIPTION
…bottom

https://highfidelity.fogbugz.com/f/cases/18673/Last-line-of-GOTO-desktop-notification-text-cropped-off-on-bottom

**Test plan**

1. Trigger multi-line notification
2. Ensure it is *not* truncated (see example of truncation below)

![image](https://user-images.githubusercontent.com/23638/46503870-e162c000-c834-11e8-95f3-eda786cc2222.png)
