### PR TITLE
Case 21091: Improved audio metering

### DIFF
--- a/interface/resources/qml/hifi/audio/MicBar.qml
+++ b/interface/resources/qml/hifi/audio/MicBar.qml
@@ -234,7 +234,7 @@ Rectangle {
         
         Rectangle {
             id: gatedIndicator;
-            visible: gated
+            visible: gated && !AudioScriptingInterface.clipping
             
             radius: 4;     
             width: 2 * radius;
@@ -242,6 +242,20 @@ Rectangle {
             color: "#0080FF";
             anchors {
                 right: parent.left;
+                verticalCenter: parent.verticalCenter;
+            }
+        }
+        
+        Rectangle {
+            id: clippingIndicator;
+            visible: AudioScriptingInterface.clipping
+            
+            radius: 4;     
+            width: 2 * radius;
+            height: 2 * radius;
+            color: colors.red;
+            anchors {
+                left: parent.right;
                 verticalCenter: parent.verticalCenter;
             }
         }

--- a/interface/resources/qml/hifi/audio/MicBar.qml
+++ b/interface/resources/qml/hifi/audio/MicBar.qml
@@ -16,7 +16,13 @@ import TabletScriptingInterface 1.0
 
 Rectangle {
     readonly property var level: AudioScriptingInterface.inputLevel;
-
+    
+    property bool gated: false;
+    Component.onCompleted: {
+        AudioScriptingInterface.noiseGateOpened.connect(function() { gated = false; });
+        AudioScriptingInterface.noiseGateClosed.connect(function() { gated = true; });
+    }
+        
     property bool standalone: false;
     property var dragTarget: null;
 
@@ -189,7 +195,7 @@ Rectangle {
 
         Rectangle { // mask
             id: mask;
-            width: parent.width * level;
+            width: gated ? 0 : parent.width * level;
             radius: 5;
             anchors {
                 bottom: parent.bottom;
@@ -223,6 +229,20 @@ Rectangle {
                     position: 1;
                     color: colors.red;
                 }
+            }
+        }
+        
+        Rectangle {
+            id: gatedIndicator;
+            visible: gated
+            
+            radius: 4;     
+            width: 2 * radius;
+            height: 2 * radius;
+            color: "#0080FF";
+            anchors {
+                right: parent.left;
+                verticalCenter: parent.verticalCenter;
             }
         }
     }

--- a/interface/resources/qml/hifi/audio/MicBar.qml
+++ b/interface/resources/qml/hifi/audio/MicBar.qml
@@ -83,6 +83,7 @@ Rectangle {
         readonly property string gutter: "#575757";
         readonly property string greenStart: "#39A38F";
         readonly property string greenEnd: "#1FC6A6";
+        readonly property string yellow: "#C0C000";
         readonly property string red: colors.muted;
         readonly property string fill: "#55000000";
         readonly property string border: standalone ? "#80FFFFFF" : "#55FFFFFF";
@@ -218,16 +219,12 @@ Rectangle {
                     color: colors.greenStart;
                 }
                 GradientStop {
-                    position: 0.8;
+                    position: 0.5;
                     color: colors.greenEnd;
                 }
                 GradientStop {
-                    position: 0.81;
-                    color: colors.red;
-                }
-                GradientStop {
                     position: 1;
-                    color: colors.red;
+                    color: colors.yellow;
                 }
             }
         }

--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -150,17 +150,32 @@ float Audio::getInputLevel() const {
     });
 }
 
-void Audio::onInputLoudnessChanged(float loudness) {
+bool Audio::isClipping() const {
+    return resultWithReadLock<bool>([&] {
+        return _isClipping;
+    });
+}
+
+void Audio::onInputLoudnessChanged(float loudness, bool isClipping) {
     float level = loudnessToLevel(loudness);
-    bool changed = false;
+    bool levelChanged = false;
+    bool isClippingChanged = false;
+
     withWriteLock([&] {
         if (_inputLevel != level) {
             _inputLevel = level;
-            changed = true;
+            levelChanged = true;
+        }
+        if (_isClipping != isClipping) {
+            _isClipping = isClipping;
+            isClippingChanged = true;
         }
     });
-    if (changed) {
+    if (levelChanged) {
         emit inputLevelChanged(level);
+    }
+    if (isClippingChanged) {
+        emit clippingChanged(isClipping);
     }
 }
 

--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -28,7 +28,7 @@ Setting::Handle<bool> enableNoiseReductionSetting { QStringList { Audio::AUDIO, 
 
 float Audio::loudnessToLevel(float loudness) {
     float level = 6.02059991f * fastLog2f(loudness);    // level in dBFS
-    level = (level + 60.0f) * (1/48.0f);                // map [-60, -12] dBFS to [0, 1]
+    level = (level + 48.0f) * (1/39.0f);                // map [-48, -9] dBFS to [0, 1]
     return glm::clamp(level, 0.0f, 1.0f);
 }
 

--- a/interface/src/scripting/Audio.h
+++ b/interface/src/scripting/Audio.h
@@ -41,6 +41,7 @@ class Audio : public AudioScriptingInterface, protected ReadWriteLockable {
      *     above the noise floor.
      * @property {number} inputLevel - The loudness of the audio input, range <code>0.0</code> (no sound) &ndash; 
      *     <code>1.0</code> (the onset of clipping). <em>Read-only.</em>
+     * @property {boolean} clipping - <code>true</code> if the audio input is clipping, otherwise <code>false</code>.
      * @property {number} inputVolume - Adjusts the volume of the input audio; range <code>0.0</code> &ndash; <code>1.0</code>. 
      *     If set to a value, the resulting value depends on the input device: for example, the volume can't be changed on some 
      *     devices, and others might only support values of <code>0.0</code> and <code>1.0</code>.
@@ -58,6 +59,7 @@ class Audio : public AudioScriptingInterface, protected ReadWriteLockable {
     Q_PROPERTY(bool noiseReduction READ noiseReductionEnabled WRITE enableNoiseReduction NOTIFY noiseReductionChanged)
     Q_PROPERTY(float inputVolume READ getInputVolume WRITE setInputVolume NOTIFY inputVolumeChanged)
     Q_PROPERTY(float inputLevel READ getInputLevel NOTIFY inputLevelChanged)
+    Q_PROPERTY(bool clipping READ isClipping NOTIFY clippingChanged)
     Q_PROPERTY(QString context READ getContext NOTIFY contextChanged)
     Q_PROPERTY(AudioDevices* devices READ getDevices NOTIFY nop)
 
@@ -74,6 +76,7 @@ public:
     bool noiseReductionEnabled() const;
     float getInputVolume() const;
     float getInputLevel() const;
+    bool isClipping() const;
     QString getContext() const;
 
     void showMicMeter(bool show);
@@ -218,6 +221,14 @@ signals:
     void inputLevelChanged(float level);
 
     /**jsdoc
+     * Triggered when the clipping state of the input audio changes.
+     * @function Audio.clippingChanged
+     * @param {boolean} isClipping - <code>true</code> if the audio input is clipping, otherwise <code>false</code>.
+     * @returns {Signal}
+     */
+    void clippingChanged(bool isClipping);
+
+    /**jsdoc
      * Triggered when the current context of the audio changes.
      * @function Audio.contextChanged
      * @param {string} context - The current context of the audio: either <code>"Desktop"</code> or <code>"HMD"</code>.
@@ -237,7 +248,7 @@ private slots:
     void setMuted(bool muted);
     void enableNoiseReduction(bool enable);
     void setInputVolume(float volume);
-    void onInputLoudnessChanged(float loudness);
+    void onInputLoudnessChanged(float loudness, bool isClipping);
 
 protected:
     // Audio must live on a separate thread from AudioClient to avoid deadlocks
@@ -247,6 +258,7 @@ private:
 
     float _inputVolume { 1.0f };
     float _inputLevel { 0.0f };
+    bool _isClipping { false };
     bool _isMuted { false };
     bool _enableNoiseReduction { true };  // Match default value of AudioClient::_isNoiseGateEnabled.
     bool _contextIsHMD { false };

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -175,7 +175,7 @@ static float computeLoudness(int16_t* samples, int numSamples, int numChannels, 
     const int32_t CLIPPING_THRESHOLD = 32392;   // -0.1 dBFS
     const int32_t CLIPPING_DETECTION = 3;       // consecutive samples over threshold
 
-    float scale = numSamples ? 1.0f / numSamples : 0.0f;
+    float scale = numSamples ? 1.0f / (numSamples * 32768.0f) : 0.0f;
 
     int32_t loudness = 0;
     isClipping = false;

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1229,8 +1229,9 @@ void AudioClient::handleMicAudioInput() {
         } else if (_timeSinceLastClip >= 0.0f) {
             _timeSinceLastClip += AudioConstants::NETWORK_FRAME_SECS;
         }
+        isClipping = (_timeSinceLastClip >= 0.0f) && (_timeSinceLastClip < 2.0f);   // 2 second hold time
 
-        emit inputLoudnessChanged(_lastInputLoudness);
+        emit inputLoudnessChanged(_lastInputLoudness, isClipping);
 
         if (!_muted) {
             possibleResampling(_inputToNetworkResampler,

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1222,7 +1222,11 @@ void AudioClient::handleMicAudioInput() {
 
         // detect loudness and clipping on the raw input
         bool isClipping = false;
-        _lastInputLoudness = computeLoudness(inputAudioSamples.get(), inputSamplesRequired, _inputFormat.channelCount(), isClipping);
+        float inputLoudness = computeLoudness(inputAudioSamples.get(), inputSamplesRequired, _inputFormat.channelCount(), isClipping);
+
+        float tc = (inputLoudness > _lastInputLoudness) ? 0.378f : 0.967f;  // 10ms attack, 300ms release @ 100Hz
+        inputLoudness += tc * (_lastInputLoudness - inputLoudness);
+        _lastInputLoudness = inputLoudness;
 
         if (isClipping) {
             _timeSinceLastClip = 0.0f;

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -248,7 +248,7 @@ signals:
     void noiseReductionChanged(bool noiseReductionEnabled);
     void mutedByMixer();
     void inputReceived(const QByteArray& inputSamples);
-    void inputLoudnessChanged(float loudness);
+    void inputLoudnessChanged(float loudness, bool isClipping);
     void outputBytesToNetwork(int numBytes);
     void inputBytesFromNetwork(int numBytes);
     void noiseGateOpened();

--- a/libraries/audio/src/AudioGate.h
+++ b/libraries/audio/src/AudioGate.h
@@ -18,9 +18,12 @@ public:
     AudioGate(int sampleRate, int numChannels);
     ~AudioGate();
 
-    // interleaved int16_t input/output (in-place is allowed)
-    void render(int16_t* input, int16_t* output, int numFrames);
-    void removeDC(int16_t* input, int16_t* output, int numFrames);
+    //
+    // Process interleaved int16_t input/output (in-place is allowed).
+    // Returns true when output is non-zero.
+    //
+    bool render(int16_t* input, int16_t* output, int numFrames);
+    bool removeDC(int16_t* input, int16_t* output, int numFrames);
 
     void setThreshold(float threshold);
     void setRelease(float release);


### PR DESCRIPTION
This PR reimplements the audio input level metering on the client, to encourage better microphone level settings.

https://highfidelity.manuscript.com/f/cases/21091/Improved-audio-metering

Level detection is now done on the raw (unprocessed) audio input.
Audio.inputLevel now reports raw mic level, unaffected by mute or gate settings.
Digital clipping is accurately detected on the unprocessed input, as 3+ consecutive overs.

The audio meter is accurately calibrated from -48dbFS to -9dBFS, with a blue "gated" indicator and a red "clipping" indicator (with two second hold). Meter attack/release times approximate a conventional PPM meter. See images below.

The intent is that:
Scripts can warn when the input is muted, but high mic levels are present.
Calibrated metering with proper clipping detection will encourage more consistent mic settings.

Input is gated:

![gated](https://user-images.githubusercontent.com/13965157/52452989-36238980-2afa-11e9-8ad7-7f028b8c20b7.png)

Input is clipping:

![clipping](https://user-images.githubusercontent.com/13965157/52453000-3cb20100-2afa-11e9-9cae-cd8a62a05020.png)
