### PR TITLE
hide progress overlays if interstitial mode

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3534,6 +3534,7 @@ void Application::setIsInterstitialMode(bool interstitialMode) {
     if (enableInterstitial) {
         if (_interstitialMode != interstitialMode) {
             _interstitialMode = interstitialMode;
+            emit interstitialModeChanged(_interstitialMode);
 
             DependencyManager::get<AudioClient>()->setAudioPaused(_interstitialMode);
             DependencyManager::get<AvatarManager>()->setMyAvatarDataPacketsPaused(_interstitialMode);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -334,6 +334,8 @@ signals:
 
     void uploadRequest(QString path);
 
+    void interstitialModeChanged(bool isInInterstitialMode);
+
     void loginDialogPoppedUp();
 
 public slots:

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -54,6 +54,9 @@ WindowScriptingInterface::WindowScriptingInterface() {
     });
 
     connect(qApp->getWindow(), &MainWindow::windowGeometryChanged, this, &WindowScriptingInterface::onWindowGeometryChanged);
+    connect(qApp, &Application::interstitialModeChanged, [this] (bool interstitialMode) {
+        emit interstitialModeChanged(interstitialMode);
+    });
 }
 
 WindowScriptingInterface::~WindowScriptingInterface() {

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -620,6 +620,14 @@ signals:
     void redirectErrorStateChanged(bool isInErrorState);
 
     /**jsdoc
+     * Triggered when interstitial mode changes.
+     * @function Window.interstitialModeChanged
+     * @param {bool} interstitialMode - The mode of the interstitial is changed to.
+     * @returns {Signal}
+     */
+    void interstitialModeChanged(bool interstitialMode);
+
+    /**jsdoc
      * Triggered when a still snapshot has been taken by calling {@link Window.takeSnapshot|takeSnapshot} with 
      *     <code>includeAnimated = false</code> or {@link Window.takeSecondaryCameraSnapshot|takeSecondaryCameraSnapshot}.
      * @function Window.stillSnapshotTaken

--- a/scripts/system/interstitialPage.js
+++ b/scripts/system/interstitialPage.js
@@ -381,8 +381,8 @@
 
     function updateOverlays(physicsEnabled) {
 
-        if (isInterstitialOverlaysVisible !== !physicsEnabled) {
-             // visible changed
+        if (isInterstitialOverlaysVisible !== !physicsEnabled && !physicsEnabled === true) {
+             // visible changed to true.
              isInterstitialOverlaysVisible = !physicsEnabled;
         }
 
@@ -431,6 +431,11 @@
 
         if (physicsEnabled) {
             Camera.mode = previousCameraMode;
+        }
+
+        if (isInterstitialOverlaysVisible !== !physicsEnabled && !physicsEnabled === false) {
+             // visible changed to false.
+             isInterstitialOverlaysVisible = !physicsEnabled;
         }
     }
 

--- a/scripts/system/interstitialPage.js
+++ b/scripts/system/interstitialPage.js
@@ -14,6 +14,7 @@
 
 (function() {
     Script.include("/~/system/libraries/Xform.js");
+    Script.include("/~/system/libraries/globals.js");
     var DEBUG = false;
     var MIN_LOADING_PROGRESS = 3.6;
     var TOTAL_LOADING_PROGRESS = 3.8;
@@ -379,6 +380,12 @@
     var currentProgress = 0.1;
 
     function updateOverlays(physicsEnabled) {
+
+        if (isInterstitialOverlaysVisible !== !physicsEnabled) {
+             // visible changed
+             isInterstitialOverlaysVisible = !physicsEnabled;
+        }
+
         var properties = {
             visible: !physicsEnabled
         };

--- a/scripts/system/libraries/globals.js
+++ b/scripts/system/libraries/globals.js
@@ -9,3 +9,5 @@
 //
 
 HIFI_PUBLIC_BUCKET = "http://s3.amazonaws.com/hifi-public/";
+
+isInterstitialOverlaysVisible = false;

--- a/scripts/system/progress.js
+++ b/scripts/system/progress.js
@@ -267,7 +267,7 @@
 
         // Update state
         if (!visible) { // Not visible because no recent downloads
-            if ((displayProgress < 100 || gpuTextures > 0) && !(isInInterstitialMode || isInterstitialOverlaysVisible)) { // Have started downloading so fade in
+            if ((displayProgress < 100 || gpuTextures > 0) && !isInInterstitialMode && !isInterstitialOverlaysVisible) { // Have started downloading so fade in
                 visible = true;
                 alphaDelta = ALPHA_DELTA_IN;
                 fadeTimer = Script.setInterval(fade, FADE_INTERVAL);
@@ -307,10 +307,13 @@
             } else {
                 x = x * BAR_HMD_REPEAT;
             }
+            if (isInInterstitialMode || isInterstitialOverlaysVisible) {
+                visible = false;
+            }
 
             // Update progress bar
             Overlays.editOverlay(barDesktop.overlay, {
-                visible: !isHMD,
+                visible: !isHMD && visible,
                 bounds: {
                     x: barDesktop.repeat - x,
                     y: windowHeight - barDesktop.height,
@@ -320,7 +323,7 @@
             });
 
             Overlays.editOverlay(barHMD.overlay, {
-                visible: isHMD,
+                visible: isHMD && visible,
                 bounds: {
                     x: BAR_HMD_REPEAT - x,
                     y: windowHeight - BAR_HMD_HEIGHT,
@@ -330,11 +333,11 @@
             });
 
             Overlays.editOverlay(textDesktop.overlay, {
-                visible: !isHMD
+                visible: !isHMD && visible
             });
 
             Overlays.editOverlay(textHMD.overlay, {
-                visible: isHMD
+                visible: isHMD && visible
             });
 
             // Update 2D overlays to maintain positions at bottom middle of window

--- a/scripts/system/progress.js
+++ b/scripts/system/progress.js
@@ -14,11 +14,11 @@
 //
 
 (function () { // BEGIN LOCAL_SCOPE
-
     function debug() {
         //print.apply(null, arguments);
     }
 
+    Script.include("/~/system/libraries/globals.js");
     var rawProgress = 100, // % raw value.
         displayProgress = 100, // % smoothed value to display.
         alpha = 0.0,
@@ -83,7 +83,9 @@
         // The initial delay cooldown keeps us from tracking progress before the allotted time
         // has passed.
         INITIAL_DELAY_COOLDOWN_TIME = 1000,
-        initialDelayCooldown = 0;
+        initialDelayCooldown = 0,
+
+        isInInterstitialMode = false;
 
     function fade() {
 
@@ -265,7 +267,7 @@
 
         // Update state
         if (!visible) { // Not visible because no recent downloads
-            if (displayProgress < 100 || gpuTextures > 0) { // Have started downloading so fade in
+            if ((displayProgress < 100 || gpuTextures > 0) && !(isInInterstitialMode || isInterstitialOverlaysVisible)) { // Have started downloading so fade in
                 visible = true;
                 alphaDelta = ALPHA_DELTA_IN;
                 fadeTimer = Script.setInterval(fade, FADE_INTERVAL);
@@ -344,6 +346,10 @@
         }
     }
 
+    function interstitialModeChanged(inMode) {
+        isInInterstitialMode = inMode;
+    }
+
     function setUp() {
         var is4k = Window.innerWidth > 3000;
 
@@ -369,6 +375,7 @@
     }
 
     setUp();
+    Window.interstitialModeChanged.connect(interstitialModeChanged);
     GlobalServices.downloadInfoChanged.connect(onDownloadInfoChanged);
     GlobalServices.updateDownloadInfo();
     Script.setInterval(update, 1000 / 60);


### PR DESCRIPTION
- Hides "LOADING CONTENT" bar in HMD/desktop mode if interstitial mode is enabled
- Fixes MS#[19357](https://highfidelity.manuscript.com/f/cases/19357/Loading-Content-Should-not-be-Visible)

## TEST PLAN
- Launch interface
- Navigate between domains
- When looking around in HMD/desktop mode in the interstitial page, you should not see the "LOADING CONTENT" message (similar to the image below)
![image](https://user-images.githubusercontent.com/10539521/46968686-b6644180-d068-11e8-95a7-c55ac0327446.png)