### PR TITLE
76.1: Implement MS19650: Oculus Store mode audio settings modification

### DIFF
--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -194,15 +194,15 @@ Rectangle {
             width: parent.width - margins.paddings*2
             x: margins.paddings
             height: Math.min(150, contentHeight);
-            spacing: 4;
+            spacing: AudioScriptingInterface.isInOculusStoreMode ? 0 : 4;
             snapMode: ListView.SnapToItem;
             clip: true;
             model: AudioScriptingInterface.devices.input;
             delegate: Item {
                 visible: !AudioScriptingInterface.isInOculusStoreMode || (AudioScriptingInterface.isInOculusStoreMode && (bar.currentIndex === 0 ? selectedDesktop : selectedHMD))
                 width: rightMostInputLevelPos
-                height: margins.sizeCheckBox > checkBoxInput.implicitHeight ?
-                            margins.sizeCheckBox : checkBoxInput.implicitHeight
+                height: visible ? (margins.sizeCheckBox > checkBoxInput.implicitHeight ?
+                            margins.sizeCheckBox : checkBoxInput.implicitHeight) : 0
 
                 AudioControls.CheckBox {
                     id: checkBoxInput
@@ -270,15 +270,15 @@ Rectangle {
             width: parent.width - margins.paddings*2
             x: margins.paddings
             height: Math.min(360 - inputView.height, contentHeight);
-            spacing: 4;
+            spacing: AudioScriptingInterface.isInOculusStoreMode ? 0 : 4;
             snapMode: ListView.SnapToItem;
             clip: true;
             model: AudioScriptingInterface.devices.output;
             delegate: Item {
                 visible: !AudioScriptingInterface.isInOculusStoreMode || (AudioScriptingInterface.isInOculusStoreMode && (bar.currentIndex === 0 ? selectedDesktop :  selectedHMD))
                 width: rightMostInputLevelPos
-                height: margins.sizeCheckBox > checkBoxOutput.implicitHeight ?
-                            margins.sizeCheckBox : checkBoxOutput.implicitHeight
+                height: visible ? (margins.sizeCheckBox > checkBoxOutput.implicitHeight ?
+                            margins.sizeCheckBox : checkBoxOutput.implicitHeight) : 0
 
                 AudioControls.CheckBox {
                     id: checkBoxOutput

--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -184,12 +184,13 @@ Rectangle {
                 anchors.leftMargin: margins.sizeCheckBox
                 size: 16;
                 color: hifi.colors.lightGrayText;
-                text: qsTr("CHOOSE INPUT DEVICE");
+                text: AudioScriptingInterface.isInOculusStoreMode ? qsTr("INPUT DEVICE") : qsTr("CHOOSE INPUT DEVICE");
             }
         }
 
         ListView {
             id: inputView
+            interactive: !AudioScriptingInterface.isInOculusStoreMode;
             width: parent.width - margins.paddings*2
             x: margins.paddings
             height: Math.min(150, contentHeight);
@@ -198,6 +199,7 @@ Rectangle {
             clip: true;
             model: AudioScriptingInterface.devices.input;
             delegate: Item {
+                visible: !AudioScriptingInterface.isInOculusStoreMode || (AudioScriptingInterface.isInOculusStoreMode && (bar.currentIndex === 0 ? selectedDesktop : selectedHMD))
                 width: rightMostInputLevelPos
                 height: margins.sizeCheckBox > checkBoxInput.implicitHeight ?
                             margins.sizeCheckBox : checkBoxInput.implicitHeight
@@ -210,7 +212,7 @@ Rectangle {
                     width: parent.width - inputLevel.width
                     clip: true
                     checkable: !checked
-                    checked: bar.currentIndex === 0 ? selectedDesktop :  selectedHMD;
+                    checked: bar.currentIndex === 0 ? selectedDesktop : selectedHMD;
                     boxSize: margins.sizeCheckBox / 2
                     isRound: true
                     text: devicename
@@ -258,12 +260,13 @@ Rectangle {
                 anchors.verticalCenter: parent.verticalCenter;
                 size: 16;
                 color: hifi.colors.lightGrayText;
-                text: qsTr("CHOOSE OUTPUT DEVICE");
+                text: AudioScriptingInterface.isInOculusStoreMode ? qsTr("OUTPUT DEVICE") : qsTr("CHOOSE OUTPUT DEVICE");
             }
         }
 
         ListView {
             id: outputView
+            interactive: !AudioScriptingInterface.isInOculusStoreMode;
             width: parent.width - margins.paddings*2
             x: margins.paddings
             height: Math.min(360 - inputView.height, contentHeight);
@@ -272,6 +275,7 @@ Rectangle {
             clip: true;
             model: AudioScriptingInterface.devices.output;
             delegate: Item {
+                visible: !AudioScriptingInterface.isInOculusStoreMode || (AudioScriptingInterface.isInOculusStoreMode && (bar.currentIndex === 0 ? selectedDesktop :  selectedHMD))
                 width: rightMostInputLevelPos
                 height: margins.sizeCheckBox > checkBoxOutput.implicitHeight ?
                             margins.sizeCheckBox : checkBoxOutput.implicitHeight

--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -12,6 +12,7 @@
 #include "Audio.h"
 
 #include <shared/QtHelpers.h>
+#include <shared/GlobalAppProperties.h>
 
 #include "Application.h"
 #include "AudioClient.h"
@@ -206,4 +207,8 @@ void Audio::setOutputDevice(const QAudioDeviceInfo& device, bool isHMD) {
     withWriteLock([&] {
         _devices.chooseOutputDevice(device, isHMD);
     });
+}
+
+bool Audio::getIsInOculusStoreMode() {
+    return qApp->property(hifi::properties::OCULUS_STORE).toBool();
 }

--- a/interface/src/scripting/Audio.h
+++ b/interface/src/scripting/Audio.h
@@ -52,6 +52,8 @@ class Audio : public AudioScriptingInterface, protected ReadWriteLockable {
      *     removed.
      * @property {boolean} isSoloing <em>Read-only.</em> <code>true</code> if any nodes are soloed.
      * @property {Uuid[]} soloList <em>Read-only.</em> Get the list of currently soloed node UUIDs.
+     * @property {boolean} isInOculusStoreMode <em>Read-only.</em> <code>true</code> if Interface is launched with --oculus-store.
+     *     Equivalent to <code>Window.isInOculusStoreMode</code>; required here because of what is accessible to Audio.qml.
      */
 
     Q_PROPERTY(bool muted READ isMuted WRITE setMuted NOTIFY mutedChanged)
@@ -60,6 +62,7 @@ class Audio : public AudioScriptingInterface, protected ReadWriteLockable {
     Q_PROPERTY(float inputLevel READ getInputLevel NOTIFY inputLevelChanged)
     Q_PROPERTY(QString context READ getContext NOTIFY contextChanged)
     Q_PROPERTY(AudioDevices* devices READ getDevices NOTIFY nop)
+    Q_PROPERTY(bool isInOculusStoreMode READ getIsInOculusStoreMode NOTIFY nop)
 
 public:
     static QString AUDIO;
@@ -252,6 +255,7 @@ private:
     bool _contextIsHMD { false };
     AudioDevices* getDevices() { return &_devices; }
     AudioDevices _devices;
+    bool getIsInOculusStoreMode();
 };
 
 };

--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 
 #include <shared/QtHelpers.h>
+#include <shared/GlobalAppProperties.h>
 #include <plugins/DisplayPlugin.h>
 
 #include "Application.h"
@@ -56,7 +57,7 @@ QHash<int, QByteArray> AudioDeviceList::_roles {
 static QString getTargetDevice(bool hmd, QAudio::Mode mode) {
     QString deviceName;
     auto& setting = getSetting(hmd, mode);
-    if (setting.isSet()) {
+    if (!qApp->property(hifi::properties::OCULUS_STORE).toBool() && setting.isSet()) {
         deviceName = setting.get();
     } else if (hmd) {
         if (mode == QAudio::AudioInput) {
@@ -71,6 +72,11 @@ static QString getTargetDevice(bool hmd, QAudio::Mode mode) {
 Qt::ItemFlags AudioDeviceList::_flags { Qt::ItemIsSelectable | Qt::ItemIsEnabled };
 
 AudioDeviceList::AudioDeviceList(QAudio::Mode mode) : _mode(mode) {
+    if (qApp->property(hifi::properties::OCULUS_STORE).toBool()) {
+        qDebug() << "Interface is in Oculus Store mode; Audio devices will not be set from Settings.";
+        return;
+    }
+
     auto& setting1 = getSetting(true, QAudio::AudioInput);
     if (setting1.isSet()) {
         qDebug() << "Device name in settings for HMD, Input" << setting1.get();
@@ -101,6 +107,11 @@ AudioDeviceList::AudioDeviceList(QAudio::Mode mode) : _mode(mode) {
 }
 
 AudioDeviceList::~AudioDeviceList() {
+    // Don't store any selected device if we're in Oculus Store mode
+    if (qApp->property(hifi::properties::OCULUS_STORE).toBool()) {
+        return;
+    }
+
     //save all selected devices
     auto& settingHMD = getSetting(true, _mode);
     auto& settingDesktop = getSetting(false, _mode);
@@ -389,13 +400,15 @@ void AudioDevices::onDeviceSelected(QAudio::Mode mode, const QAudioDeviceInfo& d
                                     const QAudioDeviceInfo& previousDevice, bool isHMD) {
     QString deviceName = device.isNull() ? QString() : device.deviceName();
 
-    auto& setting = getSetting(isHMD, mode);
+    bool wasDefault = false;
 
-    // check for a previous device
-    auto wasDefault = setting.get().isNull();
-
-    // store the selected device
-    setting.set(deviceName);
+    // store the selected device if we're not in Oculus Store mode
+    // Also set `wasDefault` properly if we're not in Oculus Store mode
+    if (!qApp->property(hifi::properties::OCULUS_STORE).toBool()) {
+        auto& setting = getSetting(isHMD, mode);
+        setting.set(deviceName);
+        wasDefault = setting.get().isNull();
+    }
 
     // log the selected device
     if (!device.isNull()) {

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -18,6 +18,7 @@
 #include <QtGui/QDesktopServices>
 #include <shared/QtHelpers.h>
 #include <SettingHandle.h>
+#include <shared/GlobalAppProperties.h>
 
 #include <display-plugins/CompositorHelper.h>
 #include <AddressManager.h>
@@ -605,4 +606,8 @@ void WindowScriptingInterface::onMessageBoxSelected(int button) {
 
 float WindowScriptingInterface::domainLoadingProgress() {
     return qApp->getOctreePacketProcessor().domainLoadingProgress();
+}
+
+bool WindowScriptingInterface::getIsInOculusStoreMode() {
+    return qApp->property(hifi::properties::OCULUS_STORE).toBool();
 }

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -52,6 +52,7 @@ class WindowScriptingInterface : public QObject, public Dependency {
     Q_PROPERTY(int x READ getX)
     Q_PROPERTY(int y READ getY)
     Q_PROPERTY(bool interstitialModeEnabled READ getInterstitialModeEnabled WRITE setInterstitialModeEnabled)
+    Q_PROPERTY(bool isInOculusStoreMode READ getIsInOculusStoreMode)
 
 public:
     WindowScriptingInterface();
@@ -572,6 +573,8 @@ public slots:
     void closeMessageBox(int id);
 
     float domainLoadingProgress();
+
+    bool getIsInOculusStoreMode();
 
 private slots:
     void onWindowGeometryChanged(const QRect& geometry);


### PR DESCRIPTION
Implements code to pass the Oculus "VRC.PC.Audio.1" test when Interface is run with the `--oculus-store` switch. See [MS19650](https://highfidelity.manuscript.com/f/cases/19650/VRC-PC-Audio-1-App-must-target-the-audio-device-selected-in-the-Audio-Output-in-VR-setting-in-the-Oculus-app) for more.

RC76.1 version of #14449.