### PR TITLE
Only initialize plugin if started through Oculus Store

### DIFF
--- a/plugins/oculus/src/OculusPlatformPlugin.cpp
+++ b/plugins/oculus/src/OculusPlatformPlugin.cpp
@@ -17,11 +17,15 @@
 QString OculusAPIPlugin::NAME { "Oculus Rift" };
 
 OculusAPIPlugin::OculusAPIPlugin() {
-    _session = hifi::ovr::acquireRenderSession();
+    if (isRunning()) {
+        _session = hifi::ovr::acquireRenderSession();
+    }
 }
 
 OculusAPIPlugin::~OculusAPIPlugin() {
-    hifi::ovr::releaseRenderSession(_session);
+    if (isRunning()) {
+        hifi::ovr::releaseRenderSession(_session);
+    }
 }
 
 bool OculusAPIPlugin::isRunning() const {


### PR DESCRIPTION
# Test Plan
- Requirements: Oculus application installed and not running
- Launch interface without `--oculus-store` argument (normally)
- Oculus desktop application should not start