### PR TITLE
Draggable numbers - fix scale buttons hiding and pressing enter on numbers

### DIFF
--- a/scripts/system/html/js/draggableNumber.js
+++ b/scripts/system/html/js/draggableNumber.js
@@ -130,6 +130,12 @@ DraggableNumber.prototype = {
         this.elText.style.visibility = "visible";
     },
     
+    keyPress: function(event) {
+        if (event.keyCode === 13) {
+            this.inputBlur();
+        }
+    },
+    
     initialize: function() {
         this.onMouseDown = this.mouseDown.bind(this);
         this.onMouseUp = this.mouseUp.bind(this);
@@ -139,6 +145,7 @@ DraggableNumber.prototype = {
         this.onStepDown = this.stepDown.bind(this);
         this.onInputChange = this.inputChange.bind(this);
         this.onInputBlur = this.inputBlur.bind(this);
+        this.onKeyPress = this.keyPress.bind(this);
         
         this.elDiv = document.createElement('div');
         this.elDiv.className = "draggable-number";
@@ -174,6 +181,7 @@ DraggableNumber.prototype = {
         this.elInput.style.visibility = "hidden";
         this.elInput.addEventListener("change", this.onInputChange);
         this.elInput.addEventListener("blur", this.onInputBlur);
+        this.elInput.addEventListener("keypress", this.onKeyPress);
         
         this.elText.appendChild(this.elLeftArrow);
         this.elText.appendChild(this.elInput);

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1877,7 +1877,7 @@ function createNumberProperty(property, elProperty) {
     elProperty.appendChild(elDraggableNumber.elDiv);
 
     if (propertyData.buttons !== undefined) {
-        addButtons(elDraggableNumber.elText, elementID, propertyData.buttons, false);
+        addButtons(elDraggableNumber.elDiv, elementID, propertyData.buttons, false);
     }
     
     return elDraggableNumber;


### PR DESCRIPTION
Addresses:
https://highfidelity.manuscript.com/f/cases/19981/
https://highfidelity.manuscript.com/f/cases/19985/

Pre-Merge Test Plan:
- Enter Interface in desktop mode into any domain with edit permissions
- Open Create and select any entity
- Verify if clicking the Scale number field to edit the number via keyboard that the Rescale and Reset buttons do not hide
- Verify after editing the number in the Scale field via keyboard and pressing enter that it returns to it's previous state with the step arrows visible and number not highlighted