### PR TITLE
Send avatar-joint translations at world scale

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1927,6 +1927,7 @@ AnimPose Rig::getJointPose(int jointIndex) const {
 void Rig::copyJointsIntoJointData(QVector<JointData>& jointDataVec) const {
 
     const AnimPose geometryToRigPose(_geometryToRigTransform);
+    const glm::vec3 geometryToRigScale(geometryToRigPose.scale());
 
     jointDataVec.resize((int)getJointStateCount());
     for (auto i = 0; i < jointDataVec.size(); i++) {
@@ -1939,9 +1940,10 @@ void Rig::copyJointsIntoJointData(QVector<JointData>& jointDataVec) const {
 
             // translations are in relative frame but scaled so that they are in meters,
             // instead of model units.
-            glm::vec3 defaultRelTrans = _geometryOffset.scale() * _animSkeleton->getRelativeDefaultPose(i).trans();
-            data.translation = _geometryOffset.scale() * (!_sendNetworkNode ? _internalPoseSet._relativePoses[i].trans() : _networkPoseSet._relativePoses[i].trans());
-            data.translationIsDefaultPose = isEqual(data.translation, defaultRelTrans);
+            glm::vec3 defaultRelTrans = _animSkeleton->getRelativeDefaultPose(i).trans();
+            glm::vec3 currentRelTrans = _sendNetworkNode ? _networkPoseSet._relativePoses[i].trans() : _internalPoseSet._relativePoses[i].trans();
+            data.translation = geometryToRigScale * currentRelTrans;
+            data.translationIsDefaultPose = isEqual(currentRelTrans, defaultRelTrans);
         } else {
             data.translationIsDefaultPose = true;
             data.rotationIsDefaultPose = true;
@@ -1967,6 +1969,8 @@ void Rig::copyJointsFromJointData(const QVector<JointData>& jointDataVec) {
     std::vector<glm::quat> rotations;
     rotations.reserve(numJoints);
     const glm::quat rigToGeometryRot(glmExtractRotation(_rigToGeometryTransform));
+    const glm::vec3 rigToGeometryScale(extractScale(_rigToGeometryTransform));
+
     for (int i = 0; i < numJoints; i++) {
         const JointData& data = jointDataVec.at(i);
         if (data.rotationIsDefaultPose) {
@@ -1992,7 +1996,7 @@ void Rig::copyJointsFromJointData(const QVector<JointData>& jointDataVec) {
             _internalPoseSet._relativePoses[i].trans() = relativeDefaultPoses[i].trans();
         } else {
             // JointData translations are in scaled relative-frame so we scale back to regular relative-frame
-            _internalPoseSet._relativePoses[i].trans() = _invGeometryOffset.scale() * data.translation;
+            _internalPoseSet._relativePoses[i].trans() = rigToGeometryScale * data.translation;
         }
     }
 }

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -40,7 +40,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::AvatarData:
         case PacketType::BulkAvatarData:
         case PacketType::KillAvatar:
-            return static_cast<PacketVersion>(AvatarMixerPacketVersion::FarGrabJointsRedux);
+            return static_cast<PacketVersion>(AvatarMixerPacketVersion::JointTransScaled);
         case PacketType::MessagesData:
             return static_cast<PacketVersion>(MessageDataVersion::TextOrBinaryData);
         // ICE packets

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -297,7 +297,8 @@ enum class AvatarMixerPacketVersion : PacketVersion {
     FarGrabJoints,
     MigrateSkeletonURLToTraits,
     MigrateAvatarEntitiesToTraits,
-    FarGrabJointsRedux
+    FarGrabJointsRedux,
+    JointTransScaled
 };
 
 enum class DomainConnectRequestVersion : PacketVersion {


### PR DESCRIPTION
Fogbugz: https://highfidelity.manuscript.com/f/cases/19401/My-avatar-appears-normally-to-me-but-everyone-else-sees-my-head-in-the-floor

Specifically this entry:
https://highfidelity.manuscript.com/f/cases/19401/#BugEvent.129699

Fixes the case where a large avatar is scaled down to regular size in the Interface UI. Also bumps avatar packet-version since it's an avatar-mixer protocol change.
