### PR TITLE
Update BUILD_LINUX.md to mention NodeJS requirement

### DIFF
--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -45,6 +45,8 @@ Install Python 3:
 sudo apt-get install python3.6
 ```
 
+Install NodeJS from https://nodejs.org/en/
+
 
 ### Get code and checkout the tag you need
 


### PR DESCRIPTION
Was getting this error because I didn't have NodeJS installed.

[100%] Linking CXX executable interface
Error copying directory from "/home/xxx/hifi/tools/jsdoc/out" to "/home/xxx/hifi/build/interface/jsdoc".
interface/CMakeFiles/interface.dir/build.make:3344: recipe for target 'interface/interface' failed

Ubuntu 16.04, cmake v3.13.2