### PR TITLE
FB17381 - Reticle.setVisible isn't working

### DIFF
--- a/scripts/system/controllers/controllerModules/mouseHMD.js
+++ b/scripts/system/controllers/controllerModules/mouseHMD.js
@@ -29,6 +29,7 @@
 
     function MouseHMD() {
         var _this = this;
+        this.hmdWasActive = HMD.active;
         this.mouseMoved = false;
         this.mouseActivity = new TimeLock(5000);
         this.handControllerActivity = new TimeLock(4000);
@@ -102,6 +103,8 @@
 
         this.isReady = function(controllerData, deltaTime) {
             var now = Date.now();
+            var hmdChanged = this.hmdWasActive !== HMD.active;
+            this.hmdWasActive = HMD.active;
             this.triggersPressed(controllerData, now);
             if (HMD.active) {
                 if (!this.mouseActivity.expired(now) && _this.handControllerActivity.expired()) {
@@ -110,7 +113,7 @@
                 } else {
                     Reticle.visible = false;
                 }
-            } else if (!Reticle.visible) {
+            } else if (hmdChanged && !Reticle.visible) {
                 Reticle.visible = true;
             }
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/17381/Reticle-setVisible-isn-t-working

**Test plan**

1. Launch interface in desktop mode
2. Apply the following script: https://raw.githubusercontent.com/huffman/hifi/b95a2180e832df62bc7c77e616c32106f2d7c3fb/script-archive/gracefulControls.js - Space toggles when it is in use or not.  
3. Ensure pressing space toggles cursor visibility
4. Switch to VR
5. Ensure pressing space toggles cursor visibility