### PR TITLE
Case 20731 for 0.78: send updates when grabbing AvatarEntities

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -879,9 +879,13 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
                 collisionlessAllowed = zone->getGhostingAllowed();
             }
             EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
-            bool force = false;
-            bool iShouldTellServer = true;
             forEachDescendant([&](SpatiallyNestablePointer object) {
+                // we need to update attached queryAACubes in our own local tree so point-select always works
+                // however we don't want to flood the update pipeline with AvatarEntity updates, so we assume
+                // others have all info required to properly update queryAACube of AvatarEntities on their end
+                EntityItemPointer entity = std::dynamic_pointer_cast<EntityItem>(object);
+                bool iShouldTellServer = !(entity && entity->isAvatarEntity());
+                const bool force = false;
                 entityTree->updateEntityQueryAACube(object, packetSender, force, iShouldTellServer);
             });
         });

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -2965,8 +2965,8 @@ void EntityTree::updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, 
     // if the queryBox has changed, tell the entity-server
     EntityItemPointer entity = std::dynamic_pointer_cast<EntityItem>(object);
     if (entity) {
-        bool tellServerThis = tellServer && (entity->getEntityHostType() != entity::HostType::AVATAR);
-        if ((entity->updateQueryAACube() || force)) {
+        // NOTE: we rely on side-effects of the entity->updateQueryAACube() call in the following if() conditional:
+        if (entity->updateQueryAACube() || force) {
             bool success;
             AACube newCube = entity->getQueryAACube(success);
             if (success) {
@@ -2974,7 +2974,7 @@ void EntityTree::updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, 
             }
             // send an edit packet to update the entity-server about the queryAABox.  We do this for domain-hosted
             // entities as well as for avatar-entities; the packet-sender will route the update accordingly
-            if (tellServerThis && packetSender && (entity->isDomainEntity() || entity->isAvatarEntity())) {
+            if (tellServer && packetSender && (entity->isDomainEntity() || entity->isAvatarEntity())) {
                 quint64 now = usecTimestampNow();
                 EntityItemProperties properties = entity->getProperties();
                 properties.setQueryAACubeDirty();
@@ -2982,6 +2982,7 @@ void EntityTree::updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, 
                 properties.setLastEdited(now);
 
                 packetSender->queueEditEntityMessage(PacketType::EntityEdit, getThisPointer(), entity->getID(), properties);
+                entity->setLastEdited(now); // so we ignore the echo from the server
                 entity->setLastBroadcast(now); // for debug/physics status icons
             }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20731/Location-of-avatar-entities-grabbed-in-VR-may-be-unreliable-and-saved-in-a-different-position-from-where-wearer-sees-them

This PR fixes a bug where we were not sending updates for grabbed AvatarEntities when we should.