### PR TITLE
RC75.2: Turn off throttling behavior when not throttling

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -435,7 +435,11 @@ void AudioMixer::start() {
             QCoreApplication::processEvents();
         }
 
-        int numToRetain = nodeList->size() * (1 - _throttlingRatio);
+        int numToRetain = -1;
+        assert(_throttlingRatio >= 0.0f && _throttlingRatio <= 1.0f);
+        if (_throttlingRatio > EPSILON) {
+            numToRetain = nodeList->size() * (1.0f - _throttlingRatio);
+        }
         nodeList->nestedEach([&](NodeList::const_iterator cbegin, NodeList::const_iterator cend) {
             // mix across slave threads
             auto mixTimer = _mixTiming.timer();


### PR DESCRIPTION
[Manuscript Ticket](https://highfidelity.manuscript.com/f/cases/19929/Audio-mixer-is-always-in-throttle-mode)