### PR TITLE
Case 20771: Make sure that the script log is in the correct location when switching to and from HMD 

### DIFF
--- a/scripts/developer/debugging/debugWindow.js
+++ b/scripts/developer/debugging/debugWindow.js
@@ -68,12 +68,21 @@ var window = new OverlayWindow({
 
 if (hasPosition) {
     window.setPosition(windowX, windowY);
+};
+
+function recenterWindow() {
+    window.setPosition(100, 100);
 }
 
 window.visibleChanged.connect(function() {
     if (!window.visible) {
         window.setVisible(true);
+        recenterWindow();
     }
+});
+
+HMD.displayModeChanged.connect(function(isHMDMode) {
+    recenterWindow();
 });
 
 window.closed.connect(function () { Script.stop(); });


### PR DESCRIPTION
 There are cases where the script log disappears in hmd and desktop mode. I think the main reason is that the log window it off screen in a location that we can not reach and move it 

Ticket - https://highfidelity.manuscript.com/f/cases/20771/DO-NOT-hide-the-Script-Log-HMD-friendly-window-when-switching-between-Desktop-and-HMD-mode