### PR TITLE
catch QString exceptions that ModelCache can throw

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -244,7 +244,7 @@ void GeometryReader::run() {
                 Q_ARG(bool, false));
         }
     } catch (QString& e) {
-        qCWarning(modelnetworking) << "Exception while loading" << _url << "--" << e;
+        qCWarning(modelnetworking) << "Exception while loading model --" << e;
         auto resource = _resource.toStrongRef();
         if (resource) {
             QMetaObject::invokeMethod(resource.data(), "finishedLoading",

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -243,6 +243,13 @@ void GeometryReader::run() {
             QMetaObject::invokeMethod(resource.data(), "finishedLoading",
                 Q_ARG(bool, false));
         }
+    } catch (QString& e) {
+        qCWarning(modelnetworking) << "Exception while loading" << _url << "--" << e;
+        auto resource = _resource.toStrongRef();
+        if (resource) {
+            QMetaObject::invokeMethod(resource.data(), "finishedLoading",
+                                      Q_ARG(bool, false));
+        }
     }
 }
 


### PR DESCRIPTION
- catch QString exceptions that ModelCache can throw

https://highfidelity.manuscript.com/f/cases/19904/Crash-on-Object-load-View-angle-loads-item-Hifiaq-Master-Metaverse-Staging
