### PR TITLE
Add PolyLine/PolyVox to entity list/properties types

### DIFF
--- a/scripts/system/html/js/entityList.js
+++ b/scripts/system/html/js/entityList.js
@@ -136,6 +136,8 @@ const FILTER_TYPES = [
     "Web",
     "Material",
     "ParticleEffect",
+    "PolyLine",
+    "PolyVox",
     "Text",
 ];
 
@@ -148,6 +150,8 @@ const ICON_FOR_TYPE = {
     Web: "q",
     Material: "&#xe00b;",
     ParticleEffect: "&#xe004;",
+    PolyLine: "&#xe01b;",
+    PolyVox: "&#xe005;",
     Text: "l",
 };
 

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1342,6 +1342,8 @@ const GROUPS_PER_TYPE = {
   Material: [ 'base', 'material', 'spatial', 'behavior' ],
   ParticleEffect: [ 'base', 'particles', 'particles_emit', 'particles_size', 'particles_color', 'particles_alpha', 
                     'particles_acceleration', 'particles_spin', 'particles_constraints', 'spatial', 'behavior', 'physics' ],
+  PolyLine: [ 'base', 'spatial', 'behavior', 'collision', 'physics' ],
+  PolyVox: [ 'base', 'spatial', 'behavior', 'collision', 'physics' ],
   Multiple: [ 'base', 'spatial', 'behavior', 'collision', 'physics' ],
 };
 


### PR DESCRIPTION
Addresses:
https://highfidelity.fogbugz.com/f/cases/19878

Test Plan:
- Enter Interface in desktop mode into your sandbox
- Open the scripting console under Developer menu -> Scripting
- Enter the following lines into the console:
Entities.addEntity({type: "PolyLine", name: "PolyLine"});
Entities.addEntity({type: "PolyVox", name: "PolyVox"});
- Open Create to the entity list and verify a PolyVox and PolyLine entity are there
- Verify the PolyVox entity filters out when unchecking PolyVox in the All Types dropdown, and filters back in when rechecking it
- Verify the PolyLine entity filters out when unchecking PolyLine in the All Types dropdown, and filters back in when rechecking it