### PR TITLE
Case 20138: Fix vive crash

### DIFF
--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -485,6 +485,7 @@ bool OpenVrDisplayPlugin::internalActivate() {
                 _submitCanvas->doneCurrent();
             });
         }
+        _submitCanvas->moveToThread(_submitThread.get());
     }
 
     return Parent::internalActivate();


### PR DESCRIPTION
77 version of: https://highfidelity.manuscript.com/f/cases/20138/Unable-to-Enter-VR-with-Vive-on-R9-200-series-AMD-GPU

Test plan:
- AMD/NVidia, i5 and i7, with Vive attached.
- Run Interface.  Should be in desktop mode.
- Switch to the Vive.  You shouldn't crash.  Interface should be in HMD mode, rendering to the vive.