### PR TITLE
Case20615 - Changing Avatars doesn't update to everyone intermittently

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -208,7 +208,9 @@ void AvatarMixerClientData::processBulkAvatarTraitsAckMessage(ReceivedMessage& m
             auto simpleReceivedIt = traitVersions.simpleCBegin();
             while (simpleReceivedIt != traitVersions.simpleCEnd()) {
                 auto traitType = static_cast<AvatarTraits::TraitType>(std::distance(traitVersions.simpleCBegin(), simpleReceivedIt));
-                _perNodeAckedTraitVersions[nodeId][traitType] = *simpleReceivedIt;
+                if (*simpleReceivedIt != AvatarTraits::DEFAULT_TRAIT_VERSION) {
+                    _perNodeAckedTraitVersions[nodeId][traitType] = *simpleReceivedIt;
+                }
                 simpleReceivedIt++;
             }
 

--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -207,8 +207,8 @@ void AvatarMixerClientData::processBulkAvatarTraitsAckMessage(ReceivedMessage& m
             // process simple traits
             auto simpleReceivedIt = traitVersions.simpleCBegin();
             while (simpleReceivedIt != traitVersions.simpleCEnd()) {
-                auto traitType = static_cast<AvatarTraits::TraitType>(std::distance(traitVersions.simpleCBegin(), simpleReceivedIt));
                 if (*simpleReceivedIt != AvatarTraits::DEFAULT_TRAIT_VERSION) {
+                    auto traitType = static_cast<AvatarTraits::TraitType>(std::distance(traitVersions.simpleCBegin(), simpleReceivedIt));
                     _perNodeAckedTraitVersions[nodeId][traitType] = *simpleReceivedIt;
                 }
                 simpleReceivedIt++;

--- a/assignment-client/src/avatars/AvatarMixerSlave.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlave.cpp
@@ -231,7 +231,7 @@ qint64 AvatarMixerSlave::addChangedTraitsToBulkPacket(AvatarMixerClientData* lis
             bytesWritten += traitsPacketList.writePrimitive(AvatarTraits::NullTrait);
             // since we send all traits for this other avatar, update the time of last traits sent
             // to match the time of last traits change
-            listeningNodeData->setLastOtherAvatarTraitsSendPoint(otherNodeLocalID, nextTimeOfLastTraitsSent);
+            listeningNodeData->setLastOtherAvatarTraitsSendPoint(sendingNodeLocalID, nextTimeOfLastTraitsSent);
         }
     }
 

--- a/assignment-client/src/avatars/AvatarMixerSlave.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlave.cpp
@@ -106,11 +106,11 @@ qint64 AvatarMixerSlave::addChangedTraitsToBulkPacket(AvatarMixerClientData* lis
     // in that packet_ are ignored.  Updates to traits not in that packet will
     // be sent.
 
-    auto otherNodeLocalID = sendingNodeData->getNodeLocalID();
+    auto sendingNodeLocalID = sendingNodeData->getNodeLocalID();
 
     // Perform a simple check with two server clock time points
     // to see if there is any new traits data for this avatar that we need to send
-    auto timeOfLastTraitsSent = listeningNodeData->getLastOtherAvatarTraitsSendPoint(otherNodeLocalID);
+    auto timeOfLastTraitsSent = listeningNodeData->getLastOtherAvatarTraitsSendPoint(sendingNodeLocalID);
     auto timeOfLastTraitsChange = sendingNodeData->getLastReceivedTraitsChange();
     auto nextTimeOfLastTraitsSent = timeOfLastTraitsChange;
 
@@ -122,8 +122,8 @@ qint64 AvatarMixerSlave::addChangedTraitsToBulkPacket(AvatarMixerClientData* lis
         auto sendingAvatar = sendingNodeData->getAvatarSharedPointer();
 
         // compare trait versions so we can see what exactly needs to go out
-        auto& lastSentVersions = listeningNodeData->getLastSentTraitVersions(otherNodeLocalID);
-        auto& lastAckedVersions = listeningNodeData->getLastAckedTraitVersions(otherNodeLocalID);
+        auto& lastSentVersions = listeningNodeData->getLastSentTraitVersions(sendingNodeLocalID);
+        auto& lastAckedVersions = listeningNodeData->getLastAckedTraitVersions(sendingNodeLocalID);
         const auto& lastReceivedVersions = sendingNodeData->getLastReceivedTraitVersions();
 
         auto simpleReceivedIt = lastReceivedVersions.simpleCBegin();
@@ -144,7 +144,7 @@ qint64 AvatarMixerSlave::addChangedTraitsToBulkPacket(AvatarMixerClientData* lis
                     lastSentVersionRef = lastReceivedVersion;
                     // Remember which versions we sent in this particular packet
                     // so we can verify when it's acked.
-                    auto& pendingTraitVersions = listeningNodeData->getPendingTraitVersions(listeningNodeData->getTraitsMessageSequence(), otherNodeLocalID);
+                    auto& pendingTraitVersions = listeningNodeData->getPendingTraitVersions(listeningNodeData->getTraitsMessageSequence(), sendingNodeLocalID);
                     pendingTraitVersions[traitType] = lastReceivedVersion;
                 }
             } else {
@@ -204,7 +204,7 @@ qint64 AvatarMixerSlave::addChangedTraitsToBulkPacket(AvatarMixerClientData* lis
 
                     auto& pendingTraitVersions =
                         listeningNodeData->getPendingTraitVersions(listeningNodeData->getTraitsMessageSequence(),
-                                                                   otherNodeLocalID);
+                                                                   sendingNodeLocalID);
                     pendingTraitVersions.instanceInsert(traitType, instanceID, receivedVersion);
 
                 } else if (isDeleted && sentInstanceIt != sentIDValuePairs.end() && absoluteReceivedVersion > sentInstanceIt->value) {
@@ -218,7 +218,7 @@ qint64 AvatarMixerSlave::addChangedTraitsToBulkPacket(AvatarMixerClientData* lis
 
                     auto& pendingTraitVersions =
                         listeningNodeData->getPendingTraitVersions(listeningNodeData->getTraitsMessageSequence(),
-                                                                   otherNodeLocalID);
+                                                                   sendingNodeLocalID);
                     pendingTraitVersions.instanceInsert(traitType, instanceID, absoluteReceivedVersion);
 
                 }


### PR DESCRIPTION
There were two problems:
1) If an update to a trait (simple or instance) was not sent because
there was an outstanding (unacked) message, it would not be resent
until a new trait was updated.  Expected - it should be sent when the
ack for the outstanding packet is received.

2) Trait versions were improperly being set to zero (the default)
when an ack is received