### PR TITLE
Plugin versioning

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -724,6 +724,8 @@ const QString TEST_RESULTS_LOCATION_COMMAND{ "--testResultsLocation" };
 bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     const char** constArgv = const_cast<const char**>(argv);
 
+    qInstallMessageHandler(messageHandler);
+
     // HRS: I could not figure out how to move these any earlier in startup, so when using this option, be sure to also supply
     // --allowMultipleInstances
     auto reportAndQuit = [&](const char* commandSwitch, std::function<void(FILE* fp)> report) {
@@ -974,6 +976,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     QApplication(argc, argv),
     _window(new MainWindow(desktop())),
     _sessionRunTimer(startupTimer),
+    _logger(new FileLogger(this)),
     _previousSessionCrashed(setupEssentials(argc, argv, runningMarkerExisted)),
     _entitySimulation(new PhysicalEntitySimulation()),
     _physicsEngine(new PhysicsEngine(Vectors::ZERO)),
@@ -1062,9 +1065,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 #ifdef Q_OS_WIN
     installNativeEventFilter(&MyNativeEventFilter::getInstance());
 #endif
-
-    _logger = new FileLogger(this);
-    qInstallMessageHandler(messageHandler);
 
     QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "styles/Inconsolata.otf");
     QFontDatabase::addApplicationFont(PathUtils::resourcesPath() + "fonts/fontawesome-webfont.ttf");

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -594,7 +594,7 @@ private:
 
     bool _aboutToQuit { false };
 
-    FileLogger* _logger;
+    FileLogger* _logger { nullptr };
 
     bool _previousSessionCrashed;
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -594,6 +594,8 @@ private:
 
     bool _aboutToQuit { false };
 
+    FileLogger* _logger;
+
     bool _previousSessionCrashed;
 
     DisplayPluginPointer _displayPlugin;
@@ -673,8 +675,6 @@ private:
     QPointer<LogDialog> _logDialog;
     QPointer<EntityScriptServerLogDialog> _entityScriptServerLogDialog;
     QDir _defaultScriptsLocation;
-
-    FileLogger* _logger;
 
     TouchEvent _lastTouchEvent;
 

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -47,26 +47,17 @@ PluginManagerPointer PluginManager::getInstance() {
 QString getPluginNameFromMetaData(const QJsonObject& object) {
     static const char* METADATA_KEY = "MetaData";
     static const char* NAME_KEY = "name";
-    if (!object.contains(METADATA_KEY) || !object[METADATA_KEY].isObject()) {
-        return QString();
-    }
     return object[METADATA_KEY][NAME_KEY].toString("");
 }
 
 QString getPluginIIDFromMetaData(const QJsonObject& object) {
     static const char* IID_KEY = "IID";
-    if (!object.contains(IID_KEY) || !object[IID_KEY].isString()) {
-        return QString();
-    }
-    return object[IID_KEY].toString();
+    return object[IID_KEY].toString("");
 }
 
 int getPluginInterfaceVersionFromMetaData(const QJsonObject& object) {
     static const QString METADATA_KEY = "MetaData";
     static const QString NAME_KEY = "version";
-    if (!object.contains(METADATA_KEY) || !object[METADATA_KEY].isObject()) {
-        return 0;
-    }
     return object[METADATA_KEY][NAME_KEY].toInt(0);
 }
 

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -47,45 +47,27 @@ PluginManagerPointer PluginManager::getInstance() {
 QString getPluginNameFromMetaData(const QJsonObject& object) {
     static const char* METADATA_KEY = "MetaData";
     static const char* NAME_KEY = "name";
-
     if (!object.contains(METADATA_KEY) || !object[METADATA_KEY].isObject()) {
         return QString();
     }
-
-    auto metaDataObject = object[METADATA_KEY].toObject();
-
-    if (!metaDataObject.contains(NAME_KEY) || !metaDataObject[NAME_KEY].isString()) {
-        return QString();
-    }
-
-    return metaDataObject[NAME_KEY].toString();
+    return object[METADATA_KEY][NAME_KEY].toString("");
 }
 
 QString getPluginIIDFromMetaData(const QJsonObject& object) {
     static const char* IID_KEY = "IID";
-
     if (!object.contains(IID_KEY) || !object[IID_KEY].isString()) {
         return QString();
     }
-
     return object[IID_KEY].toString();
 }
 
 int getPluginInterfaceVersionFromMetaData(const QJsonObject& object) {
-    static const char* METADATA_KEY = "MetaData";
-    static const char* NAME_KEY = "version";
-
+    static const QString METADATA_KEY = "MetaData";
+    static const QString NAME_KEY = "version";
     if (!object.contains(METADATA_KEY) || !object[METADATA_KEY].isObject()) {
         return 0;
     }
-
-    auto metaDataObject = object[METADATA_KEY].toObject();
-
-    if (!metaDataObject.contains(NAME_KEY) || !metaDataObject[NAME_KEY].isDouble()) {
-        return 0;
-    }
-
-    return (int)(metaDataObject[NAME_KEY].toDouble());
+    return object[METADATA_KEY][NAME_KEY].toInt(0);
 }
 
 
@@ -135,16 +117,18 @@ const LoaderList& getLoadedPlugins() {
                 QSharedPointer<QPluginLoader> loader(new QPluginLoader(pluginPath + plugin));
 
                 if (isDisabled(loader->metaData())) {
-                    qWarning() << "Plugin" << qPrintable(plugin) << "is disabled";
+                    qCWarning(plugins) << "Plugin" << qPrintable(plugin) << "is disabled";
                     // Skip this one, it's disabled
                     continue;
                 }
-
                 if (getPluginInterfaceVersionFromMetaData(loader->metaData()) != HIFI_PLUGIN_INTERFACE_VERSION) {
-                    qCDebug(plugins) << "Plugin" << qPrintable(plugin) << "interface version doesn't match, not loading:"
-                                     << getPluginInterfaceVersionFromMetaData(loader->metaData())
-                                     << "doesn't match" << HIFI_PLUGIN_INTERFACE_VERSION;
-                } else if (loader->load()) {
+                    qCWarning(plugins) << "Plugin" << qPrintable(plugin) << "interface version doesn't match, not loading:"
+                                       << getPluginInterfaceVersionFromMetaData(loader->metaData())
+                                       << "doesn't match" << HIFI_PLUGIN_INTERFACE_VERSION;
+                    continue;
+                }
+
+                if (loader->load()) {
                     qCDebug(plugins) << "Plugin" << qPrintable(plugin) << "loaded successfully";
                     loadedPlugins.push_back(loader);
                 } else {

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -44,7 +44,7 @@ PluginManagerPointer PluginManager::getInstance() {
     return DependencyManager::get<PluginManager>();
 }
 
-QString getPluginNameFromMetaData(QJsonObject object) {
+QString getPluginNameFromMetaData(const QJsonObject& object) {
     static const char* METADATA_KEY = "MetaData";
     static const char* NAME_KEY = "name";
 
@@ -61,7 +61,7 @@ QString getPluginNameFromMetaData(QJsonObject object) {
     return metaDataObject[NAME_KEY].toString();
 }
 
-QString getPluginIIDFromMetaData(QJsonObject object) {
+QString getPluginIIDFromMetaData(const QJsonObject& object) {
     static const char* IID_KEY = "IID";
 
     if (!object.contains(IID_KEY) || !object[IID_KEY].isString()) {
@@ -71,7 +71,7 @@ QString getPluginIIDFromMetaData(QJsonObject object) {
     return object[IID_KEY].toString();
 }
 
-int getPluginInterfaceVersionFromMetaData(QJsonObject object) {
+int getPluginInterfaceVersionFromMetaData(const QJsonObject& object) {
     static const char* METADATA_KEY = "MetaData";
     static const char* NAME_KEY = "version";
 

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -62,4 +62,11 @@ private:
     InputPluginList _inputPlugins;
 };
 
+// TODO: we should define this value in CMake, and then use CMake
+// templating to generate the individual plugin.json files, so that we
+// don't have to update every plugin.json file whenever we update this
+// value.  The value should match "version" in
+//   plugins/*/src/plugin.json
+//   plugins/oculus/src/oculus.json
+//   etc
 static const int HIFI_PLUGIN_INTERFACE_VERSION = 1;

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -61,3 +61,5 @@ private:
     DisplayPluginList _displayPlugins;
     InputPluginList _inputPlugins;
 };
+
+static const int HIFI_PLUGIN_INTERFACE_VERSION = 1;

--- a/plugins/hifiCodec/src/plugin.json
+++ b/plugins/hifiCodec/src/plugin.json
@@ -1,1 +1,4 @@
-{"name":"HiFi 4:1 Audio Codec"}
+{
+    "name":"HiFi 4:1 Audio Codec",
+    "version":1
+}

--- a/plugins/hifiKinect/src/plugin.json
+++ b/plugins/hifiKinect/src/plugin.json
@@ -1,1 +1,4 @@
-{"name":"Kinect"}
+{
+    "name":"Kinect",
+    "version":1
+}

--- a/plugins/hifiLeapMotion/src/plugin.json
+++ b/plugins/hifiLeapMotion/src/plugin.json
@@ -1,1 +1,4 @@
-{"name":"Leap Motion"}
+{
+    "name":"Leap Motion",
+    "version":1
+}

--- a/plugins/hifiNeuron/src/plugin.json
+++ b/plugins/hifiNeuron/src/plugin.json
@@ -1,1 +1,4 @@
-{"name":"Neuron"}
+{
+    "name":"Neuron",
+    "version":1
+}

--- a/plugins/hifiSdl2/src/plugin.json
+++ b/plugins/hifiSdl2/src/plugin.json
@@ -1,1 +1,4 @@
-{"name":"SDL2"}
+{
+    "name":"SDL2",
+    "version":1
+}

--- a/plugins/hifiSixense/src/plugin.json
+++ b/plugins/hifiSixense/src/plugin.json
@@ -1,1 +1,4 @@
-{"name":"Sixense"}
+{
+    "name":"Sixense",
+    "version":1
+}

--- a/plugins/hifiSpacemouse/src/plugin.json
+++ b/plugins/hifiSpacemouse/src/plugin.json
@@ -1,1 +1,4 @@
-{"name":"Spacemouse"}
+{
+    "name":"Spacemouse",
+    "version":1
+}

--- a/plugins/oculus/src/oculus.json
+++ b/plugins/oculus/src/oculus.json
@@ -1,1 +1,4 @@
-{"name":"Oculus Rift"}
+{
+    "name":"Oculus Rift",
+    "version":1
+}

--- a/plugins/oculusLegacy/src/oculus.json
+++ b/plugins/oculusLegacy/src/oculus.json
@@ -1,1 +1,4 @@
-{"name":"Oculus Rift"}
+{
+    "name":"Oculus Rift",
+    "version":1
+}

--- a/plugins/openvr/src/plugin.json
+++ b/plugins/openvr/src/plugin.json
@@ -1,1 +1,4 @@
-{"name":"OpenVR (Vive)"}
+{
+    "name":"OpenVR (Vive)",
+    "version":1
+}

--- a/plugins/pcmCodec/src/plugin.json
+++ b/plugins/pcmCodec/src/plugin.json
@@ -1,1 +1,4 @@
-{"name":"PCM Codec"}
+{
+    "name":"PCM Codec",
+    "version":1
+}

--- a/plugins/steamClient/src/plugin.json
+++ b/plugins/steamClient/src/plugin.json
@@ -1,1 +1,4 @@
-{"name":"Steam Client"}
+{
+    "name":"Steam Client",
+    "version":1
+}


### PR DESCRIPTION
- start up logger before loading plugins
- embed an "plugin-interface version" into plugin DLLs which we can check before loading.


https://highfidelity.manuscript.com/f/cases/19656/QSettingsPrivate-beginGroupOrArray-QSettingsGroup-const-2e931f8861402a43b9ee502431ca470df47aa414d826280a25307f51c2a00f85
