### PR TITLE
FB19396 - QML warning qrc:///qml/hifi/tablet/WindowRoot.qml:132: Type…

### DIFF
--- a/interface/resources/qml/hifi/tablet/WindowRoot.qml
+++ b/interface/resources/qml/hifi/tablet/WindowRoot.qml
@@ -129,8 +129,21 @@ Windows.ScrollingWindow {
 
         height: pane.scrollHeight
         width: pane.contentWidth
-        anchors.left: parent.left
-        anchors.top: parent.top
+
+        // this might be looking not clear from the first look
+        // but loader.parent is not tabletRoot and it can be null!
+        // unfortunately we can't use conditional bindings here due to https://bugreports.qt.io/browse/QTBUG-22005
+
+        onParentChanged: {
+            if (parent) {
+                anchors.left = Qt.binding(function() { return parent.left })
+                anchors.top = Qt.binding(function() { return parent.top })
+            } else {
+                anchors.left = undefined
+                anchors.top = undefined
+            }
+        }
+
         signal loaded;
         
         onWidthChanged: {


### PR DESCRIPTION
…Error: Cannot read property of null

https://highfidelity.fogbugz.com/f/cases/19396/QML-warning-qrc-qml-hifi-tablet-WindowRoot-qml-132-TypeError-Cannot-read-property-of-null

**Test plan**

1. Clear logs
2. Launch interface
3. Ensure logs doesn't contain entries 'qrc:///qml/hifi/tablet/WindowRoot.qml:132: TypeError: Cannot read property of null'