### PR TITLE
(case 21076) Fix missing normal textures on models (RC80)

### DIFF
--- a/libraries/model-baker/src/model-baker/CalculateMeshTangentsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateMeshTangentsTask.cpp
@@ -47,7 +47,7 @@ void CalculateMeshTangentsTask::run(const baker::BakeContextPointer& context, co
                 break;
             }
         }
-        if (needTangents) {
+        if (!needTangents) {
             continue;
         }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21076/Models-are-missing-normal-textures-RC80

This PR fixes normal textures missing on models due to missing tangent space. It is the same PR as the RC79 PR https://github.com/highfidelity/hifi/pull/14872, but targeted toward master.

## TEST PLAN
- Run this test:
    - https://github.com/sabrina-shanman/hifi_tests/tree/bug_no-normal-textures/tests/content/entity/model/modelBaking/normal_texture
    - This should show a cube model consisting of a grey design on a white background. If you see just a white cube, then normal textures are not rendering, which counts as a fail.