### PR TITLE
Case 20906: Give SendAsset.qml a background color 

### DIFF
--- a/interface/resources/qml/hifi/commerce/common/sendAsset/SendAsset.qml
+++ b/interface/resources/qml/hifi/commerce/common/sendAsset/SendAsset.qml
@@ -21,11 +21,11 @@ import "../../../../controls" as HifiControls
 import "../" as HifiCommerceCommon
 import "qrc:////qml//hifi//models" as HifiModels  // Absolute path so the same code works everywhere.
 
-Item {
+Rectangle {
     HifiConstants { id: hifi; }
 
     id: root;
-
+    color: hifi.colors.baseGray
     property int parentAppTitleBarHeight;
     property int parentAppNavBarHeight;
     property string currentActiveView: "sendAssetHome";


### PR DESCRIPTION
Give SendAsset.qml a background color, so that you do not get a white background for the tablet

ticket - https://highfidelity.manuscript.com/f/cases/20906/78-1-Opening-Secure-QML-window-in-HMD-causes-the-window-to-be-unreadable