### PR TITLE
Apply master volume to audio streams when solo is active

### DIFF
--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -504,7 +504,7 @@ void AudioMixerSlave::addStream(AudioMixerClientData::MixableStream& mixableStre
     float distance = glm::max(glm::length(relativePosition), EPSILON);
     float azimuth = isEcho ? 0.0f : computeAzimuth(listeningNodeStream, listeningNodeStream, relativePosition);
 
-    float gain = 1.0f;
+    float gain = masterListenerGain;
     if (!isSoloing) {
         gain = computeGain(masterListenerGain, listeningNodeStream, *streamToAdd, relativePosition, distance, isEcho);
     }


### PR DESCRIPTION
This PR causes master volume to affect audio streams when "solo" mode is active. 
The desired behavior is that distance-attenuation is disabled, but individual and master gains from PAL are still applied.

https://highfidelity.manuscript.com/f/cases/20556/Apply-master-volume-to-audio-streams-when-solo-is-active