### PR TITLE
Oculus Hand Fix

### DIFF
--- a/plugins/oculus/src/OculusControllerManager.h
+++ b/plugins/oculus/src/OculusControllerManager.h
@@ -24,6 +24,9 @@ class OculusControllerManager : public InputPlugin {
     Q_OBJECT
 public:
     // Plugin functions
+    void loadTouchSettings();
+    void saveTouchSettings() const;
+    void saveSettings() const;
     bool isSupported() const override;
     const QString getName() const override { return NAME; }
     bool isHandController() const override { return _touch != nullptr; }
@@ -88,6 +91,8 @@ private:
         using Locker = std::unique_lock<std::recursive_mutex>;
         template <typename F>
         void withLock(F&& f) { Locker locker(_lock); f(); }
+
+        bool _touchTrackedInDashMenu{ true };
 
         float _leftHapticDuration { 0.0f };
         float _leftHapticStrength { 0.0f };

--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -65,6 +65,8 @@ var eventMapping = Controller.newMapping(eventMappingName);
 var avatarPosition = MyAvatar.position;
 var wasHmdMounted = HMD.mounted;
 
+var goAwayOnMouseCaptureLoss = Settings.getValue('goAwayOnMouseCaptureLoss', false);
+Settings.setValue('goAwayOnMouseCaptureLoss', goAwayOnMouseCaptureLoss);
 
 // some intervals we may create/delete
 var avatarMovedInterval;
@@ -272,8 +274,10 @@ function maybeGoAway() {
     if (Reticle.mouseCaptured !== wasMouseCaptured) {
         wasMouseCaptured = !wasMouseCaptured;
         if (!wasMouseCaptured) {
-            goAway();
-            return;
+			if (goAwayOnMouseCaptureLoss) {
+				goAway();
+				return;
+			}
         }
     }
 


### PR DESCRIPTION
Changes the default behavior of hands to continue to be tracked when in the Oculus Dash menu, as well as to not go into the away state automatically when cursor loses focus, allowing you users to visibly interact with the virtual desktops and Oculus keyboards. It also by default prevents you from going into an away state when the cursor loses focus from the High Fidelity window while in VR.

https://highfidelity.fogbugz.com/f/cases/21167/