### PR TITLE
case 21040: fix Interface crash on early shutdown

### DIFF
--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -38,7 +38,6 @@ LogHandler::LogHandler() {
 }
 
 LogHandler::~LogHandler() {
-    flushRepeatedMessages();
 }
 
 const char* stringForLogType(LogMsgType msgType) {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21040/Crash-Interface-crashes-on-shut-down-when-closing-during-domain-loading

This PR fixes an Interface crash when quitting application before scene has loaded.