### PR TITLE
FB19400 during shutdown -- TypeError: Cannot read property 'buttons' …

### DIFF
--- a/interface/resources/qml/hifi/Desktop.qml
+++ b/interface/resources/qml/hifi/Desktop.qml
@@ -70,8 +70,8 @@ OriginalDesktop.Desktop {
         anchors.horizontalCenter: settings.constrainToolbarToCenterX ? desktop.horizontalCenter : undefined;
         // Literal 50 is overwritten by settings from previous session, and sysToolbar.x comes from settings when not constrained.
         x: sysToolbar.x
-        buttonModel: tablet.buttons;
-        shown: tablet.toolbarMode;
+        buttonModel: tablet ? tablet.buttons : null;
+        shown: tablet ? tablet.toolbarMode : false;
     }
 
     Settings {

--- a/interface/resources/qml/hifi/tablet/TabletHome.qml
+++ b/interface/resources/qml/hifi/tablet/TabletHome.qml
@@ -115,9 +115,9 @@ Item {
             property int previousIndex: -1
             Repeater {
                 id: pageRepeater
-                model: Math.ceil(tabletProxy.buttons.rowCount() / TabletEnums.ButtonsOnPage)
+                model: tabletProxy != null ? Math.ceil(tabletProxy.buttons.rowCount() / TabletEnums.ButtonsOnPage) : null
                 onItemAdded: {
-                    item.proxyModel.sourceModel = tabletProxy.buttons;
+                    item.proxyModel.sourceModel = tabletProxy != null ? tabletProxy.buttons : null;
                     item.proxyModel.pageIndex = index;
                 }
 

--- a/interface/resources/qml/hifi/tablet/TabletHome.qml
+++ b/interface/resources/qml/hifi/tablet/TabletHome.qml
@@ -115,7 +115,7 @@ Item {
             property int previousIndex: -1
             Repeater {
                 id: pageRepeater
-                model: tabletProxy != null ? Math.ceil(tabletProxy.buttons.rowCount() / TabletEnums.ButtonsOnPage) : null
+                model: tabletProxy != null ? Math.ceil(tabletProxy.buttons.rowCount() / TabletEnums.ButtonsOnPage) : 0
                 onItemAdded: {
                     item.proxyModel.sourceModel = tabletProxy != null ? tabletProxy.buttons : null;
                     item.proxyModel.pageIndex = index;

--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -387,8 +387,16 @@ void OffscreenSurface::finishQmlLoad(QQmlComponent* qmlComponent,
         if (!parent) {
             parent = getRootItem();
         }
-        // Allow child windows to be destroyed from JS
-        QQmlEngine::setObjectOwnership(newObject, QQmlEngine::JavaScriptOwnership);
+        // manually control children items lifetime
+        QQmlEngine::setObjectOwnership(newObject, QQmlEngine::CppOwnership);
+        // some objects we are going to delete might be already deleted (children of parent we already deleted) so use QPointer to track lifetime
+        QPointer<QObject> trackedObject(newObject);
+        connect(_sharedObject, &SharedObject::onBeforeDestroyed, [trackedObject]() {
+            if (trackedObject) {
+                delete trackedObject.data();
+            }
+        });
+
         newObject->setParent(parent);
         newItem->setParentItem(parent);
     } else {

--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -389,13 +389,9 @@ void OffscreenSurface::finishQmlLoad(QQmlComponent* qmlComponent,
         }
         // manually control children items lifetime
         QQmlEngine::setObjectOwnership(newObject, QQmlEngine::CppOwnership);
-        // some objects we are going to delete might be already deleted (children of parent we already deleted) so use QPointer to track lifetime
-        QPointer<QObject> trackedObject(newObject);
-        connect(_sharedObject, &SharedObject::onBeforeDestroyed, [trackedObject]() {
-            if (trackedObject) {
-                delete trackedObject.data();
-            }
-        });
+
+        // add object to the manual deletion list
+        _sharedObject->addToDeletionList(newObject);
 
         newObject->setParent(parent);
         newItem->setParentItem(parent);

--- a/libraries/qml/src/qml/impl/SharedObject.cpp
+++ b/libraries/qml/src/qml/impl/SharedObject.cpp
@@ -79,9 +79,11 @@ SharedObject::SharedObject() {
 
 
 SharedObject::~SharedObject() {
+
+    emit onBeforeDestroyed();
+
     // After destroy returns, the rendering thread should be gone
     destroy();
-
     // _renderTimer is created with `this` as the parent, so need no explicit destruction
 #ifndef DISABLE_QML
     // Destroy the event hand

--- a/libraries/qml/src/qml/impl/SharedObject.cpp
+++ b/libraries/qml/src/qml/impl/SharedObject.cpp
@@ -15,6 +15,7 @@
 #include <QtQml/QQmlEngine>
 
 #include <QtGui/QOpenGLContext>
+#include <QPointer>
 
 #include <NumericalConstants.h>
 #include <shared/NsightHelpers.h>
@@ -79,9 +80,6 @@ SharedObject::SharedObject() {
 
 
 SharedObject::~SharedObject() {
-
-    emit onBeforeDestroyed();
-
     // After destroy returns, the rendering thread should be gone
     destroy();
     // _renderTimer is created with `this` as the parent, so need no explicit destruction
@@ -97,6 +95,11 @@ SharedObject::~SharedObject() {
         _renderControl = nullptr;
     }
 #endif
+
+    // already deleted objects will be reset to null by QPointer so it should be safe just iterate here
+    for (auto qmlObject : _deletionList) {
+        delete qmlObject;
+    }
 
     if (_rootItem) {
         delete _rootItem;
@@ -412,6 +415,11 @@ bool SharedObject::fetchTexture(TextureAndFence& textureAndFence) {
     textureAndFence = { 0, 0 };
     std::swap(textureAndFence, _latestTextureAndFence);
     return true;
+}
+
+void hifi::qml::impl::SharedObject::addToDeletionList(QObject * object)
+{
+    _deletionList.append(QPointer<QObject>(object));
 }
 
 void SharedObject::setProxyWindow(QWindow* window) {

--- a/libraries/qml/src/qml/impl/SharedObject.h
+++ b/libraries/qml/src/qml/impl/SharedObject.h
@@ -66,9 +66,7 @@ public:
     void resume();
     bool isPaused() const;
     bool fetchTexture(TextureAndFence& textureAndFence);
-
-signals:
-    void onBeforeDestroyed();
+    void addToDeletionList(QObject* object);
 
 private:
     bool event(QEvent* e) override;
@@ -92,6 +90,8 @@ private:
     void onTimer();
     void onAboutToQuit();
     void updateTextureAndFence(const TextureAndFence& newTextureAndFence);
+
+    QList<QPointer<QObject>> _deletionList;
 
     // Texture management
     TextureAndFence _latestTextureAndFence{ 0, 0 };

--- a/libraries/qml/src/qml/impl/SharedObject.h
+++ b/libraries/qml/src/qml/impl/SharedObject.h
@@ -67,6 +67,8 @@ public:
     bool isPaused() const;
     bool fetchTexture(TextureAndFence& textureAndFence);
 
+signals:
+    void onBeforeDestroyed();
 
 private:
     bool event(QEvent* e) override;


### PR DESCRIPTION
…of null

https://highfidelity.manuscript.com/f/cases/19400/during-shutdown-TypeError-Cannot-read-property-buttons-of-null

note: PR also contains experimental code which tries to resolve all the shutdown warnings from QML at once. 

**Test plan**

1. Launch interface
2. Delete logs
3. Close interface
4. Ensure logs doesn't contain entries like the following: 

[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/tablet/TabletHome.qml:118: TypeError: Cannot read property 'buttons' of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/tablet/TabletHome.qml:118: TypeError: Cannot read property 'buttons' of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/Desktop.qml:73: TypeError: Cannot read property 'buttons' of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/Desktop.qml:74: TypeError: Cannot read property 'toolbarMode' of null
 


[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/Stats.qml:34: TypeError: Cannot read property of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/AnimStats.qml:34: TypeError: Cannot read property of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/audio/MicBar.qml:43: TypeError: Cannot read property of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/windows/DefaultFrameDecoration.qml:49: TypeError: Cannot read property of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/controls-uit/Keyboard.qml:240: TypeError: Cannot read property of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/controls-uit/Key.qml:123: TypeError: Cannot read property of null

5. Repeat steps 1,3 at least 5 times while in desktop & 5 times while in VR mode. 
6. Ensure application didn't crash during step 5. 