### PR TITLE
Move blendshape buffers to render thread

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -28,6 +28,8 @@
 #include "Rig.h"
 #include <ThreadSafeValueCache.h>
 
+#include "MetaModelPayload.h"
+
 namespace render {
     template <> const ItemKey payloadGetKey(const AvatarSharedPointer& avatar);
     template <> const Item::Bound payloadGetBound(const AvatarSharedPointer& avatar);
@@ -108,7 +110,7 @@ private:
     float _scale { 1.0f };
 };
 
-class Avatar : public AvatarData, public scriptable::ModelProvider {
+class Avatar : public AvatarData, public scriptable::ModelProvider, public MetaModelPayload {
     Q_OBJECT
 
     // This property has JSDoc in MyAvatar.h.

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -622,6 +622,9 @@ protected:
     static const float ATTACHMENT_LOADING_PRIORITY;
 
     LoadingStatus _loadingStatus { LoadingStatus::NoModel };
+
+    void metaBlendshapeOperator(int blendshapeNumber, const QVector<BlendshapeOffset>& blendshapeOffsets, const QVector<int>& blendedMeshSizes,
+                                const render::ItemIDs& subItemIDs);
 };
 
 #endif // hifi_Avatar_h

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -24,8 +24,6 @@
 
 #include "RenderableEntityItem.h"
 
-
-
 class Model;
 class EntityTreeRenderer;
 

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -96,7 +96,7 @@ void CauterizedModel::createRenderItemSet() {
                 shapeID++;
             }
         }
-        _blendshapeBuffersInitialized = true;
+        _blendshapeOffsetsInitialized = true;
     } else {
         Model::createRenderItemSet();
     }
@@ -175,7 +175,7 @@ void CauterizedModel::updateClusterMatrices() {
 
     // post the blender if we're not currently waiting for one to finish
     auto modelBlender = DependencyManager::get<ModelBlender>();
-    if (_blendshapeBuffersInitialized && modelBlender->shouldComputeBlendshapes() && geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
+    if (_blendshapeOffsetsInitialized && modelBlender->shouldComputeBlendshapes() && geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
         _blendedBlendshapeCoefficients = _blendshapeCoefficients;
         modelBlender->noteRequiresBlend(getThisPointer());
     }

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -209,7 +209,7 @@ ModelMeshPartPayload::ModelMeshPartPayload(ModelPointer model, int meshIndex, in
     bool useDualQuaternionSkinning = model->getUseDualQuaternionSkinning();
 
     auto& modelMesh = model->getGeometry()->getMeshes().at(_meshIndex);
-    _meshNumVertices = modelMesh->getNumVertices();
+    _meshNumVertices = (int)modelMesh->getNumVertices();
     const Model::MeshState& state = model->getMeshState(_meshIndex);
 
     updateMeshPart(modelMesh, partIndex);

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -209,6 +209,7 @@ ModelMeshPartPayload::ModelMeshPartPayload(ModelPointer model, int meshIndex, in
     bool useDualQuaternionSkinning = model->getUseDualQuaternionSkinning();
 
     auto& modelMesh = model->getGeometry()->getMeshes().at(_meshIndex);
+    _meshNumVertices = modelMesh->getNumVertices();
     const Model::MeshState& state = model->getMeshState(_meshIndex);
 
     updateMeshPart(modelMesh, partIndex);
@@ -238,19 +239,12 @@ ModelMeshPartPayload::ModelMeshPartPayload(ModelPointer model, int meshIndex, in
 
     initCache(model);
 
-    if (_isBlendShaped) {
-        auto buffer = model->_blendshapeBuffers.find(meshIndex);
-        if (buffer != model->_blendshapeBuffers.end()) {
-            _blendshapeBuffer = buffer->second;
-        }
-    }
-
 #ifdef Q_OS_MAC
-    // On mac AMD, we specifically need to have a _blendshapeBuffer bound when using a deformed mesh pipeline
+    // On mac AMD, we specifically need to have a _meshBlendshapeBuffer bound when using a deformed mesh pipeline
     // it cannot be null otherwise we crash in the drawcall using a deformed pipeline with a skinned only (not blendshaped) mesh
-    if ((_isBlendShaped || _isSkinned) && !_blendshapeBuffer) {
+    if ((_isBlendShaped || _isSkinned)) {
         glm::vec4 data;
-        _blendshapeBuffer = std::make_shared<gpu::Buffer>(sizeof(glm::vec4), reinterpret_cast<const gpu::Byte*>(&data));
+        _meshBlendshapeBuffer = std::make_shared<gpu::Buffer>(sizeof(glm::vec4), reinterpret_cast<const gpu::Byte*>(&data));
     }
 #endif
 
@@ -292,8 +286,7 @@ void ModelMeshPartPayload::updateClusterBuffer(const std::vector<glm::mat4>& clu
         if (!_clusterBuffer) {
             _clusterBuffer = std::make_shared<gpu::Buffer>(clusterMatrices.size() * sizeof(glm::mat4),
                 (const gpu::Byte*) clusterMatrices.data());
-        }
-        else {
+        } else {
             _clusterBuffer->setSubData(0, clusterMatrices.size() * sizeof(glm::mat4),
                 (const gpu::Byte*) clusterMatrices.data());
         }
@@ -313,8 +306,7 @@ void ModelMeshPartPayload::updateClusterBuffer(const std::vector<Model::Transfor
         if (!_clusterBuffer) {
             _clusterBuffer = std::make_shared<gpu::Buffer>(clusterDualQuaternions.size() * sizeof(Model::TransformDualQuaternion),
                 (const gpu::Byte*) clusterDualQuaternions.data());
-        }
-        else {
+        } else {
             _clusterBuffer->setSubData(0, clusterDualQuaternions.size() * sizeof(Model::TransformDualQuaternion),
                 (const gpu::Byte*) clusterDualQuaternions.data());
         }
@@ -403,8 +395,8 @@ ShapeKey ModelMeshPartPayload::getShapeKey() const {
 void ModelMeshPartPayload::bindMesh(gpu::Batch& batch) {
     batch.setIndexBuffer(gpu::UINT32, (_drawMesh->getIndexBuffer()._buffer), 0);
     batch.setInputFormat((_drawMesh->getVertexFormat()));
-    if (_blendshapeBuffer) {
-        batch.setResourceBuffer(0, _blendshapeBuffer);
+    if (_meshBlendshapeBuffer) {
+        batch.setResourceBuffer(0, _meshBlendshapeBuffer);
     }
     batch.setInputStream(0, _drawMesh->getVertexStream());
 }
@@ -431,7 +423,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
     bindMesh(batch);
 
     // IF deformed pass the mesh key
-    auto drawcallInfo = (uint16_t) (((_isBlendShaped && args->_enableBlendshape) << 0) | ((_isSkinned && args->_enableSkinning) << 1));
+    auto drawcallInfo = (uint16_t) (((_isBlendShaped && _meshBlendshapeBuffer && args->_enableBlendshape) << 0) | ((_isSkinned && args->_enableSkinning) << 1));
     if (drawcallInfo) {
         batch.setDrawcallUniform(drawcallInfo);
     }
@@ -480,6 +472,15 @@ void ModelMeshPartPayload::computeAdjustedLocalBound(const std::vector<Model::Tr
                                 clusterDualQuaternions[i].getTranslation());
             clusterBound.transform(transform);
             _adjustedLocalBound += clusterBound;
+        }
+    }
+}
+
+void ModelMeshPartPayload::setBlendshapeBuffer(const std::unordered_map<int, gpu::BufferPointer>& blendshapeBuffers, const QVector<int>& blendedMeshSizes) {
+    if (_meshIndex < blendedMeshSizes.length() && blendedMeshSizes.at(_meshIndex) == _meshNumVertices) {
+        auto blendshapeBuffer = blendshapeBuffers.find(_meshIndex);
+        if (blendshapeBuffer != blendshapeBuffers.end()) {
+            _meshBlendshapeBuffer = blendshapeBuffer->second;
         }
     }
 }

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -134,10 +134,13 @@ public:
     bool _isBlendShaped { false };
     bool _hasTangents { false };
 
+    void setBlendshapeBuffer(const std::unordered_map<int, gpu::BufferPointer>& blendshapeBuffers, const QVector<int>& blendedMeshSizes);
+
 private:
     void initCache(const ModelPointer& model);
 
-    gpu::BufferPointer _blendshapeBuffer;
+    gpu::BufferPointer _meshBlendshapeBuffer;
+    int _meshNumVertices;
     render::ShapeKey _shapeKey { render::ShapeKey::Builder::invalid() };
 };
 

--- a/libraries/render-utils/src/MetaModelPayload.cpp
+++ b/libraries/render-utils/src/MetaModelPayload.cpp
@@ -1,0 +1,55 @@
+//
+//  MetaModelPayload.cpp
+//
+//  Created by Sam Gondelman on 10/9/18.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+#include "MetaModelPayload.h"
+
+#include "AbstractViewStateInterface.h"
+#include "MeshPartPayload.h"
+
+void MetaModelPayload::setBlendedVertices(int blendNumber, const QVector<BlendshapeOffset>& blendshapeOffsets, const QVector<int>& blendedMeshSizes, const render::ItemIDs& subRenderItems) {
+    PROFILE_RANGE(render, __FUNCTION__);
+    if (blendNumber < _appliedBlendNumber) {
+        return;
+    }
+    _appliedBlendNumber = blendNumber;
+
+    // We have fewer meshes than before.  Invalidate everything
+    if (blendedMeshSizes.length() < _blendshapeBuffers.size()) {
+        _blendshapeBuffers.clear();
+    }
+
+    int index = 0;
+    for (int i = 0; i < blendedMeshSizes.size(); i++) {
+        int numVertices = blendedMeshSizes.at(i);
+
+        // This mesh isn't blendshaped
+        if (numVertices == 0) {
+            _blendshapeBuffers.erase(i);
+            continue;
+        }
+
+        const auto& buffer = _blendshapeBuffers.find(i);
+        const auto blendShapeBufferSize = numVertices * sizeof(BlendshapeOffset);
+        if (buffer == _blendshapeBuffers.end()) {
+            _blendshapeBuffers[i] = std::make_shared<gpu::Buffer>(blendShapeBufferSize, (gpu::Byte*) blendshapeOffsets.constData() + index * sizeof(BlendshapeOffset), blendShapeBufferSize);
+        } else {
+            buffer->second->setData(blendShapeBufferSize, (gpu::Byte*) blendshapeOffsets.constData() + index * sizeof(BlendshapeOffset));
+        }
+
+        index += numVertices;
+    }
+
+    render::Transaction transaction;
+    for (auto& id : subRenderItems) {
+        transaction.updateItem<ModelMeshPartPayload>(id, [this, blendedMeshSizes](ModelMeshPartPayload& data) {
+            data.setBlendshapeBuffer(_blendshapeBuffers, blendedMeshSizes);
+        });
+    }
+    AbstractViewStateInterface::instance()->getMain3DScene()->enqueueTransaction(transaction);
+}

--- a/libraries/render-utils/src/MetaModelPayload.cpp
+++ b/libraries/render-utils/src/MetaModelPayload.cpp
@@ -20,7 +20,7 @@ void MetaModelPayload::setBlendedVertices(int blendNumber, const QVector<Blendsh
     _appliedBlendNumber = blendNumber;
 
     // We have fewer meshes than before.  Invalidate everything
-    if (blendedMeshSizes.length() < _blendshapeBuffers.size()) {
+    if (blendedMeshSizes.length() < (int)_blendshapeBuffers.size()) {
         _blendshapeBuffers.clear();
     }
 

--- a/libraries/render-utils/src/MetaModelPayload.h
+++ b/libraries/render-utils/src/MetaModelPayload.h
@@ -1,0 +1,30 @@
+//
+//  MetaModelPayload.h
+//
+//  Created by Sam Gondelman on 10/9/18.
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_MetaModelPayload_h
+#define hifi_MetaModelPayload_h
+
+#include <unordered_map>
+
+#include "Model.h"
+
+#include "gpu/Buffer.h"
+
+class MetaModelPayload {
+public:
+    void setBlendedVertices(int blendNumber, const QVector<BlendshapeOffset>& blendshapeOffsets, const QVector<int>& blendedMeshSizes, const render::ItemIDs& subRenderItems);
+
+private:
+    std::unordered_map<int, gpu::BufferPointer> _blendshapeBuffers;
+    int _appliedBlendNumber { 0 };
+
+};
+
+#endif

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -978,7 +978,7 @@ const render::ItemKey Model::getRenderItemKeyGlobalFlags() const {
 bool Model::addToScene(const render::ScenePointer& scene,
                        render::Transaction& transaction,
                        render::Item::Status::Getters& statusGetters,
-                       std::function<void(int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs)> modelBlendshapeOperator) {
+                       BlendShapeOperator modelBlendshapeOperator) {
     if (!_addedToScene && isLoaded()) {
         updateClusterMatrices();
         if (_modelMeshRenderItems.empty()) {
@@ -1777,7 +1777,10 @@ void ModelBlender::noteRequiresBlend(ModelPointer model) {
 
 void ModelBlender::setBlendedVertices(ModelPointer model, int blendNumber, QVector<BlendshapeOffset> blendshapeOffsets, QVector<int> blendedMeshSizes) {
     if (model) {
-        model->getModelBlendshapeOperator()(blendNumber, blendshapeOffsets, blendedMeshSizes, model->fetchRenderItemIDs());
+        auto blendshapeOperator = model->getModelBlendshapeOperator();
+        if (blendshapeOperator) {
+            blendshapeOperator(blendNumber, blendshapeOffsets, blendedMeshSizes, model->fetchRenderItemIDs());
+        }
     }
 
     {

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -62,8 +62,6 @@ Model::Model(QObject* parent, SpatiallyNestable* spatiallyNestableOverride) :
     _snapModelToRegistrationPoint(false),
     _snappedToRegistrationPoint(false),
     _url(HTTP_INVALID_COM),
-    _blendNumber(0),
-    _appliedBlendNumber(0),
     _isWireframe(false),
     _renderItemKeyGlobalFlags(render::ItemKey::Builder().withVisible().withTagBits(render::hifi::TAG_ALL_VIEWS).build())
 {
@@ -311,7 +309,7 @@ bool Model::updateGeometry() {
             initializeBlendshapes(mesh, i);
             i++;
         }
-        _blendshapeBuffersInitialized = true;
+        _blendshapeOffsetsInitialized = true;
         needFullUpdate = true;
         emit rigReady();
     }
@@ -979,7 +977,8 @@ const render::ItemKey Model::getRenderItemKeyGlobalFlags() const {
 
 bool Model::addToScene(const render::ScenePointer& scene,
                        render::Transaction& transaction,
-                       render::Item::Status::Getters& statusGetters) {
+                       render::Item::Status::Getters& statusGetters,
+                       std::function<void(int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs)> modelBlendshapeOperator) {
     if (!_addedToScene && isLoaded()) {
         updateClusterMatrices();
         if (_modelMeshRenderItems.empty()) {
@@ -987,10 +986,11 @@ bool Model::addToScene(const render::ScenePointer& scene,
         }
     }
 
+    _modelBlendshapeOperator = modelBlendshapeOperator;
+
     bool somethingAdded = false;
 
     if (_modelMeshRenderItemsMap.empty()) {
-
         bool hasTransparent = false;
         size_t verticesCount = 0;
         foreach(auto renderItem, _modelMeshRenderItems) {
@@ -1032,9 +1032,8 @@ void Model::removeFromScene(const render::ScenePointer& scene, render::Transacti
     _modelMeshMaterialNames.clear();
     _modelMeshRenderItemShapes.clear();
 
-    _blendshapeBuffers.clear();
     _blendshapeOffsets.clear();
-    _blendshapeBuffersInitialized = false;
+    _blendshapeOffsetsInitialized = false;
 
     _addedToScene = false;
 
@@ -1437,7 +1436,7 @@ void Model::updateClusterMatrices() {
 
     // post the blender if we're not currently waiting for one to finish
     auto modelBlender = DependencyManager::get<ModelBlender>();
-    if (_blendshapeBuffersInitialized && modelBlender->shouldComputeBlendshapes() && geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
+    if (_blendshapeOffsetsInitialized && modelBlender->shouldComputeBlendshapes() && geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
         _blendedBlendshapeCoefficients = _blendshapeCoefficients;
         modelBlender->noteRequiresBlend(getThisPointer());
     }
@@ -1445,9 +1444,8 @@ void Model::updateClusterMatrices() {
 
 void Model::deleteGeometry() {
     _deleteGeometryCounter++;
-    _blendshapeBuffers.clear();
     _blendshapeOffsets.clear();
-    _blendshapeBuffersInitialized = false;
+    _blendshapeOffsetsInitialized = false;
     _meshStates.clear();
     _rig.destroyAnimGraph();
     _blendedBlendshapeCoefficients.clear();
@@ -1525,7 +1523,7 @@ void Model::createRenderItemSet() {
             shapeID++;
         }
     }
-    _blendshapeBuffersInitialized = true;
+    _blendshapeOffsetsInitialized = true;
 }
 
 bool Model::isRenderable() const {
@@ -1654,6 +1652,7 @@ Blender::Blender(ModelPointer model, int blendNumber, const Geometry::WeakPointe
 
 void Blender::run() {
     QVector<BlendshapeOffset> blendshapeOffsets;
+    QVector<int> blendedMeshSizes;
     if (_model && _model->isLoaded()) {
         DETAILED_PROFILE_RANGE_EX(simulation_animation, __FUNCTION__, 0xFFFF0000, 0, { { "url", _model->getURL().toString() } });
         int offset = 0;
@@ -1662,12 +1661,22 @@ void Blender::run() {
         foreach(const FBXMesh& mesh, meshes) {
             auto modelMeshBlendshapeOffsets = _model->_blendshapeOffsets.find(meshIndex++);
             if (mesh.blendshapes.isEmpty() || modelMeshBlendshapeOffsets == _model->_blendshapeOffsets.end()) {
+                // Not blendshaped or not initialized
+                blendedMeshSizes.push_back(0);
+                continue;
+            }
+
+            if (mesh.vertices.size() != modelMeshBlendshapeOffsets->second.size()) {
+                // Mesh sizes don't match.  Something has gone wrong
+                blendedMeshSizes.push_back(0);
                 continue;
             }
 
             blendshapeOffsets += modelMeshBlendshapeOffsets->second;
             BlendshapeOffset* meshBlendshapeOffsets = blendshapeOffsets.data() + offset;
-            offset += modelMeshBlendshapeOffsets->second.size();
+            int numVertices = modelMeshBlendshapeOffsets->second.size();
+            blendedMeshSizes.push_back(numVertices);
+            offset += numVertices;
             std::vector<BlendshapeOffsetUnpacked> unpackedBlendshapeOffsets(modelMeshBlendshapeOffsets->second.size());
 
             const float NORMAL_COEFFICIENT_SCALE = 0.01f;
@@ -1711,7 +1720,7 @@ void Blender::run() {
     }
     // post the result to the ModelBlender, which will dispatch to the model if still alive
     QMetaObject::invokeMethod(DependencyManager::get<ModelBlender>().data(), "setBlendedVertices",
-        Q_ARG(ModelPointer, _model), Q_ARG(int, _blendNumber), Q_ARG(QVector<BlendshapeOffset>, blendshapeOffsets));
+        Q_ARG(ModelPointer, _model), Q_ARG(int, _blendNumber), Q_ARG(QVector<BlendshapeOffset>, blendshapeOffsets), Q_ARG(QVector<int>, blendedMeshSizes));
 }
 
 bool Model::maybeStartBlender() {
@@ -1722,43 +1731,18 @@ bool Model::maybeStartBlender() {
     return false;
 }
 
-void Model::setBlendedVertices(int blendNumber, const QVector<BlendshapeOffset>& blendshapeOffsets) {
-    PROFILE_RANGE(render, __FUNCTION__);
-    if (!isLoaded() || blendNumber < _appliedBlendNumber || !_blendshapeBuffersInitialized) {
-        return;
-    }
-    _appliedBlendNumber = blendNumber;
-    const FBXGeometry& fbxGeometry = getFBXGeometry();
-    int index = 0;
-    for (int i = 0; i < fbxGeometry.meshes.size(); i++) {
-        const FBXMesh& mesh = fbxGeometry.meshes.at(i);
-        auto meshBlendshapeOffsets = _blendshapeOffsets.find(i);
-        const auto& buffer = _blendshapeBuffers.find(i);
-        if (mesh.blendshapes.isEmpty() || meshBlendshapeOffsets == _blendshapeOffsets.end() || buffer == _blendshapeBuffers.end()) {
-            continue;
-        }
-
-        const auto blendshapeOffsetSize = meshBlendshapeOffsets->second.size() * sizeof(BlendshapeOffset);
-        buffer->second->setSubData(0, blendshapeOffsetSize, (gpu::Byte*) blendshapeOffsets.constData() + index * sizeof(BlendshapeOffset));
-
-        index += meshBlendshapeOffsets->second.size();
-    }
-}
-
 void Model::initializeBlendshapes(const FBXMesh& mesh, int index) {
     if (mesh.blendshapes.empty()) {
         // mesh doesn't have blendshape, did we allocate one though ?
-        if (_blendshapeBuffers.find(index) != _blendshapeBuffers.end()) {
-            qWarning() << "Mesh does not have Blendshape yet a blendshapeOffset buffer is allocated ?";
+        if (_blendshapeOffsets.find(index) != _blendshapeOffsets.end()) {
+            qWarning() << "Mesh does not have Blendshape yet the blendshapeOffsets are allocated ?";
         }
         return;
     }
     // Mesh has blendshape, let s allocate the local buffer if not done yet
-    if (_blendshapeBuffers.find(index) == _blendshapeBuffers.end()) {
+    if (_blendshapeOffsets.find(index) == _blendshapeOffsets.end()) {
         QVector<BlendshapeOffset> blendshapeOffset;
         blendshapeOffset.fill(BlendshapeOffset(), mesh.vertices.size());
-        const auto blendshapeOffsetsSize = blendshapeOffset.size() * sizeof(BlendshapeOffset);
-        _blendshapeBuffers[index] = std::make_shared<gpu::Buffer>(blendshapeOffsetsSize, (const gpu::Byte*) blendshapeOffset.constData(), blendshapeOffsetsSize);
         _blendshapeOffsets[index] = blendshapeOffset;
     }
 }
@@ -1791,10 +1775,11 @@ void ModelBlender::noteRequiresBlend(ModelPointer model) {
     }
 }
 
-void ModelBlender::setBlendedVertices(ModelPointer model, int blendNumber, QVector<BlendshapeOffset> blendshapeOffsets) {
+void ModelBlender::setBlendedVertices(ModelPointer model, int blendNumber, QVector<BlendshapeOffset> blendshapeOffsets, QVector<int> blendedMeshSizes) {
     if (model) {
-        model->setBlendedVertices(blendNumber, blendshapeOffsets);
+        model->getModelBlendshapeOperator()(blendNumber, blendshapeOffsets, blendedMeshSizes, model->fetchRenderItemIDs());
     }
+
     {
         Lock lock(_mutex);
         _pendingBlenders--;

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -86,6 +86,7 @@ struct BlendshapeOffsetUnpacked {
 };
 
 using BlendshapeOffset = BlendshapeOffsetPacked;
+using BlendShapeOperator = std::function<void(int, const QVector<BlendshapeOffset>&, const QVector<int>&, const render::ItemIDs&)>;
 
 /// A generic 3D model displaying geometry loaded from a URL.
 class Model : public QObject, public std::enable_shared_from_this<Model>, public scriptable::ModelProvider {
@@ -141,14 +142,14 @@ public:
     }
     bool addToScene(const render::ScenePointer& scene,
                     render::Transaction& transaction,
-                    std::function<void(int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs)> modelBlendshapeOperator) {
+                    BlendShapeOperator modelBlendshapeOperator) {
         auto getters = render::Item::Status::Getters(0);
         return addToScene(scene, transaction, getters, modelBlendshapeOperator);
     }
     bool addToScene(const render::ScenePointer& scene,
                     render::Transaction& transaction,
                     render::Item::Status::Getters& statusGetters,
-                    std::function<void(int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs)> modelBlendshapeOperator = [](int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs) {});
+                    BlendShapeOperator modelBlendshapeOperator = nullptr);
     void removeFromScene(const render::ScenePointer& scene, render::Transaction& transaction);
     bool isRenderable() const;
 
@@ -343,7 +344,7 @@ public:
 
     uint32_t getGeometryCounter() const { return _deleteGeometryCounter; }
     const QMap<render::ItemID, render::PayloadPointer>& getRenderItems() const { return _modelMeshRenderItemsMap; }
-    std::function<void(int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs)> getModelBlendshapeOperator() const { return _modelBlendshapeOperator; }
+    BlendShapeOperator getModelBlendshapeOperator() const { return _modelBlendshapeOperator; }
 
     void renderDebugMeshBoxes(gpu::Batch& batch);
 
@@ -439,7 +440,7 @@ protected:
 
     QUrl _url;
 
-    std::function<void(int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs)> _modelBlendshapeOperator { [](int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs) {} };
+    BlendShapeOperator _modelBlendshapeOperator { nullptr };
     QVector<float> _blendshapeCoefficients;
     QVector<float> _blendedBlendshapeCoefficients;
     int _blendNumber { 0 };

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -135,6 +135,11 @@ public:
 
     bool needsReload() const { return _needsReload; }
     bool addToScene(const render::ScenePointer& scene,
+                    render::Transaction& transaction) {
+        auto getters = render::Item::Status::Getters(0);
+        return addToScene(scene, transaction, getters);
+    }
+    bool addToScene(const render::ScenePointer& scene,
                     render::Transaction& transaction,
                     std::function<void(int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs)> modelBlendshapeOperator) {
         auto getters = render::Item::Status::Getters(0);
@@ -142,7 +147,7 @@ public:
     }
     bool addToScene(const render::ScenePointer& scene,
                     render::Transaction& transaction,
-                    render::Item::Status::Getters& statusGetters = render::Item::Status::Getters(0),
+                    render::Item::Status::Getters& statusGetters,
                     std::function<void(int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs)> modelBlendshapeOperator = [](int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs) {});
     void removeFromScene(const render::ScenePointer& scene, render::Transaction& transaction);
     bool isRenderable() const;

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -137,7 +137,8 @@ public:
     bool addToScene(const render::ScenePointer& scene,
                     render::Transaction& transaction,
                     std::function<void(int, QVector<BlendshapeOffset>, QVector<int>, render::ItemIDs)> modelBlendshapeOperator) {
-        return addToScene(scene, transaction, render::Item::Status::Getters(0), modelBlendshapeOperator);
+        auto getters = render::Item::Status::Getters(0);
+        return addToScene(scene, transaction, getters, modelBlendshapeOperator);
     }
     bool addToScene(const render::ScenePointer& scene,
                     render::Transaction& transaction,

--- a/libraries/render-utils/src/SoftAttachmentModel.cpp
+++ b/libraries/render-utils/src/SoftAttachmentModel.cpp
@@ -78,7 +78,7 @@ void SoftAttachmentModel::updateClusterMatrices() {
 
     // post the blender if we're not currently waiting for one to finish
     auto modelBlender = DependencyManager::get<ModelBlender>();
-    if (_blendshapeBuffersInitialized && modelBlender->shouldComputeBlendshapes() && geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
+    if (_blendshapeOffsetsInitialized && modelBlender->shouldComputeBlendshapes() && geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
         _blendedBlendshapeCoefficients = _blendshapeCoefficients;
         modelBlender->noteRequiresBlend(getThisPointer());
     }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19097/Blendshape-Offset-buffer-should-be-updated-in-render-loop-not-game-loop
https://highfidelity.manuscript.com/f/cases/18688/

Test plan:
- Verify that blendshapes work in a domain with someone else, with both of you speaking.
- Play with "facialExpression.js" which is in the scripts/developer folder.  You should see a new "EMOTIONS" app in the toolbar.  Switch to mirror view to see your face.  Press the keys (h j k l v b n m) to modify your blendshapes.
- Run this script from the console:
```
(function() {
    Controller.keyPressEvent.connect(function(event) {
        if (event.text == '5') {
            MyAvatar.skeletonModelURL = "http://mpassets.highfidelity.com/f3fbb9f4-e159-49ed-ac32-03af9056b17e-v1/matthew.fst";
        } else if (event.text == '6') {
            MyAvatar.skeletonModelURL = "http://mpassets.highfidelity.com/e76946cc-c272-4adf-9bb6-02cde0a4b57d-v1/9e8c5c42a0cbd436962d6bd36f032ab3.fst";
        }
    });
}());
```
- Keep controlling your blendshapes with the app while pressing 5 and 6 to switch avatars.  You shouldn't crash.