### PR TITLE
FB19348 - Interface doesn't save changes to avatar animation text field

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1464,7 +1464,7 @@ void MyAvatar::loadData() {
     _yawSpeed = _yawSpeedSetting.get(_yawSpeed);
     _pitchSpeed = _pitchSpeedSetting.get(_pitchSpeed);
 
-    _prefOverrideAnimGraphUrl.set(_prefOverrideAnimGraphUrl.get().toString());
+    _prefOverrideAnimGraphUrl.set(_animGraphURLSetting.get().toString());
     _fullAvatarURLFromPreferences = _fullAvatarURLSetting.get(QUrl(AvatarData::defaultFullAvatarModelUrl()));
     _fullAvatarModelName = _fullAvatarModelNameSetting.get(DEFAULT_FULL_AVATAR_MODEL_NAME).toString();
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/19348/Interface-doesn-t-save-changes-to-avatar-animation-text-field
https://highfidelity.fogbugz.com/f/cases/19382/custom-animation-json-no-longer-persists-between-sessions

**Test plan**

1. Open Avatar app
2. Click the little menu icon on the top right of the avatar app
3. Paste the URL to a custom avatar animation JSON file in the avatar animation JSON text field
(for example this one: https://s3.amazonaws.com/hifi-public/tony/scoot-animation.json )
4. Restart High Fidelity
5. Ensure that animation was applied to avatar (avatar is sitting in face of using this ur: https://s3.amazonaws.com/hifi-public/tony/scoot-animation.json )
6. Open avatar app
7. Ensure saved avatar animation url is shown in settings