### PR TITLE
QueryAACube fixes and materials expand to include their parent

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -191,8 +191,6 @@ void Base3DOverlay::setProperties(const QVariantMap& originalProperties) {
 
     if (properties["parentID"].isValid()) {
         setParentID(QUuid(properties["parentID"].toString()));
-        bool success;
-        getParentPointer(success); // call this to hook-up the parent's back-pointers to its child overlays
         needRenderItemUpdate = true;
     }
     if (properties["parentJointIndex"].isValid()) {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1933,6 +1933,14 @@ void EntityTree::fixupNeedsParentFixups() {
                 }
             });
             entity->locationChanged(true);
+
+            // Update our parent's bounding box
+            bool success = false;
+            auto parent = entity->getParentPointer(success);
+            if (success && parent) {
+                parent->updateQueryAACube();
+            }
+
             entity->postParentFixup();
         } else if (getIsServer() || _avatarIDs.contains(entity->getParentID())) {
             // this is a child of an avatar, which the entity server will never have

--- a/libraries/entities/src/MaterialEntityItem.cpp
+++ b/libraries/entities/src/MaterialEntityItem.cpp
@@ -314,8 +314,25 @@ void MaterialEntityItem::applyMaterial() {
     _retryApply = true;
 }
 
+AACube MaterialEntityItem::calculateInitialQueryAACube(bool& success) {
+    AACube aaCube = EntityItem::calculateInitialQueryAACube(success);
+    // A Material entity's queryAACube contains its parent's queryAACube
+    auto parent = getParentPointer(success);
+    if (success && parent) {
+        success = false;
+        AACube parentQueryAACube = parent->calculateInitialQueryAACube(success);
+        if (success) {
+            aaCube += parentQueryAACube.getMinimumPoint();
+            aaCube += parentQueryAACube.getMaximumPoint();
+            return aaCube;
+        }
+    }
+}
+
 void MaterialEntityItem::postParentFixup() {
     removeMaterial();
+    _queryAACubeSet = false; // force an update so we contain our parent
+    updateQueryAACube();
     applyMaterial();
 }
 

--- a/libraries/entities/src/MaterialEntityItem.cpp
+++ b/libraries/entities/src/MaterialEntityItem.cpp
@@ -324,9 +324,9 @@ AACube MaterialEntityItem::calculateInitialQueryAACube(bool& success) {
         if (success) {
             aaCube += parentQueryAACube.getMinimumPoint();
             aaCube += parentQueryAACube.getMaximumPoint();
-            return aaCube;
         }
     }
+    return aaCube;
 }
 
 void MaterialEntityItem::postParentFixup() {

--- a/libraries/entities/src/MaterialEntityItem.h
+++ b/libraries/entities/src/MaterialEntityItem.h
@@ -85,6 +85,8 @@ public:
 
     void postParentFixup() override;
 
+    AACube calculateInitialQueryAACube(bool& success) override;
+
 private:
     // URL for this material.  Currently, only JSON format is supported.  Set to "materialData" to use the material data to live edit a material.
     // The following fields are supported in the JSON:

--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -75,7 +75,10 @@ void SpatiallyNestable::setParentID(const QUuid& parentID) {
     });
 
     bool success = false;
-    getParentPointer(success);
+    auto parent = getParentPointer(success);
+    if (success && parent) {
+        parent->updateQueryAACube();
+    }
 }
 
 Transform SpatiallyNestable::getParentTransform(bool& success, int depth) const {
@@ -155,12 +158,14 @@ void SpatiallyNestable::beParentOfChild(SpatiallyNestablePointer newChild) const
     _childrenLock.withWriteLock([&] {
         _children[newChild->getID()] = newChild;
     });
+    // Our QueryAACube will automatically be updated to include our new child
 }
 
 void SpatiallyNestable::forgetChild(SpatiallyNestablePointer newChild) const {
     _childrenLock.withWriteLock([&] {
         _children.remove(newChild->getID());
     });
+    _queryAACubeSet = false; // We need to reset our queryAACube when we lose a child
 }
 
 void SpatiallyNestable::setParentJointIndex(quint16 parentJointIndex) {
@@ -1092,7 +1097,23 @@ AACube SpatiallyNestable::getMaximumAACube(bool& success) const {
     return AACube(getWorldPosition(success) - glm::vec3(defaultAACubeSize / 2.0f), defaultAACubeSize);
 }
 
-const float PARENTED_EXPANSION_FACTOR = 3.0f;
+AACube SpatiallyNestable::calculateInitialQueryAACube(bool& success) {
+    success = false;
+    AACube maxAACube = getMaximumAACube(success);
+    if (!success) {
+        return AACube();
+    }
+
+    success = true;
+    if (shouldPuffQueryAACube()) {
+        // make an expanded AACube centered on the object
+        const float PARENTED_EXPANSION_FACTOR = 3.0f;
+        float scale = PARENTED_EXPANSION_FACTOR * maxAACube.getScale();
+        return AACube(maxAACube.calcCenter() - glm::vec3(0.5f * scale), scale);
+    } else {
+        return maxAACube;
+    }
+}
 
 bool SpatiallyNestable::updateQueryAACube() {
     if (!queryAACubeNeedsUpdate()) {
@@ -1100,20 +1121,12 @@ bool SpatiallyNestable::updateQueryAACube() {
     }
 
     bool success;
-    AACube maxAACube = getMaximumAACube(success);
+    AACube initialQueryAACube = calculateInitialQueryAACube(success);
     if (!success) {
         return false;
     }
-
-    if (shouldPuffQueryAACube()) {
-        // make an expanded AACube centered on the object
-        float scale = PARENTED_EXPANSION_FACTOR * maxAACube.getScale();
-        _queryAACube = AACube(maxAACube.calcCenter() - glm::vec3(0.5f * scale), scale);
-        _queryAACubeIsPuffed = true;
-    } else {
-        _queryAACube = maxAACube;
-        _queryAACubeIsPuffed = false;
-    }
+    _queryAACube = initialQueryAACube;
+    _queryAACubeIsPuffed = shouldPuffQueryAACube();
 
     forEachDescendant([&](const SpatiallyNestablePointer& descendant) {
         bool childSuccess;
@@ -1128,6 +1141,12 @@ bool SpatiallyNestable::updateQueryAACube() {
     });
 
     _queryAACubeSet = true;
+
+    auto parent = getParentPointer(success);
+    if (success && parent) {
+        parent->updateQueryAACube();
+    }
+
     return true;
 }
 
@@ -1158,7 +1177,7 @@ bool SpatiallyNestable::queryAACubeNeedsUpdate() const {
     // make sure children are still in their boxes, also.
     bool childNeedsUpdate = false;
     forEachDescendantTest([&](const SpatiallyNestablePointer& descendant) {
-        if (!childNeedsUpdate && descendant->queryAACubeNeedsUpdate()) {
+        if (descendant->queryAACubeNeedsUpdate() || !_queryAACube.contains(descendant->getQueryAACube())) {
             childNeedsUpdate = true;
             // Don't recurse further
             return false;

--- a/libraries/shared/src/SpatiallyNestable.h
+++ b/libraries/shared/src/SpatiallyNestable.h
@@ -112,6 +112,7 @@ public:
     virtual glm::vec3 getParentAngularVelocity(bool& success) const;
 
     virtual AACube getMaximumAACube(bool& success) const;
+    virtual AACube calculateInitialQueryAACube(bool& success);
 
     virtual void setQueryAACube(const AACube& queryAACube);
     virtual bool queryAACubeNeedsUpdate() const;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19213/network-Cull-the-material-entities-with-their-parent-BBOX-not-with-just-the-small-bbox-of-their-meta-representation

Test plan:
- Run [this](https://gist.githubusercontent.com/SamGondelman/d24436adaf64882a5c019b39a459db92/raw/5554e5adc6a0e9655a50e363334b10b6b01cc889/QueryAACubeTest.js).  Expected:
![image](https://user-images.githubusercontent.com/7650116/47049292-b55b0f00-d151-11e8-95f8-081cdf762f13.png)
- Press "i".  Expected:
![image](https://user-images.githubusercontent.com/7650116/47049298-be4be080-d151-11e8-804b-09461e805115.png)
- Press "u".  Expected:
![image](https://user-images.githubusercontent.com/7650116/47049315-cad03900-d151-11e8-96e8-93a305d13432.png)
- Move the center cube around using Create.  You might see the transparent cube flicker a little as it moves (because of the script update rate), but when you stop moving it, you should only see one bounding cube (not the smaller material entity bounding cube).
- Press "u":  Expected:
![image](https://user-images.githubusercontent.com/7650116/47049415-108d0180-d152-11e8-9c4f-1eea702a5059.png)
- Move the green and blue cubes around.  Their bounding boxes should expand to always contain them, but should NOT shrink or move otherwise unless necessary.
- Press "u":  Expected:
![image](https://user-images.githubusercontent.com/7650116/47049466-3dd9af80-d152-11e8-96f9-d861e78a3f4a.png)
