### PR TITLE
ACs don't need to call into flagtimeForConnecitonStep

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1078,6 +1078,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
     auto nodeList = DependencyManager::get<NodeList>();
     nodeList->startThread();
+    nodeList->setFlagTimeForConnectionStep(true);
 
     // move the AddressManager to the NodeList thread so that domain resets due to domain changes always occur
     // before we tell MyAvatar to go to a new location in the new domain

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -300,10 +300,10 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
             } else {
                 HIFI_FCDEBUG(networking(), "Replicated packet of type" << headerType
                     << "received from unknown upstream" << packet.getSenderSockAddr());
-                
+
                 return false;
             }
-            
+
         } else {
             emit dataReceived(NodeType::Unassigned, packet.getPayloadSize());
             return true;
@@ -319,7 +319,7 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
             SharedNodePointer matchingNode = nodeWithLocalID(sourceLocalID);
             sourceNode = matchingNode.data();
         }
-        
+
         QUuid sourceID = sourceNode ? sourceNode->getUUID() : QUuid();
 
         if (!sourceNode &&
@@ -1261,6 +1261,10 @@ void LimitedNodeList::flagTimeForConnectionStep(ConnectionStep connectionStep) {
 }
 
 void LimitedNodeList::flagTimeForConnectionStep(ConnectionStep connectionStep, quint64 timestamp) {
+    if (!_flagTimeForConnectionStep) {
+        // this is only true in interface
+        return;
+    }
     if (connectionStep == ConnectionStep::LookupAddress) {
         QWriteLocker writeLock(&_connectionTimeLock);
 

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -122,7 +122,7 @@ public:
     bool getThisNodeCanWriteAssets() const { return _permissions.can(NodePermissions::Permission::canWriteToAssetServer); }
     bool getThisNodeCanKick() const { return _permissions.can(NodePermissions::Permission::canKick); }
     bool getThisNodeCanReplaceContent() const { return _permissions.can(NodePermissions::Permission::canReplaceDomainContent); }
-    
+
     quint16 getSocketLocalPort() const { return _nodeSocket.localPort(); }
     Q_INVOKABLE void setSocketLocalPort(quint16 socketLocalPort);
 
@@ -204,9 +204,9 @@ public:
     //   This allows multiple threads (i.e. a thread pool) to share a lock
     //   without deadlocking when a dying node attempts to acquire a write lock
     template<typename NestedNodeLambda>
-    void nestedEach(NestedNodeLambda functor, 
-                    int* lockWaitOut = nullptr, 
-                    int* nodeTransformOut = nullptr, 
+    void nestedEach(NestedNodeLambda functor,
+                    int* lockWaitOut = nullptr,
+                    int* nodeTransformOut = nullptr,
                     int* functorOut = nullptr) {
         auto start = usecTimestampNow();
         {
@@ -309,6 +309,9 @@ public:
     bool isPacketVerified(const udt::Packet& packet) { return isPacketVerifiedWithSource(packet); }
     void setAuthenticatePackets(bool useAuthentication) { _useAuthentication = useAuthentication; }
     bool getAuthenticatePackets() const { return _useAuthentication; }
+
+    void setFlagTimeForConnectionStep(bool flag) { _flagTimeForConnectionStep = flag; }
+    bool isFlagTimeForConnectionStep() { return _flagTimeForConnectionStep; }
 
     static void makeSTUNRequestPacket(char* stunRequestPacket);
 
@@ -440,6 +443,7 @@ private:
     using LocalIDMapping = tbb::concurrent_unordered_map<Node::LocalID, SharedNodePointer>;
     LocalIDMapping _localIDMap;
     Node::LocalID _sessionLocalID { 0 };
+    bool _flagTimeForConnectionStep { false }; // only keep track in interface
 };
 
 #endif // hifi_LimitedNodeList_h


### PR DESCRIPTION
Since we never reset those times,  the list grows and grows and is never used.  Essentially a memory leak.  Easy enough to only record these in interface.