### PR TITLE
Remove pending avatars data structure

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -55,15 +55,7 @@ static const quint64 MIN_TIME_BETWEEN_MY_AVATAR_DATA_SENDS = USECS_PER_SECOND / 
 // We add _myAvatar into the hash with all the other AvatarData, and we use the default NULL QUid as the key.
 const QUuid MY_AVATAR_KEY;  // NULL key
 
-namespace {
-    // For an unknown avatar-data packet, wait this long before requesting the identity.
-    constexpr std::chrono::milliseconds REQUEST_UNKNOWN_IDENTITY_DELAY { 5 * 1000 };
-    constexpr int REQUEST_UNKNOWN_IDENTITY_TRANSMITS = 3;
-}
-using std::chrono::steady_clock;
-
 AvatarManager::AvatarManager(QObject* parent) :
-    _avatarsToFade(),
     _myAvatar(new MyAvatar(qApp->thread()), [](MyAvatar* ptr) { ptr->deleteLater(); })
 {
     // register a meta type for the weak pointer we'll use for the owning avatar mixer for each avatar
@@ -321,28 +313,6 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
     _numAvatarsNotUpdated = numAVatarsNotUpdated;
 
     simulateAvatarFades(deltaTime);
-
-    // Check on avatars with pending identities:
-    steady_clock::time_point now = steady_clock::now();
-    QWriteLocker writeLock(&_hashLock);
-    for (auto pendingAvatar = _pendingAvatars.begin(); pendingAvatar != _pendingAvatars.end(); ++pendingAvatar) {
-        if (now - pendingAvatar->creationTime >= REQUEST_UNKNOWN_IDENTITY_DELAY) {
-            // Too long without an ID
-            sendIdentityRequest(pendingAvatar->avatar->getID());
-            if (++pendingAvatar->transmits >= REQUEST_UNKNOWN_IDENTITY_TRANSMITS) {
-                qCDebug(avatars) << "Requesting identity for unknown avatar (final request)" <<
-                    pendingAvatar->avatar->getID().toString();
-
-                pendingAvatar = _pendingAvatars.erase(pendingAvatar);
-                if (pendingAvatar == _pendingAvatars.end()) {
-                    break;
-                }
-            } else {
-                pendingAvatar->creationTime = now;
-                qCDebug(avatars) << "Requesting identity for unknown avatar" << pendingAvatar->avatar->getID().toString();
-            }
-        }
-    }
 
     _avatarSimulationTime = (float)(usecTimestampNow() - startTime) / (float)USECS_PER_MSEC;
 }

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -258,7 +258,6 @@ AvatarSharedPointer AvatarHashMap::parseAvatarData(QSharedPointer<ReceivedMessag
 
         if (isNewAvatar) {
             QWriteLocker locker(&_hashLock);
-            _pendingAvatars.insert(sessionUUID, { std::chrono::steady_clock::now(), 0, avatar });
             avatar->setIsNewAvatar(true);
             auto replicaIDs = _replicas.getReplicaIDs(sessionUUID);
             for (auto replicaID : replicaIDs) {
@@ -300,7 +299,6 @@ void AvatarHashMap::processAvatarIdentityPacket(QSharedPointer<ReceivedMessage> 
 
     {
         QReadLocker locker(&_hashLock);
-        _pendingAvatars.remove(identityUUID);
         auto me = _avatarHash.find(EMPTY);
         if ((me != _avatarHash.end()) && (identityUUID == me.value()->getSessionUUID())) {
             // We add MyAvatar to _avatarHash with an empty UUID. Code relies on this. In order to correctly handle an
@@ -419,7 +417,6 @@ void AvatarHashMap::removeAvatar(const QUuid& sessionUUID, KillAvatarReason remo
             }
         }
 
-        _pendingAvatars.remove(sessionUUID);
         auto removedAvatar = _avatarHash.take(sessionUUID);
 
         if (removedAvatar) {

--- a/libraries/avatars/src/AvatarHashMap.h
+++ b/libraries/avatars/src/AvatarHashMap.h
@@ -183,15 +183,8 @@ protected:
     
     virtual void handleRemovedAvatar(const AvatarSharedPointer& removedAvatar, KillAvatarReason removalReason = KillAvatarReason::NoReason);
     
-    AvatarHash _avatarHash;
-    struct PendingAvatar {
-        std::chrono::steady_clock::time_point creationTime;
-        int transmits;
-        AvatarSharedPointer avatar;
-    };
-    using AvatarPendingHash = QHash<QUuid, PendingAvatar>;
-    AvatarPendingHash _pendingAvatars;
     mutable QReadWriteLock _hashLock;
+    AvatarHash _avatarHash;
 
     std::unordered_map<QUuid, AvatarTraits::TraitVersions> _processedTraitVersions;
     AvatarReplicas _replicas;


### PR DESCRIPTION
This fixes the stuck white spheres following the client to a different empty domain.