### PR TITLE
Bug 19488:  Fix access to uniforms at index 0

### DIFF
--- a/libraries/gl/src/gl/GLShaders.cpp
+++ b/libraries/gl/src/gl/GLShaders.cpp
@@ -14,7 +14,7 @@ using namespace gl;
 
 void Uniform::load(GLuint glprogram, int index) {
     this->index = index;
-    if (index > 0) {
+    if (index >= 0) {
         static const GLint NAME_LENGTH = 1024;
         GLchar glname[NAME_LENGTH];
         memset(glname, 0, NAME_LENGTH);


### PR DESCRIPTION
Possible fix for [19488](https://highfidelity.manuscript.com/f/cases/19488)


The recent uniform safety code was incorrectly ignoring uniforms with an index of 0.  0 is a valid uniform index.  

