### PR TITLE
call waitTillDoneRunning before deleting ScriptEngine

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2562,6 +2562,7 @@ void Application::cleanupBeforeQuit() {
         tree->setSimulation(nullptr);
         DependencyManager::destroy<EntityTreeRenderer>();
     }
+    DependencyManager::destroy<ScriptEngines>();
 
     bool autoLogout = Setting::Handle<bool>(AUTO_LOGOUT_SETTING_NAME, false).get();
     if (autoLogout) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2562,7 +2562,6 @@ void Application::cleanupBeforeQuit() {
         tree->setSimulation(nullptr);
         DependencyManager::destroy<EntityTreeRenderer>();
     }
-    DependencyManager::destroy<ScriptEngines>();
 
     bool autoLogout = Setting::Handle<bool>(AUTO_LOGOUT_SETTING_NAME, false).get();
     if (autoLogout) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -122,6 +122,11 @@ EntityTreeRenderer::EntityTreeRenderer(bool wantScripts, AbstractViewStateInterf
 EntityTreeRenderer::~EntityTreeRenderer() {
     // NOTE: We don't need to delete _entitiesScriptEngine because
     //       it is registered with ScriptEngines, which will call deleteLater for us.
+
+    auto entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();
+    if (entityScriptingInterface) {
+        entityScriptingInterface->setEntitiesScriptEngine(nullptr);
+    }
 }
 
 EntityRendererPointer EntityTreeRenderer::renderableForEntityId(const EntityItemID& id) const {

--- a/libraries/script-engine/src/ScriptCache.cpp
+++ b/libraries/script-engine/src/ScriptCache.cpp
@@ -113,7 +113,7 @@ void ScriptCache::getScriptContents(const QString& scriptOrURL, contentAvailable
                 nullptr, url, true, -1, "ScriptCache::getScriptContents");
             Q_ASSERT(request);
             request->setCacheEnabled(!forceDownload);
-            connect(request, &ResourceRequest::finished, this, [=]{ scriptContentAvailable(maxRetries); });
+            connect(request, &ResourceRequest::finished, this, [this, maxRetries]{ scriptContentAvailable(maxRetries); });
             request->send();
         }
     }

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -164,11 +164,11 @@ static void gracefulShutdownBeforeDelete(ScriptEngine* engine)
     if (QThreadPool::globalInstance()) {
         QtConcurrent::run([engine] {
             engine->waitTillDoneRunning();
-            delete engine;
+            engine->deleteLater();
         });
     } else {
         // we are exiting
-        delete engine;
+        engine->deleteLater();
     }
 }
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -159,8 +159,7 @@ QString ScriptEngine::logException(const QScriptValue& exception) {
     return message;
 }
 
-static void gracefulShutdownBeforeDelete(ScriptEngine* engine)
-{
+static void gracefulShutdownBeforeDelete(ScriptEngine* engine) {
     if (QThreadPool::globalInstance()) {
         QtConcurrent::run([engine] {
             engine->waitTillDoneRunning();
@@ -1336,7 +1335,7 @@ void ScriptEngine::updateMemoryCost(const qint64& deltaSize) {
 
 void ScriptEngine::timerFired() {
     {
-        if (!_scriptEngines || _scriptEngines->isStopped()) {
+        if (_scriptEngines->isStopped()) {
             scriptWarningMessage("Script.timerFired() while shutting down is ignored... parent script:" + getFilename());
             return; // bail early
         }

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -55,6 +55,7 @@ static const int DEFAULT_MAX_ENTITY_PPS = 9000;
 static const int DEFAULT_ENTITY_PPS_PER_SCRIPT = 900;
 
 class ScriptEngines;
+using ScriptEnginesPointer = QSharedPointer<ScriptEngines>;
 
 Q_DECLARE_METATYPE(ScriptEnginePointer)
 
@@ -563,6 +564,8 @@ public:
     bool getEntityScriptDetails(const EntityItemID& entityID, EntityScriptDetails &details) const;
     bool hasEntityScriptDetails(const EntityItemID& entityID) const;
 
+    void setScriptEngines(ScriptEnginesPointer scriptEngines) { _scriptEngines = scriptEngines; }
+
 public slots:
 
     /**jsdoc
@@ -817,6 +820,8 @@ protected:
     static const QString _SETTINGS_ENABLE_EXTENDED_EXCEPTIONS;
 
     Setting::Handle<bool> _enableExtendedJSExceptions { _SETTINGS_ENABLE_EXTENDED_EXCEPTIONS, true };
+
+    ScriptEnginesPointer _scriptEngines; // to keep ScriptEngines alive until all these are dead
 };
 
 ScriptEnginePointer scriptEngineFactory(ScriptEngine::Context context,

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -203,6 +203,8 @@ void ScriptEngines::shutdownScripting() {
         // Once the script is stopped, we can remove it from our set
         i.remove();
     }
+    _scriptEnginesHash.clear();
+    _allKnownScriptEngines.clear();
     qCDebug(scriptengine) << "DONE Stopping all scripts....";
 }
 


### PR DESCRIPTION
- fix crash that happens when frantically clicking between "load defaults" and "remove all"


https://highfidelity.manuscript.com/f/cases/17531
