### PR TITLE
Case 19080: Fix zone with invalid script not loading

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -205,42 +205,28 @@ private:
 
     class LayeredZones : public std::set<LayeredZone> {
     public:
-        LayeredZones(EntityTreeRenderer* parent) : _entityTreeRenderer(parent) {}
+        LayeredZones() {};
         LayeredZones(LayeredZones&& other);
 
         // avoid accidental misconstruction
-        LayeredZones() = delete;
         LayeredZones(const LayeredZones&) = delete;
         LayeredZones& operator=(const LayeredZones&) = delete;
         LayeredZones& operator=(LayeredZones&&) = delete;
 
         void clear();
         std::pair<iterator, bool> insert(const LayeredZone& layer);
-
-        void apply();
         void update(std::shared_ptr<ZoneEntityItem> zone);
-
         bool contains(const LayeredZones& other);
 
         std::shared_ptr<ZoneEntityItem> getZone() { return empty() ? nullptr : begin()->zone; }
 
     private:
-        void applyPartial(iterator layer);
-
         std::map<QUuid, iterator> _map;
-        iterator _skyboxLayer{ end() };
-        EntityTreeRenderer* _entityTreeRenderer;
+        iterator _skyboxLayer { end() };
     };
 
     LayeredZones _layeredZones;
-    QString _zoneUserData;
-    NetworkTexturePointer _ambientTexture;
-    NetworkTexturePointer _skyboxTexture;
-    QString _ambientTextureURL;
-    QString _skyboxTextureURL;
     float _avgRenderableUpdateCost { 0.0f };
-    bool _pendingAmbientTexture { false };
-    bool _pendingSkyboxTexture { false };
 
     uint64_t _lastZoneCheck { 0 };
     const uint64_t ZONE_CHECK_INTERVAL = USECS_PER_MSEC * 100; // ~10hz


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/19080/Adding-an-unrelated-script-to-a-zone-makes-the-skybox-disappear-for-user-who-added-the-script

Test plan:
- Perform these tests on master and this PR to confirm that you see the problem and that it is fixed.
- Create a Zone.  Set its Skybox Mode to "On" and give it a color.  That color should replace whatever other skybox is around where you are testing.
- Set the Zone's "Script" field to [this](https://gist.githubusercontent.com/SamGondelman/34da6d658b9ccaf939abd7261b6c54aa/raw/fcc384b556e050d47803477e156263969c04b25b/EntityScriptEventTest.js).  On master, the zone will flash but then come back.  With this PR, the zone won't change.
- Set the Zone's "Script" field to [this](https://gist.githubusercontent.com/SamGondelman/4908c42f33e627e0e741103b476185fd/raw/ace2cc04c8c1c17b4b64380b83826b4a57bca674/MouseEventTest.js).  On master, the zone would disappear.  With this PR, the zone won't change.
- Run the content/entity/zone tests: https://github.com/highfidelity/hifi_tests/tree/master/tests/content/entity/zone