### PR TITLE
Make desktop yaw and pitch directly proportional to right-click mouse

### DIFF
--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -123,7 +123,16 @@
         
         { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
           "when": "Keyboard.RightMouseButton",
-          "to": "Actions.Yaw",
+          "to": "Actions.DeltaYaw",
+          "filters":
+            [
+                { "type": "scale", "scale": 0.6 }
+            ]
+        },
+
+        { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
+          "when": "Keyboard.RightMouseButton",
+          "to": "Actions.DeltaPitch",
           "filters":
             [
                 { "type": "scale", "scale": 0.6 }
@@ -143,20 +152,6 @@
 
         { "from": "Keyboard.PgDown", "to": "Actions.VERTICAL_DOWN" },
         { "from": "Keyboard.PgUp", "to": "Actions.VERTICAL_UP" },
-
-        { "from": "Keyboard.MouseMoveUp", "when": "Keyboard.RightMouseButton", "to": "Actions.PITCH_UP",
-          "filters":
-            [
-                { "type": "scale", "scale": 0.6 }
-            ]
-
-        },
-        { "from": "Keyboard.MouseMoveDown", "when": "Keyboard.RightMouseButton", "to": "Actions.PITCH_DOWN",
-          "filters":
-            [
-                { "type": "scale", "scale": 0.6 }
-            ]
-        },
 
         { "from": "Keyboard.TouchpadDown", "to": "Actions.PITCH_DOWN" },
         { "from": "Keyboard.TouchpadUp", "to": "Actions.PITCH_UP" },

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5916,6 +5916,8 @@ void Application::update(float deltaTime) {
                 myAvatar->setDriveKey(MyAvatar::TRANSLATE_X, userInputMapper->getActionState(controller::Action::TRANSLATE_X));
                 if (deltaTime > FLT_EPSILON) {
                     myAvatar->setDriveKey(MyAvatar::PITCH, -1.0f * userInputMapper->getActionState(controller::Action::PITCH));
+                    myAvatar->setDriveKey(MyAvatar::DELTA_YAW, -1.0f * userInputMapper->getActionState(controller::Action::DELTA_YAW));
+                    myAvatar->setDriveKey(MyAvatar::DELTA_PITCH, -1.0f * userInputMapper->getActionState(controller::Action::DELTA_PITCH));
                     myAvatar->setDriveKey(MyAvatar::YAW, -1.0f * userInputMapper->getActionState(controller::Action::YAW));
                     myAvatar->setDriveKey(MyAvatar::STEP_YAW, -1.0f * userInputMapper->getActionState(controller::Action::STEP_YAW));
                 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2736,9 +2736,10 @@ void MyAvatar::updateOrientation(float deltaTime) {
             _bodyYawDelta = 0.0f;
         }
     }
-
     float totalBodyYaw = _bodyYawDelta * deltaTime;
 
+    // Rotate directly proportional to delta yaw and delta pitch from right-click mouse movement.
+    totalBodyYaw += getDriveKey(DELTA_YAW);
 
     // Comfort Mode: If you press any of the left/right rotation drive keys or input, you'll
     // get an instantaneous 15 degree turn. If you keep holding the key down you'll get another
@@ -2806,7 +2807,7 @@ void MyAvatar::updateOrientation(float deltaTime) {
         head->setBaseRoll(ROLL(euler));
     } else {
         head->setBaseYaw(0.0f);
-        head->setBasePitch(getHead()->getBasePitch() + getDriveKey(PITCH) * _pitchSpeed * deltaTime);
+        head->setBasePitch(getHead()->getBasePitch() + getDriveKey(PITCH) * _pitchSpeed * deltaTime + getDriveKey(DELTA_PITCH));
         head->setBaseRoll(0.0f);
     }
 }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -263,6 +263,8 @@ public:
         STEP_YAW,
         PITCH,
         ZOOM,
+        DELTA_YAW,
+        DELTA_PITCH,
         MAX_DRIVE_KEYS
     };
     Q_ENUM(DriveKeys)

--- a/libraries/controllers/src/controllers/Actions.cpp
+++ b/libraries/controllers/src/controllers/Actions.cpp
@@ -52,11 +52,17 @@ namespace controller {
      *     <tr><td><code>TranslateZ</code></td><td>number</td><td>number</td><td>Move the user's avatar in the direction of its 
      *       z-axis, if the camera isn't in independent or mirror modes.</td></tr>
      *     <tr><td><code>Pitch</code></td><td>number</td><td>number</td><td>Rotate the user's avatar head and attached camera 
-     *       about its negative x-axis (i.e., positive values pitch down), if the camera isn't in HMD, independent, or mirror 
-     *       modes.</td></tr>
-     *     <tr><td><code>Yaw</code></td><td>number</td><td>number</td><td>Rotate the user's avatar about its y-axis, if the 
-     *       camera isn't in independent or mirror modes.</td></tr>
+     *       about its negative x-axis (i.e., positive values pitch down) at a rate proportional to the control value, if the 
+     *       camera isn't in HMD, independent, or mirror modes.</td></tr>
+     *     <tr><td><code>Yaw</code></td><td>number</td><td>number</td><td>Rotate the user's avatar about its y-axis at a rate 
+     *       proportional to the control value, if the camera isn't in independent or mirror modes.</td></tr>
      *     <tr><td><code>Roll</code></td><td>number</td><td>number</td><td>No action.</td></tr>
+     *     <tr><td><code>DeltaPitch</code></td><td>number</td><td>number</td><td>Rotate the user's avatar head and attached 
+     *       camera about its negative x-axis (i.e., positive values pitch down) by an amount proportional to the control value, 
+     *       if the camera isn't in HMD, independent, or mirror modes.</td></tr>
+     *     <tr><td><code>DeltaYaw</code></td><td>number</td><td>number</td><td>Rotate the user's avatar about its y-axis by an 
+     *       amount proportional to the control value, if the camera isn't in independent or mirror modes.</td></tr>
+     *     <tr><td><code>DeltaRoll</code></td><td>number</td><td>number</td><td>No action.</td></tr>
      *     <tr><td><code>StepTranslateX</code></td><td>number</td><td>number</td><td>No action.</td></tr>
      *     <tr><td><code>StepTranslateY</code></td><td>number</td><td>number</td><td>No action.</td></tr>
      *     <tr><td><code>StepTranslateZ</code></td><td>number</td><td>number</td><td>No action.</td></tr>
@@ -318,6 +324,9 @@ namespace controller {
             makeAxisPair(Action::ROLL, "Roll"),
             makeAxisPair(Action::PITCH, "Pitch"),
             makeAxisPair(Action::YAW, "Yaw"),
+            makeAxisPair(Action::DELTA_YAW, "DeltaYaw"),
+            makeAxisPair(Action::DELTA_PITCH, "DeltaPitch"),
+            makeAxisPair(Action::DELTA_ROLL, "DeltaRoll"),
             makeAxisPair(Action::STEP_YAW, "StepYaw"),
             makeAxisPair(Action::STEP_PITCH, "StepPitch"),
             makeAxisPair(Action::STEP_ROLL, "StepRoll"),

--- a/libraries/controllers/src/controllers/Actions.h
+++ b/libraries/controllers/src/controllers/Actions.h
@@ -27,6 +27,10 @@ enum class Action {
     ROTATE_Y, YAW = ROTATE_Y,
     ROTATE_Z, ROLL = ROTATE_Z,
 
+    DELTA_PITCH,
+    DELTA_YAW,
+    DELTA_ROLL,
+
     STEP_YAW,
     // FIXME does this have a use case?
     STEP_PITCH,


### PR DESCRIPTION
Adds delta yaw and pitch Controller actions and wires up mouse delta movement to these actions to make yaw and pitch changes in desktop mode directly proportional to right-click mouse movement.
Fixes occasional excessive rotation in desktop mode when using right-click mouse movement.
