### PR TITLE
Bug Fix for Crazy Legs when you sit on the floor (Manuscript 17045).

### DIFF
--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -46,7 +46,7 @@ static AnimPose computeHipsInSensorFrame(MyAvatar* myAvatar, bool isFlying) {
     }
 
     glm::mat4 hipsMat;
-    if (myAvatar->getCenterOfGravityModelEnabled() && !isFlying && !(myAvatar->getIsInWalkingState())) {
+    if (myAvatar->getCenterOfGravityModelEnabled() && !isFlying && !(myAvatar->getIsInWalkingState()) && myAvatar->getHMDLeanRecenterEnabled()) {
         // then we use center of gravity model
         hipsMat = myAvatar->deriveBodyUsingCgModel();
     } else {


### PR DESCRIPTION
This pr addresses the problem of [crazy legs happening when you sit down](https://highfidelity.manuscript.com/f/cases/17045/Legs-break-when-user-goes-from-seated-position-to-lie-down-on-her-bed) on the ground.  
Any horizontal recentering that occurs will make it impossible to stretch the legs out on the ground, so it is a given that you must turn the property hmdLeanRecentering to false in order to lie down on the ground.

This fix disables positioning the hips using the center of gravity  method, when  hmdLeanRecentering is turned off.

Test plan:
1) open interface.  
2)open the console and set MyAvatar.setHMDLeanRecenterEnabled(false);
3)sit down on the ground and move your head away from your feet until the legs are stretched out.

The result should look like the video [here](http://hifi-content.s3.amazonaws.com/angus/sitStandState/hmdleanoff.mp4).