### PR TITLE
Fix MS20117: Prevent HTML link from appearing in Wallet notification

### DIFF
--- a/scripts/system/commerce/wallet.js
+++ b/scripts/system/commerce/wallet.js
@@ -615,7 +615,9 @@ function notificationPollCallbackHistory(historyArray) {
                 ui.notificationDisplayBanner(message);
             } else {
                 for (var i = 0; i < notificationCount; i++) {
-                    message = '"' + (historyArray[i].message) + '" ' +
+                    var historyMessage = historyArray[i].message;
+                    var sanitizedHistoryMessage = historyMessage.replace(/<\/?[^>]+(>|$)/g, "");
+                    message = '"' + sanitizedHistoryMessage + '" ' +
                         "Open INVENTORY to see all activity.";
                     ui.notificationDisplayBanner(message);
                 }


### PR DESCRIPTION
Fixes [MS20117](https://highfidelity.manuscript.com/f/cases/20117/Marketplace-Item-promotional-notification-showed-raw-html-for-the-link). Test plan in ticket.