### PR TITLE
Fix PickManager::removePick heap use after free

### DIFF
--- a/libraries/pointers/src/PickManager.cpp
+++ b/libraries/pointers/src/PickManager.cpp
@@ -41,8 +41,8 @@ void PickManager::removePick(unsigned int uid) {
         auto type = _typeMap.find(uid);
         if (type != _typeMap.end()) {
             _picks[type->second].erase(uid);
-            _typeMap.erase(uid);
             _totalPickCounts[type->second]--;
+            _typeMap.erase(uid);
         }
     });
 }

--- a/libraries/pointers/src/PickManager.cpp
+++ b/libraries/pointers/src/PickManager.cpp
@@ -38,11 +38,11 @@ std::shared_ptr<PickQuery> PickManager::findPick(unsigned int uid) const {
 
 void PickManager::removePick(unsigned int uid) {
     withWriteLock([&] {
-        auto type = _typeMap.find(uid);
-        if (type != _typeMap.end()) {
-            _picks[type->second].erase(uid);
-            _totalPickCounts[type->second]--;
-            _typeMap.erase(uid);
+        auto typeIt = _typeMap.find(uid);
+        if (typeIt != _typeMap.end()) {
+            _picks[typeIt->second].erase(uid);
+            _totalPickCounts[typeIt->second]--;
+            _typeMap.erase(typeIt);
         }
     });
 }


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/18963/heap-use-after-free-in-PickManager-removePick

Test plan:
- Verify that in the expanded stats, the Pick counts in the first column still work.