### PR TITLE
Fix for Case 19395

### DIFF
--- a/server-console/src/main.js
+++ b/server-console/src/main.js
@@ -919,6 +919,8 @@ app.on('ready', function() {
         trayNotifications.startPolling();
     }
     updateTrayMenu(ProcessGroupStates.STOPPED);
-
-    maybeInstallDefaultContentSet(onContentLoaded);
+    
+    if (isServerInstalled()) {
+        maybeInstallDefaultContentSet(onContentLoaded);
+    }
 });


### PR DESCRIPTION
High Fidelity Console in client only install downloads default content assets for non-existent sandbox.