### PR TITLE
Make material entities to be presented in avatarapp

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
+++ b/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
@@ -68,7 +68,7 @@ Rectangle {
                 wearable.text = extractTitleFromUrl(wearable.modelURL);
             } else if (wearable.materialURL) {
                 var materialUrlOrJson = '';
-                if (wearable.materialURL !== 'materialData') {
+                if (!wearable.materialURL.startsWith('materialData')) {
                     materialUrlOrJson = extractTitleFromUrl(wearable.materialURL);
                 } else if (wearable.materialData) {
                     materialUrlOrJson = JSON.stringify(JSON.parse(wearable.materialData))

--- a/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
+++ b/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
@@ -49,16 +49,32 @@ Rectangle {
         refresh(avatar);
     }
 
+    function extractTitleFromUrl(url) {
+        for (var j = (url.length - 1); j >= 0; --j) {
+            if (url[j] === '/') {
+                return url.substring(j + 1);
+            }
+        }
+        return url;
+    }
+
     function refresh(avatar) {
         wearablesCombobox.model.clear();
         wearablesCombobox.currentIndex = -1;
 
         for (var i = 0; i < avatar.wearables.count; ++i) {
             var wearable = avatar.wearables.get(i).properties;
-            for (var j = (wearable.modelURL.length - 1); j >= 0; --j) {
-                if (wearable.modelURL[j] === '/') {
-                    wearable.text = wearable.modelURL.substring(j + 1);
-                    break;
+            if (wearable.modelURL) {
+                wearable.text = extractTitleFromUrl(wearable.modelURL);
+            } else if (wearable.materialURL) {
+                var materialUrlOrJson = '';
+                if (wearable.materialURL !== 'materialData') {
+                    materialUrlOrJson = extractTitleFromUrl(wearable.materialURL);
+                } else if (wearable.materialData) {
+                    materialUrlOrJson = JSON.stringify(JSON.parse(wearable.materialData))
+                }
+                if(materialUrlOrJson) {
+                    wearable.text = 'Material: ' + materialUrlOrJson;
                 }
             }
             wearablesCombobox.model.append(wearable);

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1765,8 +1765,6 @@ void MyAvatar::setSkeletonModelURL(const QUrl& skeletonModelURL) {
 
 bool isWearableEntity(const EntityItemPointer& entity) {
     return entity->isVisible()
-        && (entity->getParentJointIndex() != INVALID_JOINT_INDEX
-            || (entity->getType() == EntityTypes::Model && (std::static_pointer_cast<ModelEntityItem>(entity))->getRelayParentJoints()))
         && (entity->getParentID() == DependencyManager::get<NodeList>()->getSessionUUID()
             || entity->getParentID() == AVATAR_SELF_ID);
 }

--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -28,9 +28,8 @@ function executeLater(callback) {
     Script.setTimeout(callback, 300);
 }
 
-var INVALID_JOINT_INDEX = -1
 function isWearable(avatarEntity) {
-    return avatarEntity.properties.visible === true && (avatarEntity.properties.parentJointIndex !== INVALID_JOINT_INDEX || avatarEntity.properties.relayParentJoints === true) &&
+    return avatarEntity.properties.visible === true &&
         (avatarEntity.properties.parentID === MyAvatar.sessionUUID || avatarEntity.properties.parentID === MyAvatar.SELF_ID);
 }
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/18859/Avatar-App-Bug-when-material-entity-is-added-as-avatar-entity

note: this PR relies on another PR https://github.com/highfidelity/hifi/pull/14164

**Test plan**

1. Select avatar with no wearables
2. From JS console execute the following: 
```
Entities.addEntity({
    type: "Material",
    position: MyAvatar.position,
    materialURL: "https://hifi-content.s3.amazonaws.com/samuel/TestMaterial.json",
    parentID: MyAvatar.SELF_ID,
    priority: 1
}, true)
```

and then

```
Entities.addEntity({
    type: "Material",
    position: MyAvatar.position,
    materialURL: "materialData",
    priority: 1,
    parentID: MyAvatar.SELF_ID,
    materialData: "{ \"materials\": { \"albedo\": [1, 0, 0] } }"
}, true)
```
3. Open avatarapp, ensure selected avatar has two wearables
4. Open 'adjust wearables'
5. Ensure both added wearables selectable in combobox and have names starting with 'Material: '
6. Add non-material wearable (for example fedora or glasses)
7. Ensure both material wearables and newly added one are presented in avatarapp