### PR TITLE
Fixing prebuild environment

### DIFF
--- a/cmake/ports/hifi-client-deps/CONTROL
+++ b/cmake/ports/hifi-client-deps/CONTROL
@@ -1,4 +1,4 @@
 Source: hifi-client-deps
 Version: 0
 Description: Collected dependencies for High Fidelity applications
-Build-Depends: hifi-deps, glslang, nlohmann-json, openvr (windows), sdl2 (!android), spirv-cross (!android), spirv-tools (!android), vulkanmemoryallocator
+Build-Depends: hifi-deps, glslang, nlohmann-json, openvr (windows), sdl2, shaderc, spirv-cross, spirv-tools, vulkanmemoryallocator

--- a/prebuild.py
+++ b/prebuild.py
@@ -139,6 +139,8 @@ class VcpkgRepo:
         else:
             defaultBasePath = os.path.join(tempfile.gettempdir(), 'hifi', 'vcpkg')
             basePath = os.getenv('HIFI_VCPKG_BASE', defaultBasePath)
+            if basePath == defaultBasePath:
+                print("Warning: Environment variable HIFI_VCPKG_BASE not set, using {}".format(defaultBasePath))
             if (not os.path.isdir(basePath)):
                 os.makedirs(basePath)
             self.path = os.path.join(basePath, self.id)

--- a/prebuild.py
+++ b/prebuild.py
@@ -16,6 +16,10 @@ import tempfile
 import time
 import urllib.request
 import functools
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 
 print = functools.partial(print, flush=True)
 
@@ -46,16 +50,24 @@ def hashFile(file):
             hasher.update(chunk)
     return hasher.hexdigest()
 
-
-def hashFolder(folder):
+# Assumes input files are in deterministic order
+def hashFiles(filenames):
     hasher = hashlib.sha256()
-    for dirName, subdirList, fileList in os.walk(folder):
-        for fname in fileList:
-            with open(os.path.join(folder, dirName, fname), "rb") as f:
-                for chunk in iter(lambda: f.read(4096), b""):
-                    hasher.update(chunk)
+    for filename in filenames:
+        with open(filename, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                hasher.update(chunk)
     return hasher.hexdigest()
 
+def hashFolder(folder):
+    filenames = []
+    for dirName, subdirList, fileList in os.walk(folder):
+        for fname in fileList:
+            filenames.append(os.path.join(folder, dirName, fname))
+    # Make sure we hash the files in a determinisitic order, 
+    # regardless of how the os.walk function ordered them
+    filenames.sort()
+    return hashFiles(filenames)
 
 def downloadAndExtract(url, destPath, hash=None):
     tempFileDescriptor, tempFileName = tempfile.mkstemp()
@@ -74,6 +86,43 @@ def downloadAndExtract(url, destPath, hash=None):
         tgz.extractall(destPath)
     os.remove(tempFileName)
 
+           
+class Singleton:
+    def __init__(self, path):
+        self.fh = None
+        self.windows = 'Windows' == platform.system()
+        self.path = path
+
+    def __enter__(self):
+        success = False
+        while not success:
+            try:
+                if self.windows:
+                    if os.path.exists(self.path):
+                        os.unlink(self.path)
+                    self.fh = os.open(self.path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+                else:
+                    self.fh = open(self.path, 'x')
+                    fcntl.lockf(self.fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                success = True
+            except EnvironmentError as err:
+                if self.fh is not None:
+                    if self.windows:
+                        os.close(self.fh)
+                    else:
+                        self.fh.close()
+                    self.fh = None
+                print("Couldn't aquire lock, retrying in 10 seconds")
+                time.sleep(10)
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if self.windows:
+            os.close(self.fh)
+        else:
+            fcntl.lockf(self.fh, fcntl.LOCK_UN)
+            self.fh.close()
+        os.unlink(self.path)
 
 class VcpkgRepo:
     def __init__(self):
@@ -94,6 +143,12 @@ class VcpkgRepo:
                 os.makedirs(basePath)
             self.path = os.path.join(basePath, self.id)
 
+        lockDir, lockName = os.path.split(self.path)
+        lockName += '.lock'
+        if not os.path.isdir(lockDir):
+            os.makedirs(lockDir)
+
+        self.lockFile = os.path.join(lockDir, lockName)
         self.tagFile = os.path.join(self.path, '.id')
         # A format version attached to the tag file... increment when you want to force the build systems to rebuild 
         # without the contents of the ports changing
@@ -222,10 +277,16 @@ class VcpkgRepo:
         cmakeScript = os.path.join(self.path, 'scripts/buildsystems/vcpkg.cmake')
         installPath = os.path.join(self.path, 'installed', self.triplet)
         toolsPath = os.path.join(self.path, 'installed', self.hostTriplet, 'tools')
-        cmakeTemplate = 'set(CMAKE_TOOLCHAIN_FILE "{}" CACHE FILEPATH "Toolchain file")\n'
-        cmakeTemplate += 'set(VCPKG_INSTALL_ROOT "{}" CACHE FILEPATH "vcpkg installed packages path")\n'
-        cmakeTemplate += 'set(VCPKG_TOOLS_DIR "{}" CACHE FILEPATH "vcpkg installed packages path")\n'
-        cmakeConfig = cmakeTemplate.format(cmakeScript, installPath, toolsPath).replace('\\', '/')
+        cmakeTemplate = """set(CMAKE_TOOLCHAIN_FILE "{}" CACHE FILEPATH "Toolchain file")
+set(CMAKE_TOOLCHAIN_FILE_UNCACHED "{}")
+set(VCPKG_INSTALL_ROOT "{}")
+set(VCPKG_TOOLS_DIR "{}")
+# If the cached cmake toolchain path is different from the computed one, exit
+if(NOT (CMAKE_TOOLCHAIN_FILE_UNCACHED STREQUAL CMAKE_TOOLCHAIN_FILE))
+    message(FATAL_ERROR "CMAKE_TOOLCHAIN_FILE has changed, please wipe the build directory and rerun cmake")
+endif()
+"""
+        cmakeConfig = cmakeTemplate.format(cmakeScript, cmakeScript, installPath, toolsPath).replace('\\', '/')
         with open(configFilePath, 'w') as f:
             f.write(cmakeConfig)
 
@@ -235,11 +296,14 @@ class VcpkgRepo:
             f.write(self.tagContents)
 
 def main():
+    # Only allow one instance of the program to run at a time
+    global args
     vcpkg = VcpkgRepo()
-    vcpkg.bootstrap()
-    vcpkg.buildDependencies()
-    vcpkg.writeConfig()
-    vcpkg.writeTag()
+    with Singleton(vcpkg.lockFile) as lock:
+        vcpkg.bootstrap()
+        vcpkg.buildDependencies()
+        vcpkg.writeConfig()
+        vcpkg.writeTag()
 
 
 from argparse import ArgumentParser
@@ -259,6 +323,7 @@ removeEnvVars = ['VCPKG_ROOT', 'USE_CCACHE']
 for var in removeEnvVars:
     if var in os.environ:
         del os.environ[var]
+
 
 main()
 

--- a/prebuild.py
+++ b/prebuild.py
@@ -242,7 +242,6 @@ def main():
     vcpkg.writeTag()
 
 
-
 from argparse import ArgumentParser
 parser = ArgumentParser(description='Prepare build dependencies.')
 parser.add_argument('--android', action='store_true')
@@ -251,7 +250,15 @@ parser.add_argument('--force-bootstrap', action='store_true')
 parser.add_argument('--force-build', action='store_true')
 parser.add_argument('--vcpkg-root', type=str, help='The location of the vcpkg distribution')
 parser.add_argument('--build-root', required=True, type=str, help='The location of the cmake build')
-
 args = parser.parse_args()
+
+# Fixup env variables.  Leaving `USE_CCACHE` on will cause scribe to fail to build
+# VCPKG_ROOT seems to cause confusion on Windows systems that previously used it for 
+# building OpenSSL
+removeEnvVars = ['VCPKG_ROOT', 'USE_CCACHE']
+for var in removeEnvVars:
+    if var in os.environ:
+        del os.environ[var]
+
 main()
 

--- a/prebuild.py
+++ b/prebuild.py
@@ -279,10 +279,14 @@ class VcpkgRepo:
         cmakeScript = os.path.join(self.path, 'scripts/buildsystems/vcpkg.cmake')
         installPath = os.path.join(self.path, 'installed', self.triplet)
         toolsPath = os.path.join(self.path, 'installed', self.hostTriplet, 'tools')
-        cmakeTemplate = """set(CMAKE_TOOLCHAIN_FILE "{}" CACHE FILEPATH "Toolchain file")
+        cmakeTemplate = """
+set(CMAKE_TOOLCHAIN_FILE "{}" CACHE FILEPATH "Toolchain file")
 set(CMAKE_TOOLCHAIN_FILE_UNCACHED "{}")
 set(VCPKG_INSTALL_ROOT "{}")
 set(VCPKG_TOOLS_DIR "{}")
+"""
+        if not args.android:
+            cmakeTemplate += """
 # If the cached cmake toolchain path is different from the computed one, exit
 if(NOT (CMAKE_TOOLCHAIN_FILE_UNCACHED STREQUAL CMAKE_TOOLCHAIN_FILE))
     message(FATAL_ERROR "CMAKE_TOOLCHAIN_FILE has changed, please wipe the build directory and rerun cmake")


### PR DESCRIPTION
* Remove some environment variables that will cause problems during the vcpkg prebuild step.
* Use a lock file to ensure only once instance of the prebuild script is running at a time (for a given target directory)
* Emit a warning if the default temp path is being used instead of the HIFI_VCPKG_BASE environment variable
* Change the logic that creates the ID by hashing all the port files to be deterministic, sorting the filenames before hashing them (otherwise the order of file hashing depends on the underlying filesystem)
* If the `CMAKE_TOOLCHAIN_FILE` generated by the prebuild script is different than the one cached in CMakeCache.txt, immediately emit an error and fail cmake with a message to wipe and rebuild



## Testing

No testing required, this only affects the build tool chain and does not change any code or dependencies.