### PR TITLE
CreateApp Fix entity list double click rename / highlight and virtual keyboard issue

### DIFF
--- a/scripts/system/html/js/entityList.js
+++ b/scripts/system/html/js/entityList.js
@@ -187,7 +187,7 @@ let startThClick = null;
 let renameTimeout = null;
 let renameLastBlur = null;
 let renameLastEntityID = null;
-let isRenameFieldIsBeingMoved = false;
+let isRenameFieldBeingMoved = false;
 
 let elEntityTable,
     elEntityTableHeader,
@@ -397,7 +397,7 @@ function loaded() {
         elEntityTableHeaderRow = document.querySelectorAll("#entity-table thead th");
         
         entityList = new ListView(elEntityTableBody, elEntityTableScroll, elEntityTableHeaderRow,
-                                  createRow, updateRow, clearRow, beforeUpdate, afterUpdate, WINDOW_NONVARIABLE_HEIGHT);
+                                  createRow, updateRow, clearRow, preRefresh, postRefresh, WINDOW_NONVARIABLE_HEIGHT);
 
         entityListContextMenu = new EntityListContextMenu();
 
@@ -424,7 +424,7 @@ function loaded() {
             };
 
             elRenameInput.onblur = function(event) {
-                if (isRenameFieldIsBeingMoved) {
+                if (isRenameFieldBeingMoved) {
                     return;
                 }
                 let value = elRenameInput.value;
@@ -446,18 +446,18 @@ function loaded() {
             elRenameInput.select();
         }
 
-        function beforeUpdate() {
+        function preRefresh() {
             // move the rename input to the body
             if (elRenameInput) {
-                isRenameFieldIsBeingMoved = true;
+                isRenameFieldBeingMoved = true;
                 document.body.appendChild(elRenameInput);
                 // keep the focus
                 elRenameInput.select();
             }
         }
 
-        function afterUpdate() {
-            if (!elRenameInput || !isRenameFieldIsBeingMoved) {
+        function postRefresh() {
+            if (!elRenameInput || !isRenameFieldBeingMoved) {
                 return;
             }
             let entity = entitiesByID[renameLastEntityID];
@@ -469,7 +469,7 @@ function loaded() {
             elCell.appendChild(elRenameInput);
             // keep the focus
             elRenameInput.select();
-            isRenameFieldIsBeingMoved = false;
+            isRenameFieldBeingMoved = false;
         }
 
         entityListContextMenu.setOnSelectedCallback(function(optionName, selectedEntityID) {

--- a/scripts/system/html/js/entityList.js
+++ b/scripts/system/html/js/entityList.js
@@ -396,8 +396,8 @@ function loaded() {
         
         elEntityTableHeaderRow = document.querySelectorAll("#entity-table thead th");
         
-        entityList = new ListView(elEntityTableBody, elEntityTableScroll, elEntityTableHeaderRow,
-                                  createRow, updateRow, clearRow, preRefresh, postRefresh, WINDOW_NONVARIABLE_HEIGHT);
+        entityList = new ListView(elEntityTableBody, elEntityTableScroll, elEntityTableHeaderRow, createRow, updateRow,
+                                  clearRow, preRefresh, postRefresh, preRefresh, WINDOW_NONVARIABLE_HEIGHT);
 
         entityListContextMenu = new EntityListContextMenu();
 
@@ -448,7 +448,7 @@ function loaded() {
 
         function preRefresh() {
             // move the rename input to the body
-            if (elRenameInput) {
+            if (!isRenameFieldBeingMoved && elRenameInput) {
                 isRenameFieldBeingMoved = true;
                 document.body.appendChild(elRenameInput);
                 // keep the focus

--- a/scripts/system/html/js/listView.js
+++ b/scripts/system/html/js/listView.js
@@ -14,7 +14,7 @@ debugPrint = function (message) {
 };
 
 function ListView(elTableBody, elTableScroll, elTableHeaderRow, createRowFunction, 
-                  updateRowFunction, clearRowFunction, WINDOW_NONVARIABLE_HEIGHT) {   
+                  updateRowFunction, clearRowFunction, beforeRefreshFunction, afterRefreshFunction, WINDOW_NONVARIABLE_HEIGHT) {
     this.elTableBody = elTableBody;
     this.elTableScroll = elTableScroll;
     this.elTableHeaderRow = elTableHeaderRow;
@@ -25,6 +25,8 @@ function ListView(elTableBody, elTableScroll, elTableHeaderRow, createRowFunctio
     this.createRowFunction = createRowFunction;
     this.updateRowFunction = updateRowFunction;
     this.clearRowFunction = clearRowFunction;
+    this.beforeRefreshFunction = beforeRefreshFunction;
+    this.afterRefreshFunction = afterRefreshFunction;
     
     // the list of row elements created in the table up to max viewable height plus SCROLL_ROWS rows for scrolling buffer
     this.elRows = [];
@@ -173,6 +175,7 @@ ListView.prototype = {
     },
     
     refresh: function() {
+        this.beforeRefreshFunction();
         // block refreshing before rows are initialized
         let numRows = this.getNumRows();
         if (numRows === 0) {
@@ -211,6 +214,7 @@ ListView.prototype = {
                 this.lastRowShiftScrollTop = 0;
             }
         }
+        this.afterRefreshFunction();
     },
     
     refreshBuffers: function() {
@@ -230,7 +234,7 @@ ListView.prototype = {
     
     refreshRowOffset: function() {
         // make sure the row offset isn't causing visible rows to pass the end of the item list and is clamped to 0
-        var numRows = this.getNumRows();
+        let numRows = this.getNumRows();
         if (this.rowOffset + numRows > this.itemData.length) {
             this.rowOffset = this.itemData.length - numRows;
         }

--- a/scripts/system/html/js/listView.js
+++ b/scripts/system/html/js/listView.js
@@ -13,8 +13,8 @@ debugPrint = function (message) {
     console.log(message);
 };
 
-function ListView(elTableBody, elTableScroll, elTableHeaderRow, createRowFunction, 
-                  updateRowFunction, clearRowFunction, preRefreshFunction, postRefreshFunction, WINDOW_NONVARIABLE_HEIGHT) {
+function ListView(elTableBody, elTableScroll, elTableHeaderRow, createRowFunction, updateRowFunction, clearRowFunction,
+                  preRefreshFunction, postRefreshFunction, preResizeFunction, WINDOW_NONVARIABLE_HEIGHT) {
     this.elTableBody = elTableBody;
     this.elTableScroll = elTableScroll;
     this.elTableHeaderRow = elTableHeaderRow;
@@ -27,6 +27,7 @@ function ListView(elTableBody, elTableScroll, elTableHeaderRow, createRowFunctio
     this.clearRowFunction = clearRowFunction;
     this.preRefreshFunction = preRefreshFunction;
     this.postRefreshFunction = postRefreshFunction;
+    this.preResizeFunction = preResizeFunction;
     
     // the list of row elements created in the table up to max viewable height plus SCROLL_ROWS rows for scrolling buffer
     this.elRows = [];
@@ -248,7 +249,7 @@ ListView.prototype = {
             debugPrint("ListView.resize - no valid table body or table scroll element");
             return;
         }
-
+        this.preResizeFunction();
         let prevScrollTop = this.elTableScroll.scrollTop;  
 
         // take up available window space

--- a/scripts/system/html/js/listView.js
+++ b/scripts/system/html/js/listView.js
@@ -14,7 +14,7 @@ debugPrint = function (message) {
 };
 
 function ListView(elTableBody, elTableScroll, elTableHeaderRow, createRowFunction, 
-                  updateRowFunction, clearRowFunction, beforeRefreshFunction, afterRefreshFunction, WINDOW_NONVARIABLE_HEIGHT) {
+                  updateRowFunction, clearRowFunction, preRefreshFunction, postRefreshFunction, WINDOW_NONVARIABLE_HEIGHT) {
     this.elTableBody = elTableBody;
     this.elTableScroll = elTableScroll;
     this.elTableHeaderRow = elTableHeaderRow;
@@ -25,8 +25,8 @@ function ListView(elTableBody, elTableScroll, elTableHeaderRow, createRowFunctio
     this.createRowFunction = createRowFunction;
     this.updateRowFunction = updateRowFunction;
     this.clearRowFunction = clearRowFunction;
-    this.beforeRefreshFunction = beforeRefreshFunction;
-    this.afterRefreshFunction = afterRefreshFunction;
+    this.preRefreshFunction = preRefreshFunction;
+    this.postRefreshFunction = postRefreshFunction;
     
     // the list of row elements created in the table up to max viewable height plus SCROLL_ROWS rows for scrolling buffer
     this.elRows = [];
@@ -175,7 +175,7 @@ ListView.prototype = {
     },
     
     refresh: function() {
-        this.beforeRefreshFunction();
+        this.preRefreshFunction();
         // block refreshing before rows are initialized
         let numRows = this.getNumRows();
         if (numRows === 0) {
@@ -214,7 +214,7 @@ ListView.prototype = {
                 this.lastRowShiftScrollTop = 0;
             }
         }
-        this.afterRefreshFunction();
+        this.postRefreshFunction();
     },
     
     refreshBuffers: function() {

--- a/scripts/system/libraries/entityList.js
+++ b/scripts/system/libraries/entityList.js
@@ -17,7 +17,7 @@ var profileIndent = '';
 const PROFILE_NOOP = function(_name, fn, args) {
     fn.apply(this, args);
 };
-PROFILE = !PROFILING_ENABLED ? PROFILE_NOOP : function(name, fn, args) {
+const PROFILE = !PROFILING_ENABLED ? PROFILE_NOOP : function(name, fn, args) {
     console.log("PROFILE-Script " + profileIndent + "(" + name + ") Begin");
     var previousIndent = profileIndent;
     profileIndent += '  ';


### PR DESCRIPTION
Addresses the entity list rename issues:
- https://highfidelity.fogbugz.com/f/cases/19767/In-VR-mode-entity-name-text-boxes-are-deselected-after-double-clicking-them-in-the-list-tab-of-Create-blocking-renaming (Test plan included in ticket)
- https://highfidelity.manuscript.com/f/cases/19915/Entity-List-Double-clicking-focus-also-invokes-rename-of-object (Test expected behavior in ticket)