### PR TITLE
79.0/master: Fix errors and intermittent failures in Android gradle builds in containers

### DIFF
--- a/android/containerized_build.sh
+++ b/android/containerized_build.sh
@@ -7,15 +7,12 @@ docker build --build-arg BUILD_UID=`id -u` -t "${DOCKER_IMAGE_NAME}" -f docker/D
 
 # The Jenkins PR builds use VERSION_CODE, but the release builds use VERSION
 # So make sure we use VERSION_CODE consistently
-if [-z "$VERSION_CODE"]; then
-   export VERSION_CODE=$VERSION
-fi
+test -z "$VERSION_CODE" && export VERSION_CODE=$VERSION
 
 docker run \
    --rm \
    --security-opt seccomp:unconfined \
    -v "${WORKSPACE}":/home/jenkins/hifi \
-   -v /home/jenkins/.gradle:/home/jenkins/.gradle \
    -e RELEASE_NUMBER \
    -e RELEASE_TYPE \
    -e ANDROID_APP \


### PR DESCRIPTION
The first change remove an error that was caused by the `if` statement being incorrectly formatted.  The second change, the removed `-v` should resolve an issue we've been seeing intermittently on the build machines:

> Could not create service of type FileHasher using BuildSessionScopeServices.createFileSnapshotter().

This appears to be because we were mounting the gradle cache from the host machine into the docker, which is not supported. 

## Testing

No testing required.  This is a build system only change.

