### PR TITLE
Respect changed audio settings when switch displays (Master)

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6638,11 +6638,16 @@ void Application::resetSensors(bool andReload) {
 }
 
 void Application::hmdVisibleChanged(bool visible) {
+    // TODO
+    // calling start and stop will change audio input and ouput to default audio devices.
+    // we need to add a pause/unpause functionality to AudioClient for this to work properly
+#if 0
     if (visible) {
         QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(), "start", Qt::QueuedConnection);
     } else {
         QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(), "stop", Qt::QueuedConnection);
     }
+#endif
 }
 
 void Application::updateWindowTitle() const {


### PR DESCRIPTION
This PR disable the code in Application::hmdVisibleChanged that caused this issue for oculus headsets https://highfidelity.manuscript.com/f/cases/20099/Audio-settings-HMD-audio-settings-revert-to-desktop-settings-when-exiting-HMD. 