### PR TITLE
Avatar eye tracking works again

### DIFF
--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -301,8 +301,8 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     eyeParams.eyeSaccade = head->getSaccade();
     eyeParams.modelRotation = getRotation();
     eyeParams.modelTranslation = getTranslation();
-    eyeParams.leftEyeJointIndex = hfmModel.leftEyeJointIndex;
-    eyeParams.rightEyeJointIndex = hfmModel.rightEyeJointIndex;
+    eyeParams.leftEyeJointIndex = myAvatar->getJointIndex("LeftEye");
+    eyeParams.rightEyeJointIndex = myAvatar->getJointIndex("RightEye");
 
     _rig.updateFromEyeParameters(eyeParams);
 


### PR DESCRIPTION
This was inadvertently broken by the joint name remapping feature.  #14486