### PR TITLE
Case 19291: Fix zone bugs

### DIFF
--- a/libraries/entities/src/ZoneEntityItem.cpp
+++ b/libraries/entities/src/ZoneEntityItem.cpp
@@ -119,7 +119,7 @@ bool ZoneEntityItem::setSubClassProperties(const EntityItemProperties& propertie
     SET_ENTITY_PROPERTY_FROM_PROPERTIES(bloomMode, setBloomMode);
 
     somethingChanged = somethingChanged || _keyLightPropertiesChanged || _ambientLightPropertiesChanged ||
-        _stagePropertiesChanged || _skyboxPropertiesChanged || _hazePropertiesChanged || _bloomPropertiesChanged;
+        _skyboxPropertiesChanged || _hazePropertiesChanged || _bloomPropertiesChanged;
 
     return somethingChanged;
 }
@@ -394,7 +394,6 @@ void ZoneEntityItem::resetRenderingPropertiesChanged() {
         _skyboxPropertiesChanged = false;
         _hazePropertiesChanged = false;
         _bloomPropertiesChanged = false;
-        _stagePropertiesChanged = false;
     });
 }
 

--- a/libraries/entities/src/ZoneEntityItem.h
+++ b/libraries/entities/src/ZoneEntityItem.h
@@ -102,8 +102,6 @@ public:
     bool hazePropertiesChanged() const { return _hazePropertiesChanged; }
     bool bloomPropertiesChanged() const { return _bloomPropertiesChanged; }
 
-    bool stagePropertiesChanged() const { return _stagePropertiesChanged; }
-
     void resetRenderingPropertiesChanged();
 
     virtual bool supportsDetailedIntersection() const override { return true; }
@@ -155,7 +153,6 @@ protected:
     bool _skyboxPropertiesChanged { false };
     bool _hazePropertiesChanged{ false };
     bool _bloomPropertiesChanged { false };
-    bool _stagePropertiesChanged { false };
 
     static bool _drawZoneBoundaries;
     static bool _zonesArePickable;

--- a/libraries/graphics/src/graphics/Haze.cpp
+++ b/libraries/graphics/src/graphics/Haze.cpp
@@ -182,12 +182,3 @@ void Haze::setHazeBackgroundBlend(const float hazeBackgroundBlend) {
         _hazeParametersBuffer.edit<Parameters>().hazeBackgroundBlend = newBlend;
     }
 }
-
-void Haze::setTransform(const glm::mat4& transform) {
-    auto& params = _hazeParametersBuffer.get<Parameters>();
-
-    if (params.transform != transform) {
-        _hazeParametersBuffer.edit<Parameters>().transform = transform;
-    }
-}
-

--- a/libraries/graphics/src/graphics/Haze.h
+++ b/libraries/graphics/src/graphics/Haze.h
@@ -92,8 +92,6 @@ namespace graphics {
 
         void setHazeBackgroundBlend(const float hazeBackgroundBlend);
 
-        void setTransform(const glm::mat4& transform);
-
         using UniformBufferView = gpu::BufferView;
         UniformBufferView getHazeParametersBuffer() const { return _hazeParametersBuffer; }
 
@@ -101,30 +99,32 @@ namespace graphics {
         class Parameters {
         public:
             // DO NOT CHANGE ORDER HERE WITHOUT UNDERSTANDING THE std140 LAYOUT
-            glm::vec3 hazeColor{ INITIAL_HAZE_COLOR };
-            float hazeGlareBlend{ convertGlareAngleToPower(INITIAL_HAZE_GLARE_ANGLE) };
+            glm::vec3 hazeColor { INITIAL_HAZE_COLOR };
+            float hazeGlareBlend { convertGlareAngleToPower(INITIAL_HAZE_GLARE_ANGLE) };
 
-            glm::vec3 hazeGlareColor{ INITIAL_HAZE_GLARE_COLOR };
-            float hazeBaseReference{ INITIAL_HAZE_BASE_REFERENCE };
+            glm::vec3 hazeGlareColor { INITIAL_HAZE_GLARE_COLOR };
+            float hazeBaseReference { INITIAL_HAZE_BASE_REFERENCE };
 
             glm::vec3 colorModulationFactor;
-            int hazeMode{ 0 };    // bit 0 - set to activate haze attenuation of fragment color
+            int hazeMode { 0 };   // bit 0 - set to activate haze attenuation of fragment color
                                   // bit 1 - set to add the effect of altitude to the haze attenuation
                                   // bit 2 - set to activate directional light attenuation mode
                                   // bit 3 - set to blend between blend-in and blend-out colours
 
-            glm::mat4 transform;
+            // Padding required to align the struct
+#if defined(__clang__)
+            __attribute__((unused))
+#endif
+            vec3 __padding;
 
             // Amount of background (skybox) to display, overriding the haze effect for the background
-            float hazeBackgroundBlend{ INITIAL_HAZE_BACKGROUND_BLEND };
+            float hazeBackgroundBlend { INITIAL_HAZE_BACKGROUND_BLEND };
             // The haze attenuation exponents used by both fragment and directional light attenuation
-            float hazeRangeFactor{ convertHazeRangeToHazeRangeFactor(INITIAL_HAZE_RANGE) };
-            float hazeHeightFactor{ convertHazeAltitudeToHazeAltitudeFactor(INITIAL_HAZE_HEIGHT) };
-            float hazeKeyLightRangeFactor{ convertHazeRangeToHazeRangeFactor(INITIAL_KEY_LIGHT_RANGE) };
+            float hazeRangeFactor { convertHazeRangeToHazeRangeFactor(INITIAL_HAZE_RANGE) };
+            float hazeHeightFactor { convertHazeAltitudeToHazeAltitudeFactor(INITIAL_HAZE_HEIGHT) };
+            float hazeKeyLightRangeFactor { convertHazeRangeToHazeRangeFactor(INITIAL_KEY_LIGHT_RANGE) };
 
-            float hazeKeyLightAltitudeFactor{ convertHazeAltitudeToHazeAltitudeFactor(INITIAL_KEY_LIGHT_ALTITUDE) };
-            // Padding required to align the structure to sizeof(vec4)
-            vec3 __padding;
+            float hazeKeyLightAltitudeFactor { convertHazeAltitudeToHazeAltitudeFactor(INITIAL_KEY_LIGHT_ALTITUDE) };
 
             Parameters() {}
         };

--- a/libraries/render-utils/src/Haze.slh
+++ b/libraries/render-utils/src/Haze.slh
@@ -28,7 +28,7 @@ struct HazeParams {
     vec3 colorModulationFactor;
     int hazeMode;
 
-    mat4 transform;
+    vec3 spare;
     float backgroundBlend;
 
     float hazeRangeFactor;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19291/Keylight-doesn-t-rotate-with-zone-until-you-modify-another-property

Test plan:
- Make a zone using create.  Turn the keylight on and turn shadows on.
- As you rotate the zone, the shadows should rotate with it.
- As you change the zone properties, the zone should update as expected.