### PR TITLE
Pass on dropFaceTracking flag in ScriptableAvatar::toByteArrayStateful()

### DIFF
--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -26,7 +26,7 @@ ScriptableAvatar::ScriptableAvatar() {
 
 QByteArray ScriptableAvatar::toByteArrayStateful(AvatarDataDetail dataDetail, bool dropFaceTracking) {
     _globalPosition = getWorldPosition();
-    return AvatarData::toByteArrayStateful(dataDetail);
+    return AvatarData::toByteArrayStateful(dataDetail, dropFaceTracking);
 }
 
 


### PR DESCRIPTION
>https://highfidelity.manuscript.com/f/cases/20222/quick-fix-for-agent-freezing-not-sending-joint-updates-when-it-tries-to-drop-facial-data
Simple bug in scriptable avatar.

See also https://highfidelity.manuscript.com/f/cases/20203/
 