### PR TITLE
Setup a higher memory limit for android build

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xms2g -Xmx4g


### PR DESCRIPTION
Jenkins android build is throwing java.lang.OutOfMemoryError