### PR TITLE
AnimDebugDraw: Prevent multi-threaded access to shared map collection.

### DIFF
--- a/libraries/render-utils/src/AnimDebugDraw.h
+++ b/libraries/render-utils/src/AnimDebugDraw.h
@@ -44,7 +44,8 @@ protected:
 
     typedef std::tuple<AnimSkeleton::ConstPointer, AnimPoseVec, AnimPose, glm::vec4> PosesInfo;
 
-    std::unordered_map<std::string, PosesInfo> _absolutePoses;
+    typedef std::unordered_map<std::string, PosesInfo> PosesInfoMap;
+    PosesInfoMap _posesInfoMap;
 
     // no copies
     AnimDebugDraw(const AnimDebugDraw&) = delete;


### PR DESCRIPTION
It was possible for the render thread to iterate over a map while the main thread mutates the same map.
This could have led to memory corruption and crashes.

To fix this we make a copy of the collection and pass the copy to the lambda that executes on the render thread.

https://highfidelity.manuscript.com/f/cases/19651/AnimPose-operator-glm-tmat4x4-float-0-f3c6ce443acda779a36fc9799b8a968b91f9a63644da1bad8bea26cae1a89c77