### PR TITLE
Fix ResourceCache crash on shutdown

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -252,7 +252,9 @@ ResourceCache::ResourceCache(QObject* parent) : QObject(parent) {
     }
 }
 
-ResourceCache::~ResourceCache() {}
+ResourceCache::~ResourceCache() {
+    clearUnusedResources();
+}
 
 void ResourceCache::clearATPAssets() {
     {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19494/ResourceCache-crash-on-shutdown

Test plan:
- Go to a domain with lots of models and things.  Create and delete a model with a unique URL (one that doesn't appear elsewhere in the domain).  Close Interface.  You shouldn't crash on shutdown.