### PR TITLE
Case 21047: Render backfaces of triangles on Procedural Entities

### DIFF
--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -104,13 +104,13 @@ void ProceduralData::parse(const QJsonObject& proceduralData) {
 //}
 
 Procedural::Procedural() {
-    _opaqueState->setCullMode(gpu::State::CULL_BACK);
+    _opaqueState->setCullMode(gpu::State::CULL_NONE);
     _opaqueState->setDepthTest(true, true, gpu::LESS_EQUAL);
     _opaqueState->setBlendFunction(false,
         gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,
         gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
 
-    _transparentState->setCullMode(gpu::State::CULL_BACK);
+    _transparentState->setCullMode(gpu::State::CULL_NONE);
     _transparentState->setDepthTest(true, true, gpu::LESS_EQUAL);
     _transparentState->setBlendFunction(true,
         gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21047/Procedural-Entities-need-to-render-the-backfaces-of-triangles

(I broke this a few releases ago)

Test plan:
- Run [this](https://gist.githubusercontent.com/SamGondelman/89cd68aac8b73866228de819b1b2bdcf/raw/3695725f5a0fb6ffb18db51a9ec32e5b612991f3/VoxelEdges.js).  In first person, look down and you'll see this:
![image](https://user-images.githubusercontent.com/7650116/52368805-24f85100-2a04-11e9-969d-db45087bf913.png)
- In third person you'll see this:
![image](https://user-images.githubusercontent.com/7650116/52368840-380b2100-2a04-11e9-8754-3ecac23a964d.png)