### PR TITLE
Case 19775: Add raw mouse Controller inputs on Windows and use for mouselook

### DIFF
--- a/interface/resources/controllers/keyboardMouse.json
+++ b/interface/resources/controllers/keyboardMouse.json
@@ -121,7 +121,7 @@
           "to": "Actions.Yaw"
         },
         
-        { "from": { "makeAxis" : ["Keyboard.MouseMoveLeft", "Keyboard.MouseMoveRight"] },
+        { "from": { "makeAxis" : ["Keyboard.MouseRawMoveLeft", "Keyboard.MouseRawMoveRight"] },
           "when": "Keyboard.RightMouseButton",
           "to": "Actions.DeltaYaw",
           "filters":
@@ -130,7 +130,7 @@
             ]
         },
 
-        { "from": { "makeAxis" : ["Keyboard.MouseMoveUp", "Keyboard.MouseMoveDown"] },
+        { "from": { "makeAxis" : ["Keyboard.MouseRawMoveUp", "Keyboard.MouseRawMoveDown"] },
           "when": "Keyboard.RightMouseButton",
           "to": "Actions.DeltaPitch",
           "filters":

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2976,6 +2976,9 @@ void Application::initializeUi() {
     foreach(auto inputPlugin, PluginManager::getInstance()->getInputPlugins()) {
         if (KeyboardMouseDevice::NAME == inputPlugin->getName()) {
             _keyboardMouseDevice = std::dynamic_pointer_cast<KeyboardMouseDevice>(inputPlugin);
+#ifdef Q_OS_WIN
+            installNativeEventFilter(&_keyboardMouseDevice->getNativeEventFilter());
+#endif
         }
         if (TouchscreenDevice::NAME == inputPlugin->getName()) {
             _touchscreenDevice = std::dynamic_pointer_cast<TouchscreenDevice>(inputPlugin);

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.cpp
@@ -21,6 +21,9 @@
 #ifdef Q_OS_WIN
 #include <QAbstractNativeEventFilter>
 #include <Windows.h>
+#else
+#include <QCursor>
+#include <QApplication>
 #endif
 
 const char* KeyboardMouseDevice::NAME = "Keyboard/Mouse";
@@ -64,7 +67,7 @@ public:
     }
 
 protected:
-    static KeyboardMouseDevice* KeyboardMouseDeviceNativeEventFilter::_keyboardMouseDevice;  // TODO: Initialize to nullptr?
+    static KeyboardMouseDevice* KeyboardMouseDeviceNativeEventFilter::_keyboardMouseDevice;
 };
 
 KeyboardMouseDevice* KeyboardMouseDeviceNativeEventFilter::_keyboardMouseDevice;
@@ -125,6 +128,13 @@ void KeyboardMouseDevice::pluginUpdate(float deltaTime, const controller::InputC
         updateDeltaAxisValue(MOUSE_AXIS_Y_POS, currentMove.y() < 0 ? -currentMove.y() : 0.0f);
         updateDeltaAxisValue(MOUSE_AXIS_Y_NEG, currentMove.y() > 0 ? currentMove.y() : 0.0f);
         _previousCursor = _lastCursor;
+
+#ifndef Q_OS_WIN
+        // Emulate Windows' raw cursor behavior.
+        if (QApplication::activeWindow() != nullptr) {
+            _lastRawCursor = QCursor::pos();
+        }
+#endif
 
         _inputDevice->_axisStateMap[MOUSE_RAW_AXIS_X].value = _lastRawCursor.x();
         _inputDevice->_axisStateMap[MOUSE_RAW_AXIS_Y].value = _lastRawCursor.y();
@@ -373,25 +383,25 @@ controller::Input KeyboardMouseDevice::InputDevice::makeInput(KeyboardMouseDevic
  *     <tr><td><code>MouseRawMoveRight</code></td><td>number</td><td>number</td><td>The mouse moved right, as reported by the
  *       hardware mouse driver when Interface has focus. May be higher resolution and occur more often than
  *       <code>MouseMoveRight</code>.<br />
- *       Windows-only; value is <code>undefined</code> on other OSes.</td></tr>
+ *       Raw values from the hardware mosue driver are provided on Windows only; values on other OSes are emulated.</td></tr>
  *     <tr><td><code>MouseRawMoveLeft</code></td><td>number</td><td>number</td><td>The mouse moved left, as reported by the
  *       hardware mouse driver when Interface has focus. May be higher resolution and occur more often than
  *       <code>MouseMoveLeft</code>.<br />
- *       Windows-only; value is <code>undefined</code> on other OSes.</td></tr>
+ *       Raw values from the hardware mosue driver are provided on Windows only; values on other OSes are emulated.</td></tr>
  *     <tr><td><code>MouseRawMoveUp</code></td><td>number</td><td>number</td><td>The mouse moved up, as reported by the
  *       hardware mouse driver when Interface has focus. May be higher resolution and occur more often than
  *       <code>MouseMoveUp</code>.<br />
- *       Windows-only; value is <code>undefined</code> on other OSes.</td></tr>
+ *       Raw values from the hardware mosue driver are provided on Windows only; values on other OSes are emulated.</td></tr>
  *     <tr><td><code>MouseRawMoveDown</code></td><td>number</td><td>number</td><td>The mouse moved down, as reported by the
  *       hardware mouse driver when Interface has focus. May be higher resolution and occur more often than
  *       <code>MouseMoveDown</code>.<br />
- *       Windows-only; value is <code>undefined</code> on other OSes.</td></tr>
+ *       Raw values from the hardware mosue driver are provided on Windows only; values on other OSes are emulated.</td></tr>
  *     <tr><td><code>MouseRawX</code></td><td>number</td><td>number</td><td>The raw mouse x-coordinate changed, when Interface
  *       has focus. The data value is its new raw x-coordinate value, unrelated to screen coordinates.<br />
  *       Windows-only; value is <code>undefined</code> on other OSes.</td></tr>
  *     <tr><td><code>MouseRawY</code></td><td>number</td><td>number</td><td>The raw mouse y-coordinate changed,  when Interface
  *       has focus. The data value is its new raw y-coordinate value, unrelated to screen coordinates.<br />
- *       Windows-only; value is <code>undefined</code> on other OSes.</td></tr>
+ *       Raw values from the hardware mosue driver are provided on Windows only; values on other OSes are emulated.</td></tr>
  *     <tr><td><code>MouseWheelRight</code></td><td>number</td><td>number</td><td>The mouse wheel rotated left. The data value
  *       is the number of units rotated (typically <code>1.0</code>).</td></tr>
  *     <tr><td><code>MouseWheelLeft</code></td><td>number</td><td>number</td><td>The mouse wheel rotated left. The data value 

--- a/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.h
+++ b/libraries/input-plugins/src/input-plugins/KeyboardMouseDevice.h
@@ -55,8 +55,17 @@ public:
         MOUSE_AXIS_WHEEL_X_NEG,
     };
 
+    enum MouseRawAxisChannel {
+        MOUSE_RAW_AXIS_X_POS = MOUSE_AXIS_WHEEL_X_NEG + 1,
+        MOUSE_RAW_AXIS_X_NEG,
+        MOUSE_RAW_AXIS_Y_POS,
+        MOUSE_RAW_AXIS_Y_NEG,
+        MOUSE_RAW_AXIS_X,
+        MOUSE_RAW_AXIS_Y,
+    };
+
     enum TouchAxisChannel {
-        TOUCH_AXIS_X_POS = MOUSE_AXIS_WHEEL_X_NEG + 1,
+        TOUCH_AXIS_X_POS = MOUSE_RAW_AXIS_Y + 1,
         TOUCH_AXIS_X_NEG,
         TOUCH_AXIS_Y_POS,
         TOUCH_AXIS_Y_NEG,
@@ -67,6 +76,10 @@ public:
     };
 
     // Plugin functions
+#ifdef Q_OS_WIN
+    virtual void init() override;
+    virtual void deinit() override;
+#endif
     bool isSupported() const override { return true; }
     const QString getName() const override { return NAME; }
 
@@ -89,6 +102,8 @@ public:
 
     static void enableTouch(bool enableTouch) { _enableTouch = enableTouch; }
 
+    void updateRawMousePosition(int deltaX, int deltaY);
+
     static const char* NAME;
 
 protected:
@@ -107,6 +122,7 @@ protected:
         controller::Input makeInput(Qt::Key code) const;
         controller::Input makeInput(Qt::MouseButton code, bool clicked = false) const;
         controller::Input makeInput(MouseAxisChannel axis) const;
+        controller::Input makeInput(MouseRawAxisChannel axis) const;
         controller::Input makeInput(TouchAxisChannel axis) const;
         controller::Input makeInput(TouchButtonChannel button) const;
 
@@ -116,9 +132,15 @@ protected:
 public:
     const std::shared_ptr<InputDevice>& getInputDevice() const { return _inputDevice; }
 
+#ifdef Q_OS_WIN
+    QAbstractNativeEventFilter& getNativeEventFilter();
+#endif
+
 protected:
     QPoint _lastCursor;
     QPoint _previousCursor;
+    QPoint _lastRawCursor;
+    QPoint _previousRawCursor;
     QPoint _mousePressPos;
     quint64 _mousePressTime;
     bool _clickDeadspotActive;

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -315,12 +315,14 @@ void PluginManager::shutdown() {
         if (inputPlugin->isActive()) {
             inputPlugin->deactivate();
         }
+        inputPlugin->deinit();
     }
 
-    for (auto displayPlugins : getDisplayPlugins()) {
-        if (displayPlugins->isActive()) {
-            displayPlugins->deactivate();
+    for (auto displayPlugin : getDisplayPlugins()) {
+        if (displayPlugin->isActive()) {
+            displayPlugin->deactivate();
         }
+        displayPlugin->deinit();
     }
 
     auto loadedPlugins = getLoadedPlugins();


### PR DESCRIPTION
Adds `Controller.Hardware.Keyboard.MouseRawX`, `.MouseRawY`, `.MouseRawMoveLeft`, `.MouseRawMoveRight`, `.MouseRawMoveUp`, and `.MouseRawMovedown` `Controller` outputs in Windows. 
- On Windows, they are output per the raw movement detected by the hardware mouse driver; on non-Windows they are emulated.
- They are generated whenever Interface has focus (even if the mouse cursor is not over an Interface window).
- They may occur more often (i.e., may be higher resolution) than the `.MouseX`, `.MouseY` etc. screen-based coordinates outputs - it depends on the speed of movement (more often is more likely at slower speeds) and the user's Windows mouse settings.
- They do not include pointer acceleration (ballistics) as may be applied to the mouse screen coordinates by Windows.

Uses these new `Controller` outputs for mouselook, to provide finer control of mouselook (on Windows).
