### PR TITLE
case 20805: RC78.1: Fix the distance attenuation of stereo local injectors

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4031,7 +4031,9 @@ void Application::keyPressEvent(QKeyEvent* event) {
                 if (!isShifted && !isMeta && !isOption && !event->isAutoRepeat()) {
                     AudioInjectorOptions options;
                     options.localOnly = true;
+                    options.positionSet = false;    // system sound
                     options.stereo = true;
+
                     Setting::Handle<bool> notificationSounds{ MenuOption::NotificationSounds, true };
                     Setting::Handle<bool> notificationSoundSnapshot{ MenuOption::NotificationSoundsSnapshot, true };
                     if (notificationSounds.get() && notificationSoundSnapshot.get()) {

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1333,8 +1333,12 @@ bool AudioClient::mixLocalAudioInjectors(float* mixBuffer) {
 
                 } else if (injector->isStereo()) {
 
+                    // calculate distance, gain
+                    glm::vec3 relativePosition = injector->getPosition() - _positionGetter();
+                    float distance = glm::max(glm::length(relativePosition), EPSILON);
+                    float gain = gainForSource(distance, injector->getVolume());
+
                     // stereo gets directly mixed into mixBuffer
-                    float gain = injector->getVolume();
                     for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_STEREO; i++) {
                         mixBuffer[i] += convertToFloat(_localScratchBuffer[i]) * gain;
                     }

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1310,10 +1310,17 @@ bool AudioClient::mixLocalAudioInjectors(float* mixBuffer) {
             memset(_localScratchBuffer, 0, bytesToRead);
             if (0 < injectorBuffer->readData((char*)_localScratchBuffer, bytesToRead)) {
 
+                float gain = injector->getVolume();
+
                 if (injector->isAmbisonic()) {
 
-                    // no distance attenuation
-                    float gain = injector->getVolume();
+                    if (injector->isPositionSet()) {
+
+                        // distance attenuation
+                        glm::vec3 relativePosition = injector->getPosition() - _positionGetter();
+                        float distance = glm::max(glm::length(relativePosition), EPSILON);
+                        gain = gainForSource(distance, gain);
+                    }
 
                     //
                     // Calculate the soundfield orientation relative to the listener.
@@ -1327,33 +1334,49 @@ bool AudioClient::mixLocalAudioInjectors(float* mixBuffer) {
                     float qy = -relativeOrientation.x;
                     float qz = relativeOrientation.y;
 
-                    // Ambisonic gets spatialized into mixBuffer
+                    // spatialize into mixBuffer
                     injector->getLocalFOA().render(_localScratchBuffer, mixBuffer, HRTF_DATASET_INDEX,
                                                    qw, qx, qy, qz, gain, AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
 
                 } else if (injector->isStereo()) {
 
-                    // calculate distance, gain
-                    glm::vec3 relativePosition = injector->getPosition() - _positionGetter();
-                    float distance = glm::max(glm::length(relativePosition), EPSILON);
-                    float gain = gainForSource(distance, injector->getVolume());
+                    if (injector->isPositionSet()) {
 
-                    // stereo gets directly mixed into mixBuffer
-                    for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_STEREO; i++) {
-                        mixBuffer[i] += convertToFloat(_localScratchBuffer[i]) * gain;
+                        // distance attenuation
+                        glm::vec3 relativePosition = injector->getPosition() - _positionGetter();
+                        float distance = glm::max(glm::length(relativePosition), EPSILON);
+                        gain = gainForSource(distance, gain);
                     }
 
-                } else {
+                    // direct mix into mixBuffer
+                    for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL; i++) {
+                        mixBuffer[2*i+0] += convertToFloat(_localScratchBuffer[2*i+0]) * gain;
+                        mixBuffer[2*i+1] += convertToFloat(_localScratchBuffer[2*i+1]) * gain;
+                    }
 
-                    // calculate distance, gain and azimuth for hrtf
-                    glm::vec3 relativePosition = injector->getPosition() - _positionGetter();
-                    float distance = glm::max(glm::length(relativePosition), EPSILON);
-                    float gain = gainForSource(distance, injector->getVolume());
-                    float azimuth = azimuthForSource(relativePosition);
+                } else {    // injector is mono
 
-                    // mono gets spatialized into mixBuffer
-                    injector->getLocalHRTF().render(_localScratchBuffer, mixBuffer, HRTF_DATASET_INDEX,
-                                                    azimuth, distance, gain, AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
+                    if (injector->isPositionSet()) {
+
+                        // distance attenuation
+                        glm::vec3 relativePosition = injector->getPosition() - _positionGetter();
+                        float distance = glm::max(glm::length(relativePosition), EPSILON);
+                        gain = gainForSource(distance, gain);
+
+                        float azimuth = azimuthForSource(relativePosition);
+
+                        // spatialize into mixBuffer
+                        injector->getLocalHRTF().render(_localScratchBuffer, mixBuffer, HRTF_DATASET_INDEX,
+                                                        azimuth, distance, gain, AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL);
+                    } else {
+
+                        // direct mix into mixBuffer
+                        for (int i = 0; i < AudioConstants::NETWORK_FRAME_SAMPLES_PER_CHANNEL; i++) {
+                            float sample = convertToFloat(_localScratchBuffer[i]) * gain;
+                            mixBuffer[2*i+0] += sample;
+                            mixBuffer[2*i+1] += sample;
+                        }
+                    }
                 }
 
             } else {

--- a/libraries/audio/src/AudioInjector.h
+++ b/libraries/audio/src/AudioInjector.h
@@ -67,6 +67,7 @@ public:
 
     bool isLocalOnly() const { return _options.localOnly; }
     float getVolume() const { return _options.volume; }
+    bool isPositionSet() const { return _options.positionSet; }
     glm::vec3 getPosition() const { return _options.position; }
     glm::quat getOrientation() const { return _options.orientation; }
     bool isStereo() const { return _options.stereo; }

--- a/libraries/audio/src/AudioInjectorOptions.cpp
+++ b/libraries/audio/src/AudioInjectorOptions.cpp
@@ -34,8 +34,9 @@ AudioInjectorOptions::AudioInjectorOptions() :
 
 QScriptValue injectorOptionsToScriptValue(QScriptEngine* engine, const AudioInjectorOptions& injectorOptions) {
     QScriptValue obj = engine->newObject();
-    obj.setProperty("position", vec3ToScriptValue(engine, injectorOptions.position));
-    obj.setProperty("positionSet", injectorOptions.positionSet);
+    if (injectorOptions.positionSet) {
+        obj.setProperty("position", vec3ToScriptValue(engine, injectorOptions.position));
+    }
     obj.setProperty("volume", injectorOptions.volume);
     obj.setProperty("loop", injectorOptions.loop);
     obj.setProperty("orientation", quatToScriptValue(engine, injectorOptions.orientation));

--- a/libraries/audio/src/AudioInjectorOptions.cpp
+++ b/libraries/audio/src/AudioInjectorOptions.cpp
@@ -19,6 +19,7 @@
 
 AudioInjectorOptions::AudioInjectorOptions() :
     position(0.0f, 0.0f, 0.0f),
+    positionSet(true),  // default to legacy behavior
     volume(1.0f),
     loop(false),
     orientation(glm::vec3(0.0f, 0.0f, 0.0f)),
@@ -29,12 +30,12 @@ AudioInjectorOptions::AudioInjectorOptions() :
     secondOffset(0.0f),
     pitch(1.0f)
 {
-
 }
 
 QScriptValue injectorOptionsToScriptValue(QScriptEngine* engine, const AudioInjectorOptions& injectorOptions) {
     QScriptValue obj = engine->newObject();
     obj.setProperty("position", vec3ToScriptValue(engine, injectorOptions.position));
+    obj.setProperty("positionSet", injectorOptions.positionSet);
     obj.setProperty("volume", injectorOptions.volume);
     obj.setProperty("loop", injectorOptions.loop);
     obj.setProperty("orientation", quatToScriptValue(engine, injectorOptions.orientation));
@@ -68,12 +69,18 @@ void injectorOptionsFromScriptValue(const QScriptValue& object, AudioInjectorOpt
         return;
     }
 
+    if (injectorOptions.positionSet == false) {
+        qWarning() << "Audio injector options: injectorOptionsFromScriptValue() called more than once?";
+    }
+    injectorOptions.positionSet = false;
+
     QScriptValueIterator it(object);
     while (it.hasNext()) {
         it.next();
 
         if (it.name() == "position") {
             vec3FromScriptValue(object.property("position"), injectorOptions.position);
+            injectorOptions.positionSet = true;
         } else if (it.name() == "orientation") {
             quatFromScriptValue(object.property("orientation"), injectorOptions.orientation);
         } else if (it.name() == "volume") {

--- a/libraries/audio/src/AudioInjectorOptions.h
+++ b/libraries/audio/src/AudioInjectorOptions.h
@@ -21,6 +21,7 @@ class AudioInjectorOptions {
 public:
     AudioInjectorOptions();
     glm::vec3 position;
+    bool positionSet;
     float volume;
     bool loop;
     glm::quat orientation;

--- a/libraries/script-engine/src/AudioScriptingInterface.cpp
+++ b/libraries/script-engine/src/AudioScriptingInterface.cpp
@@ -38,10 +38,10 @@ void AudioScriptingInterface::setLocalAudioInterface(AbstractAudioInterface* aud
     }
 }
 
-ScriptAudioInjector* AudioScriptingInterface::playSystemSound(SharedSoundPointer sound, const QVector3D& position) {
+ScriptAudioInjector* AudioScriptingInterface::playSystemSound(SharedSoundPointer sound) {
     AudioInjectorOptions options;
-    options.position = glm::vec3(position.x(), position.y(), position.z());
     options.localOnly = true;
+    options.positionSet = false;    // system sound
     return playSound(sound, options);
 }
 

--- a/libraries/script-engine/src/AudioScriptingInterface.h
+++ b/libraries/script-engine/src/AudioScriptingInterface.h
@@ -102,11 +102,9 @@ protected:
      * @function Audio.playSystemSound
      * @param {SoundObject} sound - The content of an audio file, loaded using {@link SoundCache.getSound}. See 
      * {@link SoundObject} for supported formats.
-     * @param {Vec3} position - The position in the domain to play the sound.
      * @returns {AudioInjector} The audio injector that plays the audio file.
      */
-    // FIXME: there is no way to play a positionless sound
-    Q_INVOKABLE ScriptAudioInjector* playSystemSound(SharedSoundPointer sound, const QVector3D& position);
+    Q_INVOKABLE ScriptAudioInjector* playSystemSound(SharedSoundPointer sound);
 
     /**jsdoc
      * Set whether or not the audio input should be used in stereo. If the audio input does not support stereo then setting a 

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -210,6 +210,7 @@ void TabletScriptingInterface::playSound(TabletAudioEvents aEvent) {
         options.stereo = sound->isStereo();
         options.ambisonic = sound->isAmbisonic();
         options.localOnly = true;
+        options.positionSet = false;    // system sound
 
         AudioInjectorPointer injector = AudioInjector::playSoundAndDelete(sound, options);
     }


### PR DESCRIPTION
RC78.1 version of #14654 

This bug:
https://highfidelity.manuscript.com/f/cases/20805/Clicking-sounds-from-the-tablet-are-loud-near-0-0-0-in-a-domain-and-quiet-everywhere-else
is fixed by preserving legacy behavior (no distance attenuation) when the injector position is not set.

### Test Plan ###
Using Interface from this PR, test as many different types of sounds as possible, to verify expected behavior of attenuation/spatialization:

1) System sounds (tablet UI clicks, camera snapshot sound, Audio tab "Play sample sound") should not be spatialized, and not be attenuated regardless of your world location.

2) Using a script, a local sound with "position" set should attenuate with distance. For example:
```
var sound = SoundCache.getSound("http://hifi-content.s3.amazonaws.com/ken/samples/Happy_Rock.mp3");
Audio.playSound(sound, { position: MyAvatar.position, localOnly: true, volume: 0.5 });
```
3) Using a script, a local sound that does not set "position" should NOT attenuate with distance:
```
var sound = SoundCache.getSound("http://hifi-content.s3.amazonaws.com/ken/samples/Happy_Rock.mp3");
Audio.playSound(sound, { localOnly: true, volume: 0.5 });
```
