### PR TITLE
Update Spacemouse plugin + Proposal to main build

### DIFF
--- a/plugins/hifiSpacemouse/src/SpacemouseManager.cpp
+++ b/plugins/hifiSpacemouse/src/SpacemouseManager.cpp
@@ -116,8 +116,8 @@ controller::Input::NamedVector SpacemouseDevice::getAvailableInputs() const {
         makePair(TRANSLATE_X, "TranslateX"),
         makePair(TRANSLATE_Y, "TranslateY"),
         makePair(TRANSLATE_Z, "TranslateZ"),
-        //makePair(ROTATE_X, "RotateX"),
-        //makePair(ROTATE_Y, "RotateY"),
+        makePair(ROTATE_X, "RotateX"),
+        makePair(ROTATE_Y, "RotateY"),
         makePair(ROTATE_Z, "RotateZ"),
 
     };

--- a/plugins/hifiSpacemouse/src/SpacemouseManager.cpp
+++ b/plugins/hifiSpacemouse/src/SpacemouseManager.cpp
@@ -20,7 +20,7 @@
 
 #include <controllers/UserInputMapper.h>
 
-const QString SpacemouseManager::NAME { "Spacemouse" };
+const char* SpacemouseManager::NAME { "Spacemouse" };
 
 const float MAX_AXIS = 75.0f;  // max forward = 2x speed
 #define LOGITECH_VENDOR_ID 0x46d

--- a/plugins/hifiSpacemouse/src/SpacemouseProvider.cpp
+++ b/plugins/hifiSpacemouse/src/SpacemouseProvider.cpp
@@ -38,6 +38,10 @@ public:
         return _inputPlugins;
     }
 
+    virtual void destroyInputPlugins() override {
+        _inputPlugins.clear();
+    }
+
 private:
     InputPluginList _inputPlugins;
 };


### PR DESCRIPTION
This PR updates the 3DSpacemouse plugin that restores functionality to the 3Dconnexion SpaceNavigator 3D mouse. It also adds access to all axis to be accessible, which was per popular request.

The only concern is that this will require our good friend, gustavo, to have an extra build instruction for the Windows builds: specifying where the library is installed.

That in itself is also a bit weird since it's really looking for a specific header (I3dMouseParams.h) which has to be added to the SDK's inc folder and then specify where the SDK inc folder is (with 3DCONNEXIONCLIENT_INCLUDE_DIRS or -D3DCONNEXIONCLIENT_INCLUDE_DIRS in the cmake command).

The SDK also seems to require some developer registration, so I'm not sure what (if any) kind of licensing agreements exist. That can be found here: https://www.3dconnexion.com/service/software-developer.html

Testing will require the SpaceNavigator, but there seems to be an odd quirk with older SpaceNavigators for some weird reason I was never able to determine. However, using a custom controller script (http://voxel.flamesoulis.com/ele/library/spaceNavigator.js) can be used as a workaround and also just controls better. It doesn't seem to play nicely with the default scheme, but that is outside the scope of the PR.

If anything, the PR updates the code so it can be compiled. The most optimal goal is to have it naturally included in the Windows builds (which requires the SDK).