### PR TITLE
Case 20924: Cleaning up Avatar findRayIntersection

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -718,7 +718,7 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersectionVector(const Pic
 
             if (rayAvatarResult._intersect && pickAgainstMesh) {
                 glm::vec3 localRayOrigin = avatar->worldToJointPoint(ray.origin, rayAvatarResult._intersectWithJoint);
-                glm::vec3 localRayPoint = avatar->worldToJointPoint(ray.origin + rayDirection, rayAvatarResult._intersectWithJoint);
+                glm::vec3 localRayPoint = avatar->worldToJointPoint(ray.origin + rayAvatarResult._distance * rayDirection, rayAvatarResult._intersectWithJoint);
 
                 auto avatarOrientation = avatar->getWorldOrientation();
                 auto avatarPosition = avatar->getWorldPosition();
@@ -728,7 +728,7 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersectionVector(const Pic
 
                 auto defaultFrameRayOrigin = jointPosition + jointOrientation * localRayOrigin;
                 auto defaultFrameRayPoint = jointPosition + jointOrientation * localRayPoint;
-                auto defaultFrameRayDirection = defaultFrameRayPoint - defaultFrameRayOrigin;
+                auto defaultFrameRayDirection = glm::normalize(defaultFrameRayPoint - defaultFrameRayOrigin);
 
                 float subMeshDistance = FLT_MAX;
                 BoxFace subMeshFace = BoxFace::UNKNOWN_FACE;
@@ -750,7 +750,7 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersectionVector(const Pic
                 result.avatarID = rayAvatarResult._intersectWithAvatar;
                 result.distance = rayAvatarResult._distance;
                 result.face = face;
-                result.intersection = rayAvatarResult._intersectionPoint;
+                result.intersection = ray.origin + rayAvatarResult._distance * rayDirection;
                 result.surfaceNormal = rayAvatarResult._intersectionNormal;
                 result.jointIndex = rayAvatarResult._intersectWithJoint;
                 result.extraInfo = extraInfo;

--- a/interface/src/raypick/RayPick.cpp
+++ b/interface/src/raypick/RayPick.cpp
@@ -56,7 +56,8 @@ PickResultPointer RayPick::getOverlayIntersection(const PickRay& pick) {
 }
 
 PickResultPointer RayPick::getAvatarIntersection(const PickRay& pick) {
-    RayToAvatarIntersectionResult avatarRes = DependencyManager::get<AvatarManager>()->findRayIntersectionVector(pick, getIncludeItemsAs<EntityItemID>(), getIgnoreItemsAs<EntityItemID>(), true);
+    bool precisionPicking = !(getFilter().isCoarse() || DependencyManager::get<PickManager>()->getForceCoarsePicking());
+    RayToAvatarIntersectionResult avatarRes = DependencyManager::get<AvatarManager>()->findRayIntersectionVector(pick, getIncludeItemsAs<EntityItemID>(), getIgnoreItemsAs<EntityItemID>(), precisionPicking);
     if (avatarRes.intersects) {
         return std::make_shared<RayPickResult>(IntersectionType::AVATAR, avatarRes.avatarID, avatarRes.distance, avatarRes.intersection, pick, avatarRes.surfaceNormal, avatarRes.extraInfo);
     } else {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20924/Clean-up-AvatarManager-findRayIntersection-after-recent-change

Test plan:
- Run [this](https://gist.githubusercontent.com/SamGondelman/b2d93371a357fbf63ab817c4471b2a1b/raw/be54627071c8366dfa3ef5fe2bb67b01d9d97c36/AvatarIntersectionTest.js).  As you hover over avatars, a white sphere will appear where your mouse intersects them. 
 `{}` will print in the logs.
- Press "o".  The white sphere will still hit them (it will be more slightly precise now).  You'll see things in the log like this:
```[01/30 15:57:49] [DEBUG] [hifi.scriptengine.script] [AvatarIntersectionTest.js] {"meshIntersectionPoint":{"x":0.13138630986213684,"y":1.4935954809188843,"z":-0.1395256519317627},"partIndex":0,"shapeID":5,"subMeshIndex":4,"subMeshName":"VGWaistcoat.Shape_LOD1","subMeshNormal":{"x":0.00397340627387166,"y":0.35652875900268555,"z":-0.9342759251594543},"subMeshTriangle":{"v0":{"x":0.13531850278377533,"y":1.4937398433685303,"z":-0.1394542008638382},"v1":{"x":0.07772129774093628,"y":1.4583289623260498,"z":-0.1532122939825058},"v2":{"x":0.07747478783130646,"y":1.5160859823226929,"z":-0.13117270171642303}},"subMeshTriangleWorld":{"v0":{"x":-0.13531842827796936,"y":-10.00625991821289,"z":0.13842566311359406},"v1":{"x":-0.07772121578454971,"y":-10.041670799255371,"z":0.15218375623226166},"v2":{"x":-0.07747470587491989,"y":-9.983914375305176,"z":0.1301441639661789}},"worldIntersectionPoint":{"x":-0.13138623535633087,"y":-10.006404876708984,"z":0.13849711418151855}}```