### PR TITLE
removed at-rest detection for hands from MyAvatar.cpp

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -795,46 +795,6 @@ void MyAvatar::simulate(float deltaTime) {
     // before we perform rig animations and IK.
     updateSensorToWorldMatrix();
 
-    // if we detect the hand controller is at rest, i.e. lying on the table, or the hand is too far away from the hmd
-    // disable the associated hand controller input.
-    {
-        // NOTE: all poses are in sensor space.
-        auto leftHandIter = _controllerPoseMap.find(controller::Action::LEFT_HAND);
-        if (leftHandIter != _controllerPoseMap.end() && leftHandIter->second.isValid()) {
-            _leftHandAtRestDetector.update(leftHandIter->second.getTranslation(), leftHandIter->second.getRotation());
-            if (_leftHandAtRestDetector.isAtRest()) {
-                leftHandIter->second.valid = false;
-            }
-        } else {
-            _leftHandAtRestDetector.invalidate();
-        }
-
-        auto rightHandIter = _controllerPoseMap.find(controller::Action::RIGHT_HAND);
-        if (rightHandIter != _controllerPoseMap.end() && rightHandIter->second.isValid()) {
-            _rightHandAtRestDetector.update(rightHandIter->second.getTranslation(), rightHandIter->second.getRotation());
-            if (_rightHandAtRestDetector.isAtRest()) {
-                rightHandIter->second.valid = false;
-            }
-        } else {
-            _rightHandAtRestDetector.invalidate();
-        }
-
-        auto headIter = _controllerPoseMap.find(controller::Action::HEAD);
-
-        // The 99th percentile man has a spine to fingertip to height ratio of 0.45.  Lets increase that by about 10% to 0.5
-        // then measure the distance the center of the eyes to the finger tips.  To come up with this ratio.
-        // From "The Measure of Man and Woman: Human Factors in Design, Revised Edition" by Alvin R. Tilley, Henry Dreyfuss Associates
-        const float MAX_HEAD_TO_HAND_DISTANCE_RATIO = 0.52f;
-
-        float maxHeadHandDistance = getUserHeight() * MAX_HEAD_TO_HAND_DISTANCE_RATIO;
-        if (glm::length(headIter->second.getTranslation() - leftHandIter->second.getTranslation()) > maxHeadHandDistance) {
-            leftHandIter->second.valid = false;
-        }
-        if (glm::length(headIter->second.getTranslation() - rightHandIter->second.getTranslation()) > maxHeadHandDistance) {
-            rightHandIter->second.valid = false;
-        }
-    }
-
     {
         PerformanceTimer perfTimer("skeleton");
 


### PR DESCRIPTION
This pr addresses the ticket at https://highfidelity.manuscript.com/f/cases/19828/0-75-0-Hand-tracking-is-disabled-due-to-lack-of-movement-even-if-controllers-are-in-use

To address the issue, the at-rest detection for the hands was removed from MyAvatar.cpp this means the hands are always where the controllers are unless you lose tracking.

### Test Plan
Preconditions:  HMD

Steps:

1)Navigate to any domain besides the tutorial
2)Enter third person view by opening the tablet and selecting Settings > View > Third person
3)While standing, set the controllers down on the desk, verify that, after a moment of inactivity, the avatar's arms stay in place
4)Pick the controllers back up.  Verify that the arms continue to be active
5)Sit down in a chair.  Rest the controllers on your lap
6)Verify that after a period of inactivity, the avatar's hands stay where the controllers are
7)Pick the controllers back up.  Verify that the arms are still active
8)Sit down on the ground.  Set the controllers by your side
9)Verify that, after a period of inactivity, the avatar's hands stay where the controllers are
10) Pick the controllers back up.  Verify that the arms are now active