### PR TITLE
Don't show stats in release builds

### DIFF
--- a/interface/resources/qml/+android/Stats.qml
+++ b/interface/resources/qml/+android/Stats.qml
@@ -10,6 +10,7 @@ Item {
     property int modality: Qt.NonModal
     implicitHeight: row.height
     implicitWidth: row.width
+    visible: false
 
     Component.onCompleted: {
         stats.parentChanged.connect(fill);


### PR DESCRIPTION
MS CASE: 19497

Stats qml was visible by default in Android releases 0.74 and 0.75 and it was hidden when it starts updating stats. This way stats were visible for a few seconds even in release builds.

This PR sets visibility of Stats.qml to invisible by default (android version only).

**Test Plan**
- Start the app and check that stats are hidden until the user choose to show them (debug builds only)
- User can show/hide stats using the stats button (debug builds only)
- User selection is persistent between app runs. It needs some seconds to store the preference

