### PR TITLE
MS19056: [CreateApp/Entity List] Context Menu

### DIFF
--- a/scripts/system/html/css/edit-style.css
+++ b/scripts/system/html/css/edit-style.css
@@ -1812,7 +1812,7 @@ body#entity-list-body {
 }
 .context-menu li {
     list-style-type: none;
-    padding: 0 5px 0 5px;
+    padding: 4px 18px 4px 18px;
     margin: 0;
     white-space: nowrap;
 }
@@ -1820,8 +1820,9 @@ body#entity-list-body {
     background-color: #e3e3e3;
 }
 .context-menu li.separator {
-    border-top: 1px solid #000000;
+    border-top: 1px solid #333333;
     margin: 5px 5px;
+    padding: 0 0;
 }
 .context-menu li.disabled {
     color: #333333;

--- a/scripts/system/html/css/edit-style.css
+++ b/scripts/system/html/css/edit-style.css
@@ -1801,3 +1801,42 @@ input[type=button]#export {
 body#entity-list-body {
     padding-bottom: 0;
 }
+
+.context-menu {
+    display: none;
+    position: fixed;
+    color: #000000;
+    background-color: #afafaf;
+    padding: 5px 0 5px 0;
+    cursor: default;
+}
+.context-menu li {
+    list-style-type: none;
+    padding: 0 5px 0 5px;
+    margin: 0;
+    white-space: nowrap;
+}
+.context-menu li:hover {
+    background-color: #e3e3e3;
+}
+.context-menu li.separator {
+    border-top: 1px solid #000000;
+    margin: 5px 5px;
+}
+.context-menu li.disabled {
+    color: #333333;
+}
+.context-menu li.separator:hover, .context-menu li.disabled:hover {
+    background-color: #afafaf;
+}
+
+input.rename-entity {
+    height: 100%;
+    width: 100%;
+    border: none;
+    font-family: FiraSans-SemiBold;
+    font-size: 15px;
+    /* need this to show the text cursor when the input field is empty */
+    padding-left: 2px;
+}
+

--- a/scripts/system/html/entityList.html
+++ b/scripts/system/html/entityList.html
@@ -16,6 +16,7 @@
         <script type="text/javascript" src="js/eventBridgeLoader.js"></script>
         <script type="text/javascript" src="js/spinButtons.js"></script>
         <script type="text/javascript" src="js/listView.js"></script>
+        <script type="text/javascript" src="js/entityListContextMenu.js"></script>
         <script type="text/javascript" src="js/entityList.js"></script>
     </head>
     <body onload='loaded();' id="entity-list-body">

--- a/scripts/system/html/js/entityList.js
+++ b/scripts/system/html/js/entityList.js
@@ -268,8 +268,9 @@ function loaded() {
                 }));
             }
 
-            let enabledContextMenuItems = [];
+            let enabledContextMenuItems = ['Copy', 'Paste', 'Duplicate'];
             if (entitiesByID[entityID] && !entitiesByID[entityID].locked) {
+                enabledContextMenuItems.push('Cut');
                 enabledContextMenuItems.push('Rename');
                 enabledContextMenuItems.push('Delete');
             }

--- a/scripts/system/html/js/entityList.js
+++ b/scripts/system/html/js/entityList.js
@@ -231,8 +231,11 @@ function loaded() {
             elRenameInput.select();
         }
 
-        entityListContextMenu.setCallback(function(optionName, selectedEntityID) {
+        entityListContextMenu.setOnSelectedCallback(function(optionName, selectedEntityID) {
             switch (optionName) {
+                case "Cut":
+                    EventBridge.emitWebEvent(JSON.stringify({ type: 'cut' }));
+                    break;
                 case "Copy":
                     EventBridge.emitWebEvent(JSON.stringify({ type: 'copy' }));
                     break;
@@ -263,8 +266,6 @@ function loaded() {
                     focus: false,
                     entityIds: selection,
                 }));
-
-                refreshFooter();
             }
 
             let enabledContextMenuItems = [];
@@ -765,7 +766,7 @@ function loaded() {
     augmentSpinButtons();
 
     document.addEventListener("contextmenu", function (event) {
-        entityListContextMenu.close.call(entityListContextMenu);
+        entityListContextMenu.close();
 
         // Disable default right-click context menu which is not visible in the HMD and makes it seem like the app has locked
         event.preventDefault();
@@ -773,6 +774,6 @@ function loaded() {
 
     // close context menu when switching focus to another window
     $(window).blur(function() {
-        entityListContextMenu.close.call(entityListContextMenu);
+        entityListContextMenu.close();
     });
 }

--- a/scripts/system/html/js/entityListContextMenu.js
+++ b/scripts/system/html/js/entityListContextMenu.js
@@ -18,7 +18,7 @@ const CONTEXT_MENU_CLASS = "context-menu";
  */
 function EntityListContextMenu() {
     this._elContextMenu = null;
-    this._callback = null;
+    this._onSelectedCallback = null;
     this._listItems = [];
     this._initialize();
 }
@@ -33,7 +33,7 @@ EntityListContextMenu.prototype = {
     /**
      * @private
      */
-    _callback: null,
+    _onSelectedCallback: null,
 
     /**
      * @private
@@ -82,20 +82,19 @@ EntityListContextMenu.prototype = {
     },
 
     /**
-     * Set the event callback
-     * @param callback
+     * Set the callback for when a menu item is selected
+     * @param onSelectedCallback
      */
-    setCallback: function(callback) {
-        this._callback = callback;
+    setOnSelectedCallback: function(onSelectedCallback) {
+        this._onSelectedCallback = onSelectedCallback;
     },
 
     /**
      * Add a labeled item to the context menu
      * @param itemLabel
-     * @param isEnabled
      * @private
      */
-    _addListItem: function(itemLabel, isEnabled) {
+    _addListItem: function(itemLabel) {
         let elListItem = document.createElement("li");
         elListItem.innerText = itemLabel;
 
@@ -106,8 +105,8 @@ EntityListContextMenu.prototype = {
         };
 
         elListItem.addEventListener("click", function () {
-            if (listItem.enabled && this._callback) {
-                this._callback.call(this, itemLabel, this._selectedEntityID);
+            if (listItem.enabled && this._onSelectedCallback) {
+                this._onSelectedCallback.call(this, itemLabel, this._selectedEntityID);
             }
         }.bind(this), false);
 
@@ -136,12 +135,12 @@ EntityListContextMenu.prototype = {
         this._elContextMenu.setAttribute("class", CONTEXT_MENU_CLASS);
         document.body.appendChild(this._elContextMenu);
 
-        // TODO: enable Copy, Paste and Duplicate items once implemented
-        this._addListItem("Copy", false);
-        this._addListItem("Paste", false);
+        this._addListItem("Cut");
+        this._addListItem("Copy");
+        this._addListItem("Paste");
         this._addListSeparator();
         this._addListItem("Rename");
-        this._addListItem("Duplicate", false);
+        this._addListItem("Duplicate");
         this._addListItem("Delete");
 
         // Ignore clicks on context menu background or separator.

--- a/scripts/system/html/js/entityListContextMenu.js
+++ b/scripts/system/html/js/entityListContextMenu.js
@@ -1,0 +1,143 @@
+//
+//  entityListContextMenu.js
+//
+//  exampleContextMenus.js was originally created by David Rowe on 22 Aug 2018.
+//  Modified to entityListContextMenu.js by Thijs Wenker on 10 Oct 2018
+//  Copyright 2018 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+/* eslint-env browser */
+const CONTEXT_MENU_CLASS = "context-menu";
+
+/**
+ * ContextMenu class for EntityList
+ * @constructor
+ */
+function EntityListContextMenu() {
+    this._elContextMenu = null;
+    this._callback = null;
+}
+
+EntityListContextMenu.prototype = {
+
+    /**
+     * @private
+     */
+    _elContextMenu: null,
+
+    /**
+     * @private
+     */
+    _callback: null,
+
+    /**
+     * @private
+     */
+    _selectedEntityID: null,
+
+    /**
+     * Close the context menu
+     */
+    close: function() {
+        if (this.isContextMenuOpen()) {
+            this._elContextMenu.style.display = "none";
+        }
+    },
+
+    isContextMenuOpen: function() {
+        return this._elContextMenu.style.display === "block";
+    },
+
+    /**
+     * Open the context menu
+     * @param clickEvent
+     * @param selectedEntityID
+     */
+    open: function(clickEvent, selectedEntityID) {
+        this._selectedEntityID = selectedEntityID;
+        // If the right-clicked item has a context menu open it.
+        this._elContextMenu.style.display = "block";
+        this._elContextMenu.style.left
+            = Math.min(clickEvent.pageX, document.body.offsetWidth - this._elContextMenu.offsetWidth).toString() + "px";
+        this._elContextMenu.style.top
+            = Math.min(clickEvent.pageY, document.body.clientHeight - this._elContextMenu.offsetHeight).toString() + "px";
+        clickEvent.stopPropagation();
+    },
+
+    /**
+     * Set the event callback
+     * @param callback
+     */
+    setCallback: function(callback) {
+        this._callback = callback;
+    },
+
+    /**
+     * Add a labeled item to the context menu
+     * @param itemLabel
+     * @param isEnabled
+     * @private
+     */
+    _addListItem: function(itemLabel, isEnabled) {
+        let elListItem = document.createElement("li");
+        elListItem.innerText = itemLabel;
+
+        if (isEnabled === undefined || isEnabled) {
+            elListItem.addEventListener("click", function () {
+                if (this._callback) {
+                    this._callback.call(this, itemLabel, this._selectedEntityID);
+                }
+            }.bind(this), false);
+        } else {
+            elListItem.setAttribute('class', 'disabled');
+        }
+        this._elContextMenu.appendChild(elListItem);
+    },
+
+    /**
+     * Add a separator item to the context menu
+     * @private
+     */
+    _addListSeparator: function() {
+        let elListItem = document.createElement("li");
+        elListItem.setAttribute('class', 'separator');
+        this._elContextMenu.appendChild(elListItem);
+    },
+
+    /**
+     * Initialize the context menu.
+     */
+    initialize: function() {
+        this._elContextMenu = document.createElement("ul");
+        this._elContextMenu.setAttribute("class", CONTEXT_MENU_CLASS);
+        document.body.appendChild(this._elContextMenu);
+
+        // TODO: enable Copy, Paste and Duplicate items once implemented
+        this._addListItem("Copy", false);
+        this._addListItem("Paste", false);
+        this._addListSeparator();
+        this._addListItem("Rename");
+        this._addListItem("Duplicate", false);
+        this._addListItem("Delete");
+
+        // Ignore clicks on context menu background or separator.
+        this._elContextMenu.addEventListener("click", function(event) {
+            // Sink clicks on context menu background or separator but let context menu item clicks through.
+            if (event.target.classList.contains(CONTEXT_MENU_CLASS)) {
+                event.stopPropagation();
+            }
+        });
+
+        // Provide means to close context menu without clicking menu item.
+        document.body.addEventListener("click", this.close.bind(this));
+        document.body.addEventListener("keydown", function(event) {
+            // Close context menu with Esc key.
+            if (this.isContextMenuOpen() && event.key === "Escape") {
+                this.close();
+            }
+        }.bind(this));
+    }
+};

--- a/scripts/system/libraries/entityList.js
+++ b/scripts/system/libraries/entityList.js
@@ -272,11 +272,11 @@ EntityListTool = function(shouldUseEditTabletApp) {
         } else if (data.type === "radius") {
             searchRadius = data.radius;
         } else if (data.type === "cut") {
-            cutSelectedEntities();
+            SelectionManager.cutSelectedEntities();
         } else if (data.type === "copy") {
-            copySelectedEntities();
+            SelectionManager.copySelectedEntities();
         } else if (data.type === "paste") {
-            pasteEntities();
+            SelectionManager.pasteEntities();
         } else if (data.type === "duplicate") {
             SelectionManager.duplicateSelection();
             that.sendUpdate();

--- a/scripts/system/libraries/entityList.js
+++ b/scripts/system/libraries/entityList.js
@@ -15,7 +15,7 @@ var PROFILING_ENABLED = false;
 var profileIndent = '';
 const PROFILE_NOOP = function(_name, fn, args) {
     fn.apply(this, args);
-} ;
+};
 PROFILE = !PROFILING_ENABLED ? PROFILE_NOOP : function(name, fn, args) {
     console.log("PROFILE-Script " + profileIndent + "(" + name + ") Begin");
     var previousIndent = profileIndent;
@@ -245,7 +245,7 @@ EntityListTool = function(shouldUseEditTabletApp) {
                 Window.saveAsync("Select Where to Save", "", "*.json");
             }
         } else if (data.type === "pal") {
-            var sessionIds = {}; // Collect the sessionsIds of all selected entitities, w/o duplicates.
+            var sessionIds = {}; // Collect the sessionsIds of all selected entities, w/o duplicates.
             selectionManager.selections.forEach(function (id) {
                 var lastEditedBy = Entities.getEntityProperties(id, 'lastEditedBy').lastEditedBy;
                 if (lastEditedBy) {
@@ -271,6 +271,16 @@ EntityListTool = function(shouldUseEditTabletApp) {
             filterInView = data.filterInView === true;
         } else if (data.type === "radius") {
             searchRadius = data.radius;
+        } else if (data.type === "copy") {
+            Window.alert("Copy is not yet implemented.");
+        } else if (data.type === "paste") {
+            Window.alert("Paste is not yet implemented.");
+        } else if (data.type === "duplicate") {
+            Window.alert("Duplicate is not yet implemented.");
+        } else if (data.type === "rename") {
+            Entities.editEntity(data.entityID, {name: data.name});
+            // make sure that the name also gets updated in the properties window
+            SelectionManager._update();
         }
     };
 

--- a/scripts/system/libraries/entityList.js
+++ b/scripts/system/libraries/entityList.js
@@ -271,12 +271,15 @@ EntityListTool = function(shouldUseEditTabletApp) {
             filterInView = data.filterInView === true;
         } else if (data.type === "radius") {
             searchRadius = data.radius;
+        } else if (data.type === "cut") {
+            cutSelectedEntities();
         } else if (data.type === "copy") {
-            Window.alert("Copy is not yet implemented.");
+            copySelectedEntities();
         } else if (data.type === "paste") {
-            Window.alert("Paste is not yet implemented.");
+            pasteEntities();
         } else if (data.type === "duplicate") {
-            Window.alert("Duplicate is not yet implemented.");
+            SelectionManager.duplicateSelection();
+            that.sendUpdate();
         } else if (data.type === "rename") {
             Entities.editEntity(data.entityID, {name: data.name});
             // make sure that the name also gets updated in the properties window

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -353,12 +353,12 @@ SelectionManager = (function() {
         }
 
         return createdEntityIDs;
-    }
+    };
 
     that.cutSelectedEntities = function() {
-        copySelectedEntities();
+        that.copySelectedEntities();
         deleteSelectedEntities();
-    }
+    };
 
     that.copySelectedEntities = function() {
         var entityProperties = Entities.getMultipleEntityProperties(that.selections);
@@ -434,7 +434,7 @@ SelectionManager = (function() {
                 z: brn.z + entityClipboard.dimensions.z / 2
             };
         }
-    }
+    };
 
     that.pasteEntities = function() {
         var dimensions = entityClipboard.dimensions;
@@ -442,7 +442,7 @@ SelectionManager = (function() {
         var pastePosition = getPositionToCreateEntity(maxDimension);
         var deltaPosition = Vec3.subtract(pastePosition, entityClipboard.position);
 
-        var copiedProperties = []
+        var copiedProperties = [];
         var ids = [];
         entityClipboard.entities.forEach(function(originalProperties) {
             var properties = deepCopy(originalProperties);
@@ -475,7 +475,7 @@ SelectionManager = (function() {
 
         redo(copiedProperties);
         undoHistory.pushCommand(undo, copiedProperties, redo, copiedProperties);
-    }
+    };
 
     that._update = function(selectionUpdated) {
         var properties = null;


### PR DESCRIPTION
## ~Note: THIS PR IS DNM until https://github.com/highfidelity/hifi/pull/14235 is merged~

https://highfidelity.manuscript.com/f/cases/19056/Add-right-click-menu-functionality-to-each-item-in-the-entity-list

## Test Plan
1. Open Create App and look at the Entity List for this PR
2. Right Click an entity in the list and rename it,  make sure you can change the name (in case it is a locked entity you should not be able to rename).
3. Try clicking twice (not doubleclick) on an entity in the list, and you should get the rename field, rename the entity.
4. Multi select a group of (unlocked) entities that could be disposed of, rightclick one of the selected entities in the list, the selection should stay. Now click the delete option in the menu. The entities should be remove.
5. Test the copy, cut, paste, duplicate right-click functionality.
     - copy ->  should copy the entity into memory
     - paste  -> should paste the copied/cut entity back in world.
     - cut  -> should copy the entity into memory and delete the instance in world
     - duplicate -> should create a duplicate of the object in world right away ( in the same spot)
