### PR TITLE
Case 19473 (#2): Fix Mirror tonemapping

### DIFF
--- a/libraries/gpu/src/gpu/Color.slh
+++ b/libraries/gpu/src/gpu/Color.slh
@@ -18,8 +18,8 @@
 
 float color_scalar_sRGBToLinear(float value) {
     const float SRGB_ELBOW = 0.04045;
-    
-    return (value <= SRGB_ELBOW) ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4);
+
+    return mix(pow((value + 0.055) / 1.055, 2.4), value / 12.92, float(value <= SRGB_ELBOW));
 }
 
 vec3 color_sRGBToLinear(vec3 srgb) {

--- a/libraries/render-utils/src/simple_textured.slf
+++ b/libraries/render-utils/src/simple_textured.slf
@@ -29,7 +29,7 @@ layout(location=RENDER_UTILS_ATTR_TEXCOORD01) in vec4 _texCoord01;
 
 void main(void) {
     vec4 texel = texture(originalTexture, _texCoord0);
-    texel = mix(color_sRGBAToLinear(texel), texel, float(_color.a <= 0.0));
+    texel = mix(texel, color_sRGBAToLinear(texel), float(_color.a <= 0.0));
     texel.rgb *= _color.rgb;
 
     packDeferredFragment(

--- a/libraries/render-utils/src/simple_textured_fade.slf
+++ b/libraries/render-utils/src/simple_textured_fade.slf
@@ -41,9 +41,9 @@ void main(void) {
     applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
     
     vec4 texel = texture(originalTexture, _texCoord0);
-    texel = mix(color_sRGBAToLinear(texel), texel, float(_color.a <= 0.0));
+    texel = mix(texel, color_sRGBAToLinear(texel), float(_color.a <= 0.0));
     texel.rgb *= _color.rgb;
-    texel.a = abs(_color.a);
+    texel.a *= abs(_color.a);
 
     const float ALPHA_THRESHOLD = 0.999;
     if (texel.a < ALPHA_THRESHOLD) {

--- a/libraries/render-utils/src/simple_textured_unlit.slf
+++ b/libraries/render-utils/src/simple_textured_unlit.slf
@@ -29,9 +29,9 @@ layout(location=RENDER_UTILS_ATTR_TEXCOORD01) in vec4 _texCoord01;
 
 void main(void) {
     vec4 texel = texture(originalTexture, _texCoord0);
-    texel = mix(color_sRGBAToLinear(texel), texel, float(_color.a <= 0.0));
+    texel = mix(texel, color_sRGBAToLinear(texel), float(_color.a <= 0.0));
     texel.rgb *= _color.rgb;
-    texel.a = abs(_color.a);
+    texel.a *= abs(_color.a);
 
     const float ALPHA_THRESHOLD = 0.999;
     if (texel.a < ALPHA_THRESHOLD) {

--- a/libraries/render-utils/src/simple_textured_unlit_fade.slf
+++ b/libraries/render-utils/src/simple_textured_unlit_fade.slf
@@ -41,9 +41,9 @@ void main(void) {
     applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
 
     vec4 texel = texture(originalTexture, _texCoord0);
-    texel = mix(color_sRGBAToLinear(texel), texel, float(_color.a <= 0.0));
+    texel = mix(texel, color_sRGBAToLinear(texel), float(_color.a <= 0.0));
     texel.rgb *= _color.rgb;
-    texel.a = abs(_color.a);
+    texel.a *= abs(_color.a);
 
     const float ALPHA_THRESHOLD = 0.999;
     if (texel.a < ALPHA_THRESHOLD) {

--- a/libraries/render-utils/src/simple_transparent_textured.slf
+++ b/libraries/render-utils/src/simple_transparent_textured.slf
@@ -29,7 +29,7 @@ layout(location=RENDER_UTILS_ATTR_TEXCOORD01) in vec4 _texCoord01;
 
 void main(void) {
     vec4 texel = texture(originalTexture, _texCoord0);
-    texel = mix(color_sRGBAToLinear(texel), texel, float(_color.a <= 0.0));
+    texel = mix(texel, color_sRGBAToLinear(texel), float(_color.a <= 0.0));
     texel.rgb *= _color.rgb;
     texel.a *= abs(_color.a);
 

--- a/libraries/render-utils/src/simple_transparent_textured_fade.slf
+++ b/libraries/render-utils/src/simple_transparent_textured_fade.slf
@@ -47,7 +47,7 @@ void main(void) {
     applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
 
     vec4 texel = texture(originalTexture, _texCoord0);
-    texel = mix(color_sRGBAToLinear(texel), texel, float(_color.a <= 0.0));
+    texel = mix(texel, color_sRGBAToLinear(texel), float(_color.a <= 0.0));
     texel.rgb *= _color.rgb;
     texel.a *= abs(_color.a);
 

--- a/libraries/render-utils/src/simple_transparent_textured_unlit.slf
+++ b/libraries/render-utils/src/simple_transparent_textured_unlit.slf
@@ -28,7 +28,7 @@ layout(location=0) out vec4 _fragColor0;
 
 void main(void) {
     vec4 texel = texture(originalTexture, _texCoord0);
-    texel = mix(color_sRGBAToLinear(texel), texel, float(_color.a <= 0.0));
+    texel = mix(texel, color_sRGBAToLinear(texel), float(_color.a <= 0.0));
     texel.rgb *= _color.rgb;
     texel.a *= abs(_color.a);
 

--- a/libraries/render-utils/src/simple_transparent_textured_unlit_fade.slf
+++ b/libraries/render-utils/src/simple_transparent_textured_unlit_fade.slf
@@ -40,7 +40,7 @@ void main(void) {
     applyFade(fadeParams, _positionWS.xyz, fadeEmissive);
 
     vec4 texel = texture(originalTexture, _texCoord0);
-    texel = mix(color_sRGBAToLinear(texel), texel, float(_color.a <= 0.0));
+    texel = mix(texel, color_sRGBAToLinear(texel), float(_color.a <= 0.0));
     texel.rgb *= _color.rgb;
     texel.a *= abs(_color.a);
 


### PR DESCRIPTION
I mixed up (heh) the order of the arguments to mix in a few places here: https://github.com/highfidelity/hifi/pull/14293

https://highfidelity.manuscript.com/f/cases/19473/Reduce-branching-in-our-shaders

Test plan:
- Mirrors should not be darker than everything else, like they are in master.