### PR TITLE
MS20328: New login breaks nitpick (RC 77)

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5261,7 +5261,12 @@ void Application::resumeAfterLoginDialogActionTaken() {
     nodeList->getDomainHandler().resetting();
 
     if (!accountManager->isLoggedIn()) {
-        addressManager->goToEntry();
+        if (arguments().contains("--url")) {
+            auto reply = SandboxUtils::getStatus();
+            connect(reply, &QNetworkReply::finished, this, [this, reply] { handleSandboxStatus(reply); });
+        } else {
+            addressManager->goToEntry();
+        }
     } else {
         QVariant testProperty = property(hifi::properties::TEST);
         if (testProperty.isValid()) {
@@ -5274,7 +5279,8 @@ void Application::resumeAfterLoginDialogActionTaken() {
                 connect(reply, &QNetworkReply::finished, this, [this, reply] { handleSandboxStatus(reply); });
             }
         } else {
-            addressManager->loadSettings();
+            auto reply = SandboxUtils::getStatus();
+            connect(reply, &QNetworkReply::finished, this, [this, reply] { handleSandboxStatus(reply); });
         }
     }
 


### PR DESCRIPTION
MS#[20328](https://highfidelity.fogbugz.com/f/cases/20328/New-login-breaks-nitpick)

- ensuring that `--no-login-suggestion` works while adding `--url` component.

#TEST PLAN
- create a file called 
   - `interface.bat` (Windows) with text:
```
cd %~dp0
.\interface.exe --no-login-suggestion --url hifi://sandbox
```

   - `interface.sh` (non-Windows) with text:
```
cd `dirname $0`
./interface --no-login-suggestion --url hifi://sandbox
```
- Place the appropriate file just created into the build folder where the PR was installed (where the interface binary is located)
- run the file (interface launches)
- you should land in the sandbox
- login
- go to some other domain using `GOTO` app
- exit interface
- create a file called 
   - `interfaceNoLogin.bat` (Windows) with text:
```
cd %~dp0
.\interface.exe --no-login-suggestion
```

   - `interfaceNoLogin.sh` (non-Windows) with text:
```
cd `dirname $0`
./interface --no-login-suggestion
```
- Place the appropriate file just created into the build folder where the PR was installed (where the interface binary is located)
- run the interfaceNoLogin file (launch interface)
- you should land in the last domain you were at from the previous session