### PR TITLE
Fix shape not getting marked changed

### DIFF
--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -3207,6 +3207,8 @@ void EntityItemProperties::markAllChanged() {
 
     _queryAACubeChanged = true;
 
+    _shapeChanged = true;
+
     _flyingAllowedChanged = true;
     _ghostingAllowedChanged = true;
     _filterURLChanged = true;


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/19516/Imported-and-exported-entities-ignore-shape-type-all-imported-shapes-are-spheres-and-new-exported-shapes-have-no-shape-value

Test plan:
- Create a Shape entity.  Give it a different shape.  Export it.  The JSON should contain the correct "shape".
- Import it.  It should have the correct shape.