### PR TITLE
Enable interaction with locked web entity

### DIFF
--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -108,10 +108,6 @@ bool WebEntityRenderer::needsRenderUpdateFromTypedEntity(const TypedEntityPointe
         return true;
     }
 
-    if (_lastLocked != entity->getLocked()) {
-        return true;
-    }
-
     return false;
 }
 
@@ -203,7 +199,6 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
                 }
 
                 _lastDPI = entity->getDPI();
-                _lastLocked = entity->getLocked();
 
                 glm::vec2 windowSize = getWindowSize(entity);
                 _webSurface->resize(QSize(windowSize.x, windowSize.y));
@@ -361,7 +356,7 @@ glm::vec2 WebEntityRenderer::getWindowSize(const TypedEntityPointer& entity) con
 }
 
 void WebEntityRenderer::hoverEnterEntity(const PointerEvent& event) {
-    if (!_lastLocked && _webSurface) {
+    if (_webSurface) {
         PointerEvent webEvent = event;
         webEvent.setPos2D(event.getPos2D() * (METERS_TO_INCHES * _lastDPI));
         _webSurface->hoverBeginEvent(webEvent, _touchDevice);
@@ -369,7 +364,7 @@ void WebEntityRenderer::hoverEnterEntity(const PointerEvent& event) {
 }
 
 void WebEntityRenderer::hoverLeaveEntity(const PointerEvent& event) {
-    if (!_lastLocked && _webSurface) {
+    if (_webSurface) {
         PointerEvent webEvent = event;
         webEvent.setPos2D(event.getPos2D() * (METERS_TO_INCHES * _lastDPI));
         _webSurface->hoverEndEvent(webEvent, _touchDevice);
@@ -377,8 +372,7 @@ void WebEntityRenderer::hoverLeaveEntity(const PointerEvent& event) {
 }
 
 void WebEntityRenderer::handlePointerEvent(const PointerEvent& event) {
-    // Ignore mouse interaction if we're locked
-    if (!_lastLocked && _webSurface) {
+    if (_webSurface) {
         PointerEvent webEvent = event;
         webEvent.setPos2D(event.getPos2D() * (METERS_TO_INCHES * _lastDPI));
         _webSurface->handlePointerEvent(webEvent, _touchDevice);

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.h
@@ -65,7 +65,6 @@ private:
     gpu::TexturePointer _texture;
     QString _lastSourceUrl;
     uint16_t _lastDPI;
-    bool _lastLocked;
     QTimer _timer;
     uint64_t _lastRenderTime { 0 };
 };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/18986/web-entities-don-t-receive-click-events-when-locked

Test plan:
- Make a locked web entity.  You should be able to click/scroll/interact with the webpage.