### PR TITLE
Fix the distance attenuation of stereo local injectors

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1333,8 +1333,12 @@ bool AudioClient::mixLocalAudioInjectors(float* mixBuffer) {
 
                 } else if (injector->isStereo()) {
 
+                    // calculate distance, gain
+                    glm::vec3 relativePosition = injector->getPosition() - _positionGetter();
+                    float distance = glm::max(glm::length(relativePosition), EPSILON);
+                    float gain = gainForSource(distance, injector->getVolume());
+
                     // stereo gets directly mixed into mixBuffer
-                    float gain = injector->getVolume();
                     for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_STEREO; i++) {
                         mixBuffer[i] += convertToFloat(_localScratchBuffer[i]) * gain;
                     }


### PR DESCRIPTION
When rendering a "head locked" stereo injector, the audio-mixer always applies distance attenuation but the client fast-path for a stereo local injector does not. This PR adds the missing distance attenuation.

https://highfidelity.manuscript.com/f/cases/20493/Local-stereo-injectors-lack-distance-attenuation