### PR TITLE
Case 19686: Possibly fix mac debug deferred issue

### DIFF
--- a/libraries/gpu/src/gpu/MipGeneration.slh
+++ b/libraries/gpu/src/gpu/MipGeneration.slh
@@ -13,7 +13,7 @@
 
 <@include gpu/ShaderConstants.h@>
 
-layout(binding=GPU_TEXTURE_MIP_CREATION_INPUT) uniform sampler2D texMap;
+LAYOUT(binding=GPU_TEXTURE_MIP_CREATION_INPUT) uniform sampler2D texMap;
 
 in vec2 varTexCoord0;
 

--- a/libraries/render-utils/src/debug_deferred_buffer.slf
+++ b/libraries/render-utils/src/debug_deferred_buffer.slf
@@ -25,7 +25,7 @@ LAYOUT(binding=RENDER_UTILS_TEXTURE_SHADOW) uniform sampler2DArrayShadow shadowM
 
 <@include debug_deferred_buffer_shared.slh@>
 
-layout(std140, binding=RENDER_UTILS_BUFFER_DEBUG_DEFERRED_PARAMS) uniform parametersBuffer {
+LAYOUT_STD140(binding=RENDER_UTILS_BUFFER_DEBUG_DEFERRED_PARAMS) uniform parametersBuffer {
     DebugParameters parameters;
 };
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19686/Automation-MAC-AMD-10-31-2018-content-entity-material-create

Test plan:
- On Mac, run luci.js and try different framebuffer debugging options.  They should work.