### PR TITLE
Fix for avatar flashing on fade out

### DIFF
--- a/libraries/render/src/render/Item.h
+++ b/libraries/render/src/render/Item.h
@@ -480,8 +480,8 @@ public:
 protected:
     PayloadPointer _payload;
     ItemKey _key;
-    ItemCell _cell{ INVALID_CELL };
-    Index _transitionId{ INVALID_INDEX };
+    ItemCell _cell { INVALID_CELL };
+    Index _transitionId { INVALID_INDEX };
 
     friend class Scene;
 };

--- a/libraries/render/src/render/Scene.cpp
+++ b/libraries/render/src/render/Scene.cpp
@@ -391,7 +391,12 @@ void Scene::transitionItems(const Transaction::TransitionAdds& transactions) {
 
         // Remove pre-existing transition, if need be
         if (!TransitionStage::isIndexInvalid(transitionId)) {
-            resetItemTransition(itemId);
+            // Only remove if:
+            // transitioning to something other than none or we're transitioning to none from ELEMENT_LEAVE_DOMAIN or USER_LEAVE_DOMAIN
+            const auto& oldTransitionType = transitionStage->getTransition(transitionId).eventType;
+            if (transitionType != Transition::NONE || !(oldTransitionType == Transition::ELEMENT_LEAVE_DOMAIN || oldTransitionType == Transition::USER_LEAVE_DOMAIN)) {
+                resetItemTransition(itemId);
+            }
         }
 
         // Add a new one.

--- a/libraries/render/src/render/Scene.h
+++ b/libraries/render/src/render/Scene.h
@@ -157,7 +157,7 @@ public:
 
     // This next call are  NOT threadsafe, you have to call them from the correct thread to avoid any potential issues
 
-    // Access a particular item form its ID
+    // Access a particular item from its ID
     // WARNING, There is No check on the validity of the ID, so this could return a bad Item
     const Item& getItem(const ItemID& id) const { return _items[id]; }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19846/Avatar-quickly-flashes-back-after-log-out-fade-effect

Test plan:
- Follow the steps from the ticket.
- You shouldn't see the other avatar flash after fading out.
- Try it multiple times.