### PR TITLE
Allow filtering on plugin metadata to avoid inappropriate plugins

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -68,6 +68,13 @@ AudioMixer::AudioMixer(ReceivedMessage& message) :
     // hash the available codecs (on the mixer)
     _availableCodecs.clear(); // Make sure struct is clean
     auto pluginManager = DependencyManager::set<PluginManager>();
+    // Only load codec plugins; for now assume codec plugins have 'codec' in their name.
+    auto codecPluginFilter = [](const QJsonObject& metaData) {
+        QJsonValue nameValue = metaData["MetaData"]["name"];
+        return nameValue.toString().contains("codec", Qt::CaseInsensitive);
+    };
+    pluginManager->setPluginFilter(codecPluginFilter);
+
     auto codecPlugins = pluginManager->getCodecPlugins();
     for_each(codecPlugins.cbegin(), codecPlugins.cend(),
         [&](const CodecPluginPointer& codec) {

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -14,6 +14,11 @@
 #include <QtCore/QDebug>
 #include <QtCore/QPluginLoader>
 
+//#define HIFI_PLUGINMANAGER_DEBUG
+#if defined(HIFI_PLUGINMANAGER_DEBUG)
+#include <QJsonDocument>
+#endif
+
 #include <DependencyManager.h>
 #include <UserActivityLogger.h>
 
@@ -79,10 +84,7 @@ bool isDisabled(QJsonObject metaData) {
     return false;
 }
 
-using Loader = QSharedPointer<QPluginLoader>;
-using LoaderList = QList<Loader>;
-
-const LoaderList& getLoadedPlugins() {
+ auto PluginManager::getLoadedPlugins() const -> const LoaderList& {
     static std::once_flag once;
     static LoaderList loadedPlugins;
     std::call_once(once, [&] {
@@ -106,15 +108,25 @@ const LoaderList& getLoadedPlugins() {
             for (auto plugin : candidates) {
                 qCDebug(plugins) << "Attempting plugin" << qPrintable(plugin);
                 QSharedPointer<QPluginLoader> loader(new QPluginLoader(pluginPath + plugin));
-
-                if (isDisabled(loader->metaData())) {
+                const QJsonObject pluginMetaData = loader->metaData();
+#if defined(HIFI_PLUGINMANAGER_DEBUG)
+                QJsonDocument metaDataDoc(pluginMetaData);
+                qCInfo(plugins) << "Metadata for " << qPrintable(plugin) << ": " << QString(metaDataDoc.toJson());
+#endif
+                if (isDisabled(pluginMetaData)) {
                     qCWarning(plugins) << "Plugin" << qPrintable(plugin) << "is disabled";
                     // Skip this one, it's disabled
                     continue;
                 }
-                if (getPluginInterfaceVersionFromMetaData(loader->metaData()) != HIFI_PLUGIN_INTERFACE_VERSION) {
+
+                if (!_pluginFilter(pluginMetaData)) {
+                    qCWarning(plugins) << "Plugin" << qPrintable(plugin) << "doesn't pass provided filter";
+                    continue;
+                }
+
+                if (getPluginInterfaceVersionFromMetaData(pluginMetaData) != HIFI_PLUGIN_INTERFACE_VERSION) {
                     qCWarning(plugins) << "Plugin" << qPrintable(plugin) << "interface version doesn't match, not loading:"
-                                       << getPluginInterfaceVersionFromMetaData(loader->metaData())
+                                       << getPluginInterfaceVersionFromMetaData(pluginMetaData)
                                        << "doesn't match" << HIFI_PLUGIN_INTERFACE_VERSION;
                     continue;
                 }

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -120,7 +120,7 @@ bool isDisabled(QJsonObject metaData) {
                 }
 
                 if (!_pluginFilter(pluginMetaData)) {
-                    qCWarning(plugins) << "Plugin" << qPrintable(plugin) << "doesn't pass provided filter";
+                    qCDebug(plugins) << "Plugin" << qPrintable(plugin) << "doesn't pass provided filter";
                     continue;
                 }
 

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -13,8 +13,7 @@
 
 #include "Forward.h"
 
-
-class PluginManager;
+class QPluginLoader;
 using PluginManagerPointer = QSharedPointer<PluginManager>;
 
 class PluginManager : public QObject, public Dependency {
@@ -47,6 +46,9 @@ public:
     void setInputPluginSettingsPersister(const InputPluginSettingsPersister& persister);
     QStringList getRunningInputDeviceNames() const;
 
+    using PluginFilter = std::function<bool(const QJsonObject&)>;
+    void setPluginFilter(PluginFilter pluginFilter) { _pluginFilter = pluginFilter; }
+
 signals:
     void inputDeviceRunningChanged(const QString& pluginName, bool isRunning, const QStringList& runningDevices);
     
@@ -60,6 +62,12 @@ private:
     PluginContainer* _container { nullptr };
     DisplayPluginList _displayPlugins;
     InputPluginList _inputPlugins;
+    PluginFilter _pluginFilter { [](const QJsonObject&) { return true; } };
+
+    using Loader = QSharedPointer<QPluginLoader>;
+    using LoaderList = QList<Loader>;
+
+    const LoaderList& getLoadedPlugins() const;
 };
 
 // TODO: we should define this value in CMake, and then use CMake


### PR DESCRIPTION
Ticket: https://highfidelity.manuscript.com/f/cases/10181/Plugins-for-Interface-are-being-loaded-by-ACs

Add a simple functor-based filtering mechanism to our PluginManager. The audio mixer uses this to only select audio codecs by limiting to DLLs that have the string 'codec' in their Qt-provided metadata name. This filtering is doing before loading to avoid the crash discussed in the ticket.