### PR TITLE
Bug fixes and improvements to audio distance attenuation

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -736,7 +736,7 @@ void AudioMixer::parseSettingsObject(const QJsonObject& settingsObject) {
                     float coefficient = coefficientObject.value(COEFFICIENT).toString().toFloat(&ok);
 
 
-                    if (ok && coefficient >= 0.0f && coefficient <= 1.0f &&
+                    if (ok && coefficient <= 1.0f &&
                         itSource != end(_audioZones) &&
                         itListener != end(_audioZones)) {
 

--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -730,6 +730,7 @@ float approximateGain(const AvatarAudioStream& listeningNodeStream, const Positi
 
     float d = (1.0f / ATTN_DISTANCE_REF) * std::max(distance, HRTF_NEARFIELD_MIN);
     gain = gain / d;
+    gain = std::min(gain, ATTN_GAIN_MAX);
 
     // avatar: skip master gain - it is constant for all streams
     return gain;
@@ -780,6 +781,7 @@ float computeGain(float masterListenerGain, const AvatarAudioStream& listeningNo
     // reference attenuation of 0dB at distance = ATTN_DISTANCE_REF
     float d = (1.0f / ATTN_DISTANCE_REF) * std::max(distance, HRTF_NEARFIELD_MIN);
     gain *= fastExp2f(fastLog2f(g) * fastLog2f(d));
+    gain = std::min(gain, ATTN_GAIN_MAX);
 
     return gain;
 }

--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -727,13 +727,9 @@ float approximateGain(const AvatarAudioStream& listeningNodeStream, const Positi
     // distance attenuation: approximate, ignore zone-specific attenuations
     glm::vec3 relativePosition = streamToAdd.getPosition() - listeningNodeStream.getPosition();
     float distance = glm::length(relativePosition);
-
-    float d = (1.0f / ATTN_DISTANCE_REF) * std::max(distance, HRTF_NEARFIELD_MIN);
-    gain = gain / d;
-    gain = std::min(gain, ATTN_GAIN_MAX);
+    return gain / distance;
 
     // avatar: skip master gain - it is constant for all streams
-    return gain;
 }
 
 float computeGain(float masterListenerGain, const AvatarAudioStream& listeningNodeStream,

--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -727,9 +727,12 @@ float approximateGain(const AvatarAudioStream& listeningNodeStream, const Positi
     // distance attenuation: approximate, ignore zone-specific attenuations
     glm::vec3 relativePosition = streamToAdd.getPosition() - listeningNodeStream.getPosition();
     float distance = glm::length(relativePosition);
-    return gain / distance;
+
+    float d = (1.0f / ATTN_DISTANCE_REF) * std::max(distance, HRTF_NEARFIELD_MIN);
+    gain = gain / d;
 
     // avatar: skip master gain - it is constant for all streams
+    return gain;
 }
 
 float computeGain(float masterListenerGain, const AvatarAudioStream& listeningNodeStream,
@@ -774,9 +777,9 @@ float computeGain(float masterListenerGain, const AvatarAudioStream& listeningNo
     float g = glm::clamp(1.0f - attenuationPerDoublingInDistance, EPSILON, 1.0f);
 
     // calculate the attenuation using the distance to this node
-    // reference attenuation of 0dB at distance = 1.0m
-    gain *= fastExp2f(fastLog2f(g) * fastLog2f(std::max(distance, HRTF_NEARFIELD_MIN)));
-    gain = std::min(gain, 1.0f / HRTF_NEARFIELD_MIN);
+    // reference attenuation of 0dB at distance = ATTN_DISTANCE_REF
+    float d = (1.0f / ATTN_DISTANCE_REF) * std::max(distance, HRTF_NEARFIELD_MIN);
+    gain *= fastExp2f(fastLog2f(g) * fastLog2f(d));
 
     return gain;
 }

--- a/assignment-client/src/audio/AudioMixerSlave.cpp
+++ b/assignment-client/src/audio/AudioMixerSlave.cpp
@@ -771,7 +771,8 @@ float computeGain(float masterListenerGain, const AvatarAudioStream& listeningNo
         }
     }
     // translate the zone setting to gain per log2(distance)
-    float g = glm::clamp(1.0f - attenuationPerDoublingInDistance, EPSILON, 1.0f);
+    const float MIN_ATTENUATION_COEFFICIENT = 0.001f;   // -60dB per log2(distance)
+    float g = glm::clamp(1.0f - attenuationPerDoublingInDistance, MIN_ATTENUATION_COEFFICIENT, 1.0f);
 
     // calculate the attenuation using the distance to this node
     // reference attenuation of 0dB at distance = ATTN_DISTANCE_REF

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1952,8 +1952,9 @@ float AudioClient::azimuthForSource(const glm::vec3& relativePosition) {
 float AudioClient::gainForSource(float distance, float volume) {
 
     // attenuation = -6dB * log2(distance)
-    // reference attenuation of 0dB at distance = 1.0m
-    float gain = volume / std::max(distance, HRTF_NEARFIELD_MIN);
+    // reference attenuation of 0dB at distance = ATTN_DISTANCE_REF
+    float d = (1.0f / ATTN_DISTANCE_REF) * std::max(distance, HRTF_NEARFIELD_MIN);
+    float gain = volume / d;
 
     return gain;
 }

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1955,6 +1955,7 @@ float AudioClient::gainForSource(float distance, float volume) {
     // reference attenuation of 0dB at distance = ATTN_DISTANCE_REF
     float d = (1.0f / ATTN_DISTANCE_REF) * std::max(distance, HRTF_NEARFIELD_MIN);
     float gain = volume / d;
+    gain = std::min(gain, ATTN_GAIN_MAX);
 
     return gain;
 }

--- a/libraries/audio/src/AudioHRTF.h
+++ b/libraries/audio/src/AudioHRTF.h
@@ -30,6 +30,9 @@ static const float HRTF_NEARFIELD_MAX = 1.0f;   // distance in meters
 static const float HRTF_NEARFIELD_MIN = 0.125f; // distance in meters
 static const float HRTF_HEAD_RADIUS = 0.0875f;  // average human head in meters
 
+// Distance attenuation
+static const float ATTN_DISTANCE_REF = 1.0f;    // distance where attn is 0dB
+
 class AudioHRTF {
 
 public:

--- a/libraries/audio/src/AudioHRTF.h
+++ b/libraries/audio/src/AudioHRTF.h
@@ -31,8 +31,8 @@ static const float HRTF_NEARFIELD_MIN = 0.125f; // distance in meters
 static const float HRTF_HEAD_RADIUS = 0.0875f;  // average human head in meters
 
 // Distance attenuation
-static const float ATTN_DISTANCE_REF = 1.0f;    // distance where attn is 0dB
-static const float ATTN_GAIN_MAX = 8.0f;        // max gain allowed by distance attn (+18dB)
+static const float ATTN_DISTANCE_REF = 2.0f;    // distance where attn is 0dB
+static const float ATTN_GAIN_MAX = 16.0f;       // max gain allowed by distance attn (+24dB)
 
 class AudioHRTF {
 

--- a/libraries/audio/src/AudioHRTF.h
+++ b/libraries/audio/src/AudioHRTF.h
@@ -32,6 +32,7 @@ static const float HRTF_HEAD_RADIUS = 0.0875f;  // average human head in meters
 
 // Distance attenuation
 static const float ATTN_DISTANCE_REF = 1.0f;    // distance where attn is 0dB
+static const float ATTN_GAIN_MAX = 8.0f;        // max gain allowed by distance attn (+18dB)
 
 class AudioHRTF {
 

--- a/libraries/shared/src/AudioHelpers.h
+++ b/libraries/shared/src/AudioHelpers.h
@@ -43,8 +43,9 @@ static inline float fastLog2f(float x) {
 }
 
 //
-// for -127 <= x < 128, returns exp2(x)
-// otherwise, returns undefined
+// for -126 <= x < 128, returns exp2(x)
+// for x < -126, returns 0
+// for x >= 128, returns undefined
 //
 // rel |error| < 9e-6, smooth (exact for x=N)
 //
@@ -60,6 +61,7 @@ static inline float fastExp2f(float x) {
     x -= xi.i;
 
     // construct exp2(xi) as a float
+    xi.i &= ~(xi.i >> 31);  // MAX(xi.i, 0)
     xi.i <<= IEEE754_MANT_BITS;
 
     // polynomial for exp2(x) over x=[0,1]


### PR DESCRIPTION
Fixes bug that caused a loud howling noise with extreme values (audio zone setting = 1.0 and distance > 32m).

https://highfidelity.manuscript.com/f/cases/20730/Extreme-audio-zone-settings-can-result-in-loud-howling-sound

Sets more reasonable min/max bounds for attenuations.
Improved value for reference distance (attenuation calibrated to 0dB at 2m, regardless of settings).

Adds an experimental "linear" falloff curve (only for testing at this time).
Before, a negative zone coefficient would be ignored. With this PR, it enables a linear (instead of logarithmic) falloff with the prescribed distance limit. So in a zone with setting = -10.0, sounds become completely inaudible after 10m. 

The graph below shows standard (logarithmic) falloff in blue, the experimental (linear) falloff in red, with the domain default setting in green.

![dist_attn_log_vs_linear](https://user-images.githubusercontent.com/13965157/51402214-b5c4c680-1b01-11e9-80c9-2441de774827.png)
