### PR TITLE
work around menu-item name hash collision for Home

### DIFF
--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -117,7 +117,7 @@ namespace MenuOption {
     const QString FrameTimer = "Show Timer";
     const QString FullscreenMirror = "Mirror";
     const QString Help = "Help...";
-    const QString HomeLocation = "Home";
+    const QString HomeLocation = "Home ";
     const QString IncreaseAvatarSize = "Increase Avatar Size";
     const QString IndependentMode = "Independent Mode";
     const QString ActionMotorControl = "Enable Default Motor Control";

--- a/libraries/ui/src/ui/Menu.h
+++ b/libraries/ui/src/ui/Menu.h
@@ -146,6 +146,11 @@ protected:
     int findPositionOfMenuItem(MenuWrapper* menu, const QString& searchMenuItem);
     int positionBeforeSeparatorIfNeeded(MenuWrapper* menu, int requestedPosition);
 
+    // There is a design flaw here -- _actionHash is system-wide and hashes the names of menu-items to their
+    // QActions.  The path (parent submenu name etc) isn't included in the hash key.  This generally works,
+    // but we add "Home" twice -- once for "go home" and once for "set startup location to home".  Anytime
+    // a user bookmarks a place and gives it a name like an existing menu-item, something will go wrong.
+    // TODO: change the js api to require the full path when referring to a specific menu item.
     QHash<QString, QAction*> _actionHash;
 
     bool isValidGrouping(const QString& grouping) const { return grouping == "Advanced" || grouping == "Developer"; }


### PR DESCRIPTION
- fix bug that kept deletion of "Home" location from working

https://highfidelity.fogbugz.com/f/cases/20025/If-Home-bookmark-was-set-in-a-previous-session-it-temporarily-cannot-be-removed-from-the-list-of-bookmarks