### PR TITLE
Fix: Shouldn't be able to write actionData from script

### DIFF
--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -486,6 +486,8 @@ QUuid EntityScriptingInterface::addEntity(const EntityItemProperties& properties
 
     propertiesWithSimID.setLastEditedBy(sessionID);
 
+    propertiesWithSimID.setActionData(QByteArray());
+
     bool scalesWithParent = propertiesWithSimID.getScalesWithParent();
 
     propertiesWithSimID = convertPropertiesFromScriptSemantics(propertiesWithSimID, scalesWithParent);
@@ -829,6 +831,8 @@ QUuid EntityScriptingInterface::editEntity(QUuid id, const EntityItemProperties&
         // set these to make EntityItemProperties::getScalesWithParent() work correctly
         properties.setClientOnly(entity->getClientOnly());
         properties.setOwningAvatarID(entity->getOwningAvatarID());
+
+        properties.setActionData(entity->getDynamicData());
 
         // make sure the properties has a type, so that the encode can know which properties to include
         properties.setType(entity->getType());


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19861/Script-killing-Interface

Test plan:
- Run the following from the console:
```
var entityID = Entities.addEntity({
          type: "Box",
          position: Vec3.sum(MyAvatar.position, Vec3.multiplyQbyV(MyAvatar.orientation, { x: 0, y: 0.75, z: -5 })),
          dimensions: 0.5,
          dynamic: true,
          collisionless: false,
          userData: JSON.stringify({
              grabbableKey: {
                  grabbable: true,
                  kinematic: false
              }
          }),
          lifetime: 300,
          actionData: "action data"
      });
Entities.editEntity(entityID, { color: "red", actionData: "action data" });
```
- You shouldn't crash and you should see a red cube in front of you.  It should be fully dynamic.  Walk into it and it will be moved around.
- Run this:
```
var actionID = Entities.addAction("slider", entityID, {
          axis: { x: 0, y: 1, z: 0 },
          linearLow: 0,
          linearHigh: 0.6
      });
```
- Try moving the box now.  It should be constrained to move only a little along one axis.