### PR TITLE
Case 20411: Fix crash on subsequent entitlements checks

### DIFF
--- a/plugins/oculus/src/OculusHelpers.cpp
+++ b/plugins/oculus/src/OculusHelpers.cpp
@@ -82,15 +82,18 @@ private:
         }
 
 #ifdef OCULUS_APP_ID
-        if (qApp->property(hifi::properties::OCULUS_STORE).toBool()) {
-            if (ovr_PlatformInitializeWindows(OCULUS_APP_ID) != ovrPlatformInitialize_Success) {
-                qCWarning(oculusLog) << "Unable to initialize the platform for entitlement check - fail the check" << ovr::getError();
-                return;
-            } else {
-                qCDebug(oculusLog) << "Performing Oculus Platform entitlement check";
-                ovr_Entitlement_GetIsViewerEntitled();
+        static std::once_flag once;
+        std::call_once(once, []() {
+            if (qApp->property(hifi::properties::OCULUS_STORE).toBool()) {
+                if (ovr_PlatformInitializeWindows(OCULUS_APP_ID) != ovrPlatformInitialize_Success) {
+                    qCWarning(oculusLog) << "Unable to initialize the platform for entitlement check - fail the check" << ovr::getError();
+                    return;
+                } else {
+                    qCDebug(oculusLog) << "Performing Oculus Platform entitlement check";
+                    ovr_Entitlement_GetIsViewerEntitled();
+                }
             }
-        }
+        });
 #endif
 
         ovrGraphicsLuid luid;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20411/Oculus-Store-version-Crashing-when-switching-between-HMD-and-Desktop-version

Test plan:
- QA isn't really possible.  Once 78 is released to the Oculus store, we'll have to see if the crashes stop.