### PR TITLE
only equip an entity to a hand-controller joint if the hand-controllers are in use, else use avatar hand

### DIFF
--- a/scripts/system/controllers/controllerModules/equipEntity.js
+++ b/scripts/system/controllers/controllerModules/equipEntity.js
@@ -485,7 +485,7 @@ EquipHotspotBuddy.prototype.update = function(deltaTime, timestamp, controllerDa
             }
 
             var handJointIndex;
-            if (grabData.grabFollowsController) {
+            if (HMD.mounted && HMD.isHandControllerAvailable() && grabData.grabFollowsController) {
                 handJointIndex = this.controllerJointIndex;
             } else {
                 handJointIndex = MyAvatar.getJointIndex(this.hand === RIGHT_HAND ? "RightHand" : "LeftHand");


### PR DESCRIPTION
- only equip an entity to a hand-controller joint if the hand-controllers are in use, else use avatar hand

https://highfidelity.manuscript.com/f/cases/19697/The-Rainbow-Thrower-and-Color-Cannon-attach-to-users-camera-when-selected-in-desktop-mode

this PR for rc75 is here https://github.com/highfidelity/hifi/pull/14342

