### PR TITLE
Case 19735: Fix ResourceCache mutex issues

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -740,6 +740,8 @@ void Resource::handleReplyFinished() {
 
     setSize(_bytesTotal);
 
+    // Make sure we keep the Resource alive here
+    auto self = _self.lock();
     ResourceCache::requestCompleted(_self);
 
     auto result = _request->getResult();

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -62,7 +62,7 @@ static const qint64 MAX_UNUSED_MAX_SIZE = MAXIMUM_CACHE_SIZE;
 class ResourceCacheSharedItems : public Dependency  {
     SINGLETON_DEPENDENCY
 
-    using Mutex = std::mutex;
+    using Mutex = std::recursive_mutex;
     using Lock = std::unique_lock<Mutex>;
 
 public:


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19735/Rift-Intermittent-crashes-when-entering-exiting-VR-mode
And *possibly* https://highfidelity.manuscript.com/f/cases/19624/subticket-on-crash-Very-long-hang-on-closing-interface-with-audio

Test plan:
- Go to a domain with various models, animations, and textures.  Switch between desktop and VR mode many times.  You shouldn't crash.
- Close interface several times.  You shouldn't hang forever on shutdown.