### PR TITLE
Fix MS20308: Allow users to checkout uncertifiable items

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -1089,9 +1089,13 @@ Rectangle {
         root.itemInfoReceived = true;
         root.itemName = result.data.title;
         root.itemPrice = result.data.cost;
-        root.itemHref = Account.metaverseServerURL + result.data.path;
         root.itemAuthor = result.data.creator;
         root.itemType = result.data.item_type || "unknown";
+        if (root.itemType === "unknown") {
+            root.itemHref = result.data.review_url;
+        } else {
+            root.itemHref = Account.metaverseServerURL + result.data.path;
+        }
         itemPreviewImage.source = result.data.thumbnail_url;
         refreshBuyUI();
     }


### PR DESCRIPTION
Fixes [MS20308](https://highfidelity.manuscript.com/f/cases/20308/JS-apps-from-the-marketplace-not-working).

QAing this involves successfully "buying" "FingerPaint (Beta)" from the stable Metaverse marketplace.