### PR TITLE
Add newly-introduced dependency class to Oven

### DIFF
--- a/tools/oven/src/Oven.cpp
+++ b/tools/oven/src/Oven.cpp
@@ -19,6 +19,7 @@
 #include <DependencyManager.h>
 #include <StatTracker.h>
 #include <ResourceManager.h>
+#include <ResourceRequestObserver.h>
 
 Oven* Oven::_staticInstance { nullptr };
 
@@ -31,6 +32,7 @@ Oven::Oven() {
     // Initialize dependencies for OBJ Baker
     DependencyManager::set<StatTracker>();
     DependencyManager::set<ResourceManager>(false);
+    DependencyManager::set<ResourceRequestObserver>();
 }
 
 Oven::~Oven() {


### PR DESCRIPTION
Originally part of https://github.com/highfidelity/hifi/pull/14266.

A new dependency-managed class, ResourceRequestObserver, has been added to the codebase. The Oven requires an instance of it to bake OBJ files.