### PR TITLE
MS20352: Keep me logged in checkbox as on by default

### DIFF
--- a/interface/resources/qml/LoginDialog/LinkAccountBody.qml
+++ b/interface/resources/qml/LoginDialog/LinkAccountBody.qml
@@ -275,6 +275,9 @@ Item {
                         Settings.setValue("keepMeLoggedIn/savedUsername", "");
                     }
                 }
+                Component.onCompleted: {
+                    keepMeLoggedInCheckbox.checked = !Account.loggedIn;
+                }
             }
             HifiControlsUit.Button {
                 id: cancelButton

--- a/interface/resources/qml/LoginDialog/SignUpBody.qml
+++ b/interface/resources/qml/LoginDialog/SignUpBody.qml
@@ -320,6 +320,9 @@ Item {
                         Settings.setValue("keepMeLoggedIn/savedUsername", "");
                     }
                 }
+                Component.onCompleted: {
+                    keepMeLoggedInCheckbox.checked = !Account.loggedIn;
+                }
             }
 
             TextMetrics {


### PR DESCRIPTION
MS#[20352](https://highfidelity.manuscript.com/f/cases/20352/Keep-me-logged-in-checkbox-needs-to-set-ON-by-default-if-not-logged-in)

# TEST PLAN
- Launch Interface
- Whenever login screen loads, the "keep me logged in" checkbox will be on if the user is not logged in, regardless of what the user sets it to between sessions