### PR TITLE
ensure packets are always added to loss list after estimated timeout

### DIFF
--- a/libraries/networking/src/udt/SendQueue.h
+++ b/libraries/networking/src/udt/SendQueue.h
@@ -68,7 +68,6 @@ public:
     void setPacketSendPeriod(int newPeriod) { _packetSendPeriod = newPeriod; }
     
     void setEstimatedTimeout(int estimatedTimeout) { _estimatedTimeout = estimatedTimeout; }
-    void setSyncInterval(int syncInterval) { _syncInterval = syncInterval; }
     
 public slots:
     void stop();
@@ -124,7 +123,6 @@ private:
     std::atomic<State> _state { State::NotStarted };
     
     std::atomic<int> _estimatedTimeout { 0 }; // Estimated timeout, set from CC
-    std::atomic<int> _syncInterval { udt::DEFAULT_SYN_INTERVAL_USECS }; // Sync interval, set from CC
     
     std::atomic<int> _flowWindowSize { 0 }; // Flow control window size (number of packets that can be on wire) - set from CC
     
@@ -140,6 +138,8 @@ private:
     std::condition_variable _handshakeACKCondition;
     
     std::condition_variable_any _emptyCondition;
+
+    std::chrono::high_resolution_clock::time_point _lastPacketSentAt;
 };
     
 }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19958/reliable-send-queue-completely-stuck-causing-missing-avatar-URLs-kill-avatar-packets-etc