### PR TITLE
MS19550 - Hide Vive from Controller Help when Run with --oculus-store

### DIFF
--- a/interface/resources/html/tabletHelp.html
+++ b/interface/resources/html/tabletHelp.html
@@ -67,6 +67,7 @@
             var handControllerImageURL = null;
             var index = 0;
             var count = 5;
+			var oculusStore = false;
 
             function showKbm() {
                 document.getElementById("main_image").setAttribute("src", "img/tablet-help-keyboard.jpg");
@@ -94,11 +95,13 @@
                 switch (index) 
                 {
                     case 0:
-                        handControllerImageURL = "img/tablet-help-oculus.jpg";
-                        showHandControllers();
-                        break;
+						if (!oculusStore) {
+							handControllerImageURL = "img/tablet-help-vive.jpg";
+							showHandControllers();
+							break;
+						}
                     case 1:
-                        handControllerImageURL = "img/tablet-help-vive.jpg";
+                        handControllerImageURL = "img/tablet-help-oculus.jpg";
                         showHandControllers();
                         break;
                     case 2:
@@ -144,9 +147,11 @@
                 }
 
                 switch (params.handControllerName) {
+					case "oculus-store":
+						oculusStore = true;
                     case "oculus":
                         handControllerImageURL = "img/tablet-help-oculus.jpg";
-                        index = 0;
+                        index = 1;
                         break;
                     case "windowsMR":
                         handControllerImageURL = "img/tablet-help-windowsMR.jpg";
@@ -155,7 +160,7 @@
                     case "vive":
                     default:
                         handControllerImageURL = "img/tablet-help-vive.jpg";
-                        index = 1;
+                        index = 0;
                 }
 
                 switch (params.defaultTab) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3360,7 +3360,9 @@ void Application::setSettingConstrainToolbarPosition(bool setting) {
 void Application::showHelp() {
     static const QString HAND_CONTROLLER_NAME_VIVE = "vive";
     static const QString HAND_CONTROLLER_NAME_OCULUS_TOUCH = "oculus";
+    static const QString HAND_CONTROLLER_NAME_OCULUS_STORE = "oculus-store";
     static const QString HAND_CONTROLLER_NAME_WINDOWS_MR = "windowsMR";
+    static const QString OCULUS_STORE_ARG = "--oculus-store";
 
     static const QString TAB_KEYBOARD_MOUSE = "kbm";
     static const QString TAB_GAMEPAD = "gamepad";
@@ -3372,6 +3374,9 @@ void Application::showHelp() {
     if (PluginUtils::isViveControllerAvailable()) {
         defaultTab = TAB_HAND_CONTROLLERS;
         handControllerName = HAND_CONTROLLER_NAME_VIVE;
+    } else if (PluginUtils::isOculusTouchControllerAvailable() && (arguments().indexOf(OCULUS_STORE_ARG) != -1)) {
+        defaultTab = TAB_HAND_CONTROLLERS;
+        handControllerName = HAND_CONTROLLER_NAME_OCULUS_STORE;
     } else if (PluginUtils::isOculusTouchControllerAvailable()) {
         defaultTab = TAB_HAND_CONTROLLERS;
         handControllerName = HAND_CONTROLLER_NAME_OCULUS_TOUCH;


### PR DESCRIPTION
This PR is related to [MS#19550](https://highfidelity.fogbugz.com/f/cases/19550/Fix-VRC-PC-Functional-8-Vive-assets-cannot-be-displayed-in-Oculus-Store-build). Hides the Vive controller help from the "Help > Controls Reference" menu.

**Test Plan:**
Step 1.)
- Launch interface from command line with "--oculus-store" parameter (e.g. "{installation_directory}\interface.exe --oculus-store").
- In desktop mode, go to "Help > Controls Reference"
- Use the arrows to check through the various control layouts for devices, e.g. XBox Controller, Oculus, Windows MR, etc
- Verify that Vive does not show up in this case.

Step 2.)
- Launch interface normally, without the CLI flag.
- In desktop mode, go to "Help > Controls Reference"
- Use the arrows on the page to check through the various control layouts for devices, e.g. Xbox Controller, Oculus, Windows MR, Vive, Keyboard...
- Verify that Vive layout still shows up in this case.