### PR TITLE
79.0/master: Fix erroneous 'CMAKE_TOOLCHAIN_FILE has changed' errors on Jenkins

### DIFF
--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -15,8 +15,8 @@ print = functools.partial(print, flush=True)
 # Encapsulates the vcpkg system 
 class VcpkgRepo:
     CMAKE_TEMPLATE = """
-set(CMAKE_TOOLCHAIN_FILE "{}" CACHE FILEPATH "Toolchain file")
-set(CMAKE_TOOLCHAIN_FILE_UNCACHED "{}")
+get_filename_component(CMAKE_TOOLCHAIN_FILE "{}" ABSOLUTE CACHE)
+get_filename_component(CMAKE_TOOLCHAIN_FILE_UNCACHED "{}" ABSOLUTE)
 set(VCPKG_INSTALL_ROOT "{}")
 set(VCPKG_TOOLS_DIR "{}")
 """


### PR DESCRIPTION
A number of windows builds were failing with an error like this:

    11:07:32 Writing cmake config to C:/jenkins/workspace/release-build-v2/label/windows/build\vcpkg.cmake
    11:07:33 CMake Error at build/vcpkg.cmake:9 (message):
    11:07:33   CMAKE_TOOLCHAIN_FILE has changed, please wipe the build directory and rerun
    11:07:33   cmake

This was happening on the second build target for a given build.  It turns out that the Windows build hosts have a temp directory variable that says "C:/Windows/TEMP", but the actual directory on the filesystem is "C:/Windows/Temp".  For whatever reason, the cached version of `CMAKE_TOOLCHAIN_FILE` was storing the correct case, while the uncached version was not (probably some version of CMake does canonicalization on cached file paths).  This was causing the check to produce a false negative.

This PR fixes the problem by using the CMake `get_filename_component` command instead of `set`.  The former will both set the variable, and canonicalize it as the same time, ensuring that both the cached and the uncached variable have the same case.

## Testing

This is strictly a build-time fix, no application testing required. 