### PR TITLE
Correctly set avatar-scale timestamp when changing in Avatar class

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -295,6 +295,7 @@ void Avatar::setTargetScale(float targetScale) {
     if (_targetScale != newValue) {
         _targetScale = newValue;
         _scaleChanged = usecTimestampNow();
+        _avatarScaleChanged = _scaleChanged;
         _isAnimatingScale = true;
 
         emit targetScaleChanged(targetScale);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20313/Scaling-issues-with-avatars

Only one of two (!) scale timestamps was being set in Avatar::setTargetScale().
