### PR TITLE
Case 20398: Fix animation URL change

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -959,23 +959,6 @@ QStringList RenderableModelEntityItem::getJointNames() const {
     return result;
 }
 
-void RenderableModelEntityItem::setAnimationURL(const QString& url) {
-    QString oldURL = getAnimationURL();
-    ModelEntityItem::setAnimationURL(url);
-    if (oldURL != getAnimationURL()) {
-        _needsAnimationReset = true;
-    }
-}
-
-bool RenderableModelEntityItem::needsAnimationReset() const {
-    return _needsAnimationReset;
-}
-
-QString RenderableModelEntityItem::getAnimationURLAndReset() {
-    _needsAnimationReset = false;
-    return getAnimationURL();
-}
-
 scriptable::ScriptableModelBase render::entities::ModelEntityRenderer::getScriptableModel() {
     auto model = resultWithReadLock<ModelPointer>([this]{ return _model; });
 
@@ -1474,11 +1457,17 @@ void ModelEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& sce
     if (_animating) {
         DETAILED_PROFILE_RANGE(simulation_physics, "Animate");
 
-        if (_animation && entity->needsAnimationReset()) {
-            //(_animation->getURL().toString() != entity->getAnimationURL())) { // bad check
-            // the joints have been mapped before but we have a new animation to load
-            _animation.reset();
-            _jointMappingCompleted = false;
+        auto animationURL = entity->getAnimationURL();
+        bool animationChanged = _animationURL != animationURL;
+        if (animationChanged) {
+            _animationURL = animationURL;
+
+            if (_animation) {
+                //(_animation->getURL().toString() != entity->getAnimationURL())) { // bad check
+                // the joints have been mapped before but we have a new animation to load
+                _animation.reset();
+                _jointMappingCompleted = false;
+            }
         }
 
         if (!_jointMappingCompleted) {
@@ -1525,7 +1514,7 @@ void ModelEntityRenderer::mapJoints(const TypedEntityPointer& entity, const Mode
     }
 
     if (!_animation) {
-        _animation = DependencyManager::get<AnimationCache>()->getAnimation(entity->getAnimationURLAndReset());
+        _animation = DependencyManager::get<AnimationCache>()->getAnimation(_animationURL);
     }
 
     if (_animation && _animation->isLoaded()) {

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -113,10 +113,6 @@ public:
     virtual int getJointIndex(const QString& name) const override;
     virtual QStringList getJointNames() const override;
 
-    void setAnimationURL(const QString& url) override;
-    bool needsAnimationReset() const;
-    QString getAnimationURLAndReset();
-
 private:
     bool needsUpdateModelBounds() const;
     void autoResizeJointArrays();
@@ -131,7 +127,6 @@ private:
     bool _originalTexturesRead { false };
     bool _dimensionsInitialized { true };
     bool _needsJointSimulation { false };
-    bool _needsAnimationReset { false };
 };
 
 namespace render { namespace entities { 
@@ -188,12 +183,12 @@ private:
 
     const void* _collisionMeshKey { nullptr };
 
-    // used on client side
+    QUrl _parsedModelURL;
     bool _jointMappingCompleted { false };
     QVector<int> _jointMapping; // domain is index into model-joints, range is index into animation-joints
     AnimationPointer _animation;
-    QUrl _parsedModelURL;
     bool _animating { false };
+    QString _animationURL;
     uint64_t _lastAnimated { 0 };
 
     render::ItemKey _itemKey { render::ItemKey::Builder().withTypeMeta() };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20398/Animations-on-Entities-broken-since-75
http://roadmap.highfidelity.com/bugs/p/fix-entity-model-animations

Test plan:
- Run [this](https://gist.githubusercontent.com/SamGondelman/c3851567b21ec1119279160a6593d3c0/raw/a7fb94128d6b3184103e7b3ccb6fb4d1d9d9f8d0/AnimationURLTest.js).  You'll see this:
![hifi-snap-by-samgondelman-on-2019-01-18_15-55-09](https://user-images.githubusercontent.com/7650116/51418638-85008380-1b39-11e9-844b-974e0c1f12b3.gif)
- Press "o".  The animation will change:
![hifi-snap-by-samgondelman-on-2019-01-18_15-55-16](https://user-images.githubusercontent.com/7650116/51418639-85008380-1b39-11e9-8f66-6206f46f5c5e.gif)