### PR TITLE
Only keep aggregated thread stats for Avatar Mixer

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -746,65 +746,27 @@ void AvatarMixer::sendStatsPacket() {
 
 
     AvatarMixerSlaveStats aggregateStats;
-    QJsonObject slavesObject;
 
-    float secondsSinceLastStats = (float)(start - _lastStatsTime) / (float)USECS_PER_SECOND;
     // gather stats
-    int slaveNumber = 1;
     _slavePool.each([&](AvatarMixerSlave& slave) {
-        QJsonObject slaveObject;
         AvatarMixerSlaveStats stats;
         slave.harvestStats(stats);
-        slaveObject["recevied_1_nodesProcessed"] = TIGHT_LOOP_STAT(stats.nodesProcessed);
-        slaveObject["received_2_numPacketsReceived"] = TIGHT_LOOP_STAT(stats.packetsProcessed);
-
-        slaveObject["sent_1_nodesBroadcastedTo"] = TIGHT_LOOP_STAT(stats.nodesBroadcastedTo);
-        slaveObject["sent_2_numBytesSent"] = TIGHT_LOOP_STAT(stats.numBytesSent);
-        slaveObject["sent_3_numPacketsSent"] = TIGHT_LOOP_STAT(stats.numPacketsSent);
-        slaveObject["sent_4_numIdentityPackets"] = TIGHT_LOOP_STAT(stats.numIdentityPackets);
-
-        float averageNodes = ((float)stats.nodesBroadcastedTo / (float)tightLoopFrames);
-        float averageOutboundAvatarKbps = averageNodes ? ((stats.numBytesSent / secondsSinceLastStats) / BYTES_PER_KILOBIT) / averageNodes : 0.0f;
-        slaveObject["sent_5_averageOutboundAvatarKbps"] = averageOutboundAvatarKbps;
-
-        float averageOthersIncluded = averageNodes ? stats.numOthersIncluded / averageNodes : 0.0f;
-        slaveObject["sent_6_averageOthersIncluded"] = TIGHT_LOOP_STAT(averageOthersIncluded);
-
-        float averageOverBudgetAvatars = averageNodes ? stats.overBudgetAvatars / averageNodes : 0.0f;
-        slaveObject["sent_7_averageOverBudgetAvatars"] = TIGHT_LOOP_STAT(averageOverBudgetAvatars);
-
-        slaveObject["timing_1_processIncomingPackets"] = TIGHT_LOOP_STAT_UINT64(stats.processIncomingPacketsElapsedTime);
-        slaveObject["timing_2_ignoreCalculation"] = TIGHT_LOOP_STAT_UINT64(stats.ignoreCalculationElapsedTime);
-        slaveObject["timing_3_toByteArray"] = TIGHT_LOOP_STAT_UINT64(stats.toByteArrayElapsedTime);
-        slaveObject["timing_4_avatarDataPacking"] = TIGHT_LOOP_STAT_UINT64(stats.avatarDataPackingElapsedTime);
-        slaveObject["timing_5_packetSending"] = TIGHT_LOOP_STAT_UINT64(stats.packetSendingElapsedTime);
-        slaveObject["timing_6_jobElapsedTime"] = TIGHT_LOOP_STAT_UINT64(stats.jobElapsedTime);
-
-        slavesObject[QString::number(slaveNumber)] = slaveObject;
-        slaveNumber++;
-
         aggregateStats += stats;
     });
 
     QJsonObject slavesAggregatObject;
 
-    slavesAggregatObject["recevied_1_nodesProcessed"] = TIGHT_LOOP_STAT(aggregateStats.nodesProcessed);
-    slavesAggregatObject["received_2_numPacketsReceived"] = TIGHT_LOOP_STAT(aggregateStats.packetsProcessed);
+    slavesAggregatObject["received_1_nodesProcessed"] = TIGHT_LOOP_STAT(aggregateStats.nodesProcessed);
 
     slavesAggregatObject["sent_1_nodesBroadcastedTo"] = TIGHT_LOOP_STAT(aggregateStats.nodesBroadcastedTo);
-    slavesAggregatObject["sent_2_numBytesSent"] = TIGHT_LOOP_STAT(aggregateStats.numBytesSent);
-    slavesAggregatObject["sent_3_numPacketsSent"] = TIGHT_LOOP_STAT(aggregateStats.numPacketsSent);
-    slavesAggregatObject["sent_4_numIdentityPackets"] = TIGHT_LOOP_STAT(aggregateStats.numIdentityPackets);
 
     float averageNodes = ((float)aggregateStats.nodesBroadcastedTo / (float)tightLoopFrames);
-    float averageOutboundAvatarKbps = averageNodes ? ((aggregateStats.numBytesSent / secondsSinceLastStats) / BYTES_PER_KILOBIT) / averageNodes : 0.0f;
-    slavesAggregatObject["sent_5_averageOutboundAvatarKbps"] = averageOutboundAvatarKbps;
 
     float averageOthersIncluded = averageNodes ? aggregateStats.numOthersIncluded / averageNodes : 0.0f;
-    slavesAggregatObject["sent_6_averageOthersIncluded"] = TIGHT_LOOP_STAT(averageOthersIncluded);
+    slavesAggregatObject["sent_2_averageOthersIncluded"] = TIGHT_LOOP_STAT(averageOthersIncluded);
 
     float averageOverBudgetAvatars = averageNodes ? aggregateStats.overBudgetAvatars / averageNodes : 0.0f;
-    slavesAggregatObject["sent_7_averageOverBudgetAvatars"] = TIGHT_LOOP_STAT(averageOverBudgetAvatars);
+    slavesAggregatObject["sent_3_averageOverBudgetAvatars"] = TIGHT_LOOP_STAT(averageOverBudgetAvatars);
 
     slavesAggregatObject["timing_1_processIncomingPackets"] = TIGHT_LOOP_STAT_UINT64(aggregateStats.processIncomingPacketsElapsedTime);
     slavesAggregatObject["timing_2_ignoreCalculation"] = TIGHT_LOOP_STAT_UINT64(aggregateStats.ignoreCalculationElapsedTime);
@@ -814,7 +776,6 @@ void AvatarMixer::sendStatsPacket() {
     slavesAggregatObject["timing_6_jobElapsedTime"] = TIGHT_LOOP_STAT_UINT64(aggregateStats.jobElapsedTime);
 
     statsObject["slaves_aggregate"] = slavesAggregatObject;
-    statsObject["slaves_individual"] = slavesObject;
 
     _handleViewFrustumPacketElapsedTime = 0;
     _handleAvatarIdentityPacketElapsedTime = 0;

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -183,9 +183,6 @@ public:
     unsigned int broadcastToNodes(std::unique_ptr<NLPacket> packet, const NodeSet& destinationNodeTypes);
     SharedNodePointer soloNodeOfType(NodeType_t nodeType);
 
-    void getPacketStats(float& packetsInPerSecond, float& bytesInPerSecond, float& packetsOutPerSecond, float& bytesOutPerSecond);
-    void resetPacketStats();
-
     std::unique_ptr<NLPacket> constructPingPacket(const QUuid& nodeId, PingType_t pingType = PingType::Agnostic);
     std::unique_ptr<NLPacket> constructPingReplyPacket(ReceivedMessage& message);
 
@@ -377,7 +374,6 @@ protected:
 
     qint64 sendPacket(std::unique_ptr<NLPacket> packet, const Node& destinationNode,
                       const HifiSockAddr& overridenSockAddr);
-    void collectPacketStats(const NLPacket& packet);
     void fillPacketHeader(const NLPacket& packet, HMACAuth* hmacAuth = nullptr);
 
     void setLocalSocket(const HifiSockAddr& sockAddr);
@@ -406,10 +402,6 @@ protected:
 
     PacketReceiver* _packetReceiver;
 
-    std::atomic<int> _numCollectedPackets { 0 };
-    std::atomic<int> _numCollectedBytes { 0 };
-
-    QElapsedTimer _packetStatTimer;
     NodePermissions _permissions;
 
     QPointer<QTimer> _initialSTUNTimer;

--- a/libraries/networking/src/PacketReceiver.cpp
+++ b/libraries/networking/src/PacketReceiver.cpp
@@ -212,17 +212,11 @@ void PacketReceiver::handleVerifiedPacket(std::unique_ptr<udt::Packet> packet) {
     auto nlPacket = NLPacket::fromBase(std::move(packet));
     auto receivedMessage = QSharedPointer<ReceivedMessage>::create(*nlPacket);
 
-    _inPacketCount += 1;
-    _inByteCount += nlPacket->size();
-
     handleVerifiedMessage(receivedMessage, true);
 }
 
 void PacketReceiver::handleVerifiedMessagePacket(std::unique_ptr<udt::Packet> packet) {
     auto nlPacket = NLPacket::fromBase(std::move(packet));
-
-    _inPacketCount += 1;
-    _inByteCount += nlPacket->size();
 
     auto key = std::pair<HifiSockAddr, udt::Packet::MessageNumber>(nlPacket->getSenderSockAddr(), nlPacket->getMessageNumber());
     auto it = _pendingMessages.find(key);

--- a/libraries/networking/src/PacketReceiver.h
+++ b/libraries/networking/src/PacketReceiver.h
@@ -49,13 +49,8 @@ public:
     PacketReceiver(const PacketReceiver&) = delete;
 
     PacketReceiver& operator=(const PacketReceiver&) = delete;
-    
-    int getInPacketCount() const { return _inPacketCount; }
-    int getInByteCount() const { return _inByteCount; }
 
     void setShouldDropPackets(bool shouldDropPackets) { _shouldDropPackets = shouldDropPackets; }
-    
-    void resetCounters() { _inPacketCount = 0; _inByteCount = 0; }
 
     // If deliverPending is false, ReceivedMessage will only be delivered once all packets for the message have
     // been received. If deliverPending is true, ReceivedMessage will be delivered as soon as the first packet
@@ -87,8 +82,7 @@ private:
 
     QMutex _packetListenerLock;
     QHash<PacketType, Listener> _messageListenerMap;
-    int _inPacketCount = 0;
-    int _inByteCount = 0;
+
     bool _shouldDropPackets = false;
     QMutex _directConnectSetMutex;
     QSet<QObject*> _directlyConnectedObjects;

--- a/libraries/networking/src/ThreadedAssignment.cpp
+++ b/libraries/networking/src/ThreadedAssignment.cpp
@@ -94,15 +94,11 @@ void ThreadedAssignment::commonInit(const QString& targetName, NodeType_t nodeTy
 void ThreadedAssignment::addPacketStatsAndSendStatsPacket(QJsonObject statsObject) {
     auto nodeList = DependencyManager::get<NodeList>();
 
-    float packetsInPerSecond, bytesInPerSecond, packetsOutPerSecond, bytesOutPerSecond;
-    nodeList->getPacketStats(packetsInPerSecond, bytesInPerSecond, packetsOutPerSecond, bytesOutPerSecond);
-    nodeList->resetPacketStats();
-
     QJsonObject ioStats;
-    ioStats["inbound_bytes_per_s"] = bytesInPerSecond;
-    ioStats["inbound_packets_per_s"] = packetsInPerSecond;
-    ioStats["outbound_bytes_per_s"] = bytesOutPerSecond;
-    ioStats["outbound_packets_per_s"] = packetsOutPerSecond;
+    ioStats["inbound_kbps"] = nodeList->getInboundKbps();
+    ioStats["inbound_pps"] = nodeList->getInboundPPS();
+    ioStats["outbound_kbps"] = nodeList->getOutboundKbps();
+    ioStats["outbound_pps"] = nodeList->getOutboundPPS();
 
     statsObject["io_stats"] = ioStats;
 


### PR DESCRIPTION
Trims down some avatar mixer stats and fixes the values for the inbound/outbound traffic all nodes send to the DS.

[Manuscript ticket](https://highfidelity.fogbugz.com/f/cases/20163/Avatar-mixer-stats-page-should-include-identity-traits-bytes)