### PR TITLE
Mini tablet tuning

### DIFF
--- a/scripts/system/miniTablet.js
+++ b/scripts/system/miniTablet.js
@@ -563,6 +563,8 @@
             MAX_LATERAL_PINKY_CAMERA_ANGLE_RAD = DEGREES_TO_RADIANS * MAX_LATERAL_PINKY_CAMERA_ANGLE,
             MAX_CAMERA_MINI_ANGLE = 30,
             MAX_CAMERA_MINI_ANGLE_COS = Math.cos(MAX_CAMERA_MINI_ANGLE * DEGREES_TO_RADIANS),
+            SHOWING_DELAY = 1000, // ms
+            lastInvisible = [0, 0],
             HIDING_DELAY = 1000, // ms
             lastVisible = [0, 0],
 
@@ -609,7 +611,8 @@
                 lateralHandVector,
                 medialAngle,
                 lateralAngle,
-                cameraToMini;
+                cameraToMini,
+                now;
 
             // Shouldn't show mini tablet if hand isn't being controlled.
             pose = Controller.getPoseValue(hand === LEFT_HAND ? Controller.Standard.LeftHand : Controller.Standard.RightHand);
@@ -673,11 +676,19 @@
                 cameraToMini = -Vec3.dot(miniToCameraDirection, Quat.getForward(Camera.orientation));
                 show = show && (cameraToMini > MAX_CAMERA_MINI_ANGLE_COS);
 
+                // Delay showing for a while after it would otherwise be shown, unless it was showing on the other hand.
+                now = Date.now();
+                if (show) {
+                    show = now - lastInvisible[hand] >= SHOWING_DELAY || now - lastVisible[otherHand(hand)] <= HIDING_DELAY;
+                } else {
+                    lastInvisible[hand] = now;
+                }
+
                 // Persist showing for a while after it would otherwise be hidden.
                 if (show) {
-                    lastVisible[hand] = Date.now();
+                    lastVisible[hand] = now;
                 } else {
-                    show = Date.now() - lastVisible[hand] <= HIDING_DELAY;
+                    show = now - lastVisible[hand] <= HIDING_DELAY;
                 }
             }
 

--- a/scripts/system/miniTablet.js
+++ b/scripts/system/miniTablet.js
@@ -551,7 +551,7 @@
             // Trigger values.
             leftTriggerOn = 0,
             rightTriggerOn = 0,
-            MAX_TRIGGER_ON_TIME = 100,
+            MAX_TRIGGER_ON_TIME = 400,
 
             // Visibility.
             MAX_HAND_CAMERA_ANGLE = 30,


### PR DESCRIPTION
##### 1) Increased the delay from start of trigger squeeze to start of mini tablet shrinking from 100ms to 400ms.

This to address the complaint that the mini tablet doesn't always expand on trigger squeeze; the conjecture is that the trigger wasn't being pulled / clicked fast enough. 
If you want to use the laser instead of expanding the mini tablet, you just have to partly squeeze and hold the trigger (blue laser displays) a little longer than previously.

To experiment with different delays: `MAX_TRIGGER_ON_TIME` circa line 551.


##### 2) Use spherical patch in deciding when to show the mini tablet according to the hand orientation.

Instead of testing the whether the camera is visible in either a cone from the mini tablet position oriented in the direction of the palm normal or a cone from the mini tablet position oriented in the direction of the mini tablet face normal, 
test wehther the camer is visible in a rectangular spherical patch from the mini tablet position oriented in the direction of the palm, with separately configurable half angles:
- medially along the hand in the direction of the fingers
- medially along the hand in the diretion of the wrist
- laterally across the hand in the direction of the thumb
- laterially across in the direction of the pinky

To experiment with different half angle values, see `MAX_MEDIAL_FINGER_CAMERA_ANGLE` and related circa line 554.


##### 3) Delay showing the mini tablet.

A 1 second delay has been added to when the mini tablet starts expanding from invisible.

There is also (already was) a 1 second delay in starting to shrink the mini tablet to make it invisible.

To experiment with different showing and hiding delays, see `SHOWING_DELAY` and `HIDING_DELAY` circa line 566.