### PR TITLE
Return more connections in pal

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -61,7 +61,7 @@ Rectangle {
                 'username';
         }
         sortAscending: connectionsTable.sortIndicatorOrder === Qt.AscendingOrder;
-        itemsPerPage: 10;
+        itemsPerPage: 1000;
         listView: connectionsTable;
         processPage: function (data) {
             return data.users.map(function (user) {


### PR DESCRIPTION
If we paginate the call to getting _sorted_ lists of user connections, we run into them changing between calls, and missing/duplicating people.  Of course you _could_ get rid of dups on the client, but you cannot fix the corresponding loss.  

One way to go is return a lot of connections -- say all of them.  But will this be performant?   Not if there are millions. But, for our largest list (500-ish), this is just fine.  So first lets just up the per-page.  This eliminates the duplicate/lost connection issue which happens when the sort order changes between paginated calls while scrolling.  Then later we will limit the connections perhaps, and not ever paginate, with a small code change on the server.

