### PR TITLE
Case 20829: Always fall when flying is not allowed

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -915,14 +915,9 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
     auto entityTreeRenderer = qApp->getEntities();
     EntityTreePointer entityTree = entityTreeRenderer ? entityTreeRenderer->getTree() : nullptr;
     if (entityTree) {
-        bool zoneAllowsFlying = true;
-        bool collisionlessAllowed = true;
+        std::pair<bool, bool> zoneInteractionProperties;
         entityTree->withWriteLock([&] {
-            std::shared_ptr<ZoneEntityItem> zone = entityTreeRenderer->myAvatarZone();
-            if (zone) {
-                zoneAllowsFlying = zone->getFlyingAllowed();
-                collisionlessAllowed = zone->getGhostingAllowed();
-            }
+            zoneInteractionProperties = entityTreeRenderer->getZoneInteractionProperties();
             EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
             forEachDescendant([&](SpatiallyNestablePointer object) {
                 // we need to update attached queryAACubes in our own local tree so point-select always works
@@ -935,6 +930,8 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
             });
         });
         bool isPhysicsEnabled = qApp->isPhysicsEnabled();
+        bool zoneAllowsFlying = zoneInteractionProperties.first;
+        bool collisionlessAllowed = zoneInteractionProperties.second;
         _characterController.setFlyingAllowed((zoneAllowsFlying && _enableFlying) || !isPhysicsEnabled);
         _characterController.setCollisionlessAllowed(collisionlessAllowed);
     }

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -1289,6 +1289,17 @@ CalculateEntityLoadingPriority EntityTreeRenderer::_calculateEntityLoadingPriori
     return 0.0f;
 };
 
+std::pair<bool, bool> EntityTreeRenderer::getZoneInteractionProperties() {
+    for (auto& zone : _layeredZones) {
+        // Only domain entities control flying allowed and ghosting allowed
+        if (zone.zone && zone.zone->isDomainEntity()) {
+            return { zone.zone->getFlyingAllowed(), zone.zone->getGhostingAllowed() };
+        }
+    }
+
+    return { true, true };
+}
+
 bool EntityTreeRenderer::wantsKeyboardFocus(const EntityItemID& id) const {
     auto renderable = renderableForEntityId(id);
     if (!renderable) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -105,7 +105,7 @@ public:
     // For Scene.shouldRenderEntities
     QList<EntityItemID>& getEntitiesLastInScene() { return _entityIDsLastInScene; }
 
-    std::shared_ptr<ZoneEntityItem> myAvatarZone() { return _layeredZones.getZone(); }
+    std::pair<bool, bool> getZoneInteractionProperties();
 
     bool wantsKeyboardFocus(const EntityItemID& id) const;
     QObject* getEventHandler(const EntityItemID& id);

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -1414,8 +1414,9 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  * @property {Entities.Bloom} bloom - The bloom properties of the zone.
  *
  * @property {boolean} flyingAllowed=true - If <code>true</code> then visitors can fly in the zone; otherwise they cannot.
+ *     Only works on domain entities.
  * @property {boolean} ghostingAllowed=true - If <code>true</code> then visitors with avatar collisions turned off will not 
- *     collide with content in the zone; otherwise visitors will always collide with content in the zone.
+ *     collide with content in the zone; otherwise visitors will always collide with content in the zone.  Only works on domain entities.
  
  * @property {string} filterURL="" - The URL of a JavaScript file that filters changes to properties of entities within the 
  *     zone. It is periodically executed for each entity in the zone. It can, for example, be used to not allow changes to 

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -672,7 +672,7 @@ void CharacterController::updateState() {
         return;
     }
     if (_pendingFlags & PENDING_FLAG_RECOMPUTE_FLYING) {
-        SET_STATE(CharacterController::State::Hover, "recomputeFlying");
+         SET_STATE(CharacterController::State::Hover, "recomputeFlying");
          _hasSupport = false;
          _stepHeight = _minStepHeight; // clears memory of last step obstacle
          _pendingFlags &= ~PENDING_FLAG_RECOMPUTE_FLYING;
@@ -784,15 +784,13 @@ void CharacterController::updateState() {
                         // Transition to hover if we are above the fall threshold
                         SET_STATE(State::Hover, "above fall threshold");
                     }
-                } else if (!rayHasHit && !_hasSupport) {
-                    SET_STATE(State::Hover, "no ground detected");
                 }
                 break;
             }
             case State::Hover:
                 btScalar horizontalSpeed = (velocity - velocity.dot(_currentUp) * _currentUp).length();
                 bool flyingFast = horizontalSpeed > (MAX_WALKING_SPEED * 0.75f);
-                if (!_flyingAllowed && rayHasHit) {
+                if (!_flyingAllowed) {
                     SET_STATE(State::InAir, "flying not allowed");
                 } else if ((_floorDistance < MIN_HOVER_HEIGHT) && !jumpButtonHeld && !flyingFast) {
                     SET_STATE(State::InAir, "near ground");


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20829/Avatar-don-t-fall-and-can-start-to-fly-when-the-zone-is-set-to-no-fly

Additionally: removes a griefing vector by which users could fly in non-flyingAllowed zones by surrounding themselves in an avatar or local zone entity.

Test plan:
- Create a zone with flying allowed.  Create a cube inside of it.  Walk on the cube.
- When you jump, you should be able to transition to flying if you hold jump.
- When you walk off the cube, you should hover there.
- Stand on the cube and set flying allowed to false in the zone.
- When you jump, you will not start flying.
- When you walk off the cube, you will fall until you reach the bottom of the zone, at which point you'll hover right below it.
- Turn flying back on and fly to the middle of the zone so you are floating.  Turn flying off, you'll fall again.
- Stand on the cube again and make sure flying is off.  Run this from the console:
```
Entities.addEntity({
    type: "Zone",
    parentID: MyAvatar.SELF_ID,
    dimensions: 5.0,
    position: MyAvatar.position,
    flyingAllowed: true
}, true);
```
- You should still not be able to fly.