### PR TITLE
Case 21048: Fix black albedo coloring

### DIFF
--- a/libraries/graphics/src/graphics/Material.cpp
+++ b/libraries/graphics/src/graphics/Material.cpp
@@ -87,7 +87,7 @@ void Material::setUnlit(bool value) {
 }
 
 void Material::setAlbedo(const glm::vec3& albedo, bool isSRGB) {
-    _key.setAlbedo(glm::any(glm::greaterThan(albedo, glm::vec3(0.0f))));
+    _key.setAlbedo(true);
     _albedo = (isSRGB ? ColorUtils::sRGBToLinearVec3(albedo) : albedo);
 }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21048/Setting-the-color-picker-values-to-0-on-an-entity-does-not-set-the-entity-to-true-black

https://github.com/highfidelity/hifi/pull/14868