### PR TITLE
MS20253: Only emit screenChanged once screen has changed

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletRoot.qml
+++ b/interface/resources/qml/hifi/tablet/TabletRoot.qml
@@ -15,6 +15,7 @@ Item {
     property var openBrowser: null;
     property string subMenu: ""
     signal showDesktop();
+    signal screenChanged(var type, var url);
     property bool shown: true
     property int currentApp: -1;
     property alias tabletApps: tabletApps
@@ -113,6 +114,8 @@ Item {
                 if (loader.item.hasOwnProperty("gotoPreviousApp")) {
                     loader.item.gotoPreviousApp = true;
                 }
+            
+                screenChanged("Web", url)
             });
         }
     }
@@ -266,6 +269,24 @@ Item {
 	            if (callback) {
 	            	callback();
 	            }
+
+                var type = "Unknown";
+                if (newSource === "") {
+                    type = "Closed";
+                } else if (newSource === "hifi/tablet/TabletMenu.qml") {
+                    type = "Menu";
+                } else if (newSource === "hifi/tablet/TabletHome.qml") {
+                    type = "Home";
+                } else if (newSource === "hifi/tablet/TabletWebView.qml") {
+                    // Handled in `callback()`
+                    return;
+                } else if (newSource.toLowerCase().indexOf(".qml") > -1) {
+                    type = "QML";
+                } else {
+                    console.log("newSource is of unknown type!");
+                }
+                
+                screenChanged(type, newSource);
 	        });
     	}
 	}

--- a/interface/resources/qml/hifi/tablet/WindowRoot.qml
+++ b/interface/resources/qml/hifi/tablet/WindowRoot.qml
@@ -20,6 +20,7 @@ Windows.ScrollingWindow {
     id: tabletRoot
     objectName: "tabletRoot"
     property string username: "Unknown user"
+    signal screenChanged(var type, var url);
 
     property var rootMenu;
     property string subMenu: ""
@@ -69,6 +70,8 @@ Windows.ScrollingWindow {
             if (loader.item.hasOwnProperty("closeButtonVisible")) {
                 loader.item.closeButtonVisible = false;
             }
+            
+            screenChanged("Web", url);
         });
     }
 
@@ -179,7 +182,25 @@ Windows.ScrollingWindow {
                 
                 if (callback) {
                     callback();
+                }                
+
+                var type = "Unknown";
+                if (newSource === "") {
+                    type = "Closed";
+                } else if (newSource === "hifi/tablet/TabletMenu.qml") {
+                    type = "Menu";
+                } else if (newSource === "hifi/tablet/TabletHome.qml") {
+                    type = "Home";
+                } else if (newSource === "hifi/tablet/TabletWebView.qml") {
+                    // Handled in `callback()`
+                    return;
+                } else if (newSource.toLowerCase().indexOf(".qml") > -1) {
+                    type = "QML";
+                } else {
+                    console.log("newSource is of unknown type!");
                 }
+                
+                screenChanged(type, newSource);
             });
         }
     }

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -377,6 +377,7 @@ void TabletProxy::setToolbarMode(bool toolbarMode) {
         QObject::connect(quickItem, SIGNAL(windowClosed()), this, SLOT(desktopWindowClosed()));
 
         QObject::connect(tabletRootWindow, SIGNAL(webEventReceived(QVariant)), this, SLOT(emitWebEvent(QVariant)), Qt::DirectConnection);
+        QObject::connect(quickItem, SIGNAL(screenChanged(QVariant, QVariant)), this, SIGNAL(screenChanged(QVariant, QVariant)), Qt::DirectConnection);
 
         // forward qml surface events to interface js
         connect(tabletRootWindow, &QmlWindowClass::fromQml, this, &TabletProxy::fromQml);
@@ -488,6 +489,7 @@ void TabletProxy::setQmlTabletRoot(OffscreenQmlSurface* qmlOffscreenSurface) {
     _qmlTabletRoot = qmlOffscreenSurface ? qmlOffscreenSurface->getRootItem() : nullptr;
     if (_qmlTabletRoot && _qmlOffscreenSurface) {
         QObject::connect(_qmlOffscreenSurface, SIGNAL(webEventReceived(QVariant)), this, SLOT(emitWebEvent(QVariant)));
+        QObject::connect(_qmlTabletRoot, SIGNAL(screenChanged(QVariant, QVariant)), this, SIGNAL(screenChanged(QVariant, QVariant)));
 
         // forward qml surface events to interface js
         connect(_qmlOffscreenSurface, &OffscreenQmlSurface::fromQml, [this](QVariant message) {
@@ -570,7 +572,6 @@ void TabletProxy::gotoMenuScreen(const QString& submenu) {
         QMetaObject::invokeMethod(root, "setMenuProperties", Q_ARG(QVariant, QVariant::fromValue(menu)), Q_ARG(const QVariant&, QVariant(submenu)));
         QMetaObject::invokeMethod(root, "loadSource", Q_ARG(const QVariant&, QVariant(VRMENU_SOURCE_URL)));
         _state = State::Menu;
-        emit screenChanged(QVariant("Menu"), QVariant(VRMENU_SOURCE_URL));
         _currentPathLoaded = VRMENU_SOURCE_URL;
         QMetaObject::invokeMethod(root, "setShown", Q_ARG(const QVariant&, QVariant(true)));
         if (_toolbarMode && _desktopWindow) {
@@ -640,9 +641,6 @@ void TabletProxy::loadQMLSource(const QVariant& path, bool resizable) {
     if (root) {
         QMetaObject::invokeMethod(root, "loadSource", Q_ARG(const QVariant&, path));
         _state = State::QML;
-        if (path != _currentPathLoaded) {
-            emit screenChanged(QVariant("QML"), path);
-        }
         _currentPathLoaded = path;
         QMetaObject::invokeMethod(root, "setShown", Q_ARG(const QVariant&, QVariant(true)));
         if (_toolbarMode && _desktopWindow) {
@@ -749,7 +747,6 @@ void TabletProxy::loadHomeScreen(bool forceOntoHomeScreen) {
             }
         }
         _state = State::Home;
-        emit screenChanged(QVariant("Home"), QVariant(TABLET_HOME_SOURCE_URL));
         _currentPathLoaded = TABLET_HOME_SOURCE_URL;
     }
 }
@@ -810,7 +807,6 @@ void TabletProxy::gotoWebScreen(const QString& url, const QString& injectedJavaS
             QMetaObject::invokeMethod(root, "setResizable", Q_ARG(const QVariant&, QVariant(false)));
         }
         _state = State::Web;
-        emit screenChanged(QVariant("Web"), QVariant(url));
         _currentPathLoaded = QVariant(url);
     } else {
         // tablet is not initialized yet, save information and load when


### PR DESCRIPTION
Implements [MS20253](https://highfidelity.manuscript.com/f/cases/edit/20253).

Testing this will involve performing a quick smoke test of all of the JS apps the tester can find, both in Desktop/Toolbar mode AND in VR/Tablet mode. Examples include:
1. All of the default apps
2. Spectator Camera
3. Finger Paint
4. Shapes