### PR TITLE
case 20326: fix drifting mexico hats

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -773,7 +773,7 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
         auto headBoneSet = _skeletonModel->getCauterizeBoneSet();
         forEachChild([&](SpatiallyNestablePointer object) {
             bool isChildOfHead = headBoneSet.find(object->getParentJointIndex()) != headBoneSet.end();
-            if (isChildOfHead) {
+            if (isChildOfHead && !object->hasGrabs()) {
                 // Cauterize or display children of head per head drawing state.
                 updateChildCauterization(object, !_prevShouldDrawHead);
                 object->forEachDescendant([&](SpatiallyNestablePointer descendant) {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1869,8 +1869,6 @@ private:
     bool _enableDebugDrawIKChains { false };
     bool _enableDebugDrawDetailedCollision { false };
 
-    mutable bool _cauterizationNeedsUpdate; // do we need to scan children and update their "cauterized" state?
-
     AudioListenerMode _audioListenerMode;
     glm::vec3 _customListenPosition;
     glm::quat _customListenOrientation;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -385,6 +385,7 @@ void Avatar::updateGrabs() {
                         entityTree->updateEntityQueryAACube(target, packetSender, force, iShouldTellServer);
                     });
                 }
+                _cauterizationNeedsUpdate = true;
             }
             _avatarGrabs.remove(grabID);
             _changedAvatarGrabs.remove(grabID);
@@ -402,6 +403,7 @@ void Avatar::updateGrabs() {
                 target->addGrab(grab);
                 // only clear this entry from the _changedAvatarGrabs if we found the entity.
                 changeItr.remove();
+                _cauterizationNeedsUpdate = true;
             }
         }
     });

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -536,6 +536,8 @@ protected:
     glm::vec3 _worldUpDirection { Vectors::UP };
     bool _moving { false }; ///< set when position is changing
 
+    mutable bool _cauterizationNeedsUpdate; // do we need to scan children and update their "cauterized" state?
+
     // protected methods...
     bool isLookingAtMe(AvatarSharedPointer avatar) const;
     void updateGrabs();

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -3833,22 +3833,22 @@ void EntityItemProperties::copySimulationRestrictedProperties(const EntityItemPo
         setParentJointIndex(entity->getParentJointIndex());
     }
     if (!_localPositionChanged && !_positionChanged) {
-        setPosition(entity->getWorldPosition());
+        setLocalPosition(entity->getLocalPosition());
     }
     if (!_localRotationChanged && !_rotationChanged) {
-        setRotation(entity->getWorldOrientation());
+        setLocalRotation(entity->getLocalOrientation());
     }
     if (!_localVelocityChanged && !_velocityChanged) {
-        setVelocity(entity->getWorldVelocity());
+        setLocalVelocity(entity->getLocalVelocity());
     }
     if (!_localAngularVelocityChanged && !_angularVelocityChanged) {
-        setAngularVelocity(entity->getWorldAngularVelocity());
+        setLocalAngularVelocity(entity->getLocalAngularVelocity());
     }
     if (!_accelerationChanged) {
         setAcceleration(entity->getAcceleration());
     }
     if (!_localDimensionsChanged && !_dimensionsChanged) {
-        setDimensions(entity->getScaledDimensions());
+        setLocalDimensions(entity->getUnscaledDimensions());
     }
 }
 

--- a/scripts/system/controllers/controllerModules/farGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farGrabEntity.js
@@ -11,7 +11,7 @@
    Entities, enableDispatcherModule, disableDispatcherModule, entityIsGrabbable, makeDispatcherModuleParameters, MSECS_PER_SEC,
    HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, TRIGGER_OFF_VALUE, TRIGGER_ON_VALUE, ZERO_VEC,
    projectOntoEntityXYPlane, ContextOverlay, HMD, Picks, makeLaserLockInfo, makeLaserParams, AddressManager,
-   getEntityParents, Selection, DISPATCHER_HOVERING_LIST, unhighlightTargetEntity, Messages, findGroupParent,
+   getEntityParents, Selection, DISPATCHER_HOVERING_LIST, unhighlightTargetEntity, Messages, findGrabbableGroupParent,
    worldPositionToRegistrationFrameMatrix, DISPATCHER_PROPERTIES
 */
 
@@ -308,7 +308,7 @@ Script.include("/~/system/libraries/controllers.js");
                 var gtProps = Entities.getEntityProperties(targetEntity, DISPATCHER_PROPERTIES);
                 if (entityIsGrabbable(gtProps)) {
                     // if we've attempted to grab a child, roll up to the root of the tree
-                    var groupRootProps = findGroupParent(controllerData, gtProps);
+                    var groupRootProps = findGrabbableGroupParent(controllerData, gtProps);
                     if (entityIsGrabbable(groupRootProps)) {
                         return groupRootProps;
                     }

--- a/scripts/system/controllers/controllerModules/nearGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/nearGrabEntity.js
@@ -8,9 +8,10 @@
 
 /* global Script, Entities, MyAvatar, Controller, RIGHT_HAND, LEFT_HAND, getControllerJointIndex, enableDispatcherModule,
    disableDispatcherModule, Messages, HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, TRIGGER_OFF_VALUE,
-   makeDispatcherModuleParameters, entityIsGrabbable, makeRunningValues, NEAR_GRAB_RADIUS, findGroupParent, Vec3, cloneEntity,
-   entityIsCloneable, HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, BUMPER_ON_VALUE, distanceBetweenPointAndEntityBoundingBox,
-   getGrabbableData, getEnabledModuleByName, DISPATCHER_PROPERTIES, HMD, NEAR_GRAB_DISTANCE
+   makeDispatcherModuleParameters, entityIsGrabbable, makeRunningValues, NEAR_GRAB_RADIUS, findGrabbableGroupParent, Vec3,
+   cloneEntity, entityIsCloneable, HAPTIC_PULSE_STRENGTH, HAPTIC_PULSE_DURATION, BUMPER_ON_VALUE,
+   distanceBetweenPointAndEntityBoundingBox, getGrabbableData, getEnabledModuleByName, DISPATCHER_PROPERTIES, HMD,
+   NEAR_GRAB_DISTANCE
 */
 
 Script.include("/~/system/libraries/controllerDispatcherUtils.js");
@@ -80,9 +81,6 @@ Script.include("/~/system/libraries/controllers.js");
         this.endNearGrabEntity = function () {
             this.endGrab();
 
-            this.grabbing = false;
-            this.targetEntityID = null;
-
             var args = [this.hand === RIGHT_HAND ? "right" : "left", MyAvatar.sessionUUID];
             Entities.callEntityMethod(this.targetEntityID, "releaseGrab", args);
             Messages.sendMessage('Hifi-Object-Manipulation', JSON.stringify({
@@ -90,6 +88,9 @@ Script.include("/~/system/libraries/controllers.js");
                 grabbedEntity: this.targetEntityID,
                 joint: this.hand === RIGHT_HAND ? "RightHand" : "LeftHand"
             }));
+
+            this.grabbing = false;
+            this.targetEntityID = null;
         };
 
         this.getTargetProps = function (controllerData) {
@@ -110,7 +111,7 @@ Script.include("/~/system/libraries/controllers.js");
                 if (entityIsGrabbable(props) || entityIsCloneable(props)) {
                     if (!entityIsCloneable(props)) {
                         // if we've attempted to grab a non-cloneable child, roll up to the root of the tree
-                        var groupRootProps = findGroupParent(controllerData, props);
+                        var groupRootProps = findGrabbableGroupParent(controllerData, props);
                         if (entityIsGrabbable(groupRootProps)) {
                             return groupRootProps;
                         }

--- a/scripts/system/libraries/controllerDispatcherUtils.js
+++ b/scripts/system/libraries/controllerDispatcherUtils.js
@@ -46,7 +46,7 @@
    makeLaserLockInfo:true,
    entityHasActions:true,
    ensureDynamic:true,
-   findGroupParent:true,
+   findGrabbableGroupParent:true,
    BUMPER_ON_VALUE:true,
    getEntityParents:true,
    findHandChildEntities:true,
@@ -439,13 +439,16 @@ ensureDynamic = function (entityID) {
     }
 };
 
-findGroupParent = function (controllerData, targetProps) {
+findGrabbableGroupParent = function (controllerData, targetProps) {
     while (targetProps.grab.grabDelegateToParent &&
            targetProps.parentID &&
            targetProps.parentID !== Uuid.NULL &&
            Entities.getNestableType(targetProps.parentID) == "entity") {
         var parentProps = Entities.getEntityProperties(targetProps.parentID, DISPATCHER_PROPERTIES);
         if (!parentProps) {
+            break;
+        }
+        if (!entityIsGrabbable(parentProps)) {
             break;
         }
         parentProps.id = targetProps.parentID;
@@ -614,7 +617,7 @@ if (typeof module !== 'undefined') {
         unhighlightTargetEntity: unhighlightTargetEntity,
         clearHighlightedEntities: clearHighlightedEntities,
         makeRunningValues: makeRunningValues,
-        findGroupParent: findGroupParent,
+        findGrabbableGroupParent: findGrabbableGroupParent,
         LEFT_HAND: LEFT_HAND,
         RIGHT_HAND: RIGHT_HAND,
         BUMPER_ON_VALUE: BUMPER_ON_VALUE,


### PR DESCRIPTION
- fix bug that was introducing a local velocity to an entity when it was parented to a moving avatar
- fix releaseGrab entity-method call when ending a nearEntityGrab
- don't make children of MyAvatar's head invisible while they are being grabbed

https://highfidelity.manuscript.com/f/cases/20326/Try-on-Items-selected-while-avatar-is-moving-cause-corresponding-wearables-to-maintain-avatar-velocity

https://highfidelity.manuscript.com/f/cases/20709/Unable-to-equip-hats-while-in-HMD-in-mexico-dev

https://highfidelity.manuscript.com/f/cases/20715/Wearables-parented-to-the-head-no-longer-temporarily-render-while-being-grabbed-and-adjusted-in-VR

rc-78 version: https://github.com/highfidelity/hifi/pull/14726