### PR TITLE
Case: 20770 allow debug prints in the log by default

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2346,7 +2346,6 @@ void Application::updateVerboseLogging() {
     bool enable = menu->isOptionChecked(MenuOption::VerboseLogging);
 
     QString rules =
-        "hifi.*.debug=%1\n"
         "hifi.*.info=%1\n"
         "hifi.audio-stream.debug=false\n"
         "hifi.audio-stream.info=false";


### PR DESCRIPTION
Allow debug prints including scripting print to be seen in the logs by default without having to enable the verbose logging option 

Ticket https://highfidelity.manuscript.com/f/cases/20770/script-print-should-show-up-in-the-main-Log-window-without-having-to-turn-on-verbose-logging