### PR TITLE
[78.1] Add failed backup as corrupted during creation

### DIFF
--- a/domain-server/src/AssetsBackupHandler.cpp
+++ b/domain-server/src/AssetsBackupHandler.cpp
@@ -246,6 +246,7 @@ void AssetsBackupHandler::createBackup(const QString& backupName, QuaZip& zip) {
 
     if (_assetServerEnabled && _lastMappingsRefresh.time_since_epoch().count() == 0) {
         qCWarning(asset_backup) << "Current mappings not yet loaded.";
+        _backups.emplace_back(backupName, AssetUtils::Mappings(), true);
         return;
     }
 


### PR DESCRIPTION
[78.1 Manuscript ticket](https://highfidelity.manuscript.com/f/cases/20895)
[79.0/master Manuscript ticket](https://highfidelity.manuscript.com/f/cases/20836)
[Manuscript ticket (related, but not fixing)](https://highfidelity.manuscript.com/f/cases/20775/Limitless-is-showing-corrupted-archives-for-a-time-window-of-1-10-1-18)

Make sure backups that fail at creation show up as corrupted instantly instead of on the next restart.