### PR TITLE
Head and Hand offsets for Vive Trackers now function as expected

### DIFF
--- a/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
@@ -207,12 +207,12 @@ Flickable {
                     width: 112
                     label: "Y Offset"
                     suffix: " cm"
-                    minimumValue: -10
+                    minimumValue: -50
+                    maximumValue: 50
                     realStepSize: 1
-                    realValue: -5
                     colorScheme: hifi.colorSchemes.dark
 
-                    onEditingFinished: {
+                    onRealValueChanged: {
                         sendConfigurationSettings();
                         openVrConfiguration.forceActiveFocus();
                     }
@@ -223,14 +223,14 @@ Flickable {
                     id: headZOffset
                     width: 112
                     label: "Z Offset"
-                    minimumValue: -10
+                    minimumValue: -50
+                    maximumValue: 50
                     realStepSize: 1
                     decimals: 1
                     suffix: " cm"
-                    realValue: -5
                     colorScheme: hifi.colorSchemes.dark
 
-                    onEditingFinished: {
+                    onRealValueChanged: {
                         sendConfigurationSettings();
                         openVrConfiguration.forceActiveFocus();
                     }
@@ -319,11 +319,12 @@ Flickable {
                     width: 112
                     suffix: " cm"
                     label: "Y Offset"
-                    minimumValue: -10
+                    minimumValue: -30
+                    maximumValue: 30
                     realStepSize: 1
                     colorScheme: hifi.colorSchemes.dark
 
-                    onEditingFinished: {
+                    onRealValueChanged: {
                         sendConfigurationSettings();
                         openVrConfiguration.forceActiveFocus();
                     }
@@ -335,12 +336,13 @@ Flickable {
                     width: 112
                     label: "Z Offset"
                     suffix: " cm"
-                    minimumValue: -10
+                    minimumValue: -30
+                    maximumValue: 30
                     realStepSize: 1
                     decimals: 1
                     colorScheme: hifi.colorSchemes.dark
 
-                    onEditingFinished: {
+                    onRealValueChanged: {
                         sendConfigurationSettings();
                         openVrConfiguration.forceActiveFocus();
                     }
@@ -574,7 +576,7 @@ Flickable {
                     colorScheme: hifi.colorSchemes.dark
                     realValue: 33.0
 
-                    onEditingFinished: {
+                    onRealValueChanged: {
                         sendConfigurationSettings();
                         openVrConfiguration.forceActiveFocus();
                     }
@@ -592,7 +594,7 @@ Flickable {
                     colorScheme: hifi.colorSchemes.dark
                     realValue: 48
 
-                    onEditingFinished: {
+                    onRealValueChanged: {
                         sendConfigurationSettings();
                         openVrConfiguration.forceActiveFocus();
                     }
@@ -771,7 +773,7 @@ Flickable {
                 realStepSize: 1.0
                 colorScheme: hifi.colorSchemes.dark
 
-                onEditingFinished: {
+                onRealValueChanged: {
                     calibrationTimer.interval = realValue * 1000;
                     openVrConfiguration.countDown = realValue;
                     numberAnimation.duration = calibrationTimer.interval;
@@ -977,6 +979,13 @@ Flickable {
                 var configurationType = settings["trackerConfiguration"];
                 displayTrackerConfiguration(configurationType);
 
+                // default offset for user wearing puck on the center of their forehead.
+                headYOffset.realValue = 4; // (cm), puck is above the head joint.
+                headZOffset.realValue = 8; // (cm), puck is in front of the head joint.
+
+                // defaults for user wearing the pucks on the backs of their palms.
+                handYOffset.realValue = 8; // (cm), puck is past the the hand joint.  (set this to zero if puck is on the wrist)
+                handZOffset.realValue = -4; // (cm), puck is on above hand joint.
 
                 var HmdHead = settings["HMDHead"];
                 var viveController = settings["handController"];


### PR DESCRIPTION
In the Settings > Controller... > Calibration menu, when using head or hand trackers, The provided Y and Z offsets should function correctly now.  This gives you the ability to adjust the offsets of the pucks to the hands/head.  For example: this allows you to wear the hand pucks on your forearms rather then the backs of your palms.

(cherry picked from commit c0bf832e393655d7e455c0c5789e7889673b5a65)

Same as PR #14518 except rebased on the v0.76.0-rc branch.