### PR TITLE
FB19219 - Make avatarapp to handle wearables update via drag&drop

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -3280,6 +3280,5 @@ void EntityItem::prepareForSimulationOwnershipBid(EntityItemProperties& properti
 }
 
 bool EntityItem::isWearable() const {
-    return isVisible() && getParentJointIndex() != INVALID_JOINT_INDEX
-        && (getParentID() == DependencyManager::get<NodeList>()->getSessionUUID() || getParentID() == AVATAR_SELF_ID);
+    return isVisible() && (getParentID() == DependencyManager::get<NodeList>()->getSessionUUID() || getParentID() == AVATAR_SELF_ID);
 }

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -3278,3 +3278,8 @@ void EntityItem::prepareForSimulationOwnershipBid(EntityItemProperties& properti
     properties.setOwningAvatarID(getOwningAvatarID());
     setLastBroadcast(now); // for debug/physics status icons
 }
+
+bool EntityItem::isWearable() const {
+    return isVisible() && getParentJointIndex() != INVALID_JOINT_INDEX
+        && (getParentID() == DependencyManager::get<NodeList>()->getSessionUUID() || getParentID() == AVATAR_SELF_ID);
+}

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -489,7 +489,7 @@ public:
     void scriptHasUnloaded();
     void setScriptHasFinishedPreload(bool value);
     bool isScriptPreloadFinished();
-
+    virtual bool isWearable() const;
     bool isDomainEntity() const { return _hostType == entity::HostType::DOMAIN; }
     bool isAvatarEntity() const { return _hostType == entity::HostType::AVATAR; }
     bool isLocalEntity() const { return _hostType == entity::HostType::LOCAL; }

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -114,6 +114,8 @@ bool EntityScriptingInterface::canReplaceContent() {
 
 void EntityScriptingInterface::setEntityTree(EntityTreePointer elementTree) {
     if (_entityTree) {
+        disconnect(_entityTree.get(), &EntityTree::addingEntityPointer, this, &EntityScriptingInterface::onAddingEntity);
+        disconnect(_entityTree.get(), &EntityTree::deletingEntityPointer, this, &EntityScriptingInterface::onDeletingEntity);
         disconnect(_entityTree.get(), &EntityTree::addingEntity, this, &EntityScriptingInterface::addingEntity);
         disconnect(_entityTree.get(), &EntityTree::deletingEntity, this, &EntityScriptingInterface::deletingEntity);
         disconnect(_entityTree.get(), &EntityTree::clearingEntities, this, &EntityScriptingInterface::clearingEntities);
@@ -122,6 +124,8 @@ void EntityScriptingInterface::setEntityTree(EntityTreePointer elementTree) {
     _entityTree = elementTree;
 
     if (_entityTree) {
+        connect(_entityTree.get(), &EntityTree::addingEntityPointer, this, &EntityScriptingInterface::onAddingEntity, Qt::DirectConnection);
+        connect(_entityTree.get(), &EntityTree::deletingEntityPointer, this, &EntityScriptingInterface::onDeletingEntity, Qt::DirectConnection);
         connect(_entityTree.get(), &EntityTree::addingEntity, this, &EntityScriptingInterface::addingEntity);
         connect(_entityTree.get(), &EntityTree::deletingEntity, this, &EntityScriptingInterface::deletingEntity);
         connect(_entityTree.get(), &EntityTree::clearingEntities, this, &EntityScriptingInterface::clearingEntities);
@@ -1060,7 +1064,17 @@ void EntityScriptingInterface::handleEntityScriptCallMethodPacket(QSharedPointer
     }
 }
 
+void EntityScriptingInterface::onAddingEntity(EntityItem* entity) {
+    if (entity->isWearable()) {
+        emit addingWearable(entity->getEntityItemID());
+    }
+}
 
+void EntityScriptingInterface::onDeletingEntity(EntityItem* entity) {
+    if (entity->isWearable()) {
+        emit deletingWearable(entity->getEntityItemID());
+    }
+}
 
 QUuid EntityScriptingInterface::findClosestEntity(const glm::vec3& center, float radius) const {
     PROFILE_RANGE(script_entities, __FUNCTION__);

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -1909,6 +1909,31 @@ signals:
     void addingEntity(const EntityItemID& entityID);
 
     /**jsdoc
+    * Triggered when an 'wearable' entity is deleted.
+    * @function Entities.deletingWearable
+    * @param {Uuid} entityID - The ID of the 'wearable' entity deleted.
+    * @returns {Signal}
+    * @example <caption>Report when an 'wearable' entity is deleted.</caption>
+    * Entities.deletingWearable.connect(function (entityID) {
+    *     print("Deleted wearable: " + entityID);
+    * });
+    */
+    void deletingWearable(const EntityItemID& entityID);
+
+    /**jsdoc
+    * Triggered when an 'wearable' entity is added to Interface's local in-memory tree of entities it knows about. This may occur when
+    * 'wearable' entities are added to avatar
+    * @function Entities.addingWearable
+    * @param {Uuid} entityID - The ID of the 'wearable' entity added.
+    * @returns {Signal}
+    * @example <caption>Report when an 'wearable' entity is added.</caption>
+    * Entities.addingWearable.connect(function (entityID) {
+    *     print("Added wearable: " + entityID);
+    * });
+    */
+    void addingWearable(const EntityItemID& entityID);
+
+    /**jsdoc
      * Triggered when you disconnect from a domain, at which time Interface's local in-memory tree of entities it knows about
      * is cleared.
      * @function Entities.clearingEntities
@@ -1938,6 +1963,8 @@ protected:
 
 private slots:
     void handleEntityScriptCallMethodPacket(QSharedPointer<ReceivedMessage> receivedMessage, SharedNodePointer senderNode);
+    void onAddingEntity(EntityItem* entity);
+    void onDeletingEntity(EntityItem* entity);
 
 private:
     bool actionWorker(const QUuid& entityID, std::function<bool(EntitySimulationPointer, EntityItemPointer)> actor);

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -305,6 +305,7 @@ void EntityTree::postAddEntity(EntityItemPointer entity) {
     fixupNeedsParentFixups();
 
     emit addingEntity(entity->getEntityItemID());
+    emit addingEntityPointer(entity.get());
 }
 
 bool EntityTree::updateEntity(const EntityItemID& entityID, const EntityItemProperties& properties, const SharedNodePointer& senderNode) {

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -309,6 +309,7 @@ signals:
     void deletingEntity(const EntityItemID& entityID);
     void deletingEntityPointer(EntityItem* entityID);
     void addingEntity(const EntityItemID& entityID);
+    void addingEntityPointer(EntityItem* entityID);
     void editingEntityPointer(const EntityItemPointer& entityID);
     void entityScriptChanging(const EntityItemID& entityItemID, const bool reload);
     void entityServerScriptChanging(const EntityItemID& entityItemID, const bool reload);

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -519,12 +519,6 @@ QVector<bool> ModelEntityItem::getJointTranslationsSet() const {
     return result;
 }
 
-bool ModelEntityItem::isWearable() const
-{
-    return isVisible() && (getParentJointIndex() != INVALID_JOINT_INDEX || getRelayParentJoints())
-        && (getParentID() == DependencyManager::get<NodeList>()->getSessionUUID() || getParentID() == AVATAR_SELF_ID);
-}
-
 bool ModelEntityItem::hasModel() const { 
     return resultWithReadLock<bool>([&] {
         return !_modelURL.isEmpty();

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -519,6 +519,11 @@ QVector<bool> ModelEntityItem::getJointTranslationsSet() const {
     return result;
 }
 
+bool ModelEntityItem::isWearable() const
+{
+    return isVisible() && (getParentJointIndex() != INVALID_JOINT_INDEX || getRelayParentJoints())
+        && (getParentID() == DependencyManager::get<NodeList>()->getSessionUUID() || getParentID() == AVATAR_SELF_ID);
+}
 
 bool ModelEntityItem::hasModel() const { 
     return resultWithReadLock<bool>([&] {

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -123,6 +123,7 @@ public:
     QVector<glm::vec3> getJointTranslations() const;
     QVector<bool> getJointTranslationsSet() const;
 
+    virtual bool isWearable() const override;
 private:
     void setAnimationSettings(const QString& value); // only called for old bitstream format
     bool applyNewAnimationProperties(AnimationPropertyGroup newProperties);

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -123,7 +123,6 @@ public:
     QVector<glm::vec3> getJointTranslations() const;
     QVector<bool> getJointTranslationsSet() const;
 
-    virtual bool isWearable() const override;
 private:
     void setAnimationSettings(const QString& value); // only called for old bitstream format
     bool applyNewAnimationProperties(AnimationPropertyGroup newProperties);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/edit/19219/Make-avatarapp-to-handle-wearables-update-via-drag-drop

**Test plan**

1. Launch interface
2. Open avatarapp
3. Select avatar with no wearables
4. Drag & drop 'aviator.json' (extract from zip archive attached) inside interface. 
5. Ensure avatar got aviator glasses and avatarapp set wearables counter to 1. 
6. Select avatar with wearables
7. Drag & drop 'aviator.json' inside interface. 
8. Ensure avatar got aviator glasses and avatarapp increased wearables counter
[aviator.zip](https://github.com/highfidelity/hifi/files/2496789/aviator.zip)

note for developers: 

disconnecting / reconnecting 'onDeletingWearable' / 'onAddingWearable' should be pretty safe because:

1. Entities.deleteEntity calls EntityScriptingInterface::deleteEntity
2. EntityScriptingInterface::deleteEntity calls EntityTree::deleteEntity
3. EntityTree::deleteEntity emits signal which results in executing EntityScriptingInterface::onDeletingEntity synchronously due to direct connection
4. EntityScriptingInterface::onDeletingEntity emits deletingWearable signal

So, disconnecting 'deletingWearable' before the sequence above and re-connecting it after should work just fine. Even though *delivery* of queued signals is asynchronous, actual *emitting* is still synchronous. And based on Qt implementation, emitting finally results in the following call: QCoreApplication::postEvent(c->receiver, ev); so 'signal-wrapping' event will be posted to particular receiver which only exists if connection exists. Disconnecting should destroy connection so there should be no receiver. 

Last but not the lease, to prove it I made sample application with three threads: one receiver and two senders. Based on what I see, receiver never receives signals from sender where I disconnect prior sending and reconnect after sending