### PR TITLE
Dismiss keyboard when backout of the login screen

### DIFF
--- a/interface/resources/qml/dialogs/TabletLoginDialog.qml
+++ b/interface/resources/qml/dialogs/TabletLoginDialog.qml
@@ -141,6 +141,7 @@ TabletModalWindow {
 
     Component.onDestruction: {
         loginKeyboard.raised = false;
+        KeyboardScriptingInterface.raised = false;
     }
 
     Component.onCompleted: {


### PR DESCRIPTION
This fixes the issue of the keyboard not getting dismissed when backing out of the login screen.

- Ticket - https://highfidelity.manuscript.com/f/cases/19829/3D-HMD-Keyboard-at-launch-doesn-t-close-properly