### PR TITLE
Case 19682: Disable interstitial on android

### DIFF
--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -231,7 +231,11 @@ private:
     QString _pendingPath;
     QTimer _settingsTimer;
     mutable ReadWriteLockable _interstitialModeSettingLock;
-    Setting::Handle<bool> _enableInterstitialMode{ "enableInterstitialMode", true };
+#ifdef Q_OS_ANDROID
+    Setting::Handle<bool> _enableInterstitialMode{ "enableInterstitialMode", false };
+#else
+    Setting::Handle<bool> _enableInterstitialMode { "enableInterstitialMode", true };
+#endif
 
     QSet<QString> _domainConnectionRefusals;
     bool _hasCheckedForAccessToken { false };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19682/Disable-interstitial-on-android

Test plan:
- Go to a domain on Android
- You should be able to move right away.  The interstitial page shouldn't come up.