### PR TITLE
make sure grabbed non-dynamic entities end up kinematic (not static) in bullet while being grabbed

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -3361,6 +3361,8 @@ void EntityItem::addGrab(GrabPointer grab) {
     enableNoBootstrap();
     SpatiallyNestable::addGrab(grab);
 
+    markDirtyFlags(Simulation::DIRTY_MOTION_TYPE);
+
     if (getDynamic() && getParentID().isNull()) {
         EntityTreePointer entityTree = getTree();
         assert(entityTree);
@@ -3403,6 +3405,8 @@ void EntityItem::addGrab(GrabPointer grab) {
 
 void EntityItem::removeGrab(GrabPointer grab) {
     SpatiallyNestable::removeGrab(grab);
+
+    markDirtyFlags(Simulation::DIRTY_MOTION_TYPE);
 
     QUuid actionID = grab->getActionID();
     if (!actionID.isNull()) {

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -211,6 +211,7 @@ PhysicsMotionType EntityMotionState::computePhysicsMotionType() const {
     }
     if (_entity->isMovingRelativeToParent() ||
         _entity->hasActions() ||
+        _entity->hasGrabs() ||
         _entity->hasAncestorOfType(NestableType::Avatar)) {
         return MOTION_TYPE_KINEMATIC;
     }


### PR DESCRIPTION
- make sure grabbed non-dynamic entities end up kinematic (not static) in bullet while being grabbed
