### PR TITLE
Squelch cmake warning CMP0074 without requiring an update to cmake 3.12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ else()
   cmake_minimum_required(VERSION 3.2)
 endif()
 
+if (${CMAKE_MAJOR_VERSION} GREATER 2 AND ${CMAKE_MINOR_VERSION} GREATER 11)
+   # squelch the Policy CMP0074 warning without requiring an update to cmake 3.12.
+   cmake_policy(SET CMP0074 NEW)
+endif()
+
 project(hifi)
 
 include("cmake/init.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ else()
   cmake_minimum_required(VERSION 3.2)
 endif()
 
-if (${CMAKE_MAJOR_VERSION} GREATER 2 AND ${CMAKE_MINOR_VERSION} GREATER 11)
-   # squelch the Policy CMP0074 warning without requiring an update to cmake 3.12.
+# squelch the Policy CMP0074 warning without requiring an update to cmake 3.12.
+if ((${CMAKE_MAJOR_VERSION} EQUAL 3 AND ${CMAKE_MINOR_VERSION} GREATER 11) OR ${CMAKE_MAJOR_VERSION} GREATER 3)
    cmake_policy(SET CMP0074 NEW)
 endif()
 


### PR DESCRIPTION
internal development cmake change.

This is to eliminate the following warning on cmake 3.12 or higher.

```
CMake Warning (dev) at cmake/macros/TargetZlib.cmake:14 (find_package):
  Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
  Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  CMake variable ZLIB_ROOT is set to:

    C:/msys64/home/tony/code/hifi/build/ext/vc14/zlib/project

  For compatibility, CMake is ignoring the variable.
Call Stack (most recent call first):
  tests-manual/render-texture-load/CMakeLists.txt:30 (target_zlib)
This warning is for project developers.  Use -Wno-dev to suppress it.
```