### PR TITLE
Make Connection class a Qt-child of Socket class

### DIFF
--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -33,7 +33,8 @@ using namespace std::chrono;
 Connection::Connection(Socket* parentSocket, HifiSockAddr destination, std::unique_ptr<CongestionControl> congestionControl) :
     _parentSocket(parentSocket),
     _destination(destination),
-    _congestionControl(move(congestionControl))
+    _congestionControl(move(congestionControl)),
+    QObject(parentSocket)
 {
     Q_ASSERT_X(parentSocket, "Connection::Connection", "Must be called with a valid Socket*");
     

--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -31,10 +31,10 @@ using namespace udt;
 using namespace std::chrono;
 
 Connection::Connection(Socket* parentSocket, HifiSockAddr destination, std::unique_ptr<CongestionControl> congestionControl) :
+    QObject(parentSocket),
     _parentSocket(parentSocket),
     _destination(destination),
-    _congestionControl(move(congestionControl)),
-    QObject(parentSocket)
+    _congestionControl(move(congestionControl))
 {
     Q_ASSERT_X(parentSocket, "Connection::Connection", "Must be called with a valid Socket*");
     


### PR DESCRIPTION
Ticket: https://highfidelity.manuscript.com/f/cases/20564/

This ensures the Connection class's associated thread is the NodeList thread so slots (etc) run there.