### PR TITLE
Case 7908: Fix Debug builds in serverless and default Sandbox domains

### DIFF
--- a/interface/src/ui/overlays/ModelOverlay.cpp
+++ b/interface/src/ui/overlays/ModelOverlay.cpp
@@ -212,7 +212,11 @@ void ModelOverlay::setProperties(const QVariantMap& properties) {
     }
     if (dimensions.isValid()) {
         _scaleToFit = true;
-        setDimensions(vec3FromVariant(dimensions));
+        glm::vec3 size = vec3FromVariant(dimensions);
+        // Don't allow a zero or negative dimension component to reach the renderTransform.
+        const float MIN_DIMENSION = 0.0001f;
+        size = glm::max(size, MIN_DIMENSION);
+        setDimensions(size);
     } else if (scale.isValid()) {
         // if "scale" property is set but "dimensions" is not.
         // do NOT scale to fit.

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1184,7 +1184,6 @@ void Rig::updateAnimations(float deltaTime, const glm::mat4& rootTransform, cons
         _internalPoseSet._relativePoses = _animNode->evaluate(_animVars, context, deltaTime, triggersOut);
         if (_networkNode) {
             // Manually blending networkPoseSet with internalPoseSet.
-            float alpha = 1.0f;
             const float FRAMES_PER_SECOND = 30.0f;
             const float TOTAL_BLEND_FRAMES = 6.0f;
             const float TOTAL_BLEND_TIME = TOTAL_BLEND_FRAMES / FRAMES_PER_SECOND;
@@ -1192,10 +1191,14 @@ void Rig::updateAnimations(float deltaTime, const glm::mat4& rootTransform, cons
             if (_sendNetworkNode) {
                 _networkPoseSet._relativePoses = _networkNode->evaluate(_networkVars, context, deltaTime, networkTriggersOut);
                 _networkAnimState.blendTime += deltaTime;
-                alpha = _computeNetworkAnimation ? (_networkAnimState.blendTime / TOTAL_BLEND_TIME) : (1.0f - (_networkAnimState.blendTime / TOTAL_BLEND_TIME));
-                alpha = glm::clamp(alpha, 0.0f, 1.0f);
-                for (size_t i = 0; i < _networkPoseSet._relativePoses.size(); i++) {
-                    _networkPoseSet._relativePoses[i].blend(_internalPoseSet._relativePoses[i], alpha);
+                // Pose sets may be different sizes (e.g., 0) during start-up.
+                if (_networkPoseSet._relativePoses.size() == _internalPoseSet._relativePoses.size()) {
+                    float alpha = _computeNetworkAnimation ? (_networkAnimState.blendTime / TOTAL_BLEND_TIME) 
+                        : (1.0f - (_networkAnimState.blendTime / TOTAL_BLEND_TIME));
+                    alpha = glm::clamp(alpha, 0.0f, 1.0f);
+                    for (size_t i = 0; i < _networkPoseSet._relativePoses.size(); i++) {
+                        _networkPoseSet._relativePoses[i].blend(_internalPoseSet._relativePoses[i], alpha);
+                    }
                 }
             }
         }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1292,7 +1292,15 @@ void Model::scaleToFit() {
     // size is our "target size in world space"
     // we need to set our model scale so that the extents of the mesh, fit in a box that size...
     glm::vec3 meshDimensions = modelMeshExtents.maximum - modelMeshExtents.minimum;
-    glm::vec3 rescaleDimensions = _scaleToFitDimensions / meshDimensions;
+    const glm::vec3 MIMINUM_ENTITY_DIMENSIONS = glm::vec3(0.001f, 0.001f, 0.001f);
+    glm::vec3 rescaleDimensions = _scaleToFitDimensions / glm::max(meshDimensions, MIMINUM_ENTITY_DIMENSIONS);
+    /*
+    // FIXME: Possibly better fix...
+    glm::vec3 rescaleDimensions;
+    rescaleDimensions.x = meshDimensions.x != 0.0f ? _scaleToFitDimensions.x / meshDimensions.x : 1.0f;
+    rescaleDimensions.y = meshDimensions.y != 0.0f ? _scaleToFitDimensions.y / meshDimensions.y : 1.0f;
+    rescaleDimensions.z = meshDimensions.z != 0.0f ? _scaleToFitDimensions.z / meshDimensions.z : 1.0f;
+    */
     setScaleInternal(rescaleDimensions);
     _scaledToFit = true;
 }


### PR DESCRIPTION
Fix Interface such that Windows Debug builds run without asserting or otherwise crashing with default avatar and default scripts in:
- Serverless tutorial.
- Default Sandbox domain content.

Problems:
01 Assert vector subscript out of range in Rig::updateAnimations().
	Triggered during Interface start-up, often.
	Fixed.
02 Assert in Buffer::Update::apply().
	Triggered when switch between display plugins (e.g., desktop and HMD mode), often.
	Not fixed. https://highfidelity.manuscript.com/f/cases/20621/assert-buffer-_applyUpdateCount-updateNumber-when-switching-displays-in-Debug-build
	Work-around: Don't switch between desktop and HMD modes or comment out the assert in Debug builds.
03 Asserts inModel::setScaleInternal() and Transform.h isValidScale()
	Triggered by teleport.js setting play area overlay dimensions to zero.
	Fixed by limiting to minimum dimension, same as Volume3DOverlay does for other overlays.
04 GeometryUtil.cpp : findRayAABoxIntersection() : assert(i >= 0 && i < this->length())
	Triggered by woodFloor.fbx in the Sandbox default content. This FBX has a mesh with one of its dimensions = 0.0. This model is not displayed in Release builds.
	Fixed by handling 0 dimension in Model::scaleToFit().
	Also makes the woodFloor.fbx model display.
	See also: https://highfidelity.manuscript.com/f/cases/20687/Wood-floor-in-Sandbox-content-doesn-t-display

https://highfidelity.manuscript.com/f/cases/7908