### PR TITLE
case 20597: fix zones using FBX models with non-trivial mesh.modelTransform

### DIFF
--- a/libraries/hfm/src/hfm/HFM.cpp
+++ b/libraries/hfm/src/hfm/HFM.cpp
@@ -205,6 +205,8 @@ bool HFMModel::convexHullContains(const glm::vec3& point) const {
 
     auto checkEachPrimitive = [=](HFMMesh& mesh, QVector<int> indices, int primitiveSize) -> bool {
         // Check whether the point is "behind" all the primitives.
+        // But first must transform from model-frame into mesh-frame
+        glm::vec3 transformedPoint = glm::vec3(glm::inverse(mesh.modelTransform) * glm::vec4(point, 1.0f));
         int verticesSize = mesh.vertices.size();
         for (int j = 0;
             j < indices.size() - 2; // -2 in case the vertices aren't the right size -- we access j + 2 below
@@ -212,7 +214,7 @@ bool HFMModel::convexHullContains(const glm::vec3& point) const {
             if (indices[j] < verticesSize &&
                 indices[j + 1] < verticesSize &&
                 indices[j + 2] < verticesSize &&
-                !isPointBehindTrianglesPlane(point,
+                !isPointBehindTrianglesPlane(transformedPoint,
                     mesh.vertices[indices[j]],
                     mesh.vertices[indices[j + 1]],
                     mesh.vertices[indices[j + 2]])) {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20597/Shaped-Zones-FBX-files-do-not-work-when-creating-a-shaped-zone

This is a partial fix for shaped zones that use a convex FBX model as their bounding shape.  There are still known cases where some models fail, but this little fix solves some of the problem.