### PR TITLE
Add raw mouse x and y Controller outputs for Windows

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -322,6 +322,8 @@ public:
     int getOtherAvatarsReplicaCount() { return DependencyManager::get<AvatarHashMap>()->getReplicaCount(); }
     void setOtherAvatarsReplicaCount(int count) { DependencyManager::get<AvatarHashMap>()->setReplicaCount(count); }
 
+    void updateRawMousePosition(int deltaX, int deltaY);
+
 #if defined(Q_OS_ANDROID)
     void beforeEnterBackground();
     void enterBackground();

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
@@ -29,6 +29,9 @@ void KeyboardMouseDevice::pluginUpdate(float deltaTime, const controller::InputC
 
         _inputDevice->_axisStateMap[MOUSE_AXIS_X] = _lastCursor.x();
         _inputDevice->_axisStateMap[MOUSE_AXIS_Y] = _lastCursor.y();
+
+        _inputDevice->_axisStateMap[MOUSE_RAW_AXIS_X] = _lastRawCursor.x();
+        _inputDevice->_axisStateMap[MOUSE_RAW_AXIS_Y] = _lastRawCursor.y();
     });
 
     // For touch event, we need to check that the last event is not too long ago
@@ -132,6 +135,10 @@ void KeyboardMouseDevice::wheelEvent(QWheelEvent* event) {
     _inputDevice->_axisStateMap[_inputDevice->makeInput(MOUSE_AXIS_WHEEL_Y_NEG).getChannel()] = (currentMove.y() < 0 ? -currentMove.y() : 0.0f);
 }
 
+void KeyboardMouseDevice::updateRawMousePosition(int deltaX, int deltaY) {
+    _lastRawCursor += QPoint(deltaX, deltaY);
+}
+
 glm::vec2 evalAverageTouchPoints(const QList<QTouchEvent::TouchPoint>& points) {
     glm::vec2 averagePoint(0.0f);
     if (points.count() > 0) {
@@ -205,6 +212,10 @@ controller::Input KeyboardMouseDevice::InputDevice::makeInput(Qt::MouseButton co
 }
 
 controller::Input KeyboardMouseDevice::InputDevice::makeInput(KeyboardMouseDevice::MouseAxisChannel axis) const {
+    return controller::Input(_deviceID, axis, controller::ChannelType::AXIS);
+}
+
+controller::Input KeyboardMouseDevice::InputDevice::makeInput(KeyboardMouseDevice::MouseRawAxisChannel axis) const {
     return controller::Input(_deviceID, axis, controller::ChannelType::AXIS);
 }
 
@@ -320,6 +331,9 @@ controller::Input::NamedVector KeyboardMouseDevice::InputDevice::getAvailableInp
 
         availableInputs.append(Input::NamedPair(makeInput(MOUSE_AXIS_X), "MouseX"));
         availableInputs.append(Input::NamedPair(makeInput(MOUSE_AXIS_Y), "MouseY"));
+
+        availableInputs.append(Input::NamedPair(makeInput(MOUSE_RAW_AXIS_X), "MouseRawX"));
+        availableInputs.append(Input::NamedPair(makeInput(MOUSE_RAW_AXIS_Y), "MouseRawY"));
 
         availableInputs.append(Input::NamedPair(makeInput(MOUSE_AXIS_WHEEL_Y_POS), "MouseWheelRight"));
         availableInputs.append(Input::NamedPair(makeInput(MOUSE_AXIS_WHEEL_Y_NEG), "MouseWheelLeft"));

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.h
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.h
@@ -55,8 +55,13 @@ public:
         MOUSE_AXIS_WHEEL_X_NEG,
     };
 
+    enum MouseRawAxisChannel {
+        MOUSE_RAW_AXIS_X = MOUSE_AXIS_WHEEL_X_NEG + 1,
+        MOUSE_RAW_AXIS_Y,
+    };
+
     enum TouchAxisChannel {
-        TOUCH_AXIS_X_POS = MOUSE_AXIS_WHEEL_X_NEG + 1,
+        TOUCH_AXIS_X_POS = MOUSE_RAW_AXIS_Y + 1,
         TOUCH_AXIS_X_NEG,
         TOUCH_AXIS_Y_POS,
         TOUCH_AXIS_Y_NEG,
@@ -89,6 +94,8 @@ public:
 
     static void enableTouch(bool enableTouch) { _enableTouch = enableTouch; }
 
+    void updateRawMousePosition(int deltaX, int deltaY);
+
     static const char* NAME;
 
 protected:
@@ -107,6 +114,7 @@ protected:
         controller::Input makeInput(Qt::Key code) const;
         controller::Input makeInput(Qt::MouseButton code, bool clicked = false) const;
         controller::Input makeInput(MouseAxisChannel axis) const;
+        controller::Input makeInput(MouseRawAxisChannel axis) const;
         controller::Input makeInput(TouchAxisChannel axis) const;
         controller::Input makeInput(TouchButtonChannel button) const;
 
@@ -118,6 +126,7 @@ public:
 
 protected:
     QPoint _lastCursor;
+    QPoint _lastRawCursor;
     QPoint _mousePressPos;
     quint64 _mousePressTime;
     bool _mouseMoved;


### PR DESCRIPTION
- Adds Controller.Hardware.Keyboard.MouseRawX and .MouseRawY properties in Windows.
- These outputs are generated whenever Interface has focus (even if the mouse cursor is not over an Interface window).
- They are output per the raw movement detected by the hardware mouse driver. 
- They may occur more often (i.e., be higher resolution) than the .MouseX and .MouseY screen-based coordinates outputs - depends on the speed of movement (more often more likely at slower speeds) and the user's Windows mouse settings.
- They do not include pointer acceleration (ballistics) as may be applied to the mouse coordinates by Windows.