### PR TITLE
MS#20355: HMD persisting extra login windows

### DIFF
--- a/interface/src/ui/LoginDialog.cpp
+++ b/interface/src/ui/LoginDialog.cpp
@@ -95,7 +95,12 @@ void LoginDialog::toggleAction() {
     } else {
         // change the menu item to login
         loginAction->setText("Log In / Sign Up");
-        connection = connect(loginAction, &QAction::triggered, [] { LoginDialog::showWithSelection(); });
+        connection = connect(loginAction, &QAction::triggered, [] {
+            // if not in login state, show.
+            if (!qApp->getLoginDialogPoppedUp()) {
+                LoginDialog::showWithSelection();
+            }
+        });
     }
 }
 


### PR DESCRIPTION
MS#[20355](https://highfidelity.fogbugz.com/f/cases/20355/HMD-Persistent-extra-login-windows)

Pre-merge test plan:
Verify bug is fixed
1)  Start a HMD device Logged Out.
2)  On the Interface's PC toolbar choose File, then Login.
3)  An extra Login window will appear after every click of the Login menu option.

Post-merge test plan:
https://highfidelity.testrail.net/index.php?/cases/view/35634