### PR TITLE
Pack all non-instanced avatar traits

### DIFF
--- a/libraries/avatars/src/ClientTraitsHandler.cpp
+++ b/libraries/avatars/src/ClientTraitsHandler.cpp
@@ -107,11 +107,10 @@ int ClientTraitsHandler::sendChangedTraitsToMixer() {
 
             if (initialSend || *simpleIt == Updated) {
                 if (traitType == AvatarTraits::SkeletonModelURL) {
-                    bytesWritten += _owningAvatar->packTrait(traitType, *traitsPacketList);
-
                     // keep track of our skeleton version in case we get an override back
                     _currentSkeletonVersion = _currentTraitVersion;
                 }
+                bytesWritten += _owningAvatar->packTrait(traitType, *traitsPacketList);
             }
 
             ++simpleIt;


### PR DESCRIPTION
Previously this code only would pack the skeletonModelURL trait.  Which is technically not a bug, because there it is the only non-instanced trait.  But, we plan to add new traits in the future.  So, let's fix this now.