### PR TITLE
Tutorial: MS 18725 & New Menu Content

### DIFF
--- a/cmake/externals/serverless-content/CMakeLists.txt
+++ b/cmake/externals/serverless-content/CMakeLists.txt
@@ -4,8 +4,8 @@ set(EXTERNAL_NAME serverless-content)
 
 ExternalProject_Add(
   ${EXTERNAL_NAME}
-  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC73.zip
-  URL_MD5 0c5edfb63cafb042311d3cf25261fbf2
+  URL http://cdn.highfidelity.com/content-sets/serverless-tutorial-RC75.zip
+  URL_MD5 b4225d058952e17976ac228330ce8d51
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""


### PR DESCRIPTION
Uses the recommended fix in MS 18725 to try to re-play audio if it doesn't download the first time
Also updates the HMD menu items to account for mini-tablet

Confirm that the Menu section in HMD mode shows a GIF with the small tablet and both audio and text display new text to reflect looking at your hands instead of the content in the current release.