### PR TITLE
Fix security-image display in HMD 

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2911,6 +2911,7 @@ void Application::initializeUi() {
         QUrl{ "hifi/dialogs/security/SecurityImageChange.qml" },
         QUrl{ "hifi/dialogs/security/SecurityImageModel.qml" },
         QUrl{ "hifi/dialogs/security/SecurityImageSelection.qml" },
+        QUrl{ "hifi/tablet/TabletMenu.qml" },
     }, commerceCallback);
     QmlContextCallback ttsCallback = [](QQmlContext* context) {
         context->setContextProperty("TextToSpeech", DependencyManager::get<TTSScriptingInterface>().data());


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20278/

The menu scripts check the wallet status via the QmlCommerce bridge class. For the desktop case the class is created when any of the qml pages are created from the menu bar. For the HMD case the qml sub-pages don't go through this code path, only the top menu-page does. I've added this page (TabletMenu) to the list of pages that trigger the QmlCommerce class (in this first commit), but ideally it should be possible to narrow the scope to just the security page.