### PR TITLE
Add a 'grabbable' option to the new-model dialog

### DIFF
--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -116,8 +116,13 @@ Rectangle {
             Column {
                 id: column2
                 width: 200
-                height: 400
+                height: 600
                 spacing: 10
+
+                CheckBox {
+                    id: grabbable
+                    text: qsTr("Grabbable")
+                }
 
                 CheckBox {
                     id: dynamic
@@ -219,7 +224,8 @@ Rectangle {
                                 params: {
                                     textInput: modelURL.text,
                                     checkBox: dynamic.checked,
-                                    comboBox: collisionType.currentIndex
+                                    comboBox: collisionType.currentIndex,
+                                    grabbable: grabbable.checked
                                 }
                             });
                         }

--- a/interface/resources/qml/hifi/tablet/NewModelDialog.qml
+++ b/interface/resources/qml/hifi/tablet/NewModelDialog.qml
@@ -222,9 +222,9 @@ Rectangle {
                             newModelDialog.sendToScript({
                                 method: "newModelDialogAdd",
                                 params: {
-                                    textInput: modelURL.text,
-                                    checkBox: dynamic.checked,
-                                    comboBox: collisionType.currentIndex,
+                                    url: modelURL.text,
+                                    dynamic: dynamic.checked,
+                                    collisionShapeIndex: collisionType.currentIndex,
                                     grabbable: grabbable.checked
                                 }
                             });

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -348,12 +348,12 @@ var toolBar = (function () {
 
             if (!properties.grab) {
                 properties.grab = {};
-            }
-            if (Menu.isOptionChecked(MENU_CREATE_ENTITIES_GRABBABLE) &&
-                !(properties.type === "Zone" || properties.type === "Light" || properties.type === "ParticleEffect")) {
-                properties.grab.grabbable = true;
-            } else {
-                properties.grab.grabbable = false;
+                if (Menu.isOptionChecked(MENU_CREATE_ENTITIES_GRABBABLE) &&
+                    !(properties.type === "Zone" || properties.type === "Light" || properties.type === "ParticleEffect")) {
+                    properties.grab.grabbable = true;
+                } else {
+                    properties.grab.grabbable = false;
+                }
             }
 
             SelectionManager.saveProperties();
@@ -473,6 +473,9 @@ var toolBar = (function () {
                     type: "Model",
                     modelURL: url,
                     shapeType: shapeType,
+                    grab: {
+                        grabbable: result.grabbable
+                    },
                     dynamic: dynamic,
                     gravity: dynamic ? { x: 0, y: -10, z: 0 } : { x: 0, y: 0, z: 0 }
                 });

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -442,9 +442,9 @@ var toolBar = (function () {
 
     function handleNewModelDialogResult(result) {
         if (result) {
-            var url = result.textInput;
+            var url = result.url;
             var shapeType;
-            switch (result.comboBox) {
+            switch (result.collisionShapeIndex) {
             case SHAPE_TYPE_SIMPLE_HULL:
                 shapeType = "simple-hull";
                 break;
@@ -464,7 +464,7 @@ var toolBar = (function () {
                 shapeType = "none";
             }
 
-            var dynamic = result.checkBox !== null ? result.checkBox : DYNAMIC_DEFAULT;
+            var dynamic = result.dynamic !== null ? result.dynamic : DYNAMIC_DEFAULT;
             if (shapeType === "static-mesh" && dynamic) {
                 // The prompt should prevent this case
                 print("Error: model cannot be both static mesh and dynamic.  This should never happen.");


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/4926/Revert-Grabbable-setting-for-imported-models-to-disabled-or-let-customers-to-define-default-setting-prior-to-importing-objects

Test plan:
- When you import a model in the edit tools, there should be a checkbox that lets you set grabbable or not... that checkbox should properly set the grabbableness of things