### PR TITLE
Fix "Good" collision not honoring mesh groups in OBJ files

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -353,7 +353,7 @@ bool RenderableModelEntityItem::isReadyToComputeShape() const {
             return false;
         }
 
-        if (model->getURL().isEmpty()) {
+        if (model->getURL().isEmpty() || !_dimensionsInitialized) {
             // we need a render geometry with a scale to proceed, so give up.
             return false;
         }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -514,15 +514,16 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& shapeInfo) {
             return;
         }
 
-        std::vector<std::shared_ptr<const graphics::Mesh>> compoundMeshes;
+        std::vector<std::shared_ptr<const graphics::Mesh>> meshes;
         if (type == SHAPE_TYPE_SIMPLE_COMPOUND) {
             auto& fbxMeshes = _compoundShapeResource->getFBXGeometry().meshes;
-            compoundMeshes.reserve(fbxMeshes.size());
+            meshes.reserve(fbxMeshes.size());
             for (auto& fbxMesh : fbxMeshes) {
-                compoundMeshes.push_back(fbxMesh._mesh);
+                meshes.push_back(fbxMesh._mesh);
             }
+        } else {
+            meshes = model->getGeometry()->getMeshes();
         }
-        auto& meshes = (type == SHAPE_TYPE_SIMPLE_COMPOUND ? compoundMeshes : model->getGeometry()->getMeshes());
         int32_t numMeshes = (int32_t)(meshes.size());
 
         const int MAX_ALLOWED_MESH_COUNT = 1000;

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -554,6 +554,10 @@ QString ModelEntityItem::getCompoundShapeURL() const {
     return _compoundShapeURL.get();
 }
 
+QString ModelEntityItem::getCollisionShapeURL() const {
+    return getShapeType() == SHAPE_TYPE_COMPOUND ? getCompoundShapeURL() : getModelURL();
+}
+
 void ModelEntityItem::setColor(const rgbColor& value) { 
     withWriteLock([&] {
         memcpy(_color, value, sizeof(_color));

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -70,6 +70,9 @@ public:
     static const QString DEFAULT_COMPOUND_SHAPE_URL;
     QString getCompoundShapeURL() const;
 
+    // Returns the URL used for the collision shape
+    QString getCollisionShapeURL() const;
+
     void setColor(const rgbColor& value);
     void setColor(const xColor& value);
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/4828/Compound-hulls-being-treated-like-dynamic-basic-hulls

A bug in the way models were loaded was causing OBJ-based models to not be broken down into meshes when the "Good" collision type was selected in the create model dialogue. The fix in this PR is to store the collision model separately from the rendered model in that case, since the rendered model has meshes combined for optimization.

This is a "conservative" fix. One of the issues with model management this PR does not address is that the model is loaded twice if it needs to be stored in a separate resource variable for collision purposes. There are also issues with the resource pipeline in general that we'd like to address in the future.

It's also worth noting that this PR does not add any "smart" handling of the OBJ model files. Meshes with the same material will only be separated if OBJ file divides them into different groups.

## TEST PLAN
- Verify this PR improves the collision bounds of [this test model](https://gist.githubusercontent.com/sabrina-shanman/457b40f2a66b517b0dc41196bf6ab96e/raw/bf5405a23cefe3662e30d14edf4d3386a406e128/wamConsole_hull_2_grouptest.obj) compared to master using these steps:
  - In a domain with create rights, open the create app.
  - In the create tools menu, under the create tab, select the "Model" icon to open the "New Model Entity" dialogue
  - Paste the URL of the provided test model into the "Model URL" text field. Select "Good - Sub-Meshes" from the "Automatic Collisions" drop-down menu.
  - Click "Add" to add the test model to the scene. Re-size the model so it is roughly the size of your avatar. The resized test model should look like a grey, chair-shaped object.
  - Walk into the test model from various directions and stand on top of it. Rotate the model so your avatar can try standing on the side and the bottom as well.
  - In this PR, the collision of the avatar with the model should look relatively realistic. In particular, the avatar should be able to stand on the "seat" of the chair-shaped model. In master, the avatar will be unable to reach the inner edge of the model.
- In this PR and in master, visit various domains and compare the way the avatar collides with things in the domain. The collision should be the same in most cases, and possibly more accurate in rare cases.
  - You can observe the collision shapes directly by enabling the debug collision meshes (however, sometimes they are hard to see because the visible models overlap them). You can make collision meshes visible by enabling Developer->Physics->Show Bullet Collision (prerequisite: Settings->Developer Menu is enabled)
