### PR TITLE
Fix ASAN warning due to mixed signed/unsigned arithmetic

### DIFF
--- a/libraries/audio/src/AudioFOA.cpp
+++ b/libraries/audio/src/AudioFOA.cpp
@@ -695,7 +695,7 @@ static void ifft_radix8_first(complex_t* x, complex_t* y, int n, int p) {
 // n >= 4
 static void rfft_post(complex_t* x, const complex_t* w, int n) {
 
-    size_t t = n/4;
+    int t = n/4;
     assert(t >= 1);
 
     // NOTE: x[n/2].re is packed into x[0].im
@@ -707,7 +707,7 @@ static void rfft_post(complex_t* x, const complex_t* w, int n) {
     complex_t* xp0 = &x[1];
     complex_t* xp1 = &x[n/2 - 1];
 
-    for (size_t i = 0; i < t; i++) {
+    for (int i = 0; i < t; i++) {
 
         float ar = xp0[i].re;
         float ai = xp0[i].im;
@@ -743,7 +743,7 @@ static void rfft_post(complex_t* x, const complex_t* w, int n) {
 // n >= 4
 static void rifft_pre(complex_t* x, const complex_t* w, int n) {
 
-    size_t t = n/4;
+    int t = n/4;
     assert(t >= 1);
 
     // NOTE: x[n/2].re is packed into x[0].im
@@ -755,7 +755,7 @@ static void rifft_pre(complex_t* x, const complex_t* w, int n) {
     complex_t* xp0 = &x[1];
     complex_t* xp1 = &x[n/2 - 1];
 
-    for (size_t i = 0; i < t; i++) {
+    for (int i = 0; i < t; i++) {
 
         float ar = xp0[i].re;
         float ai = xp0[i].im;

--- a/libraries/audio/src/avx2/AudioFOA_avx2.cpp
+++ b/libraries/audio/src/avx2/AudioFOA_avx2.cpp
@@ -973,8 +973,8 @@ FORCEINLINE static void ifft_radix8_first(complex_t* x, complex_t* y, int n, int
 // n >= 32
 static void rfft_post(complex_t* x, const complex_t* w, int n) {
 
-    size_t t = n/4;
-    assert(n/4 >= 8);   // SIMD8
+    int t = n/4;
+    assert(t >= 8); // SIMD8
 
     // NOTE: x[n/2].re is packed into x[0].im
     float tr = x[0].re;
@@ -985,7 +985,7 @@ static void rfft_post(complex_t* x, const complex_t* w, int n) {
     complex_t* xp0 = &x[1];
     complex_t* xp1 = &x[n/2 - 8];
 
-    for (size_t i = 0; i < t; i += 8) {
+    for (int i = 0; i < t; i += 8) {
 
         __m256 z0 = _mm256_loadu_ps(&xp0[i+0].re);
         __m256 z1 = _mm256_loadu_ps(&xp0[i+4].re);
@@ -1033,8 +1033,8 @@ static void rfft_post(complex_t* x, const complex_t* w, int n) {
 // n >= 32
 static void rifft_pre(complex_t* x, const complex_t* w, int n) {
 
-    size_t t = n/4;
-    assert(n/4 >= 8);   // SIMD8
+    int t = n/4;
+    assert(t >= 8); // SIMD8
 
     // NOTE: x[n/2].re is packed into x[0].im
     float tr = x[0].re;
@@ -1045,7 +1045,7 @@ static void rifft_pre(complex_t* x, const complex_t* w, int n) {
     complex_t* xp0 = &x[1];
     complex_t* xp1 = &x[n/2 - 8];
 
-    for (size_t i = 0; i < t; i += 8) {
+    for (int i = 0; i < t; i += 8) {
 
         __m256 z0 = _mm256_loadu_ps(&xp0[i+0].re);
         __m256 z1 = _mm256_loadu_ps(&xp0[i+4].re);


### PR DESCRIPTION
Fix harmless ASAN warning when a negative index is computed from size_t.
No functional change.

https://highfidelity.manuscript.com/f/cases/20561/asan-AudioFOA-warning
