### PR TITLE
MS20332: HMD Login Prompt-- small avatars cannot reach easily

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5176,7 +5176,13 @@ void Application::pauseUntilLoginDetermined() {
         return;
     }
 
-    getMyAvatar()->setEnableMeshVisible(false);
+    auto myAvatar = getMyAvatar();
+    _previousAvatarTargetScale = myAvatar->getTargetScale();
+    _previousAvatarSkeletonModel = myAvatar->getSkeletonModelURL().toString();
+    myAvatar->setTargetScale(1.0f);
+    myAvatar->setSkeletonModelURLFromScript(myAvatar->defaultFullAvatarModelUrl().toString());
+    myAvatar->setEnableMeshVisible(false);
+
     _controllerScriptingInterface->disableMapping(STANDARD_TO_ACTION_MAPPING_NAME);
 
     {
@@ -5231,8 +5237,12 @@ void Application::resumeAfterLoginDialogActionTaken() {
         userInputMapper->unloadMapping(NO_MOVEMENT_MAPPING_JSON);
         _controllerScriptingInterface->disableMapping(NO_MOVEMENT_MAPPING_NAME);
     }
-    getMyAvatar()->setEnableMeshVisible(true);
-    _controllerScriptingInterface->enableMapping(STANDARD_TO_ACTION_MAPPING_NAME);
+     auto myAvatar = getMyAvatar();
+     myAvatar->setTargetScale(_previousAvatarTargetScale);
+     myAvatar->setSkeletonModelURLFromScript(_previousAvatarSkeletonModel);
+     myAvatar->setEnableMeshVisible(true);
+
+     _controllerScriptingInterface->enableMapping(STANDARD_TO_ACTION_MAPPING_NAME);
 
     const auto& nodeList = DependencyManager::get<NodeList>();
     nodeList->getDomainHandler().setInterstitialModeEnabled(_interstitialModeEnabled);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -691,6 +691,8 @@ private:
 
     bool _loginDialogPoppedUp = false;
     bool _developerMenuVisible{ false };
+    QString _previousAvatarSkeletonModel;
+    float _previousAvatarTargetScale;
     CameraMode _previousCameraMode;
     OverlayID _loginDialogOverlayID;
     LoginStateManager _loginStateManager;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1479,6 +1479,7 @@ void MyAvatar::loadData() {
     setSnapTurn(_useSnapTurnSetting.get());
     setDominantHand(_dominantHandSetting.get(DOMINANT_RIGHT_HAND).toLower());
     setUserHeight(_userHeightSetting.get(DEFAULT_AVATAR_HEIGHT));
+    setTargetScale(_scaleSetting.get());
 
     setEnableMeshVisible(Menu::getInstance()->isOptionChecked(MenuOption::MeshVisible));
     _follow.setToggleHipsFollowing (Menu::getInstance()->isOptionChecked(MenuOption::ToggleHipsFollowing));


### PR DESCRIPTION
MS#[20332](https://highfidelity.manuscript.com/f/cases/20332/HMD-Login-Prompt-small-avatars-cannot-reach-easily)

Verify bug is fixed
1)  Open the Interface, and enter a Domain.
2)  Equip a short avatar such as the Kobold, or a Robimo.
3)  While logged out, quit the interface.
4)  Open the interface.
5)  Keyboard will spawn over an arms length away from the user.

Post-merge test plan:
https://highfidelity.testrail.net/index.php?/cases/view/35634