### PR TITLE
Make the Out of Range Strategy drop down wider

### DIFF
--- a/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
+++ b/interface/resources/qml/hifi/tablet/OpenVrConfiguration.qml
@@ -869,7 +869,7 @@ Flickable {
                     id: outOfRangeDataStrategyComboBox
 
                     height: 25
-                    width: 100
+                    width: 150
 
                     editable: true
                     colorScheme: hifi.colorSchemes.dark


### PR DESCRIPTION
So the "DropAfterDelay" item is not cut off on the Settings > Controlls > Calibration screen.

https://highfidelity.manuscript.com/f/cases/20214/Drop-down-menu-for-DropAfterDelay-functionality-is-cut-off