### PR TITLE
Case 20774: Possible fix for procedurals on mac

### DIFF
--- a/libraries/render-utils/src/simple.slf
+++ b/libraries/render-utils/src/simple.slf
@@ -91,14 +91,14 @@ void main(void) {
         position.xyz,
 #endif
         normal,
-        vec3(0.0),
+        diffuse,
         DEFAULT_SPECULAR,
-        DEFAULT_EMISSIVE,
+        emissive,
         1.0,
-        DEFAULT_ROUGHNESS,
-        DEFAULT_METALLIC,
-        DEFAULT_OCCLUSION,
-        DEFAULT_SCATTERING
+        roughness,
+        metallic,
+        occlusion,
+        scattering
     );
 
 #if defined(PROCEDURAL_V3)

--- a/libraries/render-utils/src/simple_transparent.slf
+++ b/libraries/render-utils/src/simple_transparent.slf
@@ -99,13 +99,13 @@ void main(void) {
         position.xyz,
 #endif
         normal,
-        vec3(0.0),
-        DEFAULT_SPECULAR,
-        DEFAULT_EMISSIVE,
-        1.0,
-        DEFAULT_ROUGHNESS,
-        DEFAULT_METALLIC,
-        DEFAULT_OCCLUSION,
+        diffuse,
+        fresnel,
+        emissive,
+        alpha,
+        roughness,
+        metallic,
+        occlusion,
         DEFAULT_SCATTERING
     );
 

--- a/libraries/render-utils/src/simple_transparent.slf
+++ b/libraries/render-utils/src/simple_transparent.slf
@@ -92,10 +92,10 @@ void main(void) {
     emissive = vec3(clamp(emissiveAmount, 0.0, 1.0));
 #elif defined(PROCEDURAL_V3) || defined(PROCEDURAL_V4)
 #if defined(PROCEDURAL_V3)
-    ProceduralFragment proceduralData = {
+    ProceduralFragment proceduralData = ProceduralFragment(
 #else
     vec4 position = cam._viewInverse * _positionES;
-    ProceduralFragmentWithPosition proceduralData = {
+    ProceduralFragmentWithPosition proceduralData = ProceduralFragmentWithPosition(
         position.xyz,
 #endif
         normal,
@@ -107,7 +107,7 @@ void main(void) {
         DEFAULT_METALLIC,
         DEFAULT_OCCLUSION,
         DEFAULT_SCATTERING
-    };
+    );
 
 #if defined(PROCEDURAL_V3)
     emissiveAmount = getProceduralFragment(proceduralData);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20759/Procedural-Shaders-do-not-show-up-on-Mac
https://highfidelity.manuscript.com/f/cases/20774/same-as-20759

Test plan:
- Run this from the console:
```
Entities.addEntity({
	type: "Box",
	position: Vec3.sum(MyAvatar.position, Vec3.multiply(4.0, Quat.getForward(MyAvatar.orientation))),
	dimensions: 0.5,
	collisionless: true,
	alpha: 0.5,
	userData: JSON.stringify({ "ProceduralEntity": {"version":4,"shaderUrl":"https://gist.githubusercontent.com/SamGondelman/932c8c03fd39b0549f0a07c0a736abd9/raw/85e047ff15e68c29c730823421b52a4024311753/raymarch.fs","uniforms":{"scene":0}}})
})
```
- A transparent beach ball thing should render.