### PR TITLE
[RC79] MS20909: ignore pickRay for zone shape visualizers

### DIFF
--- a/scripts/system/modules/entityShapeVisualizer.js
+++ b/scripts/system/modules/entityShapeVisualizer.js
@@ -135,6 +135,7 @@ EntityShape.prototype = {
         overlayProperties.canCastShadows = false;
         overlayProperties.parentID = this.entityID;
         overlayProperties.collisionless = true;
+        overlayProperties.ignorePickIntersection = true;
         this.entity = Entities.addEntity(overlayProperties, "local");
         var PROJECTED_MATERIALS = false;
         this.materialEntity = Entities.addEntity({


### PR DESCRIPTION
Fix for https://highfidelity.manuscript.com/f/cases/20909/New-zones-with-icons-and-preview-shapes-can-be-very-difficult-to-resize-with-lasers-in-VR