### PR TITLE
FB17479 - Fix scripted key release events for handshakes.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4069,6 +4069,10 @@ void Application::focusOutEvent(QFocusEvent* event) {
     SpacemouseManager::getInstance().ManagerFocusOutEvent();
 #endif
 
+    synthesizeKeyReleasEvents();
+}
+
+void Application::synthesizeKeyReleasEvents() {
     // synthesize events for keys currently pressed, since we may not get their release events
     // Because our key event handlers may manipulate _keysPressed, lets swap the keys pressed into a local copy,
     // clearing the existing list.
@@ -4694,6 +4698,7 @@ void Application::idle() {
         if (_keyboardDeviceHasFocus && activeFocusItem != offscreenUi->getRootItem()) {
             _keyboardMouseDevice->pluginFocusOutEvent();
             _keyboardDeviceHasFocus = false;
+            synthesizeKeyReleasEvents();
         } else if (activeFocusItem == offscreenUi->getRootItem()) {
             _keyboardDeviceHasFocus = true;
         }

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -541,6 +541,7 @@ private:
     void keyReleaseEvent(QKeyEvent* event);
 
     void focusOutEvent(QFocusEvent* event);
+    void synthesizeKeyReleasEvents();
     void focusInEvent(QFocusEvent* event);
 
     void mouseMoveEvent(QMouseEvent* event);


### PR DESCRIPTION
This PR provides a fix for scripts seeing stuck key presses when the focus moves to an internal QML item.

In particular this helps resolve stuck "X" keys during connection handshaking in desktop mode, but it should also help make any scripts that depending on balanced key press/release sequences work more predictably.

#### Testing
1. Run this PR build of Interface.
2. Open the `Edit -> Running Scripts...` dialog.
3. With `Running Scripts...` open -- primary click on an empty part of the view (to de-focus the dialog while staying within the app).
4. Hold down <kbd>X</kbd> to initiate handshaking.
5. While continuing to hold <kbd>X</kbd> -- primary click on the `Running Scripts...` dialog.
6. Verify that handshaking ends whenever `Running Scripts...` regains keyboard focus.

_Note: in current master handshaking gets "stuck" in the case where X key is released after Running Scripts... dialog has the focus._

https://highfidelity.fogbugz.com/f/cases/17479/Handshake-does-not-end-when-opening-an-app

