### PR TITLE
FB19400 during shutdown -- TypeError: Cannot read property 'buttons' of null

### DIFF
--- a/interface/resources/qml/hifi/Desktop.qml
+++ b/interface/resources/qml/hifi/Desktop.qml
@@ -70,8 +70,8 @@ OriginalDesktop.Desktop {
         anchors.horizontalCenter: settings.constrainToolbarToCenterX ? desktop.horizontalCenter : undefined;
         // Literal 50 is overwritten by settings from previous session, and sysToolbar.x comes from settings when not constrained.
         x: sysToolbar.x
-        buttonModel: tablet.buttons;
-        shown: tablet.toolbarMode;
+        buttonModel: tablet ? tablet.buttons : null;
+        shown: tablet ? tablet.toolbarMode : false;
     }
 
     Settings {

--- a/interface/resources/qml/hifi/tablet/TabletHome.qml
+++ b/interface/resources/qml/hifi/tablet/TabletHome.qml
@@ -115,9 +115,9 @@ Item {
             property int previousIndex: -1
             Repeater {
                 id: pageRepeater
-                model: Math.ceil(tabletProxy.buttons.rowCount() / TabletEnums.ButtonsOnPage)
+                model: tabletProxy != null ? Math.ceil(tabletProxy.buttons.rowCount() / TabletEnums.ButtonsOnPage) : 0
                 onItemAdded: {
-                    item.proxyModel.sourceModel = tabletProxy.buttons;
+                    item.proxyModel.sourceModel = tabletProxy != null ? tabletProxy.buttons : null;
                     item.proxyModel.pageIndex = index;
                 }
 

--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -389,6 +389,10 @@ void OffscreenSurface::finishQmlLoad(QQmlComponent* qmlComponent,
         }
         // Allow child windows to be destroyed from JS
         QQmlEngine::setObjectOwnership(newObject, QQmlEngine::JavaScriptOwnership);
+
+        // add object to the manual deletion list
+        _sharedObject->addToDeletionList(newObject);
+
         newObject->setParent(parent);
         newItem->setParentItem(parent);
     } else {

--- a/libraries/qml/src/qml/impl/SharedObject.h
+++ b/libraries/qml/src/qml/impl/SharedObject.h
@@ -66,7 +66,7 @@ public:
     void resume();
     bool isPaused() const;
     bool fetchTexture(TextureAndFence& textureAndFence);
-
+    void addToDeletionList(QObject* object);
 
 private:
     bool event(QEvent* e) override;
@@ -90,6 +90,8 @@ private:
     void onTimer();
     void onAboutToQuit();
     void updateTextureAndFence(const TextureAndFence& newTextureAndFence);
+
+    QList<QPointer<QObject>> _deletionList;
 
     // Texture management
     TextureAndFence _latestTextureAndFence{ 0, 0 };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19400/during-shutdown-TypeError-Cannot-read-property-buttons-of-null

note: PR also contains experimental code which tries to resolve all the shutdown warnings from QML at once.

Test plan

1. Launch interface
2. Delete logs
3. Close interface
4. Ensure logs doesn't contain entries like the following:

[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/tablet/TabletHome.qml:118: TypeError: Cannot read property 'buttons' of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/tablet/TabletHome.qml:118: TypeError: Cannot read property 'buttons' of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/Desktop.qml:73: TypeError: Cannot read property 'buttons' of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/Desktop.qml:74: TypeError: Cannot read property 'toolbarMode' of null

[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/Stats.qml:34: TypeError: Cannot read property of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/AnimStats.qml:34: TypeError: Cannot read property of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/hifi/audio/MicBar.qml:43: TypeError: Cannot read property of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/windows/DefaultFrameDecoration.qml:49: TypeError: Cannot read property of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/controls-uit/Keyboard.qml:240: TypeError: Cannot read property of null
[10/19 17:00:25] [WARNING] [default] file:///D:/ai/hifi-elderorb-vs2-qt10/interface/resources/qml/controls-uit/Key.qml:123: TypeError: Cannot read property of null

Repeat steps 1,3 at least 5 times while in desktop & 5 times while in VR mode.
Ensure application didn't crash during step 5.

Please also ensure PR didn't re-introduced the following issues: 
https://highfidelity.manuscript.com/f/cases/19871/Tablet-errors
https://highfidelity.manuscript.com/f/cases/19872/Login-problems
https://highfidelity.manuscript.com/f/cases/19873/Tablet-apps-do-not-open
