### PR TITLE
Don't update QueryAACube in setParentID if _parentID didn't change

### DIFF
--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -74,10 +74,12 @@ void SpatiallyNestable::setParentID(const QUuid& parentID) {
         }
     });
 
-    bool success = false;
-    auto parent = getParentPointer(success);
-    if (success && parent) {
-        parent->updateQueryAACube();
+    if (!_parentKnowsMe) {
+        bool success = false;
+        auto parent = getParentPointer(success);
+        if (success && parent) {
+            parent->updateQueryAACube();
+        }
     }
 }
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/19535/In-third-person-with-Oculus-on-most-domains-controller-inputs-can-start-to-lag-severely

Test plan:
- Recreate the situation in the ticket.  You shouldn't experience the same lag.