### PR TITLE
FB19355 - When I have avatar entities as children of my avatar, the A…

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
+++ b/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
@@ -75,6 +75,10 @@ Rectangle {
                 if(materialUrlOrJson) {
                     wearable.text = 'Material: ' + materialUrlOrJson;
                 }
+            } else if (wearable.sourceUrl) {
+                wearable.text = extractTitleFromUrl(wearable.sourceUrl);
+            } else if (wearable.name) {
+                wearable.text = wearable.name;
             }
             wearablesCombobox.model.append(wearable);
         }


### PR DESCRIPTION
…vatar app is not consistent in displaying wearables

https://highfidelity.fogbugz.com/f/cases/19355/When-I-have-avatar-entities-as-children-of-my-avatar-the-Avatar-app-is-not-consistent-in-displaying-wearables

Note: the issue is already partially fixed in master by other PRs. This PR adds correct presentation for such a wearables in wearables combobox. 

**Test plan**

1. Launch interface
2. Extract and drag&drop 1.json file into interface to apply wearables. 
[1.zip](https://github.com/highfidelity/hifi/files/2650575/1.zip)
3. Ensure avatar got 'bubble' wearable with animated cats inside .
4. Launch avatarapp, go to adjust wearables
5. Ensure both 'bubble' and 'cats' wearables are adjustable and visible in combobox. 
