### PR TITLE
omit unknown device names from clear-story data

### DIFF
--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -150,7 +150,7 @@ void UserActivityLogger::connectedDevice(QString typeOfDevice, QString deviceNam
     QJsonObject actionDetails;
     const QString TYPE_OF_DEVICE = "type_of_device";
     const QString DEVICE_NAME = "device_name";
-    qDebug() << "UserActivityLogger::connectedDevice -> type: " << typeOfDevice << " - deviceName: " << deviceName;
+
     actionDetails.insert(TYPE_OF_DEVICE, typeOfDevice);
     actionDetails.insert(DEVICE_NAME, deviceName);
 

--- a/libraries/networking/src/UserActivityLogger.cpp
+++ b/libraries/networking/src/UserActivityLogger.cpp
@@ -139,11 +139,10 @@ void UserActivityLogger::connectedDevice(QString typeOfDevice, QString deviceNam
         "NullDisplayPlugin",
         "3D TV - Side by Side Stereo",
         "3D TV - Interleaved",
-
         "Keyboard/Mouse"
     };
 
-    if (DEVICE_BLACKLIST.contains(deviceName)) {
+    if (DEVICE_BLACKLIST.contains(deviceName) || deviceName.isEmpty()) {
         return;
     }
 
@@ -151,7 +150,7 @@ void UserActivityLogger::connectedDevice(QString typeOfDevice, QString deviceNam
     QJsonObject actionDetails;
     const QString TYPE_OF_DEVICE = "type_of_device";
     const QString DEVICE_NAME = "device_name";
-
+    qDebug() << "UserActivityLogger::connectedDevice -> type: " << typeOfDevice << " - deviceName: " << deviceName;
     actionDetails.insert(TYPE_OF_DEVICE, typeOfDevice);
     actionDetails.insert(DEVICE_NAME, deviceName);
 


### PR DESCRIPTION
This makes sure that device names that are empty string are not sent to our data base. The only way the a device name would be empty is if the user is using steamvr but does not have their headset connected. So when our system callls `getOpenVrDeviceName()` it gets a null pointer from `acquireOpenVrSystem` which in that case we just return an empty string.

Ticket - https://highfidelity.manuscript.com/f/cases/16539/A-large-percentage-of-our-HMD-headsets-are-showing-up-as-NA