### PR TITLE
Case 17284: Fix tablet culling

### DIFF
--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -290,6 +290,7 @@ void Base3DOverlay::locationChanged(bool tellPhysics) {
     notifyRenderVariableChange();
 }
 
+// FIXME: Overlays shouldn't be deleted when their parents are
 void Base3DOverlay::parentDeleted() {
     qApp->getOverlays().deleteOverlay(getOverlayID());
 }

--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -59,8 +59,6 @@ public:
     void setIsGrabbable(bool value) { _isGrabbable = value; }
     virtual void setIsVisibleInSecondaryCamera(bool value) { _isVisibleInSecondaryCamera = value; }
 
-    virtual AABox getBounds() const override = 0;
-
     void update(float deltatime) override;
 
     void notifyRenderVariableChange() const;

--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -60,6 +60,8 @@ ModelOverlay::ModelOverlay(const ModelOverlay* modelOverlay) :
 }
 
 void ModelOverlay::update(float deltatime) {
+    Base3DOverlay::update(deltatime);
+
     if (_updateModel) {
         _updateModel = false;
         _model->setSnapModelToCenter(true);

--- a/interface/src/ui/overlays/Overlay.cpp
+++ b/interface/src/ui/overlays/Overlay.cpp
@@ -247,7 +247,7 @@ void Overlay::removeMaterial(graphics::MaterialPointer material, const std::stri
 }
 
 render::ItemKey Overlay::getKey() {
-    auto builder = render::ItemKey::Builder().withTypeShape();
+    auto builder = render::ItemKey::Builder().withTypeShape().withTypeMeta();
 
     builder.withViewSpace();
     builder.withLayer(render::hifi::LAYER_2D);

--- a/interface/src/ui/overlays/Volume3DOverlay.cpp
+++ b/interface/src/ui/overlays/Volume3DOverlay.cpp
@@ -20,11 +20,9 @@ Volume3DOverlay::Volume3DOverlay(const Volume3DOverlay* volume3DOverlay) :
 }
 
 AABox Volume3DOverlay::getBounds() const {
-    auto extents = Extents{_localBoundingBox};
-    extents.rotate(getWorldOrientation());
-    extents.shiftBy(getWorldPosition());
-
-    return AABox(extents);
+    AABox bounds = _localBoundingBox;
+    bounds.transform(getTransform());
+    return bounds;
 }
 
 void Volume3DOverlay::setDimensions(const glm::vec3& value) {
@@ -49,15 +47,7 @@ void Volume3DOverlay::setProperties(const QVariantMap& properties) {
         glm::vec3 scale = vec3FromVariant(dimensions);
         // don't allow a zero or negative dimension component to reach the renderTransform
         const float MIN_DIMENSION = 0.0001f;
-        if (scale.x < MIN_DIMENSION) {
-            scale.x = MIN_DIMENSION;
-        }
-        if (scale.y < MIN_DIMENSION) {
-            scale.y = MIN_DIMENSION;
-        }
-        if (scale.z < MIN_DIMENSION) {
-            scale.z = MIN_DIMENSION;
-        }
+        scale = glm::max(scale, MIN_DIMENSION);
         setDimensions(scale);
     }
 }

--- a/interface/src/ui/overlays/Volume3DOverlay.h
+++ b/interface/src/ui/overlays/Volume3DOverlay.h
@@ -24,7 +24,6 @@ public:
     virtual AABox getBounds() const override;
 
     const glm::vec3& getDimensions() const { return _localBoundingBox.getDimensions(); }
-    void setDimensions(float value) { setDimensions(glm::vec3(value)); }
     void setDimensions(const glm::vec3& value);
 
     void setProperties(const QVariantMap& properties) override;
@@ -37,7 +36,7 @@ public:
 
 protected:
     // Centered local bounding box
-    AABox _localBoundingBox{ vec3(0.0f), 1.0f };
+    AABox _localBoundingBox { vec3(-0.5), 1.0f };
 
     Transform evalRenderTransform() override;
 };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17284/Tablet-frame-model-disappears-when-looking-away-from-area-where-tablet-was-last-grabbed-or-opened

Test plan:
- Open the tablet.  Don't touch it.
- Move far away from where you opened it, keeping it open.  Look around, but keep it in your view.  Look at it at different angles.  It should continue to render.
- Create a cube overlay like this:
```
Overlays.addOverlay("cube", {
     localPosition: { x: 0, y: 0, z: 5 },
     parentID: MyAvatar.SELF_ID,
     solid: true,
     alpha: 1.0
});
```
- Open luci.js and click the "Opaques" checkbox at the bottom.  The bounds around it should enclose it completely.