### PR TITLE
Case 19724: If sorting PAL by loudness re-sort upon loudness updates

### DIFF
--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -1247,6 +1247,9 @@ Rectangle {
                     }
                 }
             }
+            if (nearbyTable.sortIndicatorColumn == 0) {  // Current sort by loudness so re-sort.
+                sortModel();
+            }
             break;
         case 'clearLocalQMLData':
             ignored = {};

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -42,6 +42,8 @@ Rectangle {
     property var activeTab: "nearbyTab";
     property bool currentlyEditingDisplayName: false
     property bool punctuationMode: false;
+    property double loudSortTime: 0.0;
+    readonly property double kLOUD_SORT_PERIOD_MS: 500.0;
 
     HifiConstants { id: hifi; }
     RootHttpRequest { id: http; }
@@ -1247,8 +1249,10 @@ Rectangle {
                     }
                 }
             }
-            if (nearbyTable.sortIndicatorColumn == 0) {  // Current sort by loudness so re-sort.
+            if (nearbyTable.sortIndicatorColumn == 0 && Date.now() - pal.loudSortTime >= pal.kLOUD_SORT_PERIOD_MS) {
+                // Current sort by loudness so re-sort.
                 sortModel();
+                pal.loudSortTime = Date.now();
             }
             break;
         case 'clearLocalQMLData':

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -43,7 +43,7 @@ Rectangle {
     property bool currentlyEditingDisplayName: false
     property bool punctuationMode: false;
     property double loudSortTime: 0.0;
-    readonly property double kLOUD_SORT_PERIOD_MS: 500.0;
+    readonly property double kLOUD_SORT_PERIOD_MS: 100.0;
 
     HifiConstants { id: hifi; }
     RootHttpRequest { id: http; }

--- a/interface/resources/qml/hifi/Pal.qml
+++ b/interface/resources/qml/hifi/Pal.qml
@@ -43,7 +43,7 @@ Rectangle {
     property bool currentlyEditingDisplayName: false
     property bool punctuationMode: false;
     property double loudSortTime: 0.0;
-    readonly property double kLOUD_SORT_PERIOD_MS: 100.0;
+    readonly property double kLOUD_SORT_PERIOD_MS: 1000.0;
 
     HifiConstants { id: hifi; }
     RootHttpRequest { id: http; }


### PR DESCRIPTION
Ticket: https://highfidelity.manuscript.com/f/cases/19724/

The ticket covers the list not being sorted on first bringing up the PAL but I noticed the table was not being sorted when a loudness update was received from the js side, unlike other updates. This simple change adds that.