### PR TITLE
case 21042: fix interface crash on early shutdown, 0.80.0 redux

### DIFF
--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -38,7 +38,6 @@ LogHandler::LogHandler() {
 }
 
 LogHandler::~LogHandler() {
-    flushRepeatedMessages();
 }
 
 const char* stringForLogType(LogMsgType msgType) {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21042/Crash-Interface-crashes-on-shut-down-when-closing-during-domain-loading-0-80-0-redux

This PR fixes an Interface crash when quitting application before scene has loaded.