### PR TITLE
Remove out-of-date backups on startup

### DIFF
--- a/domain-server/src/DomainContentBackupManager.cpp
+++ b/domain-server/src/DomainContentBackupManager.cpp
@@ -127,6 +127,10 @@ int64_t DomainContentBackupManager::getMostRecentBackupTimeInSecs(const QString&
 }
 
 void DomainContentBackupManager::setup() {
+    for (auto& rule : _backupRules) {
+        removeOldBackupVersions(rule);
+    }
+
     auto backups = getAllBackups();
     for (auto& backup : backups) {
         QFile backupFile { backup.absolutePath };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19907/automatic-content-archive-retention-rules-do-not-appear-to-be-applied-correctly

Simple addition to run the remove-backup routines at start of backup-manager thread. Fixes one issue in ticket of user being presented with several unrequested backups.