### PR TITLE
MS20921: Oculus login button not appearing (RC79)

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -761,6 +761,11 @@ bool setupEssentials(int& argc, char** argv, bool runningMarkerExisted) {
     static const auto SUPPRESS_SETTINGS_RESET = "--suppress-settings-reset";
     bool suppressPrompt = cmdOptionExists(argc, const_cast<const char**>(argv), SUPPRESS_SETTINGS_RESET);
 
+    // set the OCULUS_STORE property so the oculus plugin can know if we ran from the Oculus Store
+    static const auto OCULUS_STORE_ARG = "--oculus-store";
+    bool isStore = cmdOptionExists(argc, const_cast<const char**>(argv), OCULUS_STORE_ARG);
+    qApp->setProperty(hifi::properties::OCULUS_STORE, isStore);
+
     // Ignore any previous crashes if running from command line with a test script.
     bool inTestMode { false };
     for (int i = 0; i < argc; ++i) {
@@ -1138,10 +1143,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     qCDebug(interfaceapp) << "[VERSION] We will use DEVELOPMENT global services.";
 #endif
 
-    // set the OCULUS_STORE property so the oculus plugin can know if we ran from the Oculus Store
-    static const QString OCULUS_STORE_ARG = "--oculus-store";
-    bool isStore = arguments().indexOf(OCULUS_STORE_ARG) != -1;
-    setProperty(hifi::properties::OCULUS_STORE, isStore);
+    bool isStore = property(hifi::properties::OCULUS_STORE).toBool();
+
     DependencyManager::get<WalletScriptingInterface>()->setLimitedCommerce(isStore);  // Or we could make it a separate arg, or if either arg is set, etc. And should this instead by a hifi::properties?
 
     updateHeartbeat();


### PR DESCRIPTION
MS#[20921](https://highfidelity.manuscript.com/f/cases/20921/Oculus-login-Oculus-login-button-no-longer-appears-when-launching-through-the-oculus-store)

# TEST PLAN
- Setup metaverse environment to staging
- Get this PR uploaded into Oculus store
- Launch PR through Oculus store
- Make sure Oculus login button appears
- Ensure Oculus login flow is successful 
- Test cases:
https://highfidelity.testrail.net/index.php?/cases/view/35637
https://highfidelity.testrail.net/index.php?/cases/view/40465