### PR TITLE
MS19803: Remove extra "as" in Security.qml

### DIFF
--- a/interface/resources/qml/hifi/dialogs/security/Security.qml
+++ b/interface/resources/qml/hifi/dialogs/security/Security.qml
@@ -15,7 +15,7 @@ import Hifi 1.0 as Hifi
 import QtQuick 2.5
 import QtGraphicalEffects 1.0
 import stylesUit 1.0 as HifiStylesUit
-import controlsUit 1.0 as as HifiControlsUit
+import controlsUit 1.0 as HifiControlsUit
 import "qrc:////qml//controls" as HifiControls
 import "qrc:////qml//hifi//commerce//common" as HifiCommerceCommon
 


### PR DESCRIPTION
[This PR](https://github.com/highfidelity/hifi/pull/14263) (which is a very good idea) introduced a typo into `Security.qml`. No biggie.

Fixes [MS19803](https://highfidelity.manuscript.com/f/cases/19803/MENU-Settings-Security-Opens-blank-dialog).