### PR TITLE
Case 21070: Fix black albedo coloring

### DIFF
--- a/libraries/graphics/src/graphics/Material.cpp
+++ b/libraries/graphics/src/graphics/Material.cpp
@@ -87,7 +87,7 @@ void Material::setUnlit(bool value) {
 }
 
 void Material::setAlbedo(const glm::vec3& albedo, bool isSRGB) {
-    _key.setAlbedo(glm::any(glm::greaterThan(albedo, glm::vec3(0.0f))));
+    _key.setAlbedo(true);
     _albedo = (isSRGB ? ColorUtils::sRGBToLinearVec3(albedo) : albedo);
 }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21070/fix-color-picker-black-values-for-80

Test plan:
- Make a cube.  In create, use the color picker to make it true black.  It should be black.
- Run all the tests/engine/render and tests/content tests from hifi_tests