### PR TITLE
case 17773: reduce likelihood MyAvatar will get stuck in mesh geometry when flying around

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6289,6 +6289,8 @@ void Application::update(float deltaTime) {
                 avatarManager->handleProcessedPhysicsTransaction(transaction);
 
                 myAvatar->prepareForPhysicsSimulation();
+                _physicsEngine->enableGlobalContactAddedCallback(myAvatar->isFlying());
+
                 _physicsEngine->forEachDynamic([&](EntityDynamicPointer dynamic) {
                     dynamic->prepareForPhysicsSimulation();
                 });

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -124,6 +124,11 @@ void CharacterController::setDynamicsWorld(btDynamicsWorld* world) {
             _rigidBody->setGravity(_currentGravity * _currentUp);
             // set flag to enable custom contactAddedCallback
             _rigidBody->setCollisionFlags(btCollisionObject::CF_CUSTOM_MATERIAL_CALLBACK);
+
+            // enable CCD
+            _rigidBody->setCcdSweptSphereRadius(_radius);
+            _rigidBody->setCcdMotionThreshold(_radius);
+
             btCollisionShape* shape = _rigidBody->getCollisionShape();
             assert(shape && shape->getShapeType() == CONVEX_HULL_SHAPE_PROXYTYPE);
             _ghost.setCharacterShape(static_cast<btConvexHullShape*>(shape));
@@ -454,6 +459,12 @@ void CharacterController::setLocalBoundingBox(const glm::vec3& minCorner, const 
 
     // it's ok to change offset immediately -- there are no thread safety issues here
     _shapeLocalOffset = minCorner + 0.5f * scale;
+
+    if (_rigidBody) {
+        // update CCD with new _radius
+        _rigidBody->setCcdSweptSphereRadius(_radius);
+        _rigidBody->setCcdMotionThreshold(_radius);
+    }
 }
 
 void CharacterController::setCollisionless(bool collisionless) {

--- a/libraries/physics/src/PhysicsEngine.h
+++ b/libraries/physics/src/PhysicsEngine.h
@@ -148,6 +148,8 @@ public:
     // See PhysicsCollisionGroups.h for mask flags.
     std::vector<ContactTestResult> contactTest(uint16_t mask, const ShapeInfo& regionShapeInfo, const Transform& regionTransform, uint16_t group = USER_COLLISION_GROUP_DYNAMIC, float threshold = 0.0f) const;
 
+    void enableGlobalContactAddedCallback(bool enabled);
+
 private:
     QList<EntityDynamicPointer> removeDynamicsForBody(btRigidBody* body);
     void addObjectToDynamicsWorld(ObjectMotionState* motionState);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17773/Fast-flying-will-consistently-allow-the-user-to-clip-into-multiple-walls-and-they-are-stuck-until-domain-reloads

This PR doesn't solve or prevent all snags between MyAvatar and mesh geometry but it tries to make it harder without adding too many bad side effects.