### PR TITLE
Case 20887: Move FST joint property handling to the model preparation step

### DIFF
--- a/interface/resources/meshes/defaultAvatar_full.fst
+++ b/interface/resources/meshes/defaultAvatar_full.fst
@@ -10,10 +10,6 @@ joint = jointRoot = Hips
 joint = jointLeftHand = LeftHand
 joint = jointRightHand = RightHand
 joint = jointHead = Head
-freeJoint = LeftArm
-freeJoint = LeftForeArm
-freeJoint = RightArm
-freeJoint = RightForeArm
 bs = JawOpen = mouth_Open = 1
 bs = LipsFunnel = Oo = 1
 bs = BrowsU_L = brow_Up = 1

--- a/interface/src/ModelPackager.cpp
+++ b/interface/src/ModelPackager.cpp
@@ -294,13 +294,6 @@ void ModelPackager::populateBasicMapping(QVariantHash& mapping, QString filename
     }
 
     mapping.insert(JOINT_FIELD, joints);
-
-    if (!mapping.contains(FREE_JOINT_FIELD)) {
-        mapping.insertMulti(FREE_JOINT_FIELD, "LeftArm");
-        mapping.insertMulti(FREE_JOINT_FIELD, "LeftForeArm");
-        mapping.insertMulti(FREE_JOINT_FIELD, "RightArm");
-        mapping.insertMulti(FREE_JOINT_FIELD, "RightForeArm");
-    }
     
     // If there are no blendshape mappings, and we detect that this is likely a mixamo file,
     // then we can add the default mixamo to "faceshift" mappings

--- a/interface/src/ModelPropertiesDialog.cpp
+++ b/interface/src/ModelPropertiesDialog.cpp
@@ -58,11 +58,6 @@ _hfmModel(hfmModel)
     form->addRow("Left Hand Joint:", _leftHandJoint = createJointBox());
     form->addRow("Right Hand Joint:", _rightHandJoint = createJointBox());
 
-    form->addRow("Free Joints:", _freeJoints = new QVBoxLayout());
-    QPushButton* newFreeJoint = new QPushButton("New Free Joint");
-    _freeJoints->addWidget(newFreeJoint);
-    connect(newFreeJoint, SIGNAL(clicked(bool)), SLOT(createNewFreeJoint()));
-
     QDialogButtonBox* buttons = new QDialogButtonBox(QDialogButtonBox::Ok |
                                                      QDialogButtonBox::Cancel | QDialogButtonBox::Reset);
     connect(buttons, SIGNAL(accepted()), SLOT(accept()));
@@ -102,11 +97,6 @@ QVariantHash ModelPropertiesDialog::getMapping() const {
     insertJointMapping(joints, "jointLeftHand", _leftHandJoint->currentText());
     insertJointMapping(joints, "jointRightHand", _rightHandJoint->currentText());
 
-    mapping.remove(FREE_JOINT_FIELD);
-    for (int i = 0; i < _freeJoints->count() - 1; i++) {
-        QComboBox* box = static_cast<QComboBox*>(_freeJoints->itemAt(i)->widget()->layout()->itemAt(0)->widget());
-        mapping.insertMulti(FREE_JOINT_FIELD, box->currentText());
-    }
     mapping.insert(JOINT_FIELD, joints);
 
     return mapping;
@@ -133,16 +123,6 @@ void ModelPropertiesDialog::reset() {
     setJointText(_headJoint, jointHash.value("jointHead").toString());
     setJointText(_leftHandJoint, jointHash.value("jointLeftHand").toString());
     setJointText(_rightHandJoint, jointHash.value("jointRightHand").toString());
-
-    while (_freeJoints->count() > 1) {
-        delete _freeJoints->itemAt(0)->widget();
-    }
-    foreach (const QVariant& joint, _originalMapping.values(FREE_JOINT_FIELD)) {
-        QString jointName = joint.toString();
-        if (_hfmModel.jointIndices.contains(jointName)) {
-            createNewFreeJoint(jointName);
-        }
-    }
 }
 
 void ModelPropertiesDialog::chooseTextureDirectory() {
@@ -174,20 +154,6 @@ void ModelPropertiesDialog::chooseScriptDirectory() {
 
 void ModelPropertiesDialog::updatePivotJoint() {
     _pivotJoint->setEnabled(!_pivotAboutCenter->isChecked());
-}
-
-void ModelPropertiesDialog::createNewFreeJoint(const QString& joint) {
-    QWidget* freeJoint = new QWidget();
-    QHBoxLayout* freeJointLayout = new QHBoxLayout();
-    freeJointLayout->setContentsMargins(QMargins());
-    freeJoint->setLayout(freeJointLayout);
-    QComboBox* jointBox = createJointBox(false);
-    jointBox->setCurrentText(joint);
-    freeJointLayout->addWidget(jointBox, 1);
-    QPushButton* deleteJoint = new QPushButton("Delete");
-    freeJointLayout->addWidget(deleteJoint);
-    freeJoint->connect(deleteJoint, SIGNAL(clicked(bool)), SLOT(deleteLater()));
-    _freeJoints->insertWidget(_freeJoints->count() - 1, freeJoint);
 }
 
 QComboBox* ModelPropertiesDialog::createJointBox(bool withNone) const {

--- a/interface/src/ModelPropertiesDialog.h
+++ b/interface/src/ModelPropertiesDialog.h
@@ -39,7 +39,6 @@ private slots:
     void chooseTextureDirectory();
     void chooseScriptDirectory();
     void updatePivotJoint();
-    void createNewFreeJoint(const QString& joint = QString());
     
 private:
     QComboBox* createJointBox(bool withNone = true) const;
@@ -66,7 +65,6 @@ private:
     QComboBox* _headJoint = nullptr;
     QComboBox* _leftHandJoint = nullptr;
     QComboBox* _rightHandJoint = nullptr;
-    QVBoxLayout* _freeJoints = nullptr;
 };
 
 #endif // hifi_ModelPropertiesDialog_h

--- a/libraries/animation/src/AnimSkeleton.cpp
+++ b/libraries/animation/src/AnimSkeleton.cpp
@@ -289,8 +289,6 @@ void AnimSkeleton::dump(bool verbose) const {
         qCDebug(animation) << "        relDefaultPose =" << getRelativeDefaultPose(i);
         if (verbose) {
             qCDebug(animation) << "        hfmJoint =";
-            qCDebug(animation) << "            isFree =" << _joints[i].isFree;
-            qCDebug(animation) << "            freeLineage =" << _joints[i].freeLineage;
             qCDebug(animation) << "            parentIndex =" << _joints[i].parentIndex;
             qCDebug(animation) << "            translation =" << _joints[i].translation;
             qCDebug(animation) << "            preTransform =" << _joints[i].preTransform;

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.cpp
@@ -249,14 +249,6 @@ bool SkeletonModel::getRightHandPosition(glm::vec3& position) const {
     return getJointPositionInWorldFrame(getRightHandJointIndex(), position);
 }
 
-bool SkeletonModel::getLeftShoulderPosition(glm::vec3& position) const {
-    return getJointPositionInWorldFrame(getLastFreeJointIndex(getLeftHandJointIndex()), position);
-}
-
-bool SkeletonModel::getRightShoulderPosition(glm::vec3& position) const {
-    return getJointPositionInWorldFrame(getLastFreeJointIndex(getRightHandJointIndex()), position);
-}
-
 bool SkeletonModel::getHeadPosition(glm::vec3& headPosition) const {
     return isActive() && getJointPositionInWorldFrame(_rig.indexOfJoint("Head"), headPosition);
 }

--- a/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/SkeletonModel.h
@@ -57,16 +57,8 @@ public:
     /// \return true whether or not the position was found
     bool getRightHandPosition(glm::vec3& position) const;
 
-    /// Gets the position of the left shoulder.
-    /// \return whether or not the left shoulder joint was found
-    bool getLeftShoulderPosition(glm::vec3& position) const;
-
     /// Returns the extended length from the left hand to its last free ancestor.
     float getLeftArmLength() const;
-
-    /// Gets the position of the right shoulder.
-    /// \return whether or not the right shoulder joint was found
-    bool getRightShoulderPosition(glm::vec3& position) const;
 
     /// Returns the position of the head joint.
     /// \return whether or not the head was found

--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -444,8 +444,6 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
 
     std::map<QString, HFMLight> lights;
 
-    QVariantHash joints = mapping.value("joint").toHash();
-
     QVariantHash blendshapeMappings = mapping.value("bs").toHash();
 
     QMultiHash<QByteArray, WeightedIndex> blendshapeIndices;
@@ -473,8 +471,7 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
     HFMModel& hfmModel = *hfmModelPtr;
 
     hfmModel.originalURL = url;
-    hfmModel.hfmToHifiJointNameMapping.clear();
-    hfmModel.hfmToHifiJointNameMapping = getJointNameMapping(mapping);
+    auto hfmToHifiJointNameMapping = getJointNameMapping(mapping);
 
     float unitScaleFactor = 1.0f;
     glm::vec3 ambientColor;
@@ -1341,8 +1338,8 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
         }
         joint.inverseBindRotation = joint.inverseDefaultRotation;
         joint.name = fbxModel.name;
-        if (hfmModel.hfmToHifiJointNameMapping.contains(hfmModel.hfmToHifiJointNameMapping.key(joint.name))) {
-            joint.name = hfmModel.hfmToHifiJointNameMapping.key(fbxModel.name);
+        if (hfmToHifiJointNameMapping.contains(hfmToHifiJointNameMapping.key(joint.name))) {
+            joint.name = hfmToHifiJointNameMapping.key(fbxModel.name);
         }
 
         joint.bindTransformFoundInCluster = false;
@@ -1704,7 +1701,6 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
             generateBoundryLinesForDop14(joint.shapeInfo.dots, joint.shapeInfo.avgPoint, joint.shapeInfo.debugLines);
         }
     }
-    hfmModel.palmDirection = parseVec3(mapping.value("palmDirection", "0, -1, 0").toString());
 
     // attempt to map any meshes to a named model
     for (QHash<QString, int>::const_iterator m = meshIDsToMeshIndices.constBegin();
@@ -1728,7 +1724,7 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
         QString jointName = itr.key();
         glm::quat rotationOffset = itr.value();
         int jointIndex = hfmModel.getJointIndex(jointName);
-        if (hfmModel.hfmToHifiJointNameMapping.contains(jointName)) {
+        if (hfmToHifiJointNameMapping.contains(jointName)) {
             jointIndex = hfmModel.getJointIndex(jointName);
         }
         if (jointIndex != -1) {

--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -1252,18 +1252,8 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
         const FBXModel& fbxModel = fbxModels[modelID];
         HFMJoint joint;
         joint.parentIndex = fbxModel.parentIndex;
-
-        // get the indices of all ancestors starting with the first free one (if any)
         int jointIndex = hfmModel.joints.size();
-        joint.freeLineage.append(jointIndex);
-        int lastFreeIndex = joint.isFree ? 0 : -1;
-        for (int index = joint.parentIndex; index != -1; index = hfmModel.joints.at(index).parentIndex) {
-            if (hfmModel.joints.at(index).isFree) {
-                lastFreeIndex = joint.freeLineage.size();
-            }
-            joint.freeLineage.append(index);
-        }
-        joint.freeLineage.remove(lastFreeIndex + 1, joint.freeLineage.size() - lastFreeIndex - 1);
+
         joint.translation = fbxModel.translation; // these are usually in centimeters
         joint.preTransform = fbxModel.preTransform;
         joint.preRotation = fbxModel.preRotation;

--- a/libraries/fbx/src/FST.cpp
+++ b/libraries/fbx/src/FST.cpp
@@ -82,11 +82,6 @@ FST* FST::createFSTFromModel(const QString& fstPath, const QString& modelFilePat
     }
     mapping.insert(JOINT_INDEX_FIELD, jointIndices);
 
-    mapping.insertMulti(FREE_JOINT_FIELD, "LeftArm");
-    mapping.insertMulti(FREE_JOINT_FIELD, "LeftForeArm");
-    mapping.insertMulti(FREE_JOINT_FIELD, "RightArm");
-    mapping.insertMulti(FREE_JOINT_FIELD, "RightForeArm");
-
 
     // If there are no blendshape mappings, and we detect that this is likely a mixamo file,
     // then we can add the default mixamo to "faceshift" mappings

--- a/libraries/fbx/src/FSTReader.cpp
+++ b/libraries/fbx/src/FSTReader.cpp
@@ -84,7 +84,7 @@ void FSTReader::writeVariant(QBuffer& buffer, QVariantHash::const_iterator& it) 
 
 QByteArray FSTReader::writeMapping(const QVariantHash& mapping) {
     static const QStringList PREFERED_ORDER = QStringList() << NAME_FIELD << TYPE_FIELD << SCALE_FIELD << FILENAME_FIELD
-    << MARKETPLACE_ID_FIELD << TEXDIR_FIELD << SCRIPT_FIELD << JOINT_FIELD << FREE_JOINT_FIELD
+    << MARKETPLACE_ID_FIELD << TEXDIR_FIELD << SCRIPT_FIELD << JOINT_FIELD
     << BLENDSHAPE_FIELD << JOINT_INDEX_FIELD;
     QBuffer buffer;
     buffer.open(QIODevice::WriteOnly);
@@ -92,7 +92,7 @@ QByteArray FSTReader::writeMapping(const QVariantHash& mapping) {
     for (auto key : PREFERED_ORDER) {
         auto it = mapping.find(key);
         if (it != mapping.constEnd()) {
-            if (key == FREE_JOINT_FIELD || key == SCRIPT_FIELD) { // writeVariant does not handle strings added using insertMulti.
+            if (key == SCRIPT_FIELD) { // writeVariant does not handle strings added using insertMulti.
                 for (auto multi : mapping.values(key)) {
                     buffer.write(key.toUtf8());
                     buffer.write(" = ");

--- a/libraries/fbx/src/FSTReader.h
+++ b/libraries/fbx/src/FSTReader.h
@@ -27,7 +27,6 @@ static const QString TRANSLATION_X_FIELD = "tx";
 static const QString TRANSLATION_Y_FIELD = "ty";
 static const QString TRANSLATION_Z_FIELD = "tz";
 static const QString JOINT_FIELD = "joint";
-static const QString FREE_JOINT_FIELD = "freeJoint";
 static const QString BLENDSHAPE_FIELD = "bs";
 static const QString SCRIPT_FIELD = "script";
 static const QString JOINT_NAME_MAPPING_FIELD = "jointMap";

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -1187,8 +1187,6 @@ void GLTFSerializer::hfmDebugDump(const HFMModel& hfmModel) {
     qCDebug(modelformat) << "  hasSkeletonJoints =" << hfmModel.hasSkeletonJoints;
     qCDebug(modelformat) << "  offset =" << hfmModel.offset;
 
-    qCDebug(modelformat) << "  palmDirection = " << hfmModel.palmDirection;
-
     qCDebug(modelformat) << "  neckPivot = " << hfmModel.neckPivot;
 
     qCDebug(modelformat) << "  bindExtents.size() = " << hfmModel.bindExtents.size();

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -719,7 +719,6 @@ bool GLTFSerializer::buildGeometry(HFMModel& hfmModel, const QUrl& url) {
     
     //Build default joints
     hfmModel.joints.resize(1);
-    hfmModel.joints[0].isFree = false;
     hfmModel.joints[0].parentIndex = -1;
     hfmModel.joints[0].distanceToParent = 0;
     hfmModel.joints[0].translation = glm::vec3(0, 0, 0);
@@ -1299,8 +1298,6 @@ void GLTFSerializer::hfmDebugDump(const HFMModel& hfmModel) {
         qCDebug(modelformat) << "    shapeInfo.dots =" << joint.shapeInfo.dots;
         qCDebug(modelformat) << "    shapeInfo.points =" << joint.shapeInfo.points;
 
-        qCDebug(modelformat) << "    isFree =" << joint.isFree;
-        qCDebug(modelformat) << "    freeLineage" << joint.freeLineage;
         qCDebug(modelformat) << "    parentIndex" << joint.parentIndex;
         qCDebug(modelformat) << "    distanceToParent" << joint.distanceToParent;
         qCDebug(modelformat) << "    translation" << joint.translation;

--- a/libraries/fbx/src/OBJSerializer.cpp
+++ b/libraries/fbx/src/OBJSerializer.cpp
@@ -687,7 +687,6 @@ HFMModel::Pointer OBJSerializer::read(const QByteArray& data, const QVariantHash
         mesh.meshIndex = 0;
 
         hfmModel.joints.resize(1);
-        hfmModel.joints[0].isFree = false;
         hfmModel.joints[0].parentIndex = -1;
         hfmModel.joints[0].distanceToParent = 0;
         hfmModel.joints[0].translation = glm::vec3(0, 0, 0);
@@ -1048,8 +1047,7 @@ void hfmDebugDump(const HFMModel& hfmModel) {
     qCDebug(modelformat) << "  joints.count() =" << hfmModel.joints.count();
 
     foreach (HFMJoint joint, hfmModel.joints) {
-        qCDebug(modelformat) << "    isFree =" << joint.isFree;
-        qCDebug(modelformat) << "    freeLineage" << joint.freeLineage;
+
         qCDebug(modelformat) << "    parentIndex" << joint.parentIndex;
         qCDebug(modelformat) << "    distanceToParent" << joint.distanceToParent;
         qCDebug(modelformat) << "    translation" << joint.translation;

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -75,8 +75,6 @@ struct JointShapeInfo {
 class Joint {
 public:
     JointShapeInfo shapeInfo;
-    QVector<int> freeLineage;
-    bool isFree;
     int parentIndex;
     float distanceToParent;
 

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -291,8 +291,6 @@ public:
 
     glm::mat4 offset; // This includes offset, rotation, and scale as specified by the FST file
 
-    glm::vec3 palmDirection;
-
     glm::vec3 neckPivot;
 
     Extents bindExtents;
@@ -319,7 +317,6 @@ public:
     QList<QString> blendshapeChannelNames;
 
     QMap<int, glm::quat> jointRotationOffsets;
-    QMap<QString, QString> hfmToHifiJointNameMapping;
 };
 
 };

--- a/libraries/model-baker/src/model-baker/Baker.h
+++ b/libraries/model-baker/src/model-baker/Baker.h
@@ -12,6 +12,8 @@
 #ifndef hifi_baker_Baker_h
 #define hifi_baker_Baker_h
 
+#include <QMap>
+
 #include <hfm/HFM.h>
 
 #include "Engine.h"
@@ -19,7 +21,7 @@
 namespace baker {
     class Baker {
     public:
-        Baker(const hfm::Model::Pointer& hfmModel);
+        Baker(const hfm::Model::Pointer& hfmModel, const QVariantHash& mapping);
 
         void run();
 

--- a/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
+++ b/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
@@ -57,27 +57,12 @@ void PrepareJointsTask::run(const baker::BakeContextPointer& context, const Inpu
     auto& jointRotationOffsets = output.edit1();
     auto& jointIndices = output.edit2();
 
-    // Get which joints are free from FST file mappings
-    QVariantList freeJoints = mapping.values("freeJoint");
     // Get joint renames
     auto jointNameMapping = getJointNameMapping(mapping);
     // Apply joint metadata from FST file mappings
     for (const auto& jointIn : jointsIn) {
         jointsOut.push_back(jointIn);
         auto& jointOut = jointsOut[jointsOut.size()-1];
-
-        jointOut.isFree = freeJoints.contains(jointIn.name);
-        // Get the indices of all ancestors starting with the first free one (if any)
-        int jointIndex = jointsOut.size() - 1;
-        jointOut.freeLineage.append(jointIndex);
-        int lastFreeIndex = jointOut.isFree ? 0 : -1;
-        for (int index = jointOut.parentIndex; index != -1; index = jointsOut.at(index).parentIndex) {
-            if (jointsOut.at(index).isFree) {
-                lastFreeIndex = jointOut.freeLineage.size();
-            }
-            jointOut.freeLineage.append(index);
-        }
-        jointOut.freeLineage.remove(lastFreeIndex + 1, jointOut.freeLineage.size() - lastFreeIndex - 1);
 
         if (jointNameMapping.contains(jointNameMapping.key(jointIn.name))) {
             jointOut.name = jointNameMapping.key(jointIn.name);

--- a/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
+++ b/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
@@ -1,0 +1,89 @@
+//
+//  PrepareJointsTask.cpp
+//  model-baker/src/model-baker
+//
+//  Created by Sabrina Shanman on 2019/01/25.
+//  Copyright 2019 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "PrepareJointsTask.h"
+
+#include "ModelBakerLogging.h"
+
+QMap<QString, QString> getJointNameMapping(const QVariantHash& mapping) {
+    static const QString JOINT_NAME_MAPPING_FIELD = "jointMap";
+    QMap<QString, QString> hfmToHifiJointNameMap;
+    if (!mapping.isEmpty() && mapping.contains(JOINT_NAME_MAPPING_FIELD) && mapping[JOINT_NAME_MAPPING_FIELD].type() == QVariant::Hash) {
+        auto jointNames = mapping[JOINT_NAME_MAPPING_FIELD].toHash();
+        for (auto itr = jointNames.begin(); itr != jointNames.end(); itr++) {
+            hfmToHifiJointNameMap.insert(itr.key(), itr.value().toString());
+            qCDebug(model_baker) << "the mapped key " << itr.key() << " has a value of " << hfmToHifiJointNameMap[itr.key()];
+        }
+    }
+    return hfmToHifiJointNameMap;
+}
+
+QMap<QString, glm::quat> getJointRotationOffsets(const QVariantHash& mapping) {
+    QMap<QString, glm::quat> jointRotationOffsets;
+    static const QString JOINT_ROTATION_OFFSET_FIELD = "jointRotationOffset";
+    if (!mapping.isEmpty() && mapping.contains(JOINT_ROTATION_OFFSET_FIELD) && mapping[JOINT_ROTATION_OFFSET_FIELD].type() == QVariant::Hash) {
+        auto offsets = mapping[JOINT_ROTATION_OFFSET_FIELD].toHash();
+        for (auto itr = offsets.begin(); itr != offsets.end(); itr++) {
+            QString jointName = itr.key();
+            QString line = itr.value().toString();
+            auto quatCoords = line.split(',');
+            if (quatCoords.size() == 4) {
+                float quatX = quatCoords[0].mid(1).toFloat();
+                float quatY = quatCoords[1].toFloat();
+                float quatZ = quatCoords[2].toFloat();
+                float quatW = quatCoords[3].mid(0, quatCoords[3].size() - 1).toFloat();
+                if (!isNaN(quatX) && !isNaN(quatY) && !isNaN(quatZ) && !isNaN(quatW)) {
+                    glm::quat rotationOffset = glm::quat(quatW, quatX, quatY, quatZ);
+                    jointRotationOffsets.insert(jointName, rotationOffset);
+                }
+            }
+        }
+    }
+    return jointRotationOffsets;
+}
+
+void PrepareJointsTask::run(const baker::BakeContextPointer& context, const Input& input, Output& output) {
+    const auto& jointsIn = input.get0();
+    const auto& mapping = input.get1();
+    auto& jointsOut = output.edit0();
+    auto& jointRotationOffsets = output.edit1();
+    auto& jointIndices = output.edit2();
+
+    // Get which joints are free from FST file mappings
+    QVariantList freeJoints = mapping.values("freeJoint");
+    // Get joint renames
+    auto jointNameMapping = getJointNameMapping(mapping);
+    // Apply joint metadata from FST file mappings
+    for (const auto& jointIn : jointsIn) {
+        jointsOut.push_back(jointIn);
+        auto& jointOut = jointsOut[jointsOut.size()-1];
+
+        jointOut.isFree = freeJoints.contains(jointIn.name);
+
+        if (jointNameMapping.contains(jointNameMapping.key(jointIn.name))) {
+            jointOut.name = jointNameMapping.key(jointIn.name);
+        }
+
+        jointIndices.insert(jointOut.name, (int)jointsOut.size());
+    }
+
+    // Get joint rotation offsets from FST file mappings
+    auto offsets = getJointRotationOffsets(mapping);
+    for (auto itr = offsets.begin(); itr != offsets.end(); itr++) {
+        QString jointName = itr.key();
+        glm::quat rotationOffset = itr.value();
+        int jointIndex = jointIndices.value(jointName) - 1;
+        if (jointIndex != -1) {
+            jointRotationOffsets.insert(jointIndex, rotationOffset);
+        }
+        qCDebug(model_baker) << "Joint Rotation Offset added to Rig._jointRotationOffsets : " << " jointName: " << jointName << " jointIndex: " << jointIndex << " rotation offset: " << rotationOffset;
+    }
+}

--- a/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
+++ b/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
@@ -67,6 +67,17 @@ void PrepareJointsTask::run(const baker::BakeContextPointer& context, const Inpu
         auto& jointOut = jointsOut[jointsOut.size()-1];
 
         jointOut.isFree = freeJoints.contains(jointIn.name);
+        // Get the indices of all ancestors starting with the first free one (if any)
+        int jointIndex = jointsOut.size() - 1;
+        jointOut.freeLineage.append(jointIndex);
+        int lastFreeIndex = jointOut.isFree ? 0 : -1;
+        for (int index = jointOut.parentIndex; index != -1; index = jointsOut.at(index).parentIndex) {
+            if (jointsOut.at(index).isFree) {
+                lastFreeIndex = jointOut.freeLineage.size();
+            }
+            jointOut.freeLineage.append(index);
+        }
+        jointOut.freeLineage.remove(lastFreeIndex + 1, jointOut.freeLineage.size() - lastFreeIndex - 1);
 
         if (jointNameMapping.contains(jointNameMapping.key(jointIn.name))) {
             jointOut.name = jointNameMapping.key(jointIn.name);

--- a/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
+++ b/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
@@ -62,10 +62,11 @@ void PrepareJointsTask::run(const baker::BakeContextPointer& context, const Inpu
     // Apply joint metadata from FST file mappings
     for (const auto& jointIn : jointsIn) {
         jointsOut.push_back(jointIn);
-        auto& jointOut = jointsOut[jointsOut.size()-1];
+        auto& jointOut = jointsOut.back();
 
-        if (jointNameMapping.contains(jointNameMapping.key(jointIn.name))) {
-            jointOut.name = jointNameMapping.key(jointIn.name);
+        auto jointNameMapKey = jointNameMapping.key(jointIn.name);
+        if (jointNameMapping.contains(jointNameMapKey)) {
+            jointOut.name = jointNameMapKey;
         }
 
         jointIndices.insert(jointOut.name, (int)jointsOut.size());
@@ -75,11 +76,11 @@ void PrepareJointsTask::run(const baker::BakeContextPointer& context, const Inpu
     auto offsets = getJointRotationOffsets(mapping);
     for (auto itr = offsets.begin(); itr != offsets.end(); itr++) {
         QString jointName = itr.key();
-        glm::quat rotationOffset = itr.value();
         int jointIndex = jointIndices.value(jointName) - 1;
         if (jointIndex != -1) {
+            glm::quat rotationOffset = itr.value();
             jointRotationOffsets.insert(jointIndex, rotationOffset);
+            qCDebug(model_baker) << "Joint Rotation Offset added to Rig._jointRotationOffsets : " << " jointName: " << jointName << " jointIndex: " << jointIndex << " rotation offset: " << rotationOffset;
         }
-        qCDebug(model_baker) << "Joint Rotation Offset added to Rig._jointRotationOffsets : " << " jointName: " << jointName << " jointIndex: " << jointIndex << " rotation offset: " << rotationOffset;
     }
 }

--- a/libraries/model-baker/src/model-baker/PrepareJointsTask.h
+++ b/libraries/model-baker/src/model-baker/PrepareJointsTask.h
@@ -1,0 +1,30 @@
+//
+//  PrepareJointsTask.h
+//  model-baker/src/model-baker
+//
+//  Created by Sabrina Shanman on 2019/01/25.
+//  Copyright 2019 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_PrepareJointsTask_h
+#define hifi_PrepareJointsTask_h
+
+#include <QHash>
+
+#include <hfm/HFM.h>
+
+#include "Engine.h"
+
+class PrepareJointsTask {
+public:
+    using Input = baker::VaryingSet2<std::vector<hfm::Joint>, QVariantHash /*mapping*/>;
+    using Output = baker::VaryingSet3<std::vector<hfm::Joint>, QMap<int, glm::quat> /*jointRotationOffsets*/, QHash<QString, int> /*jointIndices*/>;
+    using JobModel = baker::Job::ModelIO<PrepareJointsTask, Input, Output>;
+
+    void run(const baker::BakeContextPointer& context, const Input& input, Output& output);
+};
+
+#endif // hifi_PrepareJointsTask_h

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -233,7 +233,7 @@ void GeometryReader::run() {
         }
 
         QMetaObject::invokeMethod(resource.data(), "setGeometryDefinition",
-                Q_ARG(HFMModel::Pointer, hfmModel));
+                Q_ARG(HFMModel::Pointer, hfmModel), Q_ARG(QVariantHash, _mapping));
     } catch (const std::exception&) {
         auto resource = _resource.toStrongRef();
         if (resource) {
@@ -261,7 +261,7 @@ public:
     virtual void downloadFinished(const QByteArray& data) override;
 
 protected:
-    Q_INVOKABLE void setGeometryDefinition(HFMModel::Pointer hfmModel);
+    Q_INVOKABLE void setGeometryDefinition(HFMModel::Pointer hfmModel, QVariantHash mapping);
 
 private:
     ModelLoader _modelLoader;
@@ -277,9 +277,9 @@ void GeometryDefinitionResource::downloadFinished(const QByteArray& data) {
     QThreadPool::globalInstance()->start(new GeometryReader(_modelLoader, _self, _effectiveBaseURL, _mapping, data, _combineParts, _request->getWebMediaType()));
 }
 
-void GeometryDefinitionResource::setGeometryDefinition(HFMModel::Pointer hfmModel) {
+void GeometryDefinitionResource::setGeometryDefinition(HFMModel::Pointer hfmModel, QVariantHash mapping) {
     // Do processing on the model
-    baker::Baker modelBaker(hfmModel);
+    baker::Baker modelBaker(hfmModel, mapping);
     modelBaker.run();
 
     // Assume ownership of the processed HFMModel

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1116,10 +1116,6 @@ int Model::getParentJointIndex(int jointIndex) const {
     return (isActive() && jointIndex != -1) ? getHFMModel().joints.at(jointIndex).parentIndex : -1;
 }
 
-int Model::getLastFreeJointIndex(int jointIndex) const {
-    return (isActive() && jointIndex != -1) ? getHFMModel().joints.at(jointIndex).freeLineage.last() : -1;
-}
-
 void Model::setTextures(const QVariantMap& textures) {
     if (isLoaded()) {
         _needsFixupInScene = true;

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -379,9 +379,6 @@ protected:
     /// Clear the joint states
     void clearJointState(int index);
 
-    /// Returns the index of the last free ancestor of the indexed joint, or -1 if not found.
-    int getLastFreeJointIndex(int jointIndex) const;
-
     /// \param jointIndex index of joint in model structure
     /// \param position[out] position of joint in model-frame
     /// \return true if joint exists


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20887/Move-FST-joint-association-to-Model-Preparation-Step

This PR moves some of the processing of the FST file out of FBXSerializer and into the model prep step, with a focus on joints. It also cleans up some unused properties I found while figuring out what to move.

The following FST properties now remain in FBXSerializer: "bs" (for blendshapes), "materialMap", and properties related to the rescaling of the model.

## TEST PLAN
- Verify animation for arbitrary test avatars (walking, emotes) is the same as in master, and the avatar's default resting pose is the same.
- Verify avatar packager still works