### PR TITLE
[78.1] Fix reload mechanic for entity server scripts

### DIFF
--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -112,7 +112,6 @@ void EntityScriptServer::handleReloadEntityServerScriptPacket(QSharedPointer<Rec
 
         if (_entityViewer.getTree() && !_shuttingDown) {
             qCDebug(entity_script_server) << "Reloading: " << entityID;
-            _entitiesScriptEngine->unloadEntityScript(entityID);
             checkAndCallPreload(entityID, true);
         }
     }
@@ -184,7 +183,6 @@ void EntityScriptServer::updateEntityPPS() {
         pps = std::min(_maxEntityPPS, pps);
     }
     _entityEditSender.setPacketsPerSecond(pps);
-    qDebug() << QString("Updating entity PPS to: %1 @ %2 PPS per script = %3 PPS").arg(numRunningScripts).arg(_entityPPSPerScript).arg(pps);
 }
 
 void EntityScriptServer::handleEntityServerScriptLogPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
@@ -525,23 +523,25 @@ void EntityScriptServer::deletingEntity(const EntityItemID& entityID) {
 
 void EntityScriptServer::entityServerScriptChanging(const EntityItemID& entityID, bool reload) {
     if (_entityViewer.getTree() && !_shuttingDown) {
-        _entitiesScriptEngine->unloadEntityScript(entityID, true);
         checkAndCallPreload(entityID, reload);
     }
 }
 
-void EntityScriptServer::checkAndCallPreload(const EntityItemID& entityID, bool reload) {
+void EntityScriptServer::checkAndCallPreload(const EntityItemID& entityID, bool forceRedownload) {
     if (_entityViewer.getTree() && !_shuttingDown && _entitiesScriptEngine) {
 
         EntityItemPointer entity = _entityViewer.getTree()->findEntityByEntityItemID(entityID);
         EntityScriptDetails details;
-        bool notRunning = !_entitiesScriptEngine->getEntityScriptDetails(entityID, details);
-        if (entity && (reload || notRunning || details.scriptText != entity->getServerScripts())) {
+        bool isRunning = _entitiesScriptEngine->getEntityScriptDetails(entityID, details);
+        if (entity && (forceRedownload || !isRunning || details.scriptText != entity->getServerScripts())) {
+            if (isRunning) {
+                _entitiesScriptEngine->unloadEntityScript(entityID, true);
+            }
+
             QString scriptUrl = entity->getServerScripts();
             if (!scriptUrl.isEmpty()) {
                 scriptUrl = DependencyManager::get<ResourceManager>()->normalizeURL(scriptUrl);
-                qCDebug(entity_script_server) << "Loading entity server script" << scriptUrl << "for" << entityID;
-                _entitiesScriptEngine->loadEntityScript(entityID, scriptUrl, reload);
+                _entitiesScriptEngine->loadEntityScript(entityID, scriptUrl, forceRedownload);
             }
         }
     }

--- a/assignment-client/src/scripts/EntityScriptServer.h
+++ b/assignment-client/src/scripts/EntityScriptServer.h
@@ -67,7 +67,7 @@ private:
     void addingEntity(const EntityItemID& entityID);
     void deletingEntity(const EntityItemID& entityID);
     void entityServerScriptChanging(const EntityItemID& entityID, bool reload);
-    void checkAndCallPreload(const EntityItemID& entityID, bool reload = false);
+    void checkAndCallPreload(const EntityItemID& entityID, bool forceRedownload = false);
 
     void cleanupOldKilledListeners();
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -981,7 +981,7 @@ void EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID, bool 
         QString scriptUrl = entity->getScript();
         if ((shouldLoad && unloadFirst) || scriptUrl.isEmpty()) {
             if (_entitiesScriptEngine) {
-            _entitiesScriptEngine->unloadEntityScript(entityID);
+                _entitiesScriptEngine->unloadEntityScript(entityID);
             }
             entity->scriptHasUnloaded();
         }


### PR DESCRIPTION
[Manuscript ticket](https://highfidelity.manuscript.com/f/cases/20104/Server-and-client-entity-scripts-have-a-chance-to-not-restart-or-stall-on-server-restart)

A bad interaction between the way entities can get send in several pieces and the fact that the script engine is running on a separate thread and that the calls are staggered was causing the ESS during an unload/reload to unload but not actually reload because it looked like the script was still running.
Even though the unload call was just pending.