### PR TITLE
[RC79] Fix assertion when trying to create multisphere shapeInfo with empty data.

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1733,15 +1733,17 @@ void Avatar::computeShapeInfo(ShapeInfo& shapeInfo) {
 void Avatar::computeDetailedShapeInfo(ShapeInfo& shapeInfo, int jointIndex) {
     if (jointIndex > -1 && jointIndex < (int)_multiSphereShapes.size()) {
         auto& data = _multiSphereShapes[jointIndex].getSpheresData();
-        std::vector<glm::vec3> positions;
-        std::vector<btScalar> radiuses;
-        positions.reserve(data.size());
-        radiuses.reserve(data.size());
-        for (auto& sphere : data) {
-            positions.push_back(sphere._position);
-            radiuses.push_back(sphere._radius);
+        if (data.size() > 0) {
+            std::vector<glm::vec3> positions;
+            std::vector<btScalar> radiuses;
+            positions.reserve(data.size());
+            radiuses.reserve(data.size());
+            for (auto& sphere : data) {
+                positions.push_back(sphere._position);
+                radiuses.push_back(sphere._radius);
+            }
+            shapeInfo.setMultiSphere(positions, radiuses);
         }
-        shapeInfo.setMultiSphere(positions, radiuses);
     }
 }
 

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -152,7 +152,8 @@ void ShapeInfo::setSphere(float radius) {
 void ShapeInfo::setMultiSphere(const std::vector<glm::vec3>& centers, const std::vector<float>& radiuses) {
     _url = "";
     _type = SHAPE_TYPE_MULTISPHERE;
-    assert(centers.size() == radiuses.size() && centers.size() > 0);
+    assert(centers.size() == radiuses.size());
+    assert(centers.size() > 0);
     for (size_t i = 0; i < centers.size(); i++) {
         SphereData sphere = SphereData(centers[i], radiuses[i]);
         _sphereCollection.push_back(sphere);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20935/Android-Interface-crashes-when-loading-into-any-domain

This PR addresses an assertion when trying to create a multisphere shape with empty data.
This error was introduced by https://github.com/highfidelity/hifi/pull/14722
 