### PR TITLE
Update eye look at interest calculation

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1562,7 +1562,12 @@ static float lookAtCostFunction(const glm::vec3& myForward, const glm::vec3& myP
 
 void MyAvatar::computeMyLookAtTarget(const AvatarHash& hash) {
     glm::vec3 myForward = getHead()->getFinalOrientationInWorldFrame() * IDENTITY_FORWARD;
-    glm::vec3 myPosition = qApp->getCamera().getPosition();
+    glm::vec3 myPosition = getHead()->getEyePosition();
+    CameraMode mode = qApp->getCamera().getMode();
+    if (mode == CAMERA_MODE_FIRST_PERSON) {
+        myPosition = qApp->getCamera().getPosition();
+    }
+
     float bestCost = FLT_MAX;
     std::shared_ptr<Avatar> bestAvatar;
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -832,6 +832,8 @@ public:
 
     AvatarWeakPointer getLookAtTargetAvatar() const { return _lookAtTargetAvatar; }
     void updateLookAtTargetAvatar();
+    void computeMyLookAtTarget(const AvatarHash& hash);
+    void snapOtherAvatarLookAtTargetsToMe(const AvatarHash& hash);
     void clearLookAtTargetAvatar();
 
     virtual void setJointRotations(const QVector<glm::quat>& jointRotations) override;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -156,9 +156,6 @@ public:
 
     virtual void postUpdate(float deltaTime, const render::ScenePointer& scene);
 
-    //setters
-    void setIsLookAtTarget(const bool isLookAtTarget) { _isLookAtTarget = isLookAtTarget; }
-    bool getIsLookAtTarget() const { return _isLookAtTarget; }
     //getters
     bool isInitialized() const { return _initialized; }
     SkeletonModelPointer getSkeletonModel() { return _skeletonModel; }
@@ -592,7 +589,6 @@ protected:
     int _rightPointerGeometryID { 0 };
     int _nameRectGeometryID { 0 };
     bool _initialized { false };
-    bool _isLookAtTarget { false };
     bool _isAnimatingScale { false };
     bool _mustFadeIn { false };
     bool _isFading { false };


### PR DESCRIPTION
This now takes distance, your facing toward other avatars, and their facing toward you into the interest calculation.

Also, separate the logic for myAvatar look at from other avatars snapping their gaze toward myAvatar.
Previously these two separate elements where merged together in a single loop.

https://highfidelity.manuscript.com/f/cases/19728/Improve-Avatar-Eye-Look-At-Calculation