### PR TITLE
Case 19385: local compare in entity list sorting

### DIFF
--- a/scripts/system/html/js/entityList.js
+++ b/scripts/system/html/js/entityList.js
@@ -681,6 +681,9 @@ function loaded() {
                         if (isNullOrEmpty(valueB)) {
                             return (isDefaultSort ? -1 : 1) * (isAscendingSort ? 1 : -1);
                         }
+                        if (typeof(valueA) === "string") {
+                            return valueA.localeCompare(valueB);
+                        }
                         return valueA < valueB ? -1 : 1;
                     });
                 });


### PR DESCRIPTION
Fixes https://highfidelity.manuscript.com/f/cases/19385/Non-alphanumeric-characters-should-appear-at-top-of-entity-list-sort