### PR TITLE
case 20705: Allow log window to stay on top

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -8107,8 +8107,18 @@ void Application::toggleLogDialog() {
         return;
     }
     if (! _logDialog) {
-        bool shouldSetParent = _keepLogWindowOnTop.get();
-        _logDialog = new LogDialog(shouldSetParent ? qApp->getWindow() : nullptr, getLogger());
+
+        bool keepOnTop =_keepLogWindowOnTop.get();
+#ifdef Q_OS_WIN
+        _logDialog = new LogDialog(keepOnTop ? qApp->getWindow() : nullptr, getLogger());
+#else
+        _logDialog = new LogDialog(nullptr, getLogger());
+
+        if (keepOnTop) {
+            Qt::WindowFlags flags = _logDialog->windowFlags() | Qt::Tool;
+            _logDialog->setWindowFlags(flags);
+        }
+#endif
     }
 
     if (_logDialog->isVisible()) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -8107,7 +8107,8 @@ void Application::toggleLogDialog() {
         return;
     }
     if (! _logDialog) {
-        _logDialog = new LogDialog(nullptr, getLogger());
+        bool shouldSetParent = _keepLogWindowOnTop.get();
+        _logDialog = new LogDialog(shouldSetParent ? qApp->getWindow() : nullptr, getLogger());
     }
 
     if (_logDialog->isVisible()) {
@@ -8116,6 +8117,19 @@ void Application::toggleLogDialog() {
         _logDialog->show();
     }
 }
+
+ void Application::recreateLogWindow(int keepOnTop) {
+     _keepLogWindowOnTop.set(keepOnTop != 0);
+     if (_logDialog) {
+         bool toggle = _logDialog->isVisible();
+         _logDialog->close();
+         _logDialog = nullptr;
+
+         if (toggle) {
+             toggleLogDialog();
+         }
+     }
+ }
 
 void Application::toggleEntityScriptServerLogDialog() {
     if (! _entityScriptServerLogDialog) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -218,6 +218,7 @@ public:
 
     bool getDesktopTabletBecomesToolbarSetting() { return _desktopTabletBecomesToolbarSetting.get(); }
     bool getLogWindowOnTopSetting() { return _keepLogWindowOnTop.get(); }
+    void setLogWindowOnTopSetting(bool keepOnTop) { _keepLogWindowOnTop.set(keepOnTop); }
     void setDesktopTabletBecomesToolbarSetting(bool value);
     bool getHmdTabletBecomesToolbarSetting() { return _hmdTabletBecomesToolbarSetting.get(); }
     void setHmdTabletBecomesToolbarSetting(bool value);

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -217,6 +217,7 @@ public:
     void setDesktopTabletScale(float desktopTabletScale);
 
     bool getDesktopTabletBecomesToolbarSetting() { return _desktopTabletBecomesToolbarSetting.get(); }
+    bool getLogWindowOnTopSetting() { return _keepLogWindowOnTop.get(); }
     void setDesktopTabletBecomesToolbarSetting(bool value);
     bool getHmdTabletBecomesToolbarSetting() { return _hmdTabletBecomesToolbarSetting.get(); }
     void setHmdTabletBecomesToolbarSetting(bool value);
@@ -365,6 +366,7 @@ public slots:
     Q_INVOKABLE void loadDialog();
     Q_INVOKABLE void loadScriptURLDialog() const;
     void toggleLogDialog();
+    void recreateLogWindow(int);
     void toggleEntityScriptServerLogDialog();
     Q_INVOKABLE void showAssetServerWidget(QString filePath = "");
     Q_INVOKABLE void loadAddAvatarBookmarkDialog() const;
@@ -654,6 +656,7 @@ private:
     Setting::Handle<bool> _constrainToolbarPosition;
     Setting::Handle<QString> _preferredCursor;
     Setting::Handle<bool> _miniTabletEnabledSetting;
+    Setting::Handle<bool> _keepLogWindowOnTop { "keepLogWindowOnTop", false };
 
     float _scaleMirror;
     float _mirrorYawOffset;

--- a/interface/src/ui/BaseLogDialog.cpp
+++ b/interface/src/ui/BaseLogDialog.cpp
@@ -20,9 +20,9 @@
 #include <PathUtils.h>
 
 const int TOP_BAR_HEIGHT = 124;
-const int INITIAL_WIDTH = 720;
+const int INITIAL_WIDTH = 800;
 const int INITIAL_HEIGHT = 480;
-const int MINIMAL_WIDTH = 700;
+const int MINIMAL_WIDTH = 780;
 const int SEARCH_BUTTON_LEFT = 25;
 const int SEARCH_BUTTON_WIDTH = 20;
 const int SEARCH_TOGGLE_BUTTON_WIDTH = 50;

--- a/interface/src/ui/LogDialog.cpp
+++ b/interface/src/ui/LogDialog.cpp
@@ -154,7 +154,11 @@ LogDialog::LogDialog(QWidget* parent, AbstractLoggerInterface* logger) : BaseLog
     _keepOnTopBox = new QCheckBox(" Keep window on top", this);
     bool isOnTop = qApp-> getLogWindowOnTopSetting();
     _keepOnTopBox->setCheckState(isOnTop ? Qt::Checked : Qt::Unchecked);
+#ifdef Q_OS_WIN
     connect(_keepOnTopBox, &QCheckBox::stateChanged, qApp, &Application::recreateLogWindow);
+#else
+    connect(_keepOnTopBox, &QCheckBox::stateChanged, this, &LogDialog::handleKeepWindowOnTop);
+#endif
     _keepOnTopBox->show();
 
     _extraDebuggingBox = new QCheckBox("Extra debugging", this);
@@ -246,6 +250,23 @@ void LogDialog::handleDebugPrintBox(int state) {
 void LogDialog::handleInfoPrintBox(int state) {
     _logger->setInfoPrint(state != 0);
     printLogFile();
+}
+
+void LogDialog::handleKeepWindowOnTop(int state) {
+    bool keepOnTop = (state != 0);
+
+    Qt::WindowFlags flags = windowFlags();
+
+    if (keepOnTop) {
+        flags |= Qt::Tool;
+    } else {
+        flags &= ~Qt::Tool;
+    }
+
+    setWindowFlags(flags);
+    qApp->setLogWindowOnTopSetting(keepOnTop);
+
+    show();
 }
 
 void LogDialog::handleCriticalPrintBox(int state) {

--- a/interface/src/ui/LogDialog.cpp
+++ b/interface/src/ui/LogDialog.cpp
@@ -19,6 +19,9 @@
 
 #include <shared/AbstractLoggerInterface.h>
 
+#include "Application.h"
+#include "MainWindow.h"
+
 const int REVEAL_BUTTON_WIDTH = 122;
 const int ALL_LOGS_BUTTON_WIDTH = 90;
 const int MARGIN_LEFT = 25;
@@ -148,6 +151,12 @@ LogDialog::LogDialog(QWidget* parent, AbstractLoggerInterface* logger) : BaseLog
     _messageCount->setObjectName("messageCount");
     _messageCount->show();
 
+    _keepOnTopBox = new QCheckBox(" Keep window on top", this);
+    bool isOnTop = qApp-> getLogWindowOnTopSetting();
+    _keepOnTopBox->setCheckState(isOnTop ? Qt::Checked : Qt::Unchecked);
+    connect(_keepOnTopBox, &QCheckBox::stateChanged, qApp, &Application::recreateLogWindow);
+    _keepOnTopBox->show();
+
     _extraDebuggingBox = new QCheckBox("Extra debugging", this);
     if (_logger->extraDebugging()) {
         _extraDebuggingBox->setCheckState(Qt::Checked);
@@ -180,6 +189,11 @@ void LogDialog::resizeEvent(QResizeEvent* event) {
         ALL_LOGS_BUTTON_WIDTH,
         ELEMENT_HEIGHT);
     _extraDebuggingBox->setGeometry(width() - ELEMENT_MARGIN - COMBOBOX_WIDTH - ELEMENT_MARGIN - ALL_LOGS_BUTTON_WIDTH,
+        THIRD_ROW,
+        COMBOBOX_WIDTH,
+        ELEMENT_HEIGHT);
+
+     _keepOnTopBox->setGeometry(width() - ELEMENT_MARGIN - COMBOBOX_WIDTH - ELEMENT_MARGIN - ALL_LOGS_BUTTON_WIDTH - ELEMENT_MARGIN - COMBOBOX_WIDTH - ELEMENT_MARGIN,
         THIRD_ROW,
         COMBOBOX_WIDTH,
         ELEMENT_HEIGHT);

--- a/interface/src/ui/LogDialog.h
+++ b/interface/src/ui/LogDialog.h
@@ -34,6 +34,7 @@ public slots:
 private slots:
     void handleRevealButton();
     void handleExtraDebuggingCheckbox(int);
+    void handleKeepWindowOnTop(int);
     void handleDebugPrintBox(int);
     void handleInfoPrintBox(int);
     void handleCriticalPrintBox(int);

--- a/interface/src/ui/LogDialog.h
+++ b/interface/src/ui/LogDialog.h
@@ -55,6 +55,7 @@ protected:
 
 private:
     QCheckBox* _extraDebuggingBox;
+    QCheckBox* _keepOnTopBox;
     QPushButton* _revealLogButton;
     QPushButton* _allLogsButton;
     QCheckBox* _debugPrintBox;


### PR DESCRIPTION
Add a menu option in developers to keep the log window on top.

Ticket: https://highfidelity.manuscript.com/f/cases/20705/Set-the-Qt-WindowStaysOnTopHint-for-the-main-log-window