### PR TITLE
RC76: Entity properties - fix subproperty updates

### DIFF
--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -1668,7 +1668,10 @@ function updateProperty(originalPropertyName, propertyValue, isParticleProperty)
         });
         particleSyncDebounce();
     } else {
-        let onlyUpdateEntity = properties[originalPropertyName].dragging === true;
+        // only update the entity property value itself if in the middle of dragging
+        // prevent undo command push, saving new property values, and property update 
+        // callback until drag is complete (additional update sent via dragEnd callback)
+        let onlyUpdateEntity = properties[originalPropertyName] && properties[originalPropertyName].dragging === true;
         updateProperties(propertyUpdate, onlyUpdateEntity);
     }
 }


### PR DESCRIPTION
Addresses: https://highfidelity.manuscript.com/f/cases/20095

Pre-Merge Test Plan:
- Enter Interface in desktop mode into any domain with edit permissions
- Open Create and select or create any entity
- Make changes to the indented subproperties under Collides
- Press Ctrl + R to reload scripts and reselect the same entity
- Verify the subproperty values under Collides are still the same