### PR TITLE
Ensure that hand is in grasp pose during desktop handshake animation

### DIFF
--- a/scripts/system/makeUserConnection.js
+++ b/scripts/system/makeUserConnection.js
@@ -229,6 +229,15 @@
         }
         animationData.rightHandRotation = Quat.fromPitchYawRollDegrees(90, 0, 90);
         animationData.rightHandType = 0; // RotationAndPosition, see IKTargets.h
+
+        // turn on the right hand grip overlay
+        animationData.rightHandOverlayAlpha = 1.0;
+
+        // make sure the right hand grip animation is the "grasp", not pointing or thumbs up.
+        animationData.isRightHandGrasp = true;
+        animationData.isRightIndexPoint = false;
+        animationData.isRightThumbRaise = false;
+        animationData.isRightIndexPointAndThumbRaise = false;
     }
     function shakeHandsAnimation() {
         return animationData;


### PR DESCRIPTION
QA Test plan:

* Run interface in desktop mode
* Fly upwards so you are hovering in mid-air
* press X to shake hands
* note that in some avatars, your arm is shaking side by side and the hand looks like a mangled fist. It also seems to still move in response to speaking

Expected result: while pressing X to shake hands, your palm is flat and no longer plays the idle speaking or breathing animations.

https://highfidelity.fogbugz.com/f/cases/19078/avatar-hand-looks-mangled-when-pressing-X-to-handshake-while-flying