### PR TITLE
new treatment for hmd/tablet login

### DIFF
--- a/scripts/system/libraries/accountUtils.js
+++ b/scripts/system/libraries/accountUtils.js
@@ -6,11 +6,5 @@
 //
 
 openLoginWindow = function openLoginWindow() {
-    if ((HMD.active && Settings.getValue("hmdTabletBecomesToolbar", false))
-        || (!HMD.active && Settings.getValue("desktopTabletBecomesToolbar", true))) {
-        Menu.triggerOption("Login/Sign Up");
-    } else {
-        tablet.loadQMLOnTop("dialogs/TabletLoginDialog.qml");
-        HMD.openTablet();
-    }
+    Menu.triggerOption("Login/Sign Up");
 };        


### PR DESCRIPTION
Fixes https://highfidelity.fogbugz.com/f/cases/19314/Snapshots-Log-in-button-in-snaps-app-isn-t-working-in-HMD-mode

The apps SNAP, MARKET, and WALLET all ask for login, and it has to work in both HMD/tablet and desktop/HUD. Historically, those had to be done differently, and the former was through a global named `tablet` that now doesn't exist.  But it appears that that the two different paths are no longer necessary.
