### PR TITLE
Case 19660: Fix HUD crash

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -538,11 +538,11 @@ std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> OpenGL
     auto hudMirrorPipeline = _mirrorHUDPipeline;
     auto hudStereo = isStereo();
     auto hudCompositeFramebufferSize = _compositeFramebuffer->getSize();
-    glm::ivec4 hudEyeViewports[2];
+    std::array<glm::ivec4, 2> hudEyeViewports;
     for_each_eye([&](Eye eye) {
         hudEyeViewports[eye] = eyeViewport(eye);
     });
-    return [hudPipeline, hudMirrorPipeline, hudStereo, hudEyeViewports, hudCompositeFramebufferSize](gpu::Batch& batch, const gpu::TexturePointer& hudTexture, bool mirror) {
+    return [=](gpu::Batch& batch, const gpu::TexturePointer& hudTexture, bool mirror) {
         if (hudPipeline && hudTexture) {
             batch.enableStereo(false);
             batch.setPipeline(mirror ? hudMirrorPipeline : hudPipeline);

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -428,7 +428,7 @@ std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> HmdDis
     auto hudUniformBuffer = uniformsBuffer;
     auto hudUniforms = uniforms;
     auto hudIndexCount = indexCount;
-    return [hudPipeline, hudFormat, hudVertices, hudIndices, hudUniformBuffer, hudUniforms, hudIndexCount](gpu::Batch& batch, const gpu::TexturePointer& hudTexture, bool mirror) {
+    return [=](gpu::Batch& batch, const gpu::TexturePointer& hudTexture, bool mirror) {
         if (hudPipeline && hudTexture) {
             batch.setPipeline(hudPipeline);
 

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -420,18 +420,26 @@ void HmdDisplayPlugin::HUDRenderer::updatePipeline() {
 
 std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> HmdDisplayPlugin::HUDRenderer::render(HmdDisplayPlugin& plugin) {
     updatePipeline();
-    return [this](gpu::Batch& batch, const gpu::TexturePointer& hudTexture, bool mirror) {
-        if (pipeline && hudTexture) {
-            batch.setPipeline(pipeline);
 
-            batch.setInputFormat(format);
-            gpu::BufferView posView(vertices, VERTEX_OFFSET, vertices->getSize(), VERTEX_STRIDE, format->getAttributes().at(gpu::Stream::POSITION)._element);
-            gpu::BufferView uvView(vertices, TEXTURE_OFFSET, vertices->getSize(), VERTEX_STRIDE, format->getAttributes().at(gpu::Stream::TEXCOORD)._element);
+    auto hudPipeline = pipeline;
+    auto hudFormat = format;
+    auto hudVertices = vertices;
+    auto hudIndices = indices;
+    auto hudUniformBuffer = uniformsBuffer;
+    auto hudUniforms = uniforms;
+    auto hudIndexCount = indexCount;
+    return [hudPipeline, hudFormat, hudVertices, hudIndices, hudUniformBuffer, hudUniforms, hudIndexCount](gpu::Batch& batch, const gpu::TexturePointer& hudTexture, bool mirror) {
+        if (hudPipeline && hudTexture) {
+            batch.setPipeline(hudPipeline);
+
+            batch.setInputFormat(hudFormat);
+            gpu::BufferView posView(hudVertices, VERTEX_OFFSET, hudVertices->getSize(), VERTEX_STRIDE, hudFormat->getAttributes().at(gpu::Stream::POSITION)._element);
+            gpu::BufferView uvView(hudVertices, TEXTURE_OFFSET, hudVertices->getSize(), VERTEX_STRIDE, hudFormat->getAttributes().at(gpu::Stream::TEXCOORD)._element);
             batch.setInputBuffer(gpu::Stream::POSITION, posView);
             batch.setInputBuffer(gpu::Stream::TEXCOORD, uvView);
-            batch.setIndexBuffer(gpu::UINT16, indices, 0);
-            uniformsBuffer->setSubData(0, uniforms);
-            batch.setUniformBuffer(0, uniformsBuffer);
+            batch.setIndexBuffer(gpu::UINT16, hudIndices, 0);
+            hudUniformBuffer->setSubData(0, hudUniforms);
+            batch.setUniformBuffer(0, hudUniformBuffer);
 
             auto compositorHelper = DependencyManager::get<CompositorHelper>();
             glm::mat4 modelTransform = compositorHelper->getUiTransform();
@@ -441,7 +449,7 @@ std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> HmdDis
             batch.setModelTransform(modelTransform);
             batch.setResourceTexture(0, hudTexture);
 
-            batch.drawIndexed(gpu::TRIANGLES, indexCount);
+            batch.drawIndexed(gpu::TRIANGLES, hudIndexCount);
         }
     };
 }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19660/std-function-void-gpu-Batch-std-shared_ptr-gpu-Texture-11a119c88dc0c455ca3ff849cca62615944e29027bd9f4652fe8f80beb42aa66

Test plan:
- No idea what causes this crash.
- In desktop mode, the HUD should render (toolbar, audio meter, etc.)
- In HMD, the HUD sphere should render (audio meter, stats).
- Switch between modes and you shouldn't crash.