### PR TITLE
Reduce the glitches of far away animating avatars

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -206,11 +206,13 @@ float AvatarData::getDistanceBasedMinRotationDOT(glm::vec3 viewerPosition) const
     if (distance < AVATAR_DISTANCE_LEVEL_1) {
         result = AVATAR_MIN_ROTATION_DOT;
     } else if (distance < AVATAR_DISTANCE_LEVEL_2) {
-        result = ROTATION_CHANGE_15D;
+        result = ROTATION_CHANGE_2D;
     } else if (distance < AVATAR_DISTANCE_LEVEL_3) {
-        result = ROTATION_CHANGE_45D;
+        result = ROTATION_CHANGE_4D;
     } else if (distance < AVATAR_DISTANCE_LEVEL_4) {
-        result = ROTATION_CHANGE_90D;
+        result = ROTATION_CHANGE_6D;
+    } else if (distance < AVATAR_DISTANCE_LEVEL_5) {
+        result = ROTATION_CHANGE_15D;
     }
     return result;
 }

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -309,16 +309,19 @@ const float AVATAR_SEND_FULL_UPDATE_RATIO = 0.02f;
 const float AVATAR_MIN_ROTATION_DOT = 0.9999999f;
 const float AVATAR_MIN_TRANSLATION = 0.0001f;
 
-const float ROTATION_CHANGE_15D = 0.9914449f;
-const float ROTATION_CHANGE_45D = 0.9238795f;
-const float ROTATION_CHANGE_90D = 0.7071068f;
-const float ROTATION_CHANGE_179D = 0.0087266f;
+// quaternion dot products
+const float ROTATION_CHANGE_2D = 0.99984770f; // 2 degrees
+const float ROTATION_CHANGE_4D = 0.99939083f; // 4 degrees
+const float ROTATION_CHANGE_6D = 0.99862953f; // 6 degrees
+const float ROTATION_CHANGE_15D = 0.99144486f; // 15 degrees
+const float ROTATION_CHANGE_179D = 0.00872653f; // 179 degrees
 
-const float AVATAR_DISTANCE_LEVEL_1 = 10.0f;
-const float AVATAR_DISTANCE_LEVEL_2 = 100.0f;
-const float AVATAR_DISTANCE_LEVEL_3 = 1000.0f;
-const float AVATAR_DISTANCE_LEVEL_4 = 10000.0f;
-
+// rotation culling distance thresholds
+const float AVATAR_DISTANCE_LEVEL_1 = 12.5f; // meters
+const float AVATAR_DISTANCE_LEVEL_2 = 16.6f; // meters
+const float AVATAR_DISTANCE_LEVEL_3 = 25.0f; // meters
+const float AVATAR_DISTANCE_LEVEL_4 = 50.0f; // meters
+const float AVATAR_DISTANCE_LEVEL_5 = 200.0f; // meters
 
 // Where one's own Avatar begins in the world (will be overwritten if avatar data file is found).
 // This is the start location in the Sandbox (xyz: 6270, 211, 6000).


### PR DESCRIPTION
Currently, the avatars that are further then 10 meters away have a very aggressive 15 degree rotation threshold, used to reduce the amount of rotation joint changes sent over the network.

This PR tunes both the distances and rotation thresholds used for this LOD culling.

| Distance (meters)  | Angle Threshold (degrees) | Avg. Bandwidth (kbps)  |
|---:|---:|---:|
| 0-12  | 0  | 150  |
| 12-16 | 2  | 90  |
| 16-25 | 4  | 60   |
| 25-50 | 6 | 50 |
| 50-200 | 15 | 30 |
| 200-Inf | 179 | 25 | 