### PR TITLE
relax 'isWearable' condition to treat entities like 'ghost.json' as …

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1765,8 +1765,6 @@ void MyAvatar::setSkeletonModelURL(const QUrl& skeletonModelURL) {
 
 bool isWearableEntity(const EntityItemPointer& entity) {
     return entity->isVisible()
-        && (entity->getParentJointIndex() != INVALID_JOINT_INDEX
-            || (entity->getType() == EntityTypes::Model && (std::static_pointer_cast<ModelEntityItem>(entity))->getRelayParentJoints()))
         && (entity->getParentID() == DependencyManager::get<NodeList>()->getSessionUUID()
             || entity->getParentID() == AVATAR_SELF_ID);
 }

--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -28,9 +28,8 @@ function executeLater(callback) {
     Script.setTimeout(callback, 300);
 }
 
-var INVALID_JOINT_INDEX = -1
 function isWearable(avatarEntity) {
-    return avatarEntity.properties.visible === true && (avatarEntity.properties.parentJointIndex !== INVALID_JOINT_INDEX || avatarEntity.properties.relayParentJoints === true) &&
+    return avatarEntity.properties.visible === true &&
         (avatarEntity.properties.parentID === MyAvatar.sessionUUID || avatarEntity.properties.parentID === MyAvatar.SELF_ID);
 }
 


### PR DESCRIPTION
…wearables

https://highfidelity.manuscript.com/f/cases/19031/Avatar-App-is-duplicating-my-wearables

**Test plan**

1. Open avatar app
2. Select avatar with no wearables
3. Close avatar app
4. Drag the attached JSON (Ghosty.json) into Interface and note that it attaches the ghost to your avatar
5. Open the avatar app and ensure it has one wearable. 
6. Go to 'adjust wearables' 
7. Cancel 'adjust wearables'
8. Ensure there is still one ghost flying and one wearable in avatarapp

[Ghosty.zip](https://github.com/highfidelity/hifi/files/2457968/Ghosty.zip)
