### PR TITLE
Fix highlight not working after HMD switch

### DIFF
--- a/libraries/render-utils/src/HighlightEffect.cpp
+++ b/libraries/render-utils/src/HighlightEffect.cpp
@@ -39,10 +39,10 @@ namespace gr {
 
 extern void initZPassPipelines(ShapePlumber& plumber, gpu::StatePointer state);
 
-HighlightRessources::HighlightRessources() {
+HighlightResources::HighlightResources() {
 }
 
-void HighlightRessources::update(const gpu::FramebufferPointer& primaryFrameBuffer) {
+void HighlightResources::update(const gpu::FramebufferPointer& primaryFrameBuffer) {
     auto newFrameSize = glm::ivec2(primaryFrameBuffer->getSize());
 
     // If the buffer size changed, we need to delete our FBOs and recreate them at the
@@ -58,32 +58,37 @@ void HighlightRessources::update(const gpu::FramebufferPointer& primaryFrameBuff
         if (!_colorFrameBuffer) {
             allocateColorBuffer(primaryFrameBuffer);
         }
+
+        // The primaryFrameBuffer render buffer can change
+        if (_colorFrameBuffer->getRenderBuffer(0) != primaryFrameBuffer->getRenderBuffer(0)) {
+            _colorFrameBuffer->setRenderBuffer(0, primaryFrameBuffer->getRenderBuffer(0));
+        }
     }
 }
 
-void HighlightRessources::allocateColorBuffer(const gpu::FramebufferPointer& primaryFrameBuffer) {
+void HighlightResources::allocateColorBuffer(const gpu::FramebufferPointer& primaryFrameBuffer) {
     _colorFrameBuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("primaryWithStencil"));
     _colorFrameBuffer->setRenderBuffer(0, primaryFrameBuffer->getRenderBuffer(0));
     _colorFrameBuffer->setStencilBuffer(_depthStencilTexture, _depthStencilTexture->getTexelFormat());
 }
 
-void HighlightRessources::allocateDepthBuffer(const gpu::FramebufferPointer& primaryFrameBuffer) {
+void HighlightResources::allocateDepthBuffer(const gpu::FramebufferPointer& primaryFrameBuffer) {
     auto depthFormat = gpu::Element(gpu::SCALAR, gpu::UINT32, gpu::DEPTH_STENCIL);
     _depthStencilTexture = gpu::TexturePointer(gpu::Texture::createRenderBuffer(depthFormat, _frameSize.x, _frameSize.y));
     _depthFrameBuffer = gpu::FramebufferPointer(gpu::Framebuffer::create("highlightDepth"));
     _depthFrameBuffer->setDepthStencilBuffer(_depthStencilTexture, depthFormat);
 }
 
-gpu::FramebufferPointer HighlightRessources::getDepthFramebuffer() {
+gpu::FramebufferPointer HighlightResources::getDepthFramebuffer() {
     assert(_depthFrameBuffer);
     return _depthFrameBuffer;
 }
 
-gpu::TexturePointer HighlightRessources::getDepthTexture() {
+gpu::TexturePointer HighlightResources::getDepthTexture() {
     return _depthStencilTexture;
 }
 
-gpu::FramebufferPointer HighlightRessources::getColorFramebuffer() {
+gpu::FramebufferPointer HighlightResources::getColorFramebuffer() {
     assert(_colorFrameBuffer);
     return _colorFrameBuffer;
 }
@@ -97,25 +102,21 @@ float HighlightSharedParameters::getBlurPixelWidth(const render::HighlightStyle&
 }
 
 PrepareDrawHighlight::PrepareDrawHighlight() {
-    _ressources = std::make_shared<HighlightRessources>();
+    _resources = std::make_shared<HighlightResources>();
 }
 
 void PrepareDrawHighlight::run(const render::RenderContextPointer& renderContext, const Inputs& inputs, Outputs& outputs) {
     auto destinationFrameBuffer = inputs;
 
-    _ressources->update(destinationFrameBuffer);
-    outputs = _ressources;
+    _resources->update(destinationFrameBuffer);
+    outputs = _resources;
 }
 
 gpu::PipelinePointer DrawHighlightMask::_stencilMaskPipeline;
 gpu::PipelinePointer DrawHighlightMask::_stencilMaskFillPipeline;
 
-DrawHighlightMask::DrawHighlightMask(unsigned int highlightIndex, 
-                                 render::ShapePlumberPointer shapePlumber, HighlightSharedParametersPointer parameters) :
-    _highlightPassIndex{ highlightIndex },
-    _shapePlumber { shapePlumber },
-    _sharedParameters{ parameters } {
-}
+DrawHighlightMask::DrawHighlightMask(unsigned int highlightIndex, render::ShapePlumberPointer shapePlumber,
+    HighlightSharedParametersPointer parameters) : _highlightPassIndex(highlightIndex), _shapePlumber(shapePlumber), _sharedParameters(parameters) {}
 
 void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, const Inputs& inputs, Outputs& outputs) {
     assert(renderContext->args);
@@ -126,13 +127,13 @@ void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, c
     const int PARAMETERS_SLOT = 0;
 
     if (!_stencilMaskPipeline || !_stencilMaskFillPipeline) {
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         state->setDepthTest(true, false, gpu::LESS_EQUAL);
-        state->setStencilTest(true, 0xFF, gpu::State::StencilTest(OUTLINE_STENCIL_MASK, 0xFF, gpu::NOT_EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_ZERO, gpu::State::STENCIL_OP_REPLACE));
+        state->setStencilTest(true, 0xFF, gpu::State::StencilTest(OUTLINE_STENCIL_MASK, 0xFF, gpu::NOT_EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_REPLACE));
         state->setColorWriteMask(false, false, false, false);
         state->setCullMode(gpu::State::CULL_FRONT);
 
-        gpu::StatePointer fillState = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer fillState = std::make_shared<gpu::State>();
         fillState->setDepthTest(false, false, gpu::LESS_EQUAL);
         fillState->setStencilTest(true, 0xFF, gpu::State::StencilTest(OUTLINE_STENCIL_MASK, 0xFF, gpu::NOT_EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_REPLACE));
         fillState->setColorWriteMask(false, false, false, false);
@@ -151,7 +152,7 @@ void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, c
     auto highlightId = _sharedParameters->_highlightIds[_highlightPassIndex];
 
     if (!inShapes.empty() && !render::HighlightStage::isIndexInvalid(highlightId)) {
-        auto ressources = inputs.get1();
+        auto resources = inputs.get1();
         auto& highlight = highlightStage->getHighlight(highlightId);
 
         RenderArgs* args = renderContext->args;
@@ -165,15 +166,11 @@ void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, c
         // while stereo is enabled triggers a warning
         gpu::doInBatch("DrawHighlightMask::run::begin", args->_context, [&](gpu::Batch& batch) {
             batch.enableStereo(false);
-            batch.setFramebuffer(ressources->getDepthFramebuffer());
+            batch.setFramebuffer(resources->getDepthFramebuffer());
             batch.clearDepthStencilFramebuffer(1.0f, 0);
         });
 
-        glm::mat4 projMat;
-        Transform viewMat;
         const auto jitter = inputs.get2();
-        args->getViewFrustum().evalProjectionMatrix(projMat);
-        args->getViewFrustum().evalViewTransform(viewMat);
 
         render::ItemBounds itemBounds;
 
@@ -185,6 +182,10 @@ void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, c
             auto maskSkinnedDQPipeline = _shapePlumber->pickPipeline(args, defaultKeyBuilder.withSkinned().withDualQuatSkinned());
 
             // Setup camera, projection and viewport for all items
+            glm::mat4 projMat;
+            Transform viewMat;
+            args->getViewFrustum().evalProjectionMatrix(projMat);
+            args->getViewFrustum().evalViewTransform(viewMat);
             batch.setViewportTransform(args->_viewport);
             batch.setProjectionTransform(projMat);
             batch.setProjectionJitter(jitter.x, jitter.y);
@@ -233,7 +234,7 @@ void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, c
 
         const auto securityMargin = 2.0f;
         const float blurPixelWidth = 2.0f * securityMargin * HighlightSharedParameters::getBlurPixelWidth(highlight._style, args->_viewport.w);
-        const auto framebufferSize = ressources->getSourceFrameSize();
+        const auto framebufferSize = resources->getSourceFrameSize();
         const glm::vec2 highlightWidth = { blurPixelWidth / framebufferSize.x, blurPixelWidth / framebufferSize.y };
 
         if (highlightWidth != _outlineWidth.get()) {
@@ -241,11 +242,6 @@ void DrawHighlightMask::run(const render::RenderContextPointer& renderContext, c
         }
 
         gpu::doInBatch("DrawHighlightMask::run::end", args->_context, [&](gpu::Batch& batch) {
-            // Setup camera, projection and viewport for all items
-            batch.setViewportTransform(args->_viewport);
-            batch.setProjectionTransform(projMat);
-            batch.setViewTransform(viewMat);
-
             // Draw stencil mask with object bounding boxes
             auto stencilPipeline = highlight._style.isFilled() ? _stencilMaskFillPipeline : _stencilMaskPipeline;
             batch.setPipeline(stencilPipeline);
@@ -264,15 +260,14 @@ gpu::PipelinePointer DrawHighlight::_pipeline;
 gpu::PipelinePointer DrawHighlight::_pipelineFilled;
 
 DrawHighlight::DrawHighlight(unsigned int highlightIndex, HighlightSharedParametersPointer parameters) :
-    _highlightPassIndex{ highlightIndex },
-    _sharedParameters{ parameters } {
+    _highlightPassIndex(highlightIndex), _sharedParameters(parameters) {
 }
 
 void DrawHighlight::run(const render::RenderContextPointer& renderContext, const Inputs& inputs) {
     auto highlightFrameBuffer = inputs.get1();
     auto highlightRect = inputs.get3();
 
-    if (highlightFrameBuffer && highlightRect.z>0 && highlightRect.w>0) {
+    if (highlightFrameBuffer && highlightRect.z > 0 && highlightRect.w > 0) {
         auto sceneDepthBuffer = inputs.get2();
         const auto frameTransform = inputs.get0();
         auto highlightedDepthTexture = highlightFrameBuffer->getDepthTexture();
@@ -334,10 +329,11 @@ void DrawHighlight::run(const render::RenderContextPointer& renderContext, const
 
 const gpu::PipelinePointer& DrawHighlight::getPipeline(const render::HighlightStyle& style) {
     if (!_pipeline) {
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         state->setDepthTest(gpu::State::DepthTest(false, false));
         state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);
         state->setStencilTest(true, 0, gpu::State::StencilTest(OUTLINE_STENCIL_MASK, 0xFF, gpu::EQUAL));
+        state->setColorWriteMask(true, true, true, true);
 
         auto program = gpu::Shader::createProgram(shader::render_utils::program::highlight);
         _pipeline = gpu::Pipeline::create(program, state);
@@ -364,10 +360,10 @@ void DebugHighlight::configure(const Config& config) {
 }
 
 void DebugHighlight::run(const render::RenderContextPointer& renderContext, const Inputs& input) {
-    const auto highlightRessources = input.get0();
+    const auto highlightResources = input.get0();
     const auto highlightRect = input.get1();
 
-    if (_isDisplayEnabled && highlightRessources && highlightRect.z>0 && highlightRect.w>0) {
+    if (_isDisplayEnabled && highlightResources && highlightRect.z > 0 && highlightRect.w > 0) {
         assert(renderContext->args);
         assert(renderContext->args->hasViewFrustum());
         RenderArgs* args = renderContext->args;
@@ -376,7 +372,7 @@ void DebugHighlight::run(const render::RenderContextPointer& renderContext, cons
         auto primaryFramebuffer = input.get3();
         gpu::doInBatch("DebugHighlight::run", args->_context, [&](gpu::Batch& batch) {
             batch.setViewportTransform(args->_viewport);
-            batch.setFramebuffer(highlightRessources->getColorFramebuffer());
+            batch.setFramebuffer(highlightResources->getColorFramebuffer());
 
             const auto geometryBuffer = DependencyManager::get<GeometryCache>();
 
@@ -386,13 +382,13 @@ void DebugHighlight::run(const render::RenderContextPointer& renderContext, cons
             args->getViewFrustum().evalViewTransform(viewMat);
             batch.setProjectionTransform(projMat);
             batch.setProjectionJitter(jitter.x, jitter.y);
-            batch.setViewTransform(viewMat, true);
+            batch.setViewTransform(viewMat);
             batch.setModelTransform(Transform());
 
             const glm::vec4 color(1.0f, 1.0f, 1.0f, 1.0f);
 
             batch.setPipeline(getDepthPipeline());
-            batch.setResourceTexture(0, highlightRessources->getDepthTexture());
+            batch.setResourceTexture(0, highlightResources->getDepthTexture());
             const glm::vec2 bottomLeft(-1.0f, -1.0f);
             const glm::vec2 topRight(1.0f, 1.0f);
             geometryBuffer->renderQuad(batch, bottomLeft, topRight, color, _geometryDepthId);
@@ -415,6 +411,7 @@ void DebugHighlight::initializePipelines() {
     auto state = std::make_shared<gpu::State>();
     state->setDepthTest(gpu::State::DepthTest(false, false));
     state->setStencilTest(true, 0, gpu::State::StencilTest(OUTLINE_STENCIL_MASK, 0xFF, gpu::EQUAL));
+    state->setColorWriteMask(true, true, true, true);
 
     const auto vs = gpu::Shader::createVertex(shader::render_utils::vertex::debug_deferred_buffer);
 
@@ -512,7 +509,7 @@ void DrawHighlightTask::build(JobModel& task, const render::Varying& inputs, ren
     const auto highlightSelectionNames = task.addJob<SelectionToHighlight>("SelectionToHighlight", sharedParameters);
 
     // Prepare for highlight group rendering.
-    const auto highlightRessources = task.addJob<PrepareDrawHighlight>("PrepareHighlight", primaryFramebuffer);
+    const auto highlightResources = task.addJob<PrepareDrawHighlight>("PrepareHighlight", primaryFramebuffer);
     render::Varying highlight0Rect;
 
     for (auto i = 0; i < HighlightSharedParameters::MAX_PASS_COUNT; i++) {
@@ -532,7 +529,7 @@ void DrawHighlightTask::build(JobModel& task, const render::Varying& inputs, ren
             stream << "HighlightMask" << i;
             name = stream.str();
         }
-        const auto drawMaskInputs = DrawHighlightMask::Inputs(sortedBounds, highlightRessources, jitter).asVarying();
+        const auto drawMaskInputs = DrawHighlightMask::Inputs(sortedBounds, highlightResources, jitter).asVarying();
         const auto highlightedRect = task.addJob<DrawHighlightMask>(name, drawMaskInputs, i, shapePlumber, sharedParameters);
         if (i == 0) {
             highlight0Rect = highlightedRect;
@@ -544,12 +541,12 @@ void DrawHighlightTask::build(JobModel& task, const render::Varying& inputs, ren
             stream << "HighlightEffect" << i;
             name = stream.str();
         }
-        const auto drawHighlightInputs = DrawHighlight::Inputs(deferredFrameTransform, highlightRessources, sceneFrameBuffer, highlightedRect, primaryFramebuffer).asVarying();
+        const auto drawHighlightInputs = DrawHighlight::Inputs(deferredFrameTransform, highlightResources, sceneFrameBuffer, highlightedRect, primaryFramebuffer).asVarying();
         task.addJob<DrawHighlight>(name, drawHighlightInputs, i, sharedParameters);
     }
 
     // Debug highlight
-    const auto debugInputs = DebugHighlight::Inputs(highlightRessources, const_cast<const render::Varying&>(highlight0Rect), jitter, primaryFramebuffer).asVarying();
+    const auto debugInputs = DebugHighlight::Inputs(highlightResources, const_cast<const render::Varying&>(highlight0Rect), jitter, primaryFramebuffer).asVarying();
     task.addJob<DebugHighlight>("HighlightDebug", debugInputs);
 }
 

--- a/libraries/render-utils/src/HighlightEffect.h
+++ b/libraries/render-utils/src/HighlightEffect.h
@@ -19,9 +19,9 @@
 #include "DeferredFramebuffer.h"
 #include "DeferredFrameTransform.h"
 
-class HighlightRessources {
+class HighlightResources {
 public:
-    HighlightRessources();
+    HighlightResources();
 
     gpu::FramebufferPointer getDepthFramebuffer();
     gpu::TexturePointer getDepthTexture();
@@ -44,7 +44,7 @@ protected:
     void allocateDepthBuffer(const gpu::FramebufferPointer& primaryFrameBuffer);
 };
 
-using HighlightRessourcesPointer = std::shared_ptr<HighlightRessources>;
+using HighlightResourcesPointer = std::shared_ptr<HighlightResources>;
 
 class HighlightSharedParameters {
 public:
@@ -65,7 +65,7 @@ using HighlightSharedParametersPointer = std::shared_ptr<HighlightSharedParamete
 class PrepareDrawHighlight {
 public:
     using Inputs = gpu::FramebufferPointer;
-    using Outputs = HighlightRessourcesPointer;
+    using Outputs = HighlightResourcesPointer;
     using JobModel = render::Job::ModelIO<PrepareDrawHighlight, Inputs, Outputs>;
 
     PrepareDrawHighlight();
@@ -74,7 +74,7 @@ public:
 
 private:
 
-    HighlightRessourcesPointer _ressources;
+    HighlightResourcesPointer _resources;
 
 };
 
@@ -112,8 +112,7 @@ private:
 
 class DrawHighlightMask {
 public:
-
-    using Inputs = render::VaryingSet3<render::ShapeBounds, HighlightRessourcesPointer, glm::vec2>;
+    using Inputs = render::VaryingSet3<render::ShapeBounds, HighlightResourcesPointer, glm::vec2>;
     using Outputs = glm::ivec4;
     using JobModel = render::Job::ModelIO<DrawHighlightMask, Inputs, Outputs>;
 
@@ -122,7 +121,6 @@ public:
     void run(const render::RenderContextPointer& renderContext, const Inputs& inputs, Outputs& outputs);
 
 protected:
-
     unsigned int _highlightPassIndex;
     render::ShapePlumberPointer _shapePlumber;
     HighlightSharedParametersPointer _sharedParameters;
@@ -136,7 +134,7 @@ protected:
 class DrawHighlight {
 public:
 
-    using Inputs = render::VaryingSet5<DeferredFrameTransformPointer, HighlightRessourcesPointer, DeferredFramebufferPointer, glm::ivec4, gpu::FramebufferPointer>;
+    using Inputs = render::VaryingSet5<DeferredFrameTransformPointer, HighlightResourcesPointer, DeferredFramebufferPointer, glm::ivec4, gpu::FramebufferPointer>;
     using Config = render::Job::Config;
     using JobModel = render::Job::ModelI<DrawHighlight, Inputs, Config>;
 
@@ -163,11 +161,10 @@ private:
 
 class DebugHighlightConfig : public render::Job::Config {
     Q_OBJECT
-        Q_PROPERTY(bool viewMask MEMBER viewMask NOTIFY dirty)
+    Q_PROPERTY(bool viewMask MEMBER viewMask NOTIFY dirty)
 
 public:
-
-    bool viewMask{ false };
+    bool viewMask { false };
 
 signals:
     void dirty();
@@ -175,7 +172,7 @@ signals:
 
 class DebugHighlight {
 public:
-    using Inputs = render::VaryingSet4<HighlightRessourcesPointer, glm::ivec4, glm::vec2, gpu::FramebufferPointer>;
+    using Inputs = render::VaryingSet4<HighlightResourcesPointer, glm::ivec4, glm::vec2, gpu::FramebufferPointer>;
     using Config = DebugHighlightConfig;
     using JobModel = render::Job::ModelI<DebugHighlight, Inputs, Config>;
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17858/Selection-highlighting-stops-working-after-re-enter-HMD-several-times

Test plan:
- Enter HMD mode and laser on a grabbable entity. Notice that it highlights.
- Switch between HMD and desktop multiple times.  In HMD each time, the thing should highlight.
- Also check the context overlay (yellowish highlight outline when you right click or laser hover something from the marketplace)