### PR TITLE
Fix minor avatar-mixer memory leaks

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -152,6 +152,8 @@ void AvatarMixerClientData::processSetTraitsMessage(ReceivedMessage& message,
                 if (packetTraitVersion > instanceVersionRef) {
                     if (traitSize == AvatarTraits::DELETED_TRAIT_SIZE) {
                         _avatar->processDeletedTraitInstance(traitType, instanceID);
+                        // Mixer doesn't need deleted IDs.
+                        _avatar->getAndClearRecentlyDetachedIDs();
 
                         // to track a deleted instance but keep version information
                         // the avatar mixer uses the negative value of the sent version

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2103,8 +2103,9 @@ void AvatarData::setJointMappingsFromNetworkReply() {
 
     // before we process this update, make sure that the skeleton model URL hasn't changed
     // since we made the FST request
-    if (networkReply->url() != _skeletonModelURL) {
+    if (networkReply->error() != QNetworkReply::NoError || networkReply->url() != _skeletonModelURL) {
         qCDebug(avatars) << "Refusing to set joint mappings for FST URL that does not match the current URL";
+        networkReply->deleteLater();
         return;
     }
 


### PR DESCRIPTION
Manuscript: https://highfidelity.manuscript.com/f/cases/19961/

Profiling on Windows showed a couple of small memory leaks:
1. Deleted avatar entity lists can grow without bound,
2. Qt network resources might not be freed if the fetch fails.
