### PR TITLE
Case 20833: Fix procedural skybox depth testing

### DIFF
--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -26,6 +26,7 @@ ProceduralSkybox::ProceduralSkybox() : graphics::Skybox() {
     const int8_t STENCIL_BACKGROUND = 0;
     _procedural._opaqueState->setStencilTest(true, 0xFF, gpu::State::StencilTest(STENCIL_BACKGROUND, 0xFF, gpu::EQUAL,
         gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
+    _procedural._opaqueState->setDepthTest(gpu::State::DepthTest(false));
 }
 
 bool ProceduralSkybox::empty() {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20833/Transparent-objects-are-not-showing-up-over-procedural-skybox

Test plan:
- Create a Procedural skybox, like the day/night cycle from the marketplace.  Create an object with transparency.  The transparent object should render over the skybox.