### PR TITLE
Case 20534: Fix light crash

### DIFF
--- a/libraries/render-utils/src/RenderShadowTask.h
+++ b/libraries/render-utils/src/RenderShadowTask.h
@@ -104,7 +104,7 @@ signals:
 class RenderShadowSetup {
 public:
     using Input = RenderShadowTask::Input;
-    using Output = render::VaryingSet4<RenderArgs::RenderMode, glm::ivec2, ViewFrustumPointer, LightStage::ShadowFramePointer>;
+    using Output = render::VaryingSet5<RenderArgs::RenderMode, glm::ivec2, ViewFrustumPointer, LightStage::ShadowFramePointer, graphics::LightPointer>;
     using Config = RenderShadowSetupConfig;
     using JobModel = render::Job::ModelIO<RenderShadowSetup, Input, Output, Config>;
 
@@ -161,7 +161,7 @@ public:
 
 class CullShadowBounds {
 public:
-    using Inputs = render::VaryingSet5<render::ShapeBounds, render::ItemFilter, ViewFrustumPointer, LightStage::FramePointer, RenderShadowTask::CullFunctor>;
+    using Inputs = render::VaryingSet5<render::ShapeBounds, render::ItemFilter, ViewFrustumPointer, graphics::LightPointer, RenderShadowTask::CullFunctor>;
     using Outputs = render::VaryingSet2<render::ShapeBounds, AABox>;
     using JobModel = render::Job::ModelIO<CullShadowBounds, Inputs, Outputs>;
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20534/Backtrace-graphics-Light-getDirection-272d78230b31e2f51d7ec2f848114e10c2dabe0bdfd43f57d7239f7984c5f678-58-Crashes-in-8-days

Test plan:
- Make sure shadows and the keylight in a zone still work.
- I don't know what causes this crash.  It sounds like it could be related to switching between two domains via GOTO.  The best plan might be to merge this and then confirm that the crash stops appearing in backtrace in 78.
