### PR TITLE
suppress 'No instance available' messages during shutdown.  try a dif…

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -302,7 +302,6 @@ void AudioClient::customDeleter() {
 #if defined(Q_OS_ANDROID)
     _shouldRestartInputSetup = false;
 #endif
-    stop();
     deleteLater();
 }
 


### PR DESCRIPTION
- suppress 'No instance available' messages during shutdown.
- try a different way of shutting down AudioClient.

https://highfidelity.fogbugz.com/f/cases/20049/debug-builds-assert-on-exit
