### PR TITLE
MS20356: Running Scripts list doesn't persist between Interface restarts

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5250,8 +5250,8 @@ void Application::resumeAfterLoginDialogActionTaken() {
         auto scriptEngines = DependencyManager::get<ScriptEngines>().data();
         // this will force the model the look at the correct directory (weird order of operations issue)
         scriptEngines->reloadLocalFiles();
-
-        if (!_defaultScriptsLocation.exists()) {
+        // if the --scripts command-line argument was used.
+        if (!_defaultScriptsLocation.exists() && (arguments().indexOf(QString("--").append(SCRIPTS_SWITCH))) != -1) {
             scriptEngines->loadDefaultScripts();
             scriptEngines->defaultScriptsLocationOverridden(true);
         } else {


### PR DESCRIPTION
MS#[20356](https://highfidelity.manuscript.com/f/cases/20356/Running-Scripts-list-doesn-t-persist-between-Interface-restarts)

#TEST PLAN
- Launch interface
- open running scripts via `Edit > Running Scripts...`
- add some extra scripts into the running scripts
- relaunch interface
- open running scripts via `Edit > Running Scripts...`
- extra scripts should be running in the running scripts