### PR TITLE
Fix for Camera-perspective-is-off-in-first-person-view, master branch 

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2417,10 +2417,10 @@ void MyAvatar::attachmentDataToEntityProperties(const AttachmentData& data, Enti
 void MyAvatar::initHeadBones() {
     int neckJointIndex = -1;
     if (_skeletonModel->isLoaded()) {
-        neckJointIndex = _skeletonModel->getHFMModel().neckJointIndex;
+        neckJointIndex = getJointIndex("Neck");
     }
     if (neckJointIndex == -1) {
-        neckJointIndex = (_skeletonModel->getHFMModel().headJointIndex - 1);
+        neckJointIndex = (getJointIndex("Head") - 1);
         if (neckJointIndex < 0) {
             // return if the head is not even there. can't cauterize!!
             return;

--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -301,8 +301,8 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     eyeParams.eyeSaccade = head->getSaccade();
     eyeParams.modelRotation = getRotation();
     eyeParams.modelTranslation = getTranslation();
-    eyeParams.leftEyeJointIndex = hfmModel.leftEyeJointIndex;
-    eyeParams.rightEyeJointIndex = hfmModel.rightEyeJointIndex;
+    eyeParams.leftEyeJointIndex = _rig.indexOfJoint("LeftEye");
+    eyeParams.rightEyeJointIndex = _rig.indexOfJoint("RightEye");;
 
     _rig.updateFromEyeParameters(eyeParams);
 

--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -302,7 +302,7 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     eyeParams.modelRotation = getRotation();
     eyeParams.modelTranslation = getTranslation();
     eyeParams.leftEyeJointIndex = _rig.indexOfJoint("LeftEye");
-    eyeParams.rightEyeJointIndex = _rig.indexOfJoint("RightEye");;
+    eyeParams.rightEyeJointIndex = _rig.indexOfJoint("RightEye");
 
     _rig.updateFromEyeParameters(eyeParams);
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -343,18 +343,18 @@ void Rig::initJointStates(const HFMModel& hfmModel, const glm::mat4& modelOffset
 
     buildAbsoluteRigPoses(_animSkeleton->getRelativeDefaultPoses(), _absoluteDefaultPoses);
 
-    _rootJointIndex = hfmModel.rootJointIndex;
-    _leftEyeJointIndex = hfmModel.leftEyeJointIndex;
-    _rightEyeJointIndex = hfmModel.rightEyeJointIndex;
-    _leftHandJointIndex = hfmModel.leftHandJointIndex;
+    _rootJointIndex = indexOfJoint("Hips");
+    _leftEyeJointIndex = indexOfJoint("LeftEye");
+    _rightEyeJointIndex = indexOfJoint("RightEye");
+    _leftHandJointIndex = indexOfJoint("LeftHand");
     _leftElbowJointIndex = _leftHandJointIndex >= 0 ? hfmModel.joints.at(_leftHandJointIndex).parentIndex : -1;
     _leftShoulderJointIndex = _leftElbowJointIndex >= 0 ? hfmModel.joints.at(_leftElbowJointIndex).parentIndex : -1;
-    _rightHandJointIndex = hfmModel.rightHandJointIndex;
+    _rightHandJointIndex = indexOfJoint("RightHand");
     _rightElbowJointIndex = _rightHandJointIndex >= 0 ? hfmModel.joints.at(_rightHandJointIndex).parentIndex : -1;
     _rightShoulderJointIndex = _rightElbowJointIndex >= 0 ? hfmModel.joints.at(_rightElbowJointIndex).parentIndex : -1;
 
-    _leftEyeJointChildren = _animSkeleton->getChildrenOfJoint(hfmModel.leftEyeJointIndex);
-    _rightEyeJointChildren = _animSkeleton->getChildrenOfJoint(hfmModel.rightEyeJointIndex);
+    _leftEyeJointChildren = _animSkeleton->getChildrenOfJoint(indexOfJoint("LeftEye"));
+    _rightEyeJointChildren = _animSkeleton->getChildrenOfJoint(indexOfJoint("RightEye"));
 }
 
 void Rig::reset(const HFMModel& hfmModel) {
@@ -390,18 +390,18 @@ void Rig::reset(const HFMModel& hfmModel) {
 
     buildAbsoluteRigPoses(_animSkeleton->getRelativeDefaultPoses(), _absoluteDefaultPoses);
 
-    _rootJointIndex = hfmModel.rootJointIndex;
-    _leftEyeJointIndex = hfmModel.leftEyeJointIndex;
-    _rightEyeJointIndex = hfmModel.rightEyeJointIndex;
-    _leftHandJointIndex = hfmModel.leftHandJointIndex;
+    _rootJointIndex = indexOfJoint("Hips");;
+    _leftEyeJointIndex = indexOfJoint("LeftEye");
+    _rightEyeJointIndex = indexOfJoint("RightEye");
+    _leftHandJointIndex = indexOfJoint("LeftHand");
     _leftElbowJointIndex = _leftHandJointIndex >= 0 ? hfmModel.joints.at(_leftHandJointIndex).parentIndex : -1;
     _leftShoulderJointIndex = _leftElbowJointIndex >= 0 ? hfmModel.joints.at(_leftElbowJointIndex).parentIndex : -1;
-    _rightHandJointIndex = hfmModel.rightHandJointIndex;
+    _rightHandJointIndex = indexOfJoint("RightHand");
     _rightElbowJointIndex = _rightHandJointIndex >= 0 ? hfmModel.joints.at(_rightHandJointIndex).parentIndex : -1;
     _rightShoulderJointIndex = _rightElbowJointIndex >= 0 ? hfmModel.joints.at(_rightElbowJointIndex).parentIndex : -1;
 
-    _leftEyeJointChildren = _animSkeleton->getChildrenOfJoint(hfmModel.leftEyeJointIndex);
-    _rightEyeJointChildren = _animSkeleton->getChildrenOfJoint(hfmModel.rightEyeJointIndex);
+    _leftEyeJointChildren = _animSkeleton->getChildrenOfJoint(indexOfJoint("LeftEye"));
+    _rightEyeJointChildren = _animSkeleton->getChildrenOfJoint(indexOfJoint("RightEye"));
 
     if (!_animGraphURL.isEmpty()) {
         _animNode.reset();

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1314,7 +1314,7 @@ glm::quat Avatar::getAbsoluteJointRotationInObjectFrame(int index) const {
         case CAMERA_MATRIX_INDEX: {
             glm::quat rotation;
             if (_skeletonModel && _skeletonModel->isActive()) {
-                int headJointIndex = _skeletonModel->getHFMModel().headJointIndex;
+                int headJointIndex = getJointIndex("Head");
                 if (headJointIndex >= 0) {
                     _skeletonModel->getAbsoluteJointRotationInRigFrame(headJointIndex, rotation);
                 }
@@ -1363,7 +1363,7 @@ glm::vec3 Avatar::getAbsoluteJointTranslationInObjectFrame(int index) const {
         case CAMERA_MATRIX_INDEX: {
             glm::vec3 translation;
             if (_skeletonModel && _skeletonModel->isActive()) {
-                int headJointIndex = _skeletonModel->getHFMModel().headJointIndex;
+                int headJointIndex = getJointIndex("Head");
                 if (headJointIndex >= 0) {
                     _skeletonModel->getAbsoluteJointTranslationInRigFrame(headJointIndex, translation);
                 }

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
@@ -66,7 +66,7 @@ void SkeletonModel::initJointStates() {
     }
 
     // Determine the default eye position for avatar scale = 1.0
-    int headJointIndex = hfmModel.headJointIndex;
+    int headJointIndex = _rig.indexOfJoint("Head");
     if (0 > headJointIndex || headJointIndex >= _rig.getJointStateCount()) {
         qCWarning(avatars_renderer) << "Bad head joint! Got:" << headJointIndex << "jointCount:" << _rig.getJointStateCount();
     }
@@ -74,7 +74,7 @@ void SkeletonModel::initJointStates() {
     getEyeModelPositions(leftEyePosition, rightEyePosition);
     glm::vec3 midEyePosition = (leftEyePosition + rightEyePosition) / 2.0f;
 
-    int rootJointIndex = hfmModel.rootJointIndex;
+    int rootJointIndex = _rig.indexOfJoint("Hips");
     glm::vec3 rootModelPosition;
     getJointPosition(rootJointIndex, rootModelPosition);
 
@@ -124,7 +124,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
     // If the head is not positioned, updateEyeJoints won't get the math right
     glm::quat headOrientation;
-    _rig.getJointRotation(hfmModel.headJointIndex, headOrientation);
+    _rig.getJointRotation(_rig.indexOfJoint("Head"), headOrientation);
     glm::vec3 eulers = safeEulerAngles(headOrientation);
     head->setBasePitch(glm::degrees(-eulers.x));
     head->setBaseYaw(glm::degrees(eulers.y));
@@ -135,8 +135,8 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     eyeParams.eyeSaccade = glm::vec3(0.0f);
     eyeParams.modelRotation = getRotation();
     eyeParams.modelTranslation = getTranslation();
-    eyeParams.leftEyeJointIndex = hfmModel.leftEyeJointIndex;
-    eyeParams.rightEyeJointIndex = hfmModel.rightEyeJointIndex;
+    eyeParams.leftEyeJointIndex = _rig.indexOfJoint("LeftEye");
+    eyeParams.rightEyeJointIndex = _rig.indexOfJoint("RightEye");
 
     _rig.updateFromEyeParameters(eyeParams);
 }
@@ -259,15 +259,15 @@ bool SkeletonModel::getRightShoulderPosition(glm::vec3& position) const {
 }
 
 bool SkeletonModel::getHeadPosition(glm::vec3& headPosition) const {
-    return isActive() && getJointPositionInWorldFrame(getHFMModel().headJointIndex, headPosition);
+    return isActive() && getJointPositionInWorldFrame(_rig.indexOfJoint("Head"), headPosition);
 }
 
 bool SkeletonModel::getNeckPosition(glm::vec3& neckPosition) const {
-    return isActive() && getJointPositionInWorldFrame(getHFMModel().neckJointIndex, neckPosition);
+    return isActive() && getJointPositionInWorldFrame(_rig.indexOfJoint("Neck"), neckPosition);
 }
 
 bool SkeletonModel::getLocalNeckPosition(glm::vec3& neckPosition) const {
-    return isActive() && getJointPosition(getHFMModel().neckJointIndex, neckPosition);
+    return isActive() && getJointPosition(_rig.indexOfJoint("Neck"), neckPosition);
 }
 
 bool SkeletonModel::getEyeModelPositions(glm::vec3& firstEyePosition, glm::vec3& secondEyePosition) const {
@@ -276,28 +276,28 @@ bool SkeletonModel::getEyeModelPositions(glm::vec3& firstEyePosition, glm::vec3&
     }
     const HFMModel& hfmModel = getHFMModel();
 
-    if (getJointPosition(hfmModel.leftEyeJointIndex, firstEyePosition) &&
-        getJointPosition(hfmModel.rightEyeJointIndex, secondEyePosition)) {
+    if (getJointPosition(_rig.indexOfJoint("LeftEye"), firstEyePosition) &&
+        getJointPosition(_rig.indexOfJoint("RightEye"), secondEyePosition)) {
         return true;
     }
     // no eye joints; try to estimate based on head/neck joints
     glm::vec3 neckPosition, headPosition;
-    if (getJointPosition(hfmModel.neckJointIndex, neckPosition) &&
-        getJointPosition(hfmModel.headJointIndex, headPosition)) {
+    if (getJointPosition(_rig.indexOfJoint("Neck"), neckPosition) &&
+        getJointPosition(_rig.indexOfJoint("Head"), headPosition)) {
         const float EYE_PROPORTION = 0.6f;
         glm::vec3 baseEyePosition = glm::mix(neckPosition, headPosition, EYE_PROPORTION);
         glm::quat headRotation;
-        getJointRotation(hfmModel.headJointIndex, headRotation);
+        getJointRotation(_rig.indexOfJoint("Head"), headRotation);
         const float EYES_FORWARD = 0.25f;
         const float EYE_SEPARATION = 0.1f;
         float headHeight = glm::distance(neckPosition, headPosition);
         firstEyePosition = baseEyePosition + headRotation * glm::vec3(EYE_SEPARATION, 0.0f, EYES_FORWARD) * headHeight;
         secondEyePosition = baseEyePosition + headRotation * glm::vec3(-EYE_SEPARATION, 0.0f, EYES_FORWARD) * headHeight;
         return true;
-    } else if (getJointPosition(hfmModel.headJointIndex, headPosition)) {
+    } else if (getJointPosition(_rig.indexOfJoint("Head"), headPosition)) {
         glm::vec3 baseEyePosition = headPosition;
         glm::quat headRotation;
-        getJointRotation(hfmModel.headJointIndex, headRotation);
+        getJointRotation(_rig.indexOfJoint("Head"), headRotation);
         const float EYES_FORWARD_HEAD_ONLY = 0.30f;
         const float EYE_SEPARATION = 0.1f;
         firstEyePosition = baseEyePosition + headRotation * glm::vec3(EYE_SEPARATION, 0.0f, EYES_FORWARD_HEAD_ONLY);
@@ -331,7 +331,7 @@ void SkeletonModel::computeBoundingShape() {
     }
 
     const HFMModel& hfmModel = getHFMModel();
-    if (hfmModel.joints.isEmpty() || hfmModel.rootJointIndex == -1) {
+    if (hfmModel.joints.isEmpty() || _rig.indexOfJoint("Hips") == -1) {
         // rootJointIndex == -1 if the avatar model has no skeleton
         return;
     }
@@ -369,7 +369,7 @@ void SkeletonModel::renderBoundingCollisionShapes(RenderArgs* args, gpu::Batch& 
 }
 
 bool SkeletonModel::hasSkeleton() {
-    return isActive() ? getHFMModel().rootJointIndex != -1 : false;
+    return isActive() ? _rig.indexOfJoint("Hips") != -1 : false;
 }
 
 void SkeletonModel::onInvalidate() {

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
@@ -96,7 +96,6 @@ void SkeletonModel::initJointStates() {
 // Called within Model::simulate call, below.
 void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     assert(!_owningAvatar->isMyAvatar());
-    const HFMModel& hfmModel = getHFMModel();
 
     Head* head = _owningAvatar->getHead();
 
@@ -274,7 +273,6 @@ bool SkeletonModel::getEyeModelPositions(glm::vec3& firstEyePosition, glm::vec3&
     if (!isActive()) {
         return false;
     }
-    const HFMModel& hfmModel = getHFMModel();
 
     if (getJointPosition(_rig.indexOfJoint("LeftEye"), firstEyePosition) &&
         getJointPosition(_rig.indexOfJoint("RightEye"), secondEyePosition)) {

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
@@ -41,10 +41,10 @@ public:
     void updateAttitude(const glm::quat& orientation);
 
     /// Returns the index of the left hand joint, or -1 if not found.
-    int getLeftHandJointIndex() const { return isActive() ? getHFMModel().leftHandJointIndex : -1; }
+    int getLeftHandJointIndex() const { return isActive() ? _rig.indexOfJoint("LeftHand") : -1; }
 
     /// Returns the index of the right hand joint, or -1 if not found.
-    int getRightHandJointIndex() const { return isActive() ? getHFMModel().rightHandJointIndex : -1; }
+    int getRightHandJointIndex() const { return isActive() ? _rig.indexOfJoint("RightHand") : -1; }
 
     bool getLeftGrabPosition(glm::vec3& position) const;
     bool getRightGrabPosition(glm::vec3& position) const;

--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -583,7 +583,7 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
                     if (modelname.startsWith("hifi")) {
                         hifiGlobalNodeID = id;
                     }
-                    
+
                     int humanIKJointIndex = humanIKJointNames.indexOf(name);
                     if (humanIKJointIndex != -1) {
                         humanIKJointIDs[humanIKJointIndex] = getID(object.properties);

--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -21,7 +21,6 @@
 #include <QtEndian>
 #include <QFileInfo>
 
-
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/quaternion.hpp>
 #include <glm/gtx/transform.hpp>

--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -127,26 +127,6 @@ QString getID(const QVariantList& properties, int index = 0) {
     return processID(properties.at(index).toString());
 }
 
-/// The names of the joints in the Maya HumanIK rig
-static const std::array<const char*, 16> HUMANIK_JOINTS = {{
-    "RightHand",
-    "RightForeArm",
-    "RightArm",
-    "Head",
-    "LeftArm",
-    "LeftForeArm",
-    "LeftHand",
-    "Neck",
-    "Spine",
-    "Hips",
-    "RightUpLeg",
-    "LeftUpLeg",
-    "RightLeg",
-    "LeftLeg",
-    "RightFoot",
-    "LeftFoot"
-}};
-
 class FBXModel {
 public:
     QString name;
@@ -480,13 +460,6 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
 
     QVariantHash joints = mapping.value("joint").toHash();
 
-    QVector<QString> humanIKJointNames;
-    for (int i = 0; i <  (int) HUMANIK_JOINTS.size(); i++) {
-        QByteArray jointName = HUMANIK_JOINTS[i];
-        humanIKJointNames.append(processID(getString(joints.value(jointName, jointName))));
-    }
-    QVector<QString> humanIKJointIDs(humanIKJointNames.size());
-
     QVariantHash blendshapeMappings = mapping.value("bs").toHash();
 
     QMultiHash<QByteArray, WeightedIndex> blendshapeIndices;
@@ -582,11 +555,6 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
                     QString modelname = name.toLower();
                     if (modelname.startsWith("hifi")) {
                         hifiGlobalNodeID = id;
-                    }
-
-                    int humanIKJointIndex = humanIKJointNames.indexOf(name);
-                    if (humanIKJointIndex != -1) {
-                        humanIKJointIDs[humanIKJointIndex] = getID(object.properties);
                     }
 
                     glm::vec3 translation;
@@ -1399,10 +1367,6 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
     // NOTE: shapeVertices are in joint-frame
     std::vector<ShapeVertices> shapeVertices;
     shapeVertices.resize(std::max(1, hfmModel.joints.size()) );
-
-    foreach (const QString& id, humanIKJointIDs) {
-        hfmModel.humanIKJointIndices.append(modelIDs.indexOf(id));
-    }
 
     hfmModel.bindExtents.reset();
     hfmModel.meshExtents.reset();

--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -21,6 +21,7 @@
 #include <QtEndian>
 #include <QFileInfo>
 
+
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/quaternion.hpp>
 #include <glm/gtx/transform.hpp>
@@ -478,25 +479,6 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
     std::map<QString, HFMLight> lights;
 
     QVariantHash joints = mapping.value("joint").toHash();
-    QString jointEyeLeftName = "EyeLeft";
-    QString jointEyeRightName = "EyeRight";
-    QString jointNeckName = "Neck";
-    QString jointRootName = "Hips";
-    QString jointLeanName = "Spine";
-    QString jointHeadName = "Head";
-    QString jointLeftHandName = "LeftHand";
-    QString jointRightHandName = "RightHand";
-    QString jointEyeLeftID;
-    QString jointEyeRightID;
-    QString jointNeckID;
-    QString jointRootID;
-    QString jointLeanID;
-    QString jointHeadID;
-    QString jointLeftHandID;
-    QString jointRightHandID;
-    QString jointLeftToeID;
-    QString jointRightToeID;
-
 
     QVector<QString> humanIKJointNames;
     for (int i = 0; i <  (int) HUMANIK_JOINTS.size(); i++) {
@@ -601,38 +583,7 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
                     if (modelname.startsWith("hifi")) {
                         hifiGlobalNodeID = id;
                     }
-
-                    if (name == jointEyeLeftName || name == "EyeL" || name == "joint_Leye" || (hfmModel.hfmToHifiJointNameMapping.contains(jointEyeLeftName) && (name == hfmModel.hfmToHifiJointNameMapping[jointEyeLeftName]))) {
-                        jointEyeLeftID = getID(object.properties);
-
-                    } else if (name == jointEyeRightName || name == "EyeR" || name == "joint_Reye" || (hfmModel.hfmToHifiJointNameMapping.contains(jointEyeRightName) && (name == hfmModel.hfmToHifiJointNameMapping[jointEyeRightName]))) {
-                        jointEyeRightID = getID(object.properties);
-
-                    } else if (name == jointNeckName || name == "NeckRot" || name == "joint_neck" || (hfmModel.hfmToHifiJointNameMapping.contains(jointNeckName) && (name == hfmModel.hfmToHifiJointNameMapping[jointNeckName]))) {
-                        jointNeckID = getID(object.properties);
-
-                    } else if (name == jointRootName || (hfmModel.hfmToHifiJointNameMapping.contains(jointRootName) && (name == hfmModel.hfmToHifiJointNameMapping[jointRootName]))) {
-                        jointRootID = getID(object.properties);
-
-                    } else if (name == jointLeanName || (hfmModel.hfmToHifiJointNameMapping.contains(jointLeanName) && (name == hfmModel.hfmToHifiJointNameMapping[jointLeanName]))) {
-                        jointLeanID = getID(object.properties);
-
-                    } else if ((name == jointHeadName) || (hfmModel.hfmToHifiJointNameMapping.contains(jointHeadName) && (name == hfmModel.hfmToHifiJointNameMapping[jointHeadName]))) {
-                        jointHeadID = getID(object.properties);
-
-                    } else if (name == jointLeftHandName || name == "LeftHand" || name == "joint_L_hand" || (hfmModel.hfmToHifiJointNameMapping.contains(jointLeftHandName) && (name == hfmModel.hfmToHifiJointNameMapping[jointLeftHandName]))) {
-                        jointLeftHandID = getID(object.properties);
-
-                    } else if (name == jointRightHandName || name == "RightHand" || name == "joint_R_hand" || (hfmModel.hfmToHifiJointNameMapping.contains(jointRightHandName) && (name == hfmModel.hfmToHifiJointNameMapping[jointRightHandName]))) {
-                        jointRightHandID = getID(object.properties);
-
-                    } else if (name == "LeftToe" || name == "joint_L_toe" || name == "LeftToe_End" || (hfmModel.hfmToHifiJointNameMapping.contains("LeftToe") && (name == hfmModel.hfmToHifiJointNameMapping["LeftToe"]))) {
-                        jointLeftToeID = getID(object.properties);
-
-                    } else if (name == "RightToe" || name == "joint_R_toe" || name == "RightToe_End" || (hfmModel.hfmToHifiJointNameMapping.contains("RightToe") && (name == hfmModel.hfmToHifiJointNameMapping["RightToe"]))) {
-                        jointRightToeID = getID(object.properties);
-                    }
-
+                    
                     int humanIKJointIndex = humanIKJointNames.indexOf(name);
                     if (humanIKJointIndex != -1) {
                         humanIKJointIDs[humanIKJointIndex] = getID(object.properties);
@@ -1449,26 +1400,8 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
     std::vector<ShapeVertices> shapeVertices;
     shapeVertices.resize(std::max(1, hfmModel.joints.size()) );
 
-    // find our special joints
-    hfmModel.leftEyeJointIndex = modelIDs.indexOf(jointEyeLeftID);
-    hfmModel.rightEyeJointIndex = modelIDs.indexOf(jointEyeRightID);
-    hfmModel.neckJointIndex = modelIDs.indexOf(jointNeckID);
-    hfmModel.rootJointIndex = modelIDs.indexOf(jointRootID);
-    hfmModel.leanJointIndex = modelIDs.indexOf(jointLeanID);
-    hfmModel.headJointIndex = modelIDs.indexOf(jointHeadID);
-    hfmModel.leftHandJointIndex = modelIDs.indexOf(jointLeftHandID);
-    hfmModel.rightHandJointIndex = modelIDs.indexOf(jointRightHandID);
-    hfmModel.leftToeJointIndex = modelIDs.indexOf(jointLeftToeID);
-    hfmModel.rightToeJointIndex = modelIDs.indexOf(jointRightToeID);
-
     foreach (const QString& id, humanIKJointIDs) {
         hfmModel.humanIKJointIndices.append(modelIDs.indexOf(id));
-    }
-
-    // extract the translation component of the neck transform
-    if (hfmModel.neckJointIndex != -1) {
-        const glm::mat4& transform = hfmModel.joints.at(hfmModel.neckJointIndex).transform;
-        hfmModel.neckPivot = glm::vec3(transform[3][0], transform[3][1], transform[3][2]);
     }
 
     hfmModel.bindExtents.reset();

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -1188,9 +1188,6 @@ void GLTFSerializer::hfmDebugDump(const HFMModel& hfmModel) {
     qCDebug(modelformat) << "  hasSkeletonJoints =" << hfmModel.hasSkeletonJoints;
     qCDebug(modelformat) << "  offset =" << hfmModel.offset;
 
-    qCDebug(modelformat) << "  leftEyeSize = " << hfmModel.leftEyeSize;
-    qCDebug(modelformat) << "  rightEyeSize = " << hfmModel.rightEyeSize;
-
     qCDebug(modelformat) << "  palmDirection = " << hfmModel.palmDirection;
 
     qCDebug(modelformat) << "  neckPivot = " << hfmModel.neckPivot;

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -1188,16 +1188,6 @@ void GLTFSerializer::hfmDebugDump(const HFMModel& hfmModel) {
     qCDebug(modelformat) << "  hasSkeletonJoints =" << hfmModel.hasSkeletonJoints;
     qCDebug(modelformat) << "  offset =" << hfmModel.offset;
 
-    qCDebug(modelformat) << "  leftEyeJointIndex =" << hfmModel.leftEyeJointIndex;
-    qCDebug(modelformat) << "  rightEyeJointIndex =" << hfmModel.rightEyeJointIndex;
-    qCDebug(modelformat) << "  neckJointIndex =" << hfmModel.neckJointIndex;
-    qCDebug(modelformat) << "  rootJointIndex =" << hfmModel.rootJointIndex;
-    qCDebug(modelformat) << "  leanJointIndex =" << hfmModel.leanJointIndex;
-    qCDebug(modelformat) << "  headJointIndex =" << hfmModel.headJointIndex;
-    qCDebug(modelformat) << "  leftHandJointIndex" << hfmModel.leftHandJointIndex;
-    qCDebug(modelformat) << "  rightHandJointIndex" << hfmModel.rightHandJointIndex;
-    qCDebug(modelformat) << "  leftToeJointIndex" << hfmModel.leftToeJointIndex;
-    qCDebug(modelformat) << "  rightToeJointIndex" << hfmModel.rightToeJointIndex;
     qCDebug(modelformat) << "  leftEyeSize = " << hfmModel.leftEyeSize;
     qCDebug(modelformat) << "  rightEyeSize = " << hfmModel.rightEyeSize;
 

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -270,17 +270,6 @@ public:
 
     glm::mat4 offset; // This includes offset, rotation, and scale as specified by the FST file
 
-    int leftEyeJointIndex = -1;
-    int rightEyeJointIndex = -1;
-    int neckJointIndex = -1;
-    int rootJointIndex = -1;
-    int leanJointIndex = -1;
-    int headJointIndex = -1;
-    int leftHandJointIndex = -1;
-    int rightHandJointIndex = -1;
-    int leftToeJointIndex = -1;
-    int rightToeJointIndex = -1;
-
     float leftEyeSize = 0.0f;  // Maximum mesh extents dimension
     float rightEyeSize = 0.0f;
 

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -270,11 +270,6 @@ public:
 
     glm::mat4 offset; // This includes offset, rotation, and scale as specified by the FST file
 
-    float leftEyeSize = 0.0f;  // Maximum mesh extents dimension
-    float rightEyeSize = 0.0f;
-
-    QVector<int> humanIKJointIndices;
-
     glm::vec3 palmDirection;
 
     glm::vec3 neckPivot;

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -137,7 +137,7 @@ void CauterizedModel::updateClusterMatrices() {
     // as an optimization, don't build cautrizedClusterMatrices if the boneSet is empty.
     if (!_cauterizeBoneSet.empty()) {
 
-        AnimPose cauterizePose = _rig.getJointPose(hfmModel.neckJointIndex);
+        AnimPose cauterizePose = _rig.getJointPose(_rig.indexOfJoint("Neck"));
         cauterizePose.scale() = glm::vec3(0.0001f, 0.0001f, 0.0001f);
 
         static const glm::mat4 zeroScale(
@@ -145,7 +145,7 @@ void CauterizedModel::updateClusterMatrices() {
             glm::vec4(0.0f, 0.0001f, 0.0f, 0.0f),
             glm::vec4(0.0f, 0.0f, 0.0001f, 0.0f),
             glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
-        auto cauterizeMatrix = _rig.getJointTransform(hfmModel.neckJointIndex) * zeroScale;
+        auto cauterizeMatrix = _rig.getJointTransform(_rig.indexOfJoint("Neck")) * zeroScale;
 
         for (int i = 0; i < _cauterizeMeshStates.size(); i++) {
             Model::MeshState& state = _cauterizeMeshStates[i];


### PR DESCRIPTION
This pr addresses:
https://highfidelity.manuscript.com/f/cases/20350/Camera-perspective-is-off-in-first-person-view
This fixes the problem where the eye joints were not being found for determining camera position in first person mode.

It also removes cruft code that used hfm members that redundantly kept the the indexes for essential joints of the skeleton. These included head, neck, eyes, hands, and toes indexes.

With the new joint mapping fields in the avatar fst files these essential joints will be mapped to hifi joint names and are no longer needed.

Test Plan
part 1
Avatar 1 Wear "Matthew" avatar
Avatar 2 walks in front of Matthew
Avatar 2 notices Matthews eyes do not follow Avatar 2
part 2
Wear Robimo avatar, available in store, in first person mode. Turnoff draw mesh and turn on debug draw default pose.
Use the mouse wheel to enter 3rd person and then re-enter 1st person. As you approach the back of the avatar head the camera should be at the level of the eyes. Not the neck.

Same PR as #14594 except for master branch