### PR TITLE
Added DropAfterDelay strategy to Vive Tracker Calibration Dialog

### DIFF
--- a/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
@@ -871,7 +871,7 @@ Flickable {
 
                     editable: true
                     colorScheme: hifi.colorSchemes.dark
-                    model: ["None", "Freeze", "Drop"]
+                    model: ["None", "Freeze", "Drop", "DropAfterDelay"]
                     label: ""
 
                     onCurrentIndexChanged: {

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -63,7 +63,8 @@ public:
     enum class OutOfRangeDataStrategy {
         None,
         Freeze,
-        Drop
+        Drop,
+        DropAfterDelay
     };
 
 private:
@@ -204,6 +205,8 @@ private:
         mutable std::recursive_mutex _lock;
 
         bool _hmdTrackingEnabled { true };
+
+        std::map<uint32_t, uint64_t> _simDataRunningOkTimestampMap;
 
         QString configToString(Config config);
         friend class ViveControllerManager;


### PR DESCRIPTION
This is a hybrid of None and Drop strategies. If the puck is out of range for less than 0.5 seconds we still use it, however any longer then that and we mark it as invalid. Drop will mark data invalid immediately when it becomes out of range. None will always trust data even if it is out of range.

This is now the default out of range data strategy, as we fell this is the best choice for performers using trackers.

(cherry picked from commit 7f2e427584c469c47e071da5a7351210a3bca7fc)

This is the same as PR #14531 except against the v0.76.0-rc branch.