### PR TITLE
Fix small bug in teleport.js

### DIFF
--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -413,7 +413,7 @@ Script.include("/~/system/libraries/controllers.js");
 
 
             _this.playArea = HMD.playArea;
-            _this.isPlayAreaAvailable = HMD.active && _this.playArea.width !== 0 && _this.playArea.height !== 0;
+            _this.isPlayAreaAvailable = HMD.active && _this.playArea.x !== 0 && _this.playArea.y !== 0;
             if (_this.isPlayAreaAvailable) {
                 _this.playAreaCenterOffset = Vec3.sum({ x: _this.playArea.x, y: 0, z: _this.playArea.y },
                     _this.PLAY_AREA_OVERLAY_OFFSET);

--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -197,9 +197,9 @@ Script.include("/~/system/libraries/controllers.js");
             var playAreaOverlayProperties = {
                 dimensions:
                     Vec3.multiply(this.teleportScaleFactor * avatarScale, {
-                        x: this.playArea.width,
+                        x: this.playArea.x,
                         y: this.PLAY_AREA_OVERLAY_MODEL_DIMENSIONS.y,
-                        z: this.playArea.height
+                        z: this.playArea.y
                     })
             };
 


### PR DESCRIPTION
Line 416, there was an attempt to access nonexistent data members in `this.playArea`. All other references to this object in the file were for data members `x` and `y`. Changed accordingly.

When the code was triggered, it would cause `teleport.js` to halt, breaking teleport for the user.