### PR TITLE
18518 - Make record.js unsubscribe from messaging channel

### DIFF
--- a/unpublishedScripts/marketplace/record/record.js
+++ b/unpublishedScripts/marketplace/record/record.js
@@ -395,7 +395,7 @@
             Script.clearInterval(updateTimer);
 
             Messages.messageReceived.disconnect(onMessageReceived);
-            Messages.subscribe(HIFI_RECORDER_CHANNEL);
+            Messages.unsubscribe(HIFI_RECORDER_CHANNEL);
         }
 
         return {


### PR DESCRIPTION
Record.js was not unsubscribing from the `HIFI_RECORDER_CHANNEL` on script ending.

[Relevant MS ticket.](https://highfidelity.fogbugz.com/f/cases/18518/record-js-App-Not-Unsubscribing-from-Message-Channel)

So, after consulting with Jeff and Dante... There's really no good test plan for this. We don't have a way of polling whether a script is subscribed or not. So long as `record.js` operates as before (the one in `unpublishedScripts/marketplace/record/record.js`), then there's no issue. This was basically just fixing a small typo.