### PR TITLE
MS20366: Restarting interface and skipping login causes user to appear in serverless

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2460,6 +2460,10 @@ void Application::updateHeartbeat() const {
 void Application::onAboutToQuit() {
     emit beforeAboutToQuit();
 
+    if (getLoginDialogPoppedUp() && _firstRun.get()) {
+        _firstRun.set(false);
+    }
+
     foreach(auto inputPlugin, PluginManager::getInstance()->getInputPlugins()) {
         if (inputPlugin->isActive()) {
             inputPlugin->deactivate();
@@ -5259,39 +5263,25 @@ void Application::resumeAfterLoginDialogActionTaken() {
         }
     }
 
-    if (_firstRun.get()) {
-        // not first run anymore since action was taken.
-        _firstRun.set(false);
-    }
-
     auto accountManager = DependencyManager::get<AccountManager>();
     auto addressManager = DependencyManager::get<AddressManager>();
 
     // restart domain handler.
     nodeList->getDomainHandler().resetting();
 
-    if (!accountManager->isLoggedIn()) {
+    QVariant testProperty = property(hifi::properties::TEST);
+    if (testProperty.isValid()) {
+        const auto testScript = property(hifi::properties::TEST).toUrl();
+        // Set last parameter to exit interface when the test script finishes, if so requested
+        DependencyManager::get<ScriptEngines>()->loadScript(testScript, false, false, false, false, quitWhenFinished);
+        // This is done so we don't get a "connection time-out" message when we haven't passed in a URL.
         if (arguments().contains("--url")) {
             auto reply = SandboxUtils::getStatus();
             connect(reply, &QNetworkReply::finished, this, [this, reply] { handleSandboxStatus(reply); });
-        } else {
-            addressManager->goToEntry();
         }
     } else {
-        QVariant testProperty = property(hifi::properties::TEST);
-        if (testProperty.isValid()) {
-            const auto testScript = property(hifi::properties::TEST).toUrl();
-            // Set last parameter to exit interface when the test script finishes, if so requested
-            DependencyManager::get<ScriptEngines>()->loadScript(testScript, false, false, false, false, quitWhenFinished);
-            // This is done so we don't get a "connection time-out" message when we haven't passed in a URL.
-            if (arguments().contains("--url")) {
-                auto reply = SandboxUtils::getStatus();
-                connect(reply, &QNetworkReply::finished, this, [this, reply] { handleSandboxStatus(reply); });
-            }
-        } else {
-            auto reply = SandboxUtils::getStatus();
-            connect(reply, &QNetworkReply::finished, this, [this, reply] { handleSandboxStatus(reply); });
-        }
+        auto reply = SandboxUtils::getStatus();
+        connect(reply, &QNetworkReply::finished, this, [this, reply] { handleSandboxStatus(reply); });
     }
 
     auto menu = Menu::getInstance();


### PR DESCRIPTION
MS#[20366](https://highfidelity.manuscript.com/f/cases/20366/Restarting-interface-and-skipping-login-causes-user-to-appear-in-serverless)

# TEST PLAN
- Launch Interface (with HMD attached)
- You should start in HMD mode
- Switch to desktop mode
- Dismiss login dialog
- You should be sent to serverless tutorial (check #1)
- Go to some domain in the `GOTO` app
- Relaunch interface
- You should launch in desktop mode (check #2)
- Dismiss login dialog
- You should be sent to your previously visited domain from the `GOTO` app in the last session (check #3)