### PR TITLE
revert PR-14238 "TypeError: Cannot read property 'buttons'" until we can adjust it.

### DIFF
--- a/interface/resources/qml/hifi/Desktop.qml
+++ b/interface/resources/qml/hifi/Desktop.qml
@@ -70,8 +70,8 @@ OriginalDesktop.Desktop {
         anchors.horizontalCenter: settings.constrainToolbarToCenterX ? desktop.horizontalCenter : undefined;
         // Literal 50 is overwritten by settings from previous session, and sysToolbar.x comes from settings when not constrained.
         x: sysToolbar.x
-        buttonModel: tablet ? tablet.buttons : null;
-        shown: tablet ? tablet.toolbarMode : false;
+        buttonModel: tablet.buttons;
+        shown: tablet.toolbarMode;
     }
 
     Settings {

--- a/interface/resources/qml/hifi/tablet/TabletHome.qml
+++ b/interface/resources/qml/hifi/tablet/TabletHome.qml
@@ -115,9 +115,9 @@ Item {
             property int previousIndex: -1
             Repeater {
                 id: pageRepeater
-                model: tabletProxy != null ? Math.ceil(tabletProxy.buttons.rowCount() / TabletEnums.ButtonsOnPage) : 0
+                model: Math.ceil(tabletProxy.buttons.rowCount() / TabletEnums.ButtonsOnPage)
                 onItemAdded: {
-                    item.proxyModel.sourceModel = tabletProxy != null ? tabletProxy.buttons : null;
+                    item.proxyModel.sourceModel = tabletProxy.buttons;
                     item.proxyModel.pageIndex = index;
                 }
 

--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -387,12 +387,8 @@ void OffscreenSurface::finishQmlLoad(QQmlComponent* qmlComponent,
         if (!parent) {
             parent = getRootItem();
         }
-        // manually control children items lifetime
-        QQmlEngine::setObjectOwnership(newObject, QQmlEngine::CppOwnership);
-
-        // add object to the manual deletion list
-        _sharedObject->addToDeletionList(newObject);
-
+        // Allow child windows to be destroyed from JS
+        QQmlEngine::setObjectOwnership(newObject, QQmlEngine::JavaScriptOwnership);
         newObject->setParent(parent);
         newItem->setParentItem(parent);
     } else {

--- a/libraries/qml/src/qml/impl/SharedObject.cpp
+++ b/libraries/qml/src/qml/impl/SharedObject.cpp
@@ -15,7 +15,6 @@
 #include <QtQml/QQmlEngine>
 
 #include <QtGui/QOpenGLContext>
-#include <QPointer>
 
 #include <NumericalConstants.h>
 #include <shared/NsightHelpers.h>
@@ -82,6 +81,7 @@ SharedObject::SharedObject() {
 SharedObject::~SharedObject() {
     // After destroy returns, the rendering thread should be gone
     destroy();
+
     // _renderTimer is created with `this` as the parent, so need no explicit destruction
 #ifndef DISABLE_QML
     // Destroy the event hand
@@ -95,11 +95,6 @@ SharedObject::~SharedObject() {
         _renderControl = nullptr;
     }
 #endif
-
-    // already deleted objects will be reset to null by QPointer so it should be safe just iterate here
-    for (auto qmlObject : _deletionList) {
-        delete qmlObject;
-    }
 
     if (_rootItem) {
         delete _rootItem;
@@ -415,11 +410,6 @@ bool SharedObject::fetchTexture(TextureAndFence& textureAndFence) {
     textureAndFence = { 0, 0 };
     std::swap(textureAndFence, _latestTextureAndFence);
     return true;
-}
-
-void hifi::qml::impl::SharedObject::addToDeletionList(QObject * object)
-{
-    _deletionList.append(QPointer<QObject>(object));
 }
 
 void SharedObject::setProxyWindow(QWindow* window) {

--- a/libraries/qml/src/qml/impl/SharedObject.h
+++ b/libraries/qml/src/qml/impl/SharedObject.h
@@ -66,7 +66,7 @@ public:
     void resume();
     bool isPaused() const;
     bool fetchTexture(TextureAndFence& textureAndFence);
-    void addToDeletionList(QObject* object);
+
 
 private:
     bool event(QEvent* e) override;
@@ -90,8 +90,6 @@ private:
     void onTimer();
     void onAboutToQuit();
     void updateTextureAndFence(const TextureAndFence& newTextureAndFence);
-
-    QList<QPointer<QObject>> _deletionList;
 
     // Texture management
     TextureAndFence _latestTextureAndFence{ 0, 0 };


### PR DESCRIPTION
- revert PR-14238 "TypeError: Cannot read property 'buttons'" until we can adjust it.

https://highfidelity.manuscript.com/f/cases/19871/Tablet-errors
https://highfidelity.manuscript.com/f/cases/19872/Login-problems
https://highfidelity.manuscript.com/f/cases/19873/Tablet-apps-do-not-open

this reverts https://github.com/highfidelity/hifi/pull/14238
and reopens https://highfidelity.manuscript.com/f/cases/19400/during-shutdown-TypeError-Cannot-read-property-buttons-of-null