### PR TITLE
Disable user hand controllers if they are too far away or not moving.

### DIFF
--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1766,8 +1766,8 @@ private:
     glm::vec3 _customListenPosition;
     glm::quat _customListenOrientation;
 
-    AtRestDetector _hmdAtRestDetector;
-    bool _lastIsMoving { false };
+    AtRestDetector _leftHandAtRestDetector;
+    AtRestDetector _rightHandAtRestDetector;
 
     // all poses are in sensor-frame
     std::map<controller::Action, controller::Pose> _controllerPoseMap;

--- a/libraries/shared/src/AtRestDetector.cpp
+++ b/libraries/shared/src/AtRestDetector.cpp
@@ -30,32 +30,37 @@ void AtRestDetector::reset(const glm::vec3& startPosition, const glm::quat& star
     _isAtRest = false;
 }
 
-bool AtRestDetector::update(const glm::vec3& position, const glm::quat& rotation) {
-    uint64_t now = usecTimestampNow();
-    float dt = (float)(now - _lastUpdateTime) / (float)USECS_PER_SECOND;
-    _lastUpdateTime = now;
-    const float TAU = 1.0f;
-    float delta = glm::min(dt / TAU, 1.0f);
+void AtRestDetector::update(const glm::vec3& position, const glm::quat& rotation) {
+    _lastIsAtRest = _isAtRest;
+    if (_isValid) {
+        uint64_t now = usecTimestampNow();
+        float dt = (float)(now - _lastUpdateTime) / (float)USECS_PER_SECOND;
+        _lastUpdateTime = now;
+        const float TAU = 1.0f;
+        float delta = glm::min(dt / TAU, 1.0f);
 
-    // keep a running average of position.
-    _positionAverage = position * delta + _positionAverage * (1 - delta);
+        // keep a running average of position.
+        _positionAverage = position * delta + _positionAverage * (1 - delta);
 
-    // keep a running average of position variances.
-    glm::vec3 dx = position - _positionAverage;
-    _positionVariance = glm::dot(dx, dx) * delta + _positionVariance * (1 - delta);
+        // keep a running average of position variances.
+        glm::vec3 dx = position - _positionAverage;
+        _positionVariance = glm::dot(dx, dx) * delta + _positionVariance * (1 - delta);
 
-    // keep a running average of quaternion logarithms.
-    glm::quat quatLogAsQuat = glm::log(rotation);
-    glm::vec3 quatLog(quatLogAsQuat.x, quatLogAsQuat.y, quatLogAsQuat.z);
-    _quatLogAverage = quatLog * delta + _quatLogAverage * (1 - delta);
+        // keep a running average of quaternion logarithms.
+        glm::quat quatLogAsQuat = glm::log(rotation);
+        glm::vec3 quatLog(quatLogAsQuat.x, quatLogAsQuat.y, quatLogAsQuat.z);
+        _quatLogAverage = quatLog * delta + _quatLogAverage * (1 - delta);
 
-    // keep a running average of quatLog variances.
-    glm::vec3 dql = quatLog - _quatLogAverage;
-    _quatLogVariance = glm::dot(dql, dql) * delta + _quatLogVariance * (1 - delta);
+        // keep a running average of quatLog variances.
+        glm::vec3 dql = quatLog - _quatLogAverage;
+        _quatLogVariance = glm::dot(dql, dql) * delta + _quatLogVariance * (1 - delta);
 
-    const float POSITION_VARIANCE_THRESHOLD = 0.001f;
-    const float QUAT_LOG_VARIANCE_THRESHOLD = 0.00002f;
+        const float POSITION_VARIANCE_THRESHOLD = 0.001f;
+        const float QUAT_LOG_VARIANCE_THRESHOLD = 0.00002f;
 
-    _isAtRest = _positionVariance < POSITION_VARIANCE_THRESHOLD && _quatLogVariance < QUAT_LOG_VARIANCE_THRESHOLD;
-    return _isAtRest;
+        _isAtRest = _positionVariance < POSITION_VARIANCE_THRESHOLD && _quatLogVariance < QUAT_LOG_VARIANCE_THRESHOLD;
+    } else {
+        reset(position, rotation);
+        _isValid = true;
+    }
 }

--- a/libraries/shared/src/AtRestDetector.h
+++ b/libraries/shared/src/AtRestDetector.h
@@ -17,21 +17,27 @@
 
 class AtRestDetector {
 public:
+    AtRestDetector() {};
     AtRestDetector(const glm::vec3& startPosition, const glm::quat& startRotation);
     void reset(const glm::vec3& startPosition, const glm::quat& startRotation);
 
     // returns true if object is at rest, dt in assumed to be seconds.
-    bool update(const glm::vec3& position, const glm::quat& startRotation);
+    void update(const glm::vec3& position, const glm::quat& startRotation);
 
+    void invalidate() { _isValid = false; }
     bool isAtRest() const { return _isAtRest; }
+    bool onRest() const { return !_lastIsAtRest && _isAtRest; }
+    bool onWake() const { return _lastIsAtRest && !_isAtRest; }
 
 protected:
+    bool _isValid { false };
     glm::vec3 _positionAverage;
     glm::vec3 _quatLogAverage;
     uint64_t _lastUpdateTime { 0 };
     float _positionVariance { 0.0f };
     float _quatLogVariance { 0.0f };
     bool _isAtRest { false };
+    bool _lastIsAtRest { false };
 };
 
 #endif


### PR DESCRIPTION
This is to make users avatars look more natural when their hand controllers are left sitting on the desk, or resting on the arm rests of a chair.