### PR TITLE
RC 75: Don't update QueryAACube in setParentID if _parentID didn't change

### DIFF
--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -74,10 +74,12 @@ void SpatiallyNestable::setParentID(const QUuid& parentID) {
         }
     });
 
-    bool success = false;
-    auto parent = getParentPointer(success);
-    if (success && parent) {
-        parent->updateQueryAACube();
+    if (!_parentKnowsMe) {
+        bool success = false;
+        auto parent = getParentPointer(success);
+        if (success && parent) {
+            parent->updateQueryAACube();
+        }
     }
 }
 


### PR DESCRIPTION
See https://github.com/highfidelity/hifi/pull/14302