### PR TITLE
Implement MS20089: ACs playing avatar recordings now correctly handle playAvatarSound

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -756,6 +756,11 @@ void Agent::processAgentAvatarAudio() {
         const int16_t* nextSoundOutput = NULL;
 
         if (_avatarSound) {
+            if (isPlayingRecording) {
+                recordingInterface->stopPlaying();
+                _recordingInterrupted = true;
+            }
+
             auto audioData = _avatarSound->getAudioData();
             nextSoundOutput = reinterpret_cast<const int16_t*>(audioData->rawData()
                     + _numAvatarSoundSentBytes);
@@ -781,6 +786,11 @@ void Agent::processAgentAvatarAudio() {
                 _avatarSound.clear();
                 _numAvatarSoundSentBytes = 0;
                 _flushEncoder = true;
+
+                if (_recordingInterrupted) {
+                    _recordingInterrupted = false;
+                    recordingInterface->startPlaying();
+                }
             }
         }
 

--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -428,6 +428,10 @@ void Agent::executeScript() {
         using namespace recording;
         static const FrameType AUDIO_FRAME_TYPE = Frame::registerFrameType(AudioConstants::getAudioFrameName());
         Frame::registerFrameHandler(AUDIO_FRAME_TYPE, [this, &scriptedAvatar](Frame::ConstPointer frame) {
+            if (_shouldMuteRecordingAudio) {
+                return;
+            }
+
             static quint16 audioSequenceNumber{ 0 };
 
             QByteArray audio(frame->data);
@@ -756,9 +760,8 @@ void Agent::processAgentAvatarAudio() {
         const int16_t* nextSoundOutput = NULL;
 
         if (_avatarSound) {
-            if (isPlayingRecording) {
-                recordingInterface->stopPlaying();
-                _recordingInterrupted = true;
+            if (isPlayingRecording && !_shouldMuteRecordingAudio) {
+                _shouldMuteRecordingAudio = true;
             }
 
             auto audioData = _avatarSound->getAudioData();
@@ -787,9 +790,8 @@ void Agent::processAgentAvatarAudio() {
                 _numAvatarSoundSentBytes = 0;
                 _flushEncoder = true;
 
-                if (_recordingInterrupted) {
-                    _recordingInterrupted = false;
-                    recordingInterface->startPlaying();
+                if (_shouldMuteRecordingAudio) {
+                    _shouldMuteRecordingAudio = false;
                 }
             }
         }

--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -107,6 +107,7 @@ private:
     ResourceRequest* _pendingScriptRequest { nullptr };
     bool _isListeningToAudioStream = false;
     SharedSoundPointer _avatarSound;
+    bool _shouldMuteRecordingAudio{ false };
     int _numAvatarSoundSentBytes = 0;
     bool _isAvatar = false;
     QTimer* _avatarIdentityTimer = nullptr;
@@ -122,8 +123,6 @@ private:
     Encoder* _encoder { nullptr };
     QTimer _avatarAudioTimer;
     bool _flushEncoder { false };
-
-    bool _recordingInterrupted { false };
 };
 
 #endif // hifi_Agent_h

--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -122,6 +122,8 @@ private:
     Encoder* _encoder { nullptr };
     QTimer _avatarAudioTimer;
     bool _flushEncoder { false };
+
+    bool _recordingInterrupted { false };
 };
 
 #endif // hifi_Agent_h

--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -107,7 +107,7 @@ private:
     ResourceRequest* _pendingScriptRequest { nullptr };
     bool _isListeningToAudioStream = false;
     SharedSoundPointer _avatarSound;
-    bool _shouldMuteRecordingAudio{ false };
+    bool _shouldMuteRecordingAudio { false };
     int _numAvatarSoundSentBytes = 0;
     bool _isAvatar = false;
     QTimer* _avatarIdentityTimer = nullptr;


### PR DESCRIPTION
Fixes [MS20089](https://highfidelity.fogbugz.com/f/cases/20089/make-agent-behave-appropriately-if-asked-to-playAvatarSound-while-already-playing-a-Recording).

The behavior here is now:

1. AC begins playback of a `.hfr` recording
2. AC is asked to play a new sound via `Agent.playAvatarSound()`
3. AC will continue visually playing back the avatar recording, but will play the audio from `playAvatarSound()` _instead of_ the audio from the recording.

I created a version of `playRecordingAC.js` that'll accept a specific message from a client, instructing it to play audio. [Here is that modified script](https://www.dropbox.com/s/ttkdikjx7tqvtc4/playRecordingAC_modified.js?dl=0) that you can use during QA testing.

Here's the script that you can run from the Interface Scripting Console to interrupt the recording:
```
var message = {};
var PLAY_AVATAR_SOUND_TEST_SCRIPT_CHANNEL = "com.highfidelity.playSoundTest";

message.soundURL = "https://hifi-content.s3.amazonaws.com/zfox/temp/song.wav";

Messages.sendMessage(PLAY_AVATAR_SOUND_TEST_SCRIPT_CHANNEL, JSON.stringify(message));
```