### PR TITLE
Case 22439: Fix HMD auto switch detection

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2187,31 +2187,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         properties["active_display_plugin"] = getActiveDisplayPlugin()->getName();
         properties["using_hmd"] = isHMDMode();
 
-        _autoSwitchDisplayModeSupportedHMDPlugin = nullptr;
-        foreach(DisplayPluginPointer displayPlugin, PluginManager::getInstance()->getDisplayPlugins()) {
-            if (displayPlugin->isHmd() &&
-                displayPlugin->getSupportsAutoSwitch()) {
-                _autoSwitchDisplayModeSupportedHMDPlugin = displayPlugin;
-                _autoSwitchDisplayModeSupportedHMDPluginName =
-                    _autoSwitchDisplayModeSupportedHMDPlugin->getName();
-                _previousHMDWornStatus =
-                    _autoSwitchDisplayModeSupportedHMDPlugin->isDisplayVisible();
-                break;
-            }
-        }
-
-        if (_autoSwitchDisplayModeSupportedHMDPlugin) {
-            if (getActiveDisplayPlugin() != _autoSwitchDisplayModeSupportedHMDPlugin &&
-                !_autoSwitchDisplayModeSupportedHMDPlugin->isSessionActive()) {
-                    startHMDStandBySession();
-            }
-            // Poll periodically to check whether the user has worn HMD or not. Switch Display mode accordingly.
-            // If the user wears HMD then switch to VR mode. If the user removes HMD then switch to Desktop mode.
-            QTimer* autoSwitchDisplayModeTimer = new QTimer(this);
-            connect(autoSwitchDisplayModeTimer, SIGNAL(timeout()), this, SLOT(switchDisplayMode()));
-            autoSwitchDisplayModeTimer->start(INTERVAL_TO_CHECK_HMD_WORN_STATUS);
-        }
-
         auto glInfo = getGLContextData();
         properties["gl_info"] = glInfo;
         properties["gpu_used_memory"] = (int)BYTES_TO_MB(gpu::Context::getUsedGPUMemSize());
@@ -2908,9 +2883,19 @@ void Application::initializeDisplayPlugins() {
         if (displayPlugin->getName() == lastActiveDisplayPluginName) {
             targetDisplayPlugin = displayPlugin;
         }
+
+        if (!_autoSwitchDisplayModeSupportedHMDPlugin) {
+            if (displayPlugin->isHmd() && displayPlugin->getSupportsAutoSwitch()) {
+                _autoSwitchDisplayModeSupportedHMDPlugin = displayPlugin;
+                _autoSwitchDisplayModeSupportedHMDPluginName = _autoSwitchDisplayModeSupportedHMDPlugin->getName();
+                _previousHMDWornStatus = _autoSwitchDisplayModeSupportedHMDPlugin->isDisplayVisible() && _autoSwitchDisplayModeSupportedHMDPlugin->isActive();
+            }
+        }
+
         QObject::connect(displayPlugin.get(), &DisplayPlugin::recommendedFramebufferSizeChanged,
             [this](const QSize& size) { resizeGL(); });
         QObject::connect(displayPlugin.get(), &DisplayPlugin::resetSensorsRequested, this, &Application::requestReset);
+
         if (displayPlugin->isHmd()) {
             auto hmdDisplayPlugin = dynamic_cast<HmdDisplayPlugin*>(displayPlugin.get());
             QObject::connect(hmdDisplayPlugin, &HmdDisplayPlugin::hmdMountedChanged,
@@ -2926,6 +2911,17 @@ void Application::initializeDisplayPlugins() {
     // Now set the desired plugin if it's not the same as the default plugin
     if (targetDisplayPlugin && (targetDisplayPlugin != defaultDisplayPlugin)) {
         setDisplayPlugin(targetDisplayPlugin);
+    }
+
+    if (_autoSwitchDisplayModeSupportedHMDPlugin) {
+        if (getActiveDisplayPlugin() != _autoSwitchDisplayModeSupportedHMDPlugin && !_autoSwitchDisplayModeSupportedHMDPlugin->isSessionActive()) {
+            startHMDStandBySession();
+        }
+        // Poll periodically to check whether the user has worn HMD or not. Switch Display mode accordingly.
+        // If the user wears HMD then switch to VR mode. If the user removes HMD then switch to Desktop mode.
+        QTimer* autoSwitchDisplayModeTimer = new QTimer(this);
+        connect(autoSwitchDisplayModeTimer, SIGNAL(timeout()), this, SLOT(switchDisplayMode()));
+        autoSwitchDisplayModeTimer->start(INTERVAL_TO_CHECK_HMD_WORN_STATUS);
     }
 
     // Submit a default frame to render until the engine starts up
@@ -8531,6 +8527,7 @@ void Application::switchDisplayMode() {
     if (!_autoSwitchDisplayModeSupportedHMDPlugin) {
         return;
     }
+
     bool currentHMDWornStatus = _autoSwitchDisplayModeSupportedHMDPlugin->isDisplayVisible();
     if (currentHMDWornStatus != _previousHMDWornStatus) {
         // Switch to respective mode as soon as currentHMDWornStatus changes

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -775,7 +775,7 @@ private:
     SharedSoundPointer _snapshotSound;
     SharedSoundPointer _sampleSound;
 
-    DisplayPluginPointer _autoSwitchDisplayModeSupportedHMDPlugin;
+    DisplayPluginPointer _autoSwitchDisplayModeSupportedHMDPlugin { nullptr };
     QString _autoSwitchDisplayModeSupportedHMDPluginName;
     bool _previousHMDWornStatus;
     void startHMDStandBySession();


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22439/HMD-auto-switch-code-is-broken-and-in-the-wrong-place

Starting Interface with a Rift on wouldn't always go to HMD mode.

Test plan:
- While wearing your Rift, start Interface.  Once everything loads, Interface should be in HMD mode.  It might not be rendering in the headset because of https://highfidelity.manuscript.com/f/cases/19534/sometimes-when-putting-on-the-oculus-you-get-sent-to-oculus-home-after-a-couple-seconds, but the desktop preview should show you in HMD.
- Switch to desktop mode and close Interface.
- While wearing the Rift, restart Interface.  Once everything loads, Interface should be in HMD mode.
- Try taking off your HMD/putting it back on repeatedly.  You should never get stuck in a state where you're wearing the HMD but you're in desktop mode permanently, or you're not wearing the HMD and Interface is in HMD mode.