### PR TITLE
add throttle start and backoff to DS settings

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -488,11 +488,8 @@ void AudioMixer::throttle(chrono::microseconds duration, int frame) {
 
     // target different mix and backoff ratios (they also have different backoff rates)
     // this is to prevent oscillation, and encourage throttling to find a steady state
-    const float TARGET = 0.9f;
-    // on a "regular" machine with 100 avatars, this is the largest value where
-    // - overthrottling can be recovered
-    // - oscillations will not occur after the recovery
-    const float BACKOFF_TARGET = 0.44f;
+    const float TARGET = _throttleStartTarget;
+    const float BACKOFF_TARGET = _throttleBackoffTarget;
 
     // the mixer is known to struggle at about 80 on a "regular" machine
     // so throttle 2/80 the streams to ensure smooth audio (throttling is linear)
@@ -551,6 +548,14 @@ void AudioMixer::parseSettingsObject(const QJsonObject& settingsObject) {
                 _slavePool.setNumThreads(numThreads);
             }
         }
+
+        const QString THROTTLE_START_KEY = "throttle_start";
+        const QString THROTTLE_BACKOFF_KEY = "throttle_backoff";
+
+        _throttleStartTarget = audioThreadingGroupObject[THROTTLE_START_KEY].toDouble(_throttleStartTarget);
+        _throttleBackoffTarget = audioThreadingGroupObject[THROTTLE_BACKOFF_KEY].toDouble(_throttleBackoffTarget);
+
+        qCDebug(audio) << "Throttle Start:" << _throttleStartTarget << "Throttle Backoff:" << _throttleBackoffTarget;
     }
 
     if (settingsObject.contains(AUDIO_BUFFER_GROUP_KEY)) {

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -552,8 +552,18 @@ void AudioMixer::parseSettingsObject(const QJsonObject& settingsObject) {
         const QString THROTTLE_START_KEY = "throttle_start";
         const QString THROTTLE_BACKOFF_KEY = "throttle_backoff";
 
-        _throttleStartTarget = audioThreadingGroupObject[THROTTLE_START_KEY].toDouble(_throttleStartTarget);
-        _throttleBackoffTarget = audioThreadingGroupObject[THROTTLE_BACKOFF_KEY].toDouble(_throttleBackoffTarget);
+        float settingsThrottleStart = audioThreadingGroupObject[THROTTLE_START_KEY].toDouble(_throttleStartTarget);
+        float settingsThrottleBackoff = audioThreadingGroupObject[THROTTLE_BACKOFF_KEY].toDouble(_throttleBackoffTarget);
+
+        if (settingsThrottleBackoff > settingsThrottleStart) {
+            qCWarning(audio) << "Throttle backoff target cannot be higher than throttle start target. Using default values.";
+        } else if (settingsThrottleBackoff < 0.0f || settingsThrottleStart > 1.0f) {
+            qCWarning(audio) << "Throttle start and backoff targets must be greater than or equal to 0.0"
+                << "and lesser than or equal to 1.0. Using default values.";
+        } else {
+            _throttleStartTarget = settingsThrottleStart;
+            _throttleBackoffTarget = settingsThrottleBackoff;
+        }
 
         qCDebug(audio) << "Throttle Start:" << _throttleStartTarget << "Throttle Backoff:" << _throttleBackoffTarget;
     }

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -144,10 +144,12 @@ private:
     static std::map<QString, CodecPluginPointer> _availableCodecs;
     static QStringList _codecPreferenceOrder;
 
-
     static std::vector<ZoneDescription> _audioZones;
     static std::vector<ZoneSettings> _zoneSettings;
     static std::vector<ReverbSettings> _zoneReverbSettings;
+
+    float _throttleStartTarget = 0.9f;
+    float _throttleBackoffTarget = 0.44f;
 
     AudioMixerSlave::SharedData _workerSharedData;
 };

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1012,6 +1012,24 @@
           "placeholder": "1",
           "default": "1",
           "advanced": true
+        },
+        {
+          "name": "throttle_start",
+          "type": "double",
+          "label": "Throttle Start Target",
+          "help": "Target percentage of frame time to start throttling",
+          "placeholder": "0.9",
+          "default": 0.9,
+          "advanced": true
+        },
+        {
+          "name": "throttle_backoff",
+          "type": "double",
+          "label": "Throttle Backoff Target",
+          "help": "Target percentage of frame time to backoff throttling",
+          "placeholder": "0.44",
+          "default": 0.44,
+          "advanced": true
         }
       ]
     },


### PR DESCRIPTION
- Fix for https://highfidelity.manuscript.com/f/cases/19914/Audio-target-and-backoff-for-throttling-should-be-configurable-from-domain-server-settings