### PR TITLE
Case 19876: Fix procedurals using the iGlobalTime input

### DIFF
--- a/libraries/procedural/src/procedural/ProceduralCommon.slh
+++ b/libraries/procedural/src/procedural/ProceduralCommon.slh
@@ -32,8 +32,10 @@ LAYOUT_STD140(binding=0) uniform standardInputsBuffer {
     vec4 date;
     // Offset 16, acts as vec4 for alignment purposes
     vec3 worldPosition;
-    // Offset 32, acts as vec4 for alignment purposes
+    // Offset 32, acts as vec4 for alignment purposes (but not packing purposes)
     vec3 worldScale;
+    // We need this float here to keep globalTime from getting pulled to offset 44
+    float _spare0;
     // Offset 48
     float globalTime;
     // Offset 52


### PR DESCRIPTION
Fix for [19876](https://highfidelity.manuscript.com/f/cases/19876/Some-procedural-shaders-no-longer-work-in-v0-75-0). 

RC75.1 version of #14407