### PR TITLE
Case 20250: Disable splash screen on android

### DIFF
--- a/interface/src/graphics/GraphicsEngine.cpp
+++ b/interface/src/graphics/GraphicsEngine.cpp
@@ -56,9 +56,11 @@ void GraphicsEngine::initializeGPU(GLWidget* glwidget) {
     glwidget->makeCurrent();
     _gpuContext = std::make_shared<gpu::Context>();
 
+#ifndef Q_OS_ANDROID
     _gpuContext->pushProgramsToSync(shader::allPrograms(), [this] {
         _programsCompiled.store(true);
     }, 1);
+#endif
 
     DependencyManager::get<TextureCache>()->setGPUContext(_gpuContext);
 }

--- a/interface/src/graphics/GraphicsEngine.h
+++ b/interface/src/graphics/GraphicsEngine.h
@@ -86,7 +86,11 @@ protected:
     FrameTimingsScriptingInterface _frameTimingsScriptingInterface;
 
     std::shared_ptr<ProceduralSkybox> _splashScreen { std::make_shared<ProceduralSkybox>() };
+#ifndef Q_OS_ANDROID
     std::atomic<bool> _programsCompiled { false };
+#else
+    std::atomic<bool> _programsCompiled { true };
+#endif
 
     friend class Application;
 };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20250/

Workaround a startup crash on android

Test plan:
- Interface should run on Android.  Verify that the domain selection screen comes up and that you can go to a domain and have it render.