### PR TITLE
Fix lasers going through tablet to drawInFrontOverlays

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -8476,6 +8476,16 @@ QUuid Application::getTabletFrameID() const {
     return HMD->getCurrentTabletFrameID();
 }
 
+QVector<QUuid> Application::getTabletIDs() const {
+    // Most important overlays first. 
+    QVector<QUuid> result;
+    auto HMD = DependencyManager::get<HMDScriptingInterface>();
+    result << HMD->getCurrentTabletScreenID();
+    result << HMD->getCurrentHomeButtonID();
+    result << HMD->getCurrentTabletFrameID();
+    return result;
+}
+
 void Application::setAvatarOverrideUrl(const QUrl& url, bool save) {
     _avatarOverrideUrl = url;
     _saveAvatarOverrideUrl = save;

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -298,6 +298,7 @@ public:
     OverlayID getTabletScreenID() const;
     OverlayID getTabletHomeButtonID() const;
     QUuid getTabletFrameID() const; // may be an entity or an overlay
+    QVector<QUuid> getTabletIDs() const; // In order of most important IDs first.
 
     void setAvatarOverrideUrl(const QUrl& url, bool save);
     void clearAvatarOverrideUrl() { _avatarOverrideUrl = QUrl(); _saveAvatarOverrideUrl = false; }

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -557,8 +557,8 @@ RayToOverlayIntersectionResult Overlays::findRayIntersectionVector(const PickRay
                                                           thisFace, thisSurfaceNormal, thisExtraInfo, precisionPicking)) {
                 bool isDrawInFront = thisOverlay->getDrawInFront();
                 bool isTablet = tabletIDs.contains(thisID);
-                if (isDrawInFront && !bestIsFront && !bestIsTablet
-                        || (isTablet || isDrawInFront || !bestIsFront) && thisDistance < bestDistance) {
+                if ((isDrawInFront && !bestIsFront && !bestIsTablet)
+                        || ((isTablet || isDrawInFront || !bestIsFront) && thisDistance < bestDistance)) {
                     bestIsFront = isDrawInFront;
                     bestIsTablet = isTablet;
                     bestDistance = thisDistance;

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -831,40 +831,12 @@ PointerEvent Overlays::calculateOverlayPointerEvent(OverlayID overlayID, PickRay
 }
 
 
-RayToOverlayIntersectionResult Overlays::findRayIntersectionForMouseEvent(PickRay ray) {
-    QVector<OverlayID> overlaysToInclude;
-    QVector<OverlayID> overlaysToDiscard;
-    RayToOverlayIntersectionResult rayPickResult;
-
-    // first priority is tablet screen
-    overlaysToInclude << qApp->getTabletScreenID();
-    rayPickResult = findRayIntersectionVector(ray, true, overlaysToInclude, overlaysToDiscard);
-    if (rayPickResult.intersects) {
-        return rayPickResult;
-    }
-    // then tablet home button
-    overlaysToInclude.clear();
-    overlaysToInclude << qApp->getTabletHomeButtonID();
-    rayPickResult = findRayIntersectionVector(ray, true, overlaysToInclude, overlaysToDiscard);
-    if (rayPickResult.intersects) {
-        return rayPickResult;
-    }
-    // then tablet frame
-    overlaysToInclude.clear();
-    overlaysToInclude << OverlayID(qApp->getTabletFrameID());
-    rayPickResult = findRayIntersectionVector(ray, true, overlaysToInclude, overlaysToDiscard);
-    if (rayPickResult.intersects) {
-        return rayPickResult;
-    }
-    // then whatever
-    return findRayIntersection(ray);
-}
-
 bool Overlays::mousePressEvent(QMouseEvent* event) {
     PerformanceTimer perfTimer("Overlays::mousePressEvent");
 
     PickRay ray = qApp->computePickRay(event->x(), event->y());
-    RayToOverlayIntersectionResult rayPickResult = findRayIntersectionForMouseEvent(ray);
+    RayToOverlayIntersectionResult rayPickResult = findRayIntersectionVector(ray, true, QVector<OverlayID>(),
+        QVector<OverlayID>());
     if (rayPickResult.intersects) {
         _currentClickingOnOverlayID = rayPickResult.overlayID;
 
@@ -904,7 +876,8 @@ bool Overlays::mouseDoublePressEvent(QMouseEvent* event) {
     PerformanceTimer perfTimer("Overlays::mouseDoublePressEvent");
 
     PickRay ray = qApp->computePickRay(event->x(), event->y());
-    RayToOverlayIntersectionResult rayPickResult = findRayIntersectionForMouseEvent(ray);
+    RayToOverlayIntersectionResult rayPickResult = findRayIntersectionVector(ray, true, QVector<OverlayID>(),
+        QVector<OverlayID>());
     if (rayPickResult.intersects) {
         _currentClickingOnOverlayID = rayPickResult.overlayID;
 
@@ -967,7 +940,8 @@ bool Overlays::mouseReleaseEvent(QMouseEvent* event) {
     PerformanceTimer perfTimer("Overlays::mouseReleaseEvent");
 
     PickRay ray = qApp->computePickRay(event->x(), event->y());
-    RayToOverlayIntersectionResult rayPickResult = findRayIntersectionForMouseEvent(ray);
+    RayToOverlayIntersectionResult rayPickResult = findRayIntersectionVector(ray, true, QVector<OverlayID>(),
+        QVector<OverlayID>());
     if (rayPickResult.intersects) {
         auto pointerEvent = calculateOverlayPointerEvent(rayPickResult.overlayID, ray, rayPickResult, event, PointerEvent::Release);
         mouseReleasePointerEvent(rayPickResult.overlayID, pointerEvent);
@@ -996,7 +970,8 @@ bool Overlays::mouseMoveEvent(QMouseEvent* event) {
     PerformanceTimer perfTimer("Overlays::mouseMoveEvent");
 
     PickRay ray = qApp->computePickRay(event->x(), event->y());
-    RayToOverlayIntersectionResult rayPickResult = findRayIntersectionForMouseEvent(ray);
+    RayToOverlayIntersectionResult rayPickResult = findRayIntersectionVector(ray, true, QVector<OverlayID>(),
+        QVector<OverlayID>());
     if (rayPickResult.intersects) {
         auto pointerEvent = calculateOverlayPointerEvent(rayPickResult.overlayID, ray, rayPickResult, event, PointerEvent::Move);
         mouseMovePointerEvent(rayPickResult.overlayID, pointerEvent);

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -532,6 +532,8 @@ RayToOverlayIntersectionResult Overlays::findRayIntersectionVector(const PickRay
                                                                    bool visibleOnly, bool collidableOnly) {
     float bestDistance = std::numeric_limits<float>::max();
     bool bestIsFront = false;
+    bool bestIsTablet = false;
+    auto tabletIDs = qApp->getTabletIDs();
 
     QMutexLocker locker(&_mutex);
     RayToOverlayIntersectionResult result;
@@ -554,10 +556,11 @@ RayToOverlayIntersectionResult Overlays::findRayIntersectionVector(const PickRay
             if (thisOverlay->findRayIntersectionExtraInfo(ray.origin, ray.direction, thisDistance,
                                                           thisFace, thisSurfaceNormal, thisExtraInfo, precisionPicking)) {
                 bool isDrawInFront = thisOverlay->getDrawInFront();
-                if ((bestIsFront && isDrawInFront && thisDistance < bestDistance)
-                    || (!bestIsFront && (isDrawInFront || thisDistance < bestDistance))) {
-
+                bool isTablet = tabletIDs.contains(thisID);
+                if (isDrawInFront && !bestIsFront && !bestIsTablet
+                        || (isTablet || isDrawInFront || !bestIsFront) && thisDistance < bestDistance) {
                     bestIsFront = isDrawInFront;
+                    bestIsTablet = isTablet;
                     bestDistance = thisDistance;
                     result.intersects = true;
                     result.distance = thisDistance;

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -44,8 +44,7 @@ void OverlayPropertyResultFromScriptValue(const QScriptValue& object, OverlayPro
 const OverlayID UNKNOWN_OVERLAY_ID = OverlayID();
 
 /**jsdoc
- * The result of a {@link PickRay} search using {@link Overlays.findRayIntersection|findRayIntersection} or 
- * {@link Overlays.findRayIntersectionVector|findRayIntersectionVector}.
+ * The result of a {@link PickRay} search using {@link Overlays.findRayIntersection|findRayIntersection}.
  * @typedef {object} Overlays.RayToOverlayIntersectionResult
  * @property {boolean} intersects - <code>true</code> if the {@link PickRay} intersected with a 3D overlay, otherwise
  *     <code>false</code>.

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -383,7 +383,11 @@ public slots:
     OverlayPropertyResult getOverlaysProperties(const QVariant& overlaysProperties);
 
     /**jsdoc
-     * Find the closest 3D overlay intersected by a {@link PickRay}.
+     *  Find the closest 3D overlay intersected by a {@link PickRay}. Overlays with their <code>drawInFront</code> property set  
+     * to <code>true</code> have priority over overlays that don't, except that tablet overlays have priority over any  
+     * <code>drawInFront</code> overlays behind them. I.e., if a <code>drawInFront</code> overlay is behind one that isn't  
+     * <code>drawInFront</code>, the <code>drawInFront</code> overlay is returned, but if a tablet overlay is in front of a  
+     * <code>drawInFront</code> overlay, the tablet overlay is returned.
      * @function Overlays.findRayIntersection
      * @param {PickRay} pickRay - The PickRay to use for finding overlays.
      * @param {boolean} [precisionPicking=false] - <em>Unused</em>; exists to match Entity API.

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -754,8 +754,6 @@ private:
     OverlayID _currentClickingOnOverlayID { UNKNOWN_OVERLAY_ID };
     OverlayID _currentHoverOverOverlayID { UNKNOWN_OVERLAY_ID };
 
-    RayToOverlayIntersectionResult findRayIntersectionForMouseEvent(PickRay ray);
-
 private slots:
     void mousePressPointerEvent(const OverlayID& overlayID, const PointerEvent& event);
     void mouseMovePointerEvent(const OverlayID& overlayID, const PointerEvent& event);


### PR DESCRIPTION
In particular, this fixes the laser going through to tablet to Create app edit handles behind the tablet.
Also makes the mouse pointer use the same code instead of its own.