### PR TITLE
0.77 case 20304: please don't flood the avatar-mixer with unnecessary AvatarEntity udpates

### DIFF
--- a/interface/src/AvatarBookmarks.cpp
+++ b/interface/src/AvatarBookmarks.cpp
@@ -60,7 +60,6 @@ void addAvatarEntities(const QVariantList& avatarEntities) {
         entityProperties.setParentID(myNodeID);
         entityProperties.setEntityHostType(entity::HostType::AVATAR);
         entityProperties.setOwningAvatarID(myNodeID);
-        entityProperties.setSimulationOwner(myNodeID, AVATAR_ENTITY_SIMULATION_PRIORITY);
         entityProperties.markAllChanged();
 
         EntityItemID id = EntityItemID(QUuid::createUuid());

--- a/interface/src/ui/overlays/Base3DOverlay.cpp
+++ b/interface/src/ui/overlays/Base3DOverlay.cpp
@@ -27,6 +27,9 @@ Base3DOverlay::Base3DOverlay() :
     _drawInFront(false),
     _drawHUDLayer(false)
 {
+    // HACK: queryAACube stuff not actually relevant for 3DOverlays, and by setting _queryAACubeSet true here
+    // we can avoid incorrect evaluation for sending updates for entities with 3DOverlays children.
+    _queryAACubeSet = true;
 }
 
 Base3DOverlay::Base3DOverlay(const Base3DOverlay* base3DOverlay) :
@@ -41,6 +44,9 @@ Base3DOverlay::Base3DOverlay(const Base3DOverlay* base3DOverlay) :
     _isVisibleInSecondaryCamera(base3DOverlay->_isVisibleInSecondaryCamera)
 {
     setTransform(base3DOverlay->getTransform());
+    // HACK: queryAACube stuff not actually relevant for 3DOverlays, and by setting _queryAACubeSet true here
+    // we can avoid incorrect evaluation for sending updates for entities with 3DOverlays children.
+    _queryAACubeSet = true;
 }
 
 QVariantMap convertOverlayLocationFromScriptSemantics(const QVariantMap& properties, bool scalesWithParent) {
@@ -207,6 +213,7 @@ void Base3DOverlay::setProperties(const QVariantMap& originalProperties) {
             transaction.updateItem(itemID);
             scene->enqueueTransaction(transaction);
         }
+        _queryAACubeSet = true; // HACK: just in case some SpatiallyNestable code accidentally set it false
     }
 }
 

--- a/interface/src/ui/overlays/Base3DOverlay.h
+++ b/interface/src/ui/overlays/Base3DOverlay.h
@@ -25,6 +25,7 @@ public:
     Base3DOverlay(const Base3DOverlay* base3DOverlay);
 
     void setVisible(bool visible) override;
+    bool queryAACubeNeedsUpdate() const override { return false; } // HACK: queryAACube not relevant for Overlays
 
     virtual OverlayID getOverlayID() const override { return OverlayID(getID().toString()); }
     void setOverlayID(OverlayID overlayID) override { setID(overlayID); }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -392,10 +392,6 @@ void Avatar::updateAvatarEntities() {
             properties.setEntityHostType(entity::HostType::AVATAR);
             properties.setOwningAvatarID(getID());
 
-            // there's no entity-server to tell us we're the simulation owner, so always set the
-            // simulationOwner to the owningAvatarID and a high priority.
-            properties.setSimulationOwner(getID(), AVATAR_ENTITY_SIMULATION_PRIORITY);
-
             if (properties.getParentID() == AVATAR_SELF_ID) {
                 properties.setParentID(getID());
             }

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -2447,7 +2447,9 @@ bool EntityItem::shouldSuppressLocationEdits() const {
         }
         i++;
     }
-    return false;
+
+    // if any of the ancestors are MyAvatar, suppress
+    return isChildOfMyAvatar();
 }
 
 QList<EntityDynamicPointer> EntityItem::getActionsOfType(EntityDynamicType typeToGet) const {

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -2447,9 +2447,7 @@ bool EntityItem::shouldSuppressLocationEdits() const {
         }
         i++;
     }
-
-    // if any of the ancestors are MyAvatar, suppress
-    return isChildOfMyAvatar();
+    return false;
 }
 
 QList<EntityDynamicPointer> EntityItem::getActionsOfType(EntityDynamicType typeToGet) const {

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -281,7 +281,7 @@ public:
     DEFINE_PROPERTY(PROP_FILTER_URL, FilterURL, filterURL, QString, ZoneEntityItem::DEFAULT_FILTER_URL);
 
     DEFINE_PROPERTY_REF_ENUM(PROP_ENTITY_HOST_TYPE, EntityHostType, entityHostType, entity::HostType, entity::HostType::DOMAIN);
-    DEFINE_PROPERTY_REF(PROP_OWNING_AVATAR_ID, OwningAvatarID, owningAvatarID, QUuid, UNKNOWN_ENTITY_ID);
+    DEFINE_PROPERTY_REF_WITH_SETTER(PROP_OWNING_AVATAR_ID, OwningAvatarID, owningAvatarID, QUuid, UNKNOWN_ENTITY_ID);
 
     DEFINE_PROPERTY_REF(PROP_DPI, DPI, dpi, uint16_t, ENTITY_ITEM_DEFAULT_DPI);
 
@@ -450,6 +450,16 @@ void EntityPropertyFlagsFromScriptValue(const QScriptValue& object, EntityProper
 // define these inline here so the macros work
 inline void EntityItemProperties::setPosition(const glm::vec3& value)
                     { _position = glm::clamp(value, (float)-HALF_TREE_SCALE, (float)HALF_TREE_SCALE); _positionChanged = true; }
+
+inline void EntityItemProperties::setOwningAvatarID(const QUuid& id) {
+    _owningAvatarID = id;
+    if (!_owningAvatarID.isNull()) {
+        // for AvatarEntities there's no entity-server to tell us we're the simulation owner,
+        // so always set the simulationOwner to the owningAvatarID and a high priority.
+        setSimulationOwner(_owningAvatarID, AVATAR_ENTITY_SIMULATION_PRIORITY);
+    }
+    _owningAvatarIDChanged = true;
+}
 
 inline QDebug operator<<(QDebug debug, const EntityItemProperties& properties) {
     debug << "EntityItemProperties[" << "\n";

--- a/libraries/entities/src/SimulationOwner.h
+++ b/libraries/entities/src/SimulationOwner.h
@@ -96,7 +96,7 @@ const uint8_t RECRUIT_SIMULATION_PRIORITY = VOLUNTEER_SIMULATION_PRIORITY + 1;
 // When poking objects with scripts an observer will bid at SCRIPT_EDIT priority.
 const uint8_t SCRIPT_GRAB_SIMULATION_PRIORITY = 128;
 const uint8_t SCRIPT_POKE_SIMULATION_PRIORITY = SCRIPT_GRAB_SIMULATION_PRIORITY - 1;
-const uint8_t AVATAR_ENTITY_SIMULATION_PRIORITY = SCRIPT_GRAB_SIMULATION_PRIORITY + 1;
+const uint8_t AVATAR_ENTITY_SIMULATION_PRIORITY = 255;
 
 // PERSONAL priority (needs a better name) is the level at which a simulation observer owns its own avatar
 // which really just means: things that collide with it will be bid at a priority level one lower

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -307,6 +307,8 @@ const btCollisionShape* EntityMotionState::computeNewShape() {
     return getShapeManager()->getShape(shapeInfo);
 }
 
+const uint8_t MAX_NUM_INACTIVE_UPDATES = 20;
+
 bool EntityMotionState::remoteSimulationOutOfSync(uint32_t simulationStep) {
     // NOTE: this method is only ever called when the entity simulation is locally owned
     DETAILED_PROFILE_RANGE(simulation_physics, "CheckOutOfSync");
@@ -316,15 +318,10 @@ bool EntityMotionState::remoteSimulationOutOfSync(uint32_t simulationStep) {
     // TODO: need to be able to detect when logic dictates we *decrease* priority
     // WIP: print info whenever _bidPriority mismatches what is known to the entity
 
-    if (_entity->dynamicDataNeedsTransmit()) {
-        return true;
-    }
-
     int numSteps = simulationStep - _lastStep;
     float dt = (float)(numSteps) * PHYSICS_ENGINE_FIXED_SUBSTEP;
 
     if (_numInactiveUpdates > 0) {
-        const uint8_t MAX_NUM_INACTIVE_UPDATES = 20;
         if (_numInactiveUpdates > MAX_NUM_INACTIVE_UPDATES) {
             // clear local ownership (stop sending updates) and let the server clear itself
             _entity->clearSimulationOwnership();
@@ -441,7 +438,7 @@ bool EntityMotionState::shouldSendUpdate(uint32_t simulationStep) {
     if (_entity->shouldSuppressLocationEdits()) {
         // "shouldSuppressLocationEdits" really means: "the entity has a 'Hold' action therefore
         // we don't need send an update unless the entity is not contained by its queryAACube"
-        return !_entity->isChildOfMyAvatar() && _entity->queryAACubeNeedsUpdate();
+        return _entity->queryAACubeNeedsUpdate();
     }
 
     return remoteSimulationOutOfSync(simulationStep);
@@ -452,8 +449,13 @@ void EntityMotionState::updateSendVelocities() {
         if (!_body->isKinematicObject()) {
             clearObjectVelocities();
         }
-        // we pretend we sent the inactive update for this object
-        _numInactiveUpdates = 1;
+        if (_entity->getEntityHostType() == entity::HostType::AVATAR) {
+            // AvatarEntities only ever need to send one update (their updates are sent over a lossless protocol)
+            // so we set the count to the max to prevent resends
+            _numInactiveUpdates = MAX_NUM_INACTIVE_UPDATES;
+        } else {
+            ++_numInactiveUpdates;
+        }
     } else {
         glm::vec3 gravity = _entity->getGravity();
 

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -441,7 +441,7 @@ bool EntityMotionState::shouldSendUpdate(uint32_t simulationStep) {
     if (_entity->shouldSuppressLocationEdits()) {
         // "shouldSuppressLocationEdits" really means: "the entity has a 'Hold' action therefore
         // we don't need send an update unless the entity is not contained by its queryAACube"
-        return _entity->queryAACubeNeedsUpdate();
+        return !_entity->isChildOfMyAvatar() && _entity->queryAACubeNeedsUpdate();
     }
 
     return remoteSimulationOutOfSync(simulationStep);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20304/too-much-avatar-entity-data

In case we want it: this PR fixes case 20304 in 0.77.0

The problem was: sometimes when an AvatarEntity is created its simulation ownership is not properly assumed and the  ownership bid logic sends a bid... but gets no response (entity-server doesn't know about the entity) so it bids again... and again... at a rate of about 2Hz.

This bug is fixed for the master branch in the larger PR #14558.