### PR TITLE
Case 22169: GLTF Importer Improvements

### DIFF
--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -1349,7 +1349,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                     }
                 }
 
-                if (texcoords.size() == partVerticesCount * texCoord2Stride) {
+                if (texcoords2.size() == partVerticesCount * texCoord2Stride) {
                     for (int n = 0; n < texcoords2.size(); n = n + 2) {
                         mesh.texCoords1.push_back(glm::vec2(texcoords2[n], texcoords2[n + 1]));
                     }

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -813,7 +813,7 @@ void GLTFSerializer::getSkinInverseBindMatrices(std::vector<std::vector<float>>&
     for (auto &skin : _file.skins) {
         GLTFAccessor& indicesAccessor = _file.accessors[skin.inverseBindMatrices];
         QVector<float> matrices;
-        addArrayOfFromAccessor(indicesAccessor, matrices);
+        addArrayFromAccessor(indicesAccessor, matrices);
         inverseBindMatrixValues.push_back(matrices.toStdVector());
     }
 }
@@ -821,7 +821,7 @@ void GLTFSerializer::getSkinInverseBindMatrices(std::vector<std::vector<float>>&
 void GLTFSerializer::generateTargetData(int index, float weight, QVector<glm::vec3>& returnVector) {
     GLTFAccessor& accessor = _file.accessors[index];
     QVector<float> storedValues;
-    addArrayOfFromAccessor(accessor, storedValues);
+    addArrayFromAccessor(accessor, storedValues);
     for (int n = 0; n < storedValues.size(); n = n + 3) {
         returnVector.push_back(glm::vec3(weight * storedValues[n], weight * storedValues[n + 1], weight * storedValues[n + 2]));
     }
@@ -849,7 +849,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
     nodecount = 0;
     foreach(auto &node, _file.nodes) {
         // collect node transform
-        _file.nodes[nodecount].transforms.push_back(getModelTransform(node)); 
+        _file.nodes[nodecount].transforms.push_back(getModelTransform(node));
         int parentIndex = parents[nodecount];
         while (parentIndex != -1) {
             const auto& parentNode = _file.nodes[parentIndex];
@@ -1038,7 +1038,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                 QVector<float> weights;
                 int weightStride = 0;
 
-                bool success = addArrayOfFromAccessor(indicesAccessor, indices);
+                bool success = addArrayFromAccessor(indicesAccessor, indices);
 
                 if (!success) {
                     qWarning(modelformat) << "There was a problem reading glTF INDICES data for model " << _url;
@@ -1058,7 +1058,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                     GLTFAccessor& accessor = _file.accessors[accessorIdx];
 
                     if (key == "POSITION") {
-                        success = addArrayOfFromAccessor(accessor, vertices);
+                        success = addArrayFromAccessor(accessor, vertices);
                         if (!success) {
                             qWarning(modelformat) << "There was a problem reading glTF POSITION data for model " << _url;
                             continue;
@@ -1069,7 +1069,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                             continue;
                         }
                     } else if (key == "NORMAL") {
-                        success = addArrayOfFromAccessor(accessor, normals);
+                        success = addArrayFromAccessor(accessor, normals);
                         if (!success) {
                             qWarning(modelformat) << "There was a problem reading glTF NORMAL data for model " << _url;
                             continue;
@@ -1080,7 +1080,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                             continue;
                         }
                     } else if (key == "TANGENT") {
-                        success = addArrayOfFromAccessor(accessor, tangents);
+                        success = addArrayFromAccessor(accessor, tangents);
                         if (!success) {
                             qWarning(modelformat) << "There was a problem reading glTF TANGENT data for model " << _url;
                             continue;
@@ -1095,7 +1095,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                             continue;
                         }
                     } else if (key == "TEXCOORD_0") {
-                        success = addArrayOfFromAccessor(accessor, texcoords);
+                        success = addArrayFromAccessor(accessor, texcoords);
                         if (!success) {
                             qWarning(modelformat) << "There was a problem reading glTF TEXCOORD_0 data for model " << _url;
                             continue;
@@ -1106,7 +1106,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                             continue;
                         }
                     } else if (key == "TEXCOORD_1") {
-                        success = addArrayOfFromAccessor(accessor, texcoords2);
+                        success = addArrayFromAccessor(accessor, texcoords2);
                         if (!success) {
                             qWarning(modelformat) << "There was a problem reading glTF TEXCOORD_1 data for model " << _url;
                             continue;
@@ -1117,7 +1117,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                             continue;
                         }
                     } else if (key == "COLOR_0") {
-                        success = addArrayOfFromAccessor(accessor, colors);
+                        success = addArrayFromAccessor(accessor, colors);
                         if (!success) {
                             qWarning(modelformat) << "There was a problem reading glTF COLOR_0 data for model " << _url;
                             continue;
@@ -1132,7 +1132,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                             continue;
                         }
                     } else if (key == "JOINTS_0") {
-                        success = addArrayOfFromAccessor(accessor, joints);
+                        success = addArrayFromAccessor(accessor, joints);
                         if (!success) {
                             qWarning(modelformat) << "There was a problem reading glTF JOINTS_0 data for model " << _url;
                             continue;
@@ -1151,7 +1151,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                             continue;
                         }
                     } else if (key == "WEIGHTS_0") {
-                        success = addArrayOfFromAccessor(accessor, weights);
+                        success = addArrayFromAccessor(accessor, weights);
                         if (!success) {
                             qWarning(modelformat) << "There was a problem reading glTF WEIGHTS_0 data for model " << _url;
                             continue;
@@ -1252,15 +1252,10 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                     const float ALMOST_HALF = 0.499f;
                     int numVertices = mesh.vertices.size() - prevMeshVerticesCount;
 
-                    // Append new cluster indices and weights for this mesh part
-                    for (int i = 0; i < numVertices * WEIGHTS_PER_VERTEX; i++) {
-                        mesh.clusterIndices.push_back(mesh.clusters.size() - 1);
-                        mesh.clusterWeights.push_back(0);
-                    }
-
-                    for (int c = 0; c < clusterJoints.size(); c++) {
-                        mesh.clusterIndices[prevMeshClusterIndexCount+c] = originalToNewNodeIndexMap[_file.skins[node.skin].joints[clusterJoints[c]]];
-                    }
+                    mesh.clusterIndices.resize(mesh.clusterIndices.size()
+                        + numVertices * WEIGHTS_PER_VERTEX);
+                    mesh.clusterWeights.resize(mesh.clusterWeights.size()
+                        + numVertices * WEIGHTS_PER_VERTEX);
 
                     // normalize and compress to 16-bits
                     for (int i = 0; i < numVertices; ++i) {
@@ -1268,15 +1263,21 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
 
                         float totalWeight = 0.0f;
                         for (int k = j; k < j + WEIGHTS_PER_VERTEX; ++k) {
+                            mesh.clusterIndices[prevMeshClusterIndexCount + k] =
+                                originalToNewNodeIndexMap[_file.skins[node.skin].joints[clusterJoints[k]]];
+
                             totalWeight += clusterWeights[k];
                         }
                         if (totalWeight > 0.0f) {
                             float weightScalingFactor = (float)(UINT16_MAX) / totalWeight;
                             for (int k = j; k < j + WEIGHTS_PER_VERTEX; ++k) {
-                                mesh.clusterWeights[prevMeshClusterWeightCount+k] = (uint16_t)(weightScalingFactor * clusterWeights[k] + ALMOST_HALF);
+                                mesh.clusterWeights[prevMeshClusterWeightCount + k] = (uint16_t)(weightScalingFactor * clusterWeights[k] + ALMOST_HALF);
                             }
                         } else {
-                            mesh.clusterWeights[prevMeshClusterWeightCount+j] = (uint16_t)((float)(UINT16_MAX) + ALMOST_HALF);
+                            mesh.clusterWeights[prevMeshClusterWeightCount + j] = (uint16_t)((float)(UINT16_MAX) + ALMOST_HALF);
+                            for (int k = j + 1; k < j + WEIGHTS_PER_VERTEX; ++k) {
+                                mesh.clusterWeights[prevMeshClusterWeightCount + k] = 0;
+                            }
                         }
                     }
                 }
@@ -1678,7 +1679,7 @@ bool GLTFSerializer::addArrayOfType(const hifi::ByteArray& bin, int byteOffset, 
 }
 
 template <typename T>
-bool GLTFSerializer::addArrayOfFromAccessor(GLTFAccessor& accessor, QVector<T>& outarray) {
+bool GLTFSerializer::addArrayFromAccessor(GLTFAccessor& accessor, QVector<T>& outarray) {
     bool success = true;
 
     if (accessor.defined["bufferView"]) {

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -872,7 +872,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
             // collect transforms for a node's parents, grandparents, etc.
             _file.nodes[nodecount].transforms.push_back(getModelTransform(parentNode));
             parentIndex = parents[parentIndex];
-            }
+        }
         nodecount++;
     }
 
@@ -900,10 +900,10 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                     sortedNodes[j] = currentNode;
                     i++;
                     currentNode = sortedNodes[i];
-    }
+                }
                 j++;
-    }
-    }
+            }
+        }
     }
 
 
@@ -931,7 +931,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
         joint.translation = extractTranslation(joint.transform);
         joint.rotation = glmExtractRotation(joint.transform);
         glm::vec3 scale = extractScale(joint.transform);
-        joint.postTransform = glm::scale(glm::mat4(), scale);        
+        joint.postTransform = glm::scale(glm::mat4(), scale);
 
         joint.name = node.name;
         joint.isSkeletonJoint = false;
@@ -982,7 +982,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
     QString unknown = "Default";
     int ukcount = 0;
     foreach(auto material, _file.materials) {
-        if (!(material.defined["name"])) {
+        if (!material.defined["name"]) {
             QString name = unknown + QString::number(ukcount++);
             material.name = name;
             material.defined.insert("name", true);
@@ -1017,8 +1017,8 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                 cluster.inverseBindMatrix = glm::mat4();
                 cluster.inverseBindTransform = Transform(cluster.inverseBindMatrix);
                 mesh.clusters.append(cluster);
-                } else { // skinned model
-                    for (int j = 0; j < numNodes; j++) {
+            } else { // skinned model
+                for (int j = 0; j < numNodes; j++) {
                     HFMCluster cluster;
                     cluster.jointIndex = j;
                     cluster.inverseBindMatrix = jointInverseBindTransforms[j];
@@ -1026,7 +1026,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                     mesh.clusters.append(cluster);
                 }
             }
-            HFMCluster root; 
+            HFMCluster root;
             root.jointIndex = 0;
             root.inverseBindMatrix = jointInverseBindTransforms[root.jointIndex];
             root.inverseBindTransform = Transform(root.inverseBindMatrix);

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -37,27 +37,27 @@
 
 #include "FBXSerializer.h"
 
-#define GLTF_GET_INDICIES(acc_count) int index1 = (indices[n + 0] * acc_count); int index2 = (indices[n + 1] * acc_count); int index3 = (indices[n + 2] * acc_count);
+#define GLTF_GET_INDICIES(accCount) int index1 = (indices[n + 0] * accCount); int index2 = (indices[n + 1] * accCount); int index3 = (indices[n + 2] * accCount);
 
-#define GLTF_APPEND_ARRAY_1(new_array, old_array) GLTF_GET_INDICIES(1) \
-new_array.append(old_array[index1]); \
-new_array.append(old_array[index2]); \
-new_array.append(old_array[index3]);
+#define GLTF_APPEND_ARRAY_1(newArray, oldArray) GLTF_GET_INDICIES(1) \
+newArray.append(oldArray[index1]); \
+newArray.append(oldArray[index2]); \
+newArray.append(oldArray[index3]);
 
-#define GLTF_APPEND_ARRAY_2(new_array, old_array) GLTF_GET_INDICIES(2) \
-new_array.append(old_array[index1]); new_array.append(old_array[index1 + 1]); \
-new_array.append(old_array[index2]); new_array.append(old_array[index2 + 1]); \
-new_array.append(old_array[index3]); new_array.append(old_array[index3 + 1]);
+#define GLTF_APPEND_ARRAY_2(newArray, oldArray) GLTF_GET_INDICIES(2) \
+newArray.append(oldArray[index1]); newArray.append(oldArray[index1 + 1]); \
+newArray.append(oldArray[index2]); newArray.append(oldArray[index2 + 1]); \
+newArray.append(oldArray[index3]); newArray.append(oldArray[index3 + 1]);
 
-#define GLTF_APPEND_ARRAY_3(new_array, old_array) GLTF_GET_INDICIES(3) \
-new_array.append(old_array[index1]); new_array.append(old_array[index1 + 1]); new_array.append(old_array[index1 + 2]); \
-new_array.append(old_array[index2]); new_array.append(old_array[index2 + 1]); new_array.append(old_array[index2 + 2]); \
-new_array.append(old_array[index3]); new_array.append(old_array[index3 + 1]); new_array.append(old_array[index3 + 2]);
+#define GLTF_APPEND_ARRAY_3(newArray, oldArray) GLTF_GET_INDICIES(3) \
+newArray.append(oldArray[index1]); newArray.append(oldArray[index1 + 1]); newArray.append(oldArray[index1 + 2]); \
+newArray.append(oldArray[index2]); newArray.append(oldArray[index2 + 1]); newArray.append(oldArray[index2 + 2]); \
+newArray.append(oldArray[index3]); newArray.append(oldArray[index3 + 1]); newArray.append(oldArray[index3 + 2]);
 
-#define GLTF_APPEND_ARRAY_4(new_array, old_array) GLTF_GET_INDICIES(4) \
-new_array.append(old_array[index1]); new_array.append(old_array[index1 + 1]); new_array.append(old_array[index1 + 2]); new_array.append(old_array[index1 + 3]); \
-new_array.append(old_array[index2]); new_array.append(old_array[index2 + 1]); new_array.append(old_array[index2 + 2]); new_array.append(old_array[index2 + 3]); \
-new_array.append(old_array[index3]); new_array.append(old_array[index3 + 1]); new_array.append(old_array[index3 + 2]); new_array.append(old_array[index3 + 3]);
+#define GLTF_APPEND_ARRAY_4(newArray, oldArray) GLTF_GET_INDICIES(4) \
+newArray.append(oldArray[index1]); newArray.append(oldArray[index1 + 1]); newArray.append(oldArray[index1 + 2]); newArray.append(oldArray[index1 + 3]); \
+newArray.append(oldArray[index2]); newArray.append(oldArray[index2 + 1]); newArray.append(oldArray[index2 + 2]); newArray.append(oldArray[index2 + 3]); \
+newArray.append(oldArray[index3]); newArray.append(oldArray[index3 + 1]); newArray.append(oldArray[index3 + 2]); newArray.append(oldArray[index3 + 3]);
 
 bool GLTFSerializer::getStringVal(const QJsonObject& object, const QString& fieldname,
                               QString& value, QMap<QString, bool>&  defined) {
@@ -997,7 +997,7 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
         hfmModel.materials[matid] = HFMMaterial();
         HFMMaterial& hfmMaterial = hfmModel.materials[matid];
         hfmMaterial._material = std::make_shared<graphics::Material>();
-		hfmMaterial.name = hfmMaterial.materialID = matid;
+        hfmMaterial.name = hfmMaterial.materialID = matid;
         setHFMMaterial(hfmMaterial, _file.materials[i]);
     }
 
@@ -1044,15 +1044,15 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                 QVector<float> vertices;
                 QVector<float> normals;
                 QVector<float> tangents;
-                int tangent_stride = 0;
+                int tangentStride = 0;
                 QVector<float> texcoords;
                 QVector<float> texcoords2;
                 QVector<float> colors;
-                int color_stride = 0;
+                int colorStride = 0;
                 QVector<uint16_t> joints;
-                int joint_stride = 0;
+                int jointStride = 0;
                 QVector<float> weights;
-                int weight_stride = 0;
+                int weightStride = 0;
 
                 bool success = addArrayOfFromAccessor(indicesAccessor, indices);
 
@@ -1073,7 +1073,6 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
 
                     GLTFAccessor& accessor = _file.accessors[accessorIdx];
 
-                    int accBoffset = accessor.defined["byteOffset"] ? accessor.byteOffset : 0;
                     if (key == "POSITION") {
                         success = addArrayOfFromAccessor(accessor, vertices);
                         if (!success) {
@@ -1104,9 +1103,9 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                         }
 
                         if (accessor.type == GLTFAccessorType::VEC4) {
-                            tangent_stride = 4;
+                            tangentStride = 4;
                         } else if (accessor.type == GLTFAccessorType::VEC3) {
-                            tangent_stride = 3;
+                            tangentStride = 3;
                         } else {
                             qWarning(modelformat) << "Invalid accessor type on glTF TANGENT data for model " << _url;
                             continue;
@@ -1141,9 +1140,9 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                         }
 
                         if (accessor.type == GLTFAccessorType::VEC4) {
-                            color_stride = 4;
+                            colorStride = 4;
                         } else if (accessor.type == GLTFAccessorType::VEC3) {
-                            color_stride = 3;
+                            colorStride = 3;
                         } else {
                             qWarning(modelformat) << "Invalid accessor type on glTF COLOR_0 data for model " << _url;
                             continue;
@@ -1156,13 +1155,13 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                         }
 
                         if (accessor.type == GLTFAccessorType::VEC4) {
-                            joint_stride = 4;
+                            jointStride = 4;
                         } else if (accessor.type == GLTFAccessorType::VEC3) {
-                            joint_stride = 3;
+                            jointStride = 3;
                         } else if (accessor.type == GLTFAccessorType::VEC2) {
-                            joint_stride = 2;
+                            jointStride = 2;
                         } else if (accessor.type == GLTFAccessorType::SCALAR) {
-                            joint_stride = 1;
+                            jointStride = 1;
                         } else {
                             qWarning(modelformat) << "Invalid accessor type on glTF JOINTS_0 data for model " << _url;
                             continue;
@@ -1175,113 +1174,18 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                         }
 
                         if (accessor.type == GLTFAccessorType::VEC4) {
-                            weight_stride = 4;
+                            weightStride = 4;
                         } else if (accessor.type == GLTFAccessorType::VEC3) {
-                            weight_stride = 3;
+                            weightStride = 3;
                         } else if (accessor.type == GLTFAccessorType::VEC2) {
-                            weight_stride = 2;
+                            weightStride = 2;
                         } else if (accessor.type == GLTFAccessorType::SCALAR) {
-                            weight_stride = 1;
+                            weightStride = 1;
                         } else {
                             qWarning(modelformat) << "Invalid accessor type on glTF WEIGHTS_0 data for model " << _url;
                             continue;
                         }
                     }
-                }
-
-                // generate the normals if they don't exist
-                if (normals.size() == 0) {
-                    QVector<int> new_indices;
-                    QVector<float> new_vertices;
-                    QVector<float> new_normals;
-                    QVector<float> new_tangents;
-                    QVector<float> new_texcoords;
-                    QVector<float> new_texcoords2;
-                    QVector<float> new_colors;
-                    QVector<uint16_t> new_joints;
-                    QVector<float> new_weights;
-
-                    for (int n = 0; n < indices.size(); n = n + 3) {
-                        int v1_index = (indices[n + 0] * 3);
-                        int v2_index = (indices[n + 1] * 3);
-                        int v3_index = (indices[n + 2] * 3);
-
-                        glm::vec3 v1 = glm::vec3(vertices[v1_index], vertices[v1_index + 1], vertices[v1_index + 2]);
-                        glm::vec3 v2 = glm::vec3(vertices[v2_index], vertices[v2_index + 1], vertices[v2_index + 2]);
-                        glm::vec3 v3 = glm::vec3(vertices[v3_index], vertices[v3_index + 1], vertices[v3_index + 2]);
-
-                        new_vertices.append(v1.x); new_vertices.append(v1.y); new_vertices.append(v1.z);
-                        new_vertices.append(v2.x); new_vertices.append(v2.y); new_vertices.append(v2.z);
-                        new_vertices.append(v3.x); new_vertices.append(v3.y); new_vertices.append(v3.z);
-
-                        glm::vec3 norm = glm::normalize(glm::cross(v2 - v1, v3 - v1));
-
-                        new_normals.append(norm.x); new_normals.append(norm.y); new_normals.append(norm.z);
-                        new_normals.append(norm.x); new_normals.append(norm.y); new_normals.append(norm.z);
-                        new_normals.append(norm.x); new_normals.append(norm.y); new_normals.append(norm.z);
-
-                        if (tangents.size() > 0) {
-							if (tangent_stride == 4) {
-                                GLTF_APPEND_ARRAY_4(new_tangents, tangents)
-                            } else {
-                                GLTF_APPEND_ARRAY_3(new_tangents, tangents)
-                            }
-                        }
-
-                        if (texcoords.size() > 0) {
-                            GLTF_APPEND_ARRAY_2(new_texcoords, texcoords)
-                        }
-
-                        if (texcoords2.size() > 0) {
-                            GLTF_APPEND_ARRAY_2(new_texcoords2, texcoords2)
-                        }
-
-                        if (colors.size() > 0) {
-                            if (color_stride == 4) {
-                                GLTF_APPEND_ARRAY_4(new_colors, colors)
-                            } else {
-                                GLTF_APPEND_ARRAY_3(new_colors, colors)
-                            }
-                        }
-
-                        if (joints.size() > 0) {
-                            if (joint_stride == 4) {
-                                GLTF_APPEND_ARRAY_4(new_joints, joints)
-                            } else if (joint_stride == 3) {
-                                GLTF_APPEND_ARRAY_3(new_joints, joints)
-                            } else if (joint_stride == 2) {
-                                GLTF_APPEND_ARRAY_2(new_joints, joints)
-                            } else {
-                                GLTF_APPEND_ARRAY_1(new_joints, joints)
-                            }
-                        }
-
-                        if (weights.size() > 0) {
-                            if (weight_stride == 4) {
-                                GLTF_APPEND_ARRAY_4(new_weights, weights)
-                            } else if (weight_stride == 3) {
-                                GLTF_APPEND_ARRAY_3(new_weights, weights)
-                            } else if (weight_stride == 2) {
-                                GLTF_APPEND_ARRAY_2(new_weights, weights)
-                            } else {
-                                GLTF_APPEND_ARRAY_1(new_weights, weights)
-                            }
-                        }
-
-                        new_indices.append(n);
-                        new_indices.append(n + 1);
-                        new_indices.append(n + 2);
-                    }
-
-                    vertices = new_vertices;
-                    normals = new_normals;
-                    tangents = new_tangents;
-                    indices = new_indices;
-                    texcoords = new_texcoords;
-                    texcoords2 = new_texcoords2;
-                    colors = new_colors;
-                    joints = new_joints;
-                    weights = new_weights;
                 }
 
                 for (int n = 0; n < indices.count(); n++) {
@@ -1296,8 +1200,8 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                     mesh.normals.push_back(glm::vec3(normals[n], normals[n + 1], normals[n + 2]));
                 }
 
-                for (int n = 0; n < tangents.size(); n += tangent_stride) {
-                    float tanW = tangent_stride == 4 ? tangents[n + 3] : 1;
+                for (int n = 0; n < tangents.size(); n += tangentStride) {
+                    float tanW = tangentStride == 4 ? tangents[n + 3] : 1;
                     mesh.tangents.push_back(glm::vec3(tanW * tangents[n], tangents[n + 1], tanW * tangents[n + 2]));
                 }
 
@@ -1308,17 +1212,17 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                     mesh.texCoords1.push_back(glm::vec2(texcoords2[n], texcoords2[n + 1]));
                 }
 
-                for (int n = 0; n < colors.size(); n += color_stride) {
+                for (int n = 0; n < colors.size(); n += colorStride) {
                     mesh.colors.push_back(glm::vec3(colors[n], colors[n + 1], colors[n + 2]));
                 }
 
-                for (int n = 0; n < joints.size(); n += joint_stride) {
+                for (int n = 0; n < joints.size(); n += jointStride) {
                     clusterJoints.push_back(joints[n]);
-                    if (joint_stride > 1) {
+                    if (jointStride > 1) {
                         clusterJoints.push_back(joints[n + 1]);
-                        if (joint_stride > 2) {
+                        if (jointStride > 2) {
                             clusterJoints.push_back(joints[n + 2]);
-                            if (joint_stride > 3) {
+                            if (jointStride > 3) {
                                 clusterJoints.push_back(joints[n + 3]);
                             } else {
                                 clusterJoints.push_back(0);
@@ -1334,13 +1238,13 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const hifi::VariantHash& 
                     }
                 }
 
-                for (int n = 0; n < weights.size(); n += weight_stride) {
+                for (int n = 0; n < weights.size(); n += weightStride) {
                     clusterWeights.push_back(weights[n]);
-                    if (weight_stride > 1) {
+                    if (weightStride > 1) {
                         clusterWeights.push_back(weights[n + 1]);
-                        if (weight_stride > 2) {
+                        if (weightStride > 2) {
                             clusterWeights.push_back(weights[n + 2]);
-                            if (weight_stride > 3) {
+                            if (weightStride > 3) {
                                 clusterWeights.push_back(weights[n + 3]);
                             } else {
                                 clusterWeights.push_back(0);

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -812,32 +812,16 @@ glm::mat4 GLTFSerializer::getModelTransform(const GLTFNode& node) {
 void GLTFSerializer::getSkinInverseBindMatrices(std::vector<std::vector<float>>& inverseBindMatrixValues) {
     for (auto &skin : _file.skins) {
         GLTFAccessor& indicesAccessor = _file.accessors[skin.inverseBindMatrices];
-        GLTFBufferView& indicesBufferview = _file.bufferviews[indicesAccessor.bufferView];
-        GLTFBuffer& indicesBuffer = _file.buffers[indicesBufferview.buffer];
-        int accBoffset = indicesAccessor.defined["byteOffset"] ? indicesAccessor.byteOffset : 0;
         QVector<float> matrices;
-        addArrayOfType(indicesBuffer.blob, 
-            indicesBufferview.byteOffset + accBoffset, 
-            indicesAccessor.count, 
-            matrices,
-            indicesAccessor.type, 
-            indicesAccessor.componentType);
+        addArrayOfFromAccessor(indicesAccessor, matrices);
         inverseBindMatrixValues.push_back(matrices.toStdVector());
     }
 }
 
 void GLTFSerializer::generateTargetData(int index, float weight, QVector<glm::vec3>& returnVector) {
     GLTFAccessor& accessor = _file.accessors[index];
-    GLTFBufferView& bufferview = _file.bufferviews[accessor.bufferView];
-    GLTFBuffer& buffer = _file.buffers[bufferview.buffer];
-    int accBoffset = accessor.defined["byteOffset"] ? accessor.byteOffset : 0;
     QVector<float> storedValues;
-    addArrayOfType(buffer.blob, 
-        bufferview.byteOffset + accBoffset, 
-        accessor.count, 
-        storedValues,
-        accessor.type,
-        accessor.componentType);
+    addArrayOfFromAccessor(accessor, storedValues);
     for (int n = 0; n < storedValues.size(); n = n + 3) {
         returnVector.push_back(glm::vec3(weight * storedValues[n], weight * storedValues[n + 1], weight * storedValues[n + 2]));
     }

--- a/libraries/fbx/src/GLTFSerializer.h
+++ b/libraries/fbx/src/GLTFSerializer.h
@@ -481,6 +481,49 @@ namespace GLTFAccessorComponentType {
     };
 }
 struct GLTFAccessor {
+    struct GLTFAccessorSparse {
+        struct GLTFAccessorSparseIndices {
+            int bufferView;
+            int byteOffset{ 0 };
+            int componentType;
+
+            QMap<QString, bool> defined;
+            void dump() {
+                if (defined["bufferView"]) {
+                    qCDebug(modelformat) << "bufferView: " << bufferView;
+                }
+                if (defined["byteOffset"]) {
+                    qCDebug(modelformat) << "byteOffset: " << byteOffset;
+                }
+                if (defined["componentType"]) {
+                    qCDebug(modelformat) << "componentType: " << componentType;
+                }
+            }
+        };
+        struct GLTFAccessorSparseValues {
+            int bufferView;
+            int byteOffset{ 0 };
+
+            QMap<QString, bool> defined;
+            void dump() {
+                if (defined["bufferView"]) {
+                    qCDebug(modelformat) << "bufferView: " << bufferView;
+                }
+                if (defined["byteOffset"]) {
+                    qCDebug(modelformat) << "byteOffset: " << byteOffset;
+                }
+            }
+        };
+
+        int count;
+        GLTFAccessorSparseIndices indices;
+        GLTFAccessorSparseValues values;
+
+        QMap<QString, bool> defined;
+        void dump() {
+        
+        }
+    };
     int bufferView;
     int byteOffset { 0 };
     int componentType; //required
@@ -489,6 +532,7 @@ struct GLTFAccessor {
     bool normalized{ false };
     QVector<double> max;
     QVector<double> min;
+    GLTFAccessorSparse sparse;
     QMap<QString, bool> defined;
     void dump() {
         if (defined["bufferView"]) {
@@ -520,6 +564,10 @@ struct GLTFAccessor {
             foreach(float m, min) {
                 qCDebug(modelformat) << m;
             }
+        }
+        if (defined["sparse"]) {
+            qCDebug(modelformat) << "sparse: ";
+            sparse.dump();
         }
     }
 };
@@ -763,6 +811,11 @@ private:
                             int& outidx, QMap<QString, bool>& defined);
 
     bool setAsset(const QJsonObject& object);
+
+    GLTFAccessor::GLTFAccessorSparse::GLTFAccessorSparseIndices createAccessorSparseIndices(const QJsonObject& object);
+    GLTFAccessor::GLTFAccessorSparse::GLTFAccessorSparseValues createAccessorSparseValues(const QJsonObject& object);
+    GLTFAccessor::GLTFAccessorSparse createAccessorSparse(const QJsonObject& object);
+
     bool addAccessor(const QJsonObject& object);
     bool addAnimation(const QJsonObject& object);
     bool addBufferView(const QJsonObject& object);
@@ -782,7 +835,7 @@ private:
     template<typename T, typename L>
     bool readArray(const hifi::ByteArray& bin, int byteOffset, int count,
                    QVector<L>& outarray, int accessorType);
-    
+
     template<typename T>
     bool addArrayOfType(const hifi::ByteArray& bin, int byteOffset, int count,
                         QVector<T>& outarray, int accessorType, int componentType);

--- a/libraries/fbx/src/GLTFSerializer.h
+++ b/libraries/fbx/src/GLTFSerializer.h
@@ -840,6 +840,9 @@ private:
     bool addArrayOfType(const hifi::ByteArray& bin, int byteOffset, int count,
                         QVector<T>& outarray, int accessorType, int componentType);
 
+    template <typename T>
+    bool addArrayOfFromAccessor(GLTFAccessor& accessor, QVector<T>& outarray);
+
     void retriangulate(const QVector<int>& in_indices, const QVector<glm::vec3>& in_vertices, 
                        const QVector<glm::vec3>& in_normals, QVector<int>& out_indices, 
                        QVector<glm::vec3>& out_vertices, QVector<glm::vec3>& out_normals);

--- a/libraries/fbx/src/GLTFSerializer.h
+++ b/libraries/fbx/src/GLTFSerializer.h
@@ -841,7 +841,7 @@ private:
                         QVector<T>& outarray, int accessorType, int componentType);
 
     template <typename T>
-    bool addArrayOfFromAccessor(GLTFAccessor& accessor, QVector<T>& outarray);
+    bool addArrayFromAccessor(GLTFAccessor& accessor, QVector<T>& outarray);
 
     void retriangulate(const QVector<int>& in_indices, const QVector<glm::vec3>& in_vertices, 
                        const QVector<glm::vec3>& in_normals, QVector<int>& out_indices, 


### PR DESCRIPTION
This PR contains an ongoing collection of commits for improving the compatibility of the pre-existing GLTF 2.0 Importer with the official Khronos Group spec (https://www.khronos.org/gltf/). Among other things it contains improved support for unnamed materials and vertex colours, sparse accessors, thin bounding boxes, and general cleanup/refactor. Test with this model to see fixes for normal generation and sparse accessors: https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/SimpleSparseAccessor/glTF/SimpleSparseAccessor.gltf

https://highfidelity.manuscript.com/f/cases/22169/GLTF-improvements-sparse-accessors-vertex-colors-multiple-unnamed-materials-thin-bounding-boxes