### PR TITLE
case 20805: tablet click sounds play near tablet rather than at world origin

### DIFF
--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -382,6 +382,8 @@ public:
 
     TabletButtonListModel* getButtons() { return &_buttons; }
 
+    glm::vec3 getWorldPosition() const;
+
 signals:
     /**jsdoc
      * Signaled when this tablet receives an event from the html/js embedded in the tablet.


### PR DESCRIPTION
- tablet click sounds play near tablet rather than at world origin

https://highfidelity.manuscript.com/f/cases/20805/Clicking-sounds-from-the-tablet-are-loud-near-0-0-0-in-a-domain-and-quiet-everywhere-else
