### PR TITLE
Increase velocity increments when the avatar is really small.

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1942,7 +1942,7 @@ void MyAvatar::updateMotors() {
         horizontalMotorTimescale = FLYING_MOTOR_TIMESCALE;
         verticalMotorTimescale = FLYING_MOTOR_TIMESCALE;
     } else {
-        horizontalMotorTimescale = WALKING_MOTOR_TIMESCALE;
+        horizontalMotorTimescale = WALKING_MOTOR_TIMESCALE * getSensorToWorldScale();
         verticalMotorTimescale = INVALID_MOTOR_TIMESCALE;
     }
 


### PR DESCRIPTION
The increments in linear velocity `tau*(desireVelocity-actualVelocity)` become really small when the avatar becomes really small. This creates a situation where these increments are insufficient to move the avatar capsule during physic simulation. 
https://highfidelity.manuscript.com/f/cases/18958/Avatars-Scaled-to-0-1-Cannot-Move
This PR makes tau inversely proportional to the avatar scale so every increment in linear velocity is bigger and the capsule is able to move.
The current solution also creates smaller increments when the avatar is really big, giving the impression of a really heavy avatar that takes several seconds to meet its final velocity.