### PR TITLE
Fix MS20208: Change an instance of 'ASSETS' to 'INVENTORY'

### DIFF
--- a/interface/resources/qml/hifi/dialogs/security/Security.qml
+++ b/interface/resources/qml/hifi/dialogs/security/Security.qml
@@ -328,7 +328,7 @@ Rectangle {
 
                 HifiStylesUit.RalewayRegular {
                     text: "Your wallet is not set up.\n" +
-                        "Open the ASSETS app to get started.";
+                        "Open the INVENTORY app to get started.";
                     // Anchors
                     anchors.fill: parent;
                     // Text size


### PR DESCRIPTION
Fixes [MS20208](https://highfidelity.manuscript.com/f/cases/20208/wrong-language-in-HMD-UI-change-from-asset-to-inventory).