### PR TITLE
Case 19417: Add prebuild script, currently does nothing

### DIFF
--- a/prebuild.py
+++ b/prebuild.py
@@ -1,0 +1,10 @@
+#! /usr/bin/python3
+
+import os
+import sys
+
+def main():
+    print("Prebuild complete")
+
+main()
+


### PR DESCRIPTION
This is pre-requisite work for [19417](https://highfidelity.manuscript.com/f/cases/19417/Create-a-runtime-library-of-the-Shader-Compiler-tool-chain).  19417 will require adding several new libraries to the external dependencies, which will compound some of our existing problems with external libraries.  To address that I am working on a new pre-build system in #14297 (for which this is also a pre-requisite).

In order to improve build times and reduce the disk footprint for external projects on which we depend,  Before using CMake to create our project, we would use a pre-build script to set up dependencies.   The theory is that this script would perform any required actions to download and install the external dependencies if they're missing, and would take negligible time if they're not.

However, in order to support this mechanism the continuous integration servers would need to start calling this new script.  The CI servers can't call a script that doesn't exist, and we can't test the PR that implements this unless the CI servers call the script.  

This PR adds a `prebuild.py` script that does nothing at all (other than print out a line).  This will allow the  changes to the CI servers to be done without impacting the existing build process.  

## Testing

No testing required.  This adds a single python script which is currently completely uninvolved in the build process.  