### PR TITLE
Case 21093: recompute collision group/mask when Grab ends

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -5312,3 +5312,15 @@ void MyAvatar::releaseGrab(const QUuid& grabID) {
     }
 }
 
+void MyAvatar::sendPacket(const QUuid& entityID, const EntityItemProperties& properties) const {
+    auto treeRenderer = DependencyManager::get<EntityTreeRenderer>();
+    EntityTreePointer entityTree = treeRenderer ? treeRenderer->getTree() : nullptr;
+    if (entityTree) {
+        entityTree->withWriteLock([&] {
+            // force an update packet
+            EntityEditPacketSender* packetSender = qApp->getEntityEditPacketSender();
+            packetSender->queueEditEntityMessage(PacketType::EntityEdit, entityTree, entityID, properties);
+        });
+    }
+}
+

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1882,6 +1882,7 @@ private:
     bool didTeleport();
     bool getIsAway() const { return _isAway; }
     void setAway(bool value);
+    void sendPacket(const QUuid& entityID, const EntityItemProperties& properties) const override;
 
     std::mutex _pinnedJointsMutex;
     std::vector<int> _pinnedJoints;

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -510,6 +510,11 @@ void OtherAvatar::handleChangedAvatarEntityData() {
                 }
             }
             stateItr.value().success = success;
+            if (success) {
+                stateItr.value().hash = newHash;
+            } else {
+                stateItr.value().hash = 0;
+            }
         }
 
         AvatarEntityIDs recentlyRemovedAvatarEntities = getAndClearRecentlyRemovedIDs();

--- a/interface/src/avatar/OtherAvatar.h
+++ b/interface/src/avatar/OtherAvatar.h
@@ -76,6 +76,16 @@ protected:
     void onAddAttachedAvatarEntity(const QUuid& id);
     void onRemoveAttachedAvatarEntity(const QUuid& id);
 
+    class AvatarEntityDataHash {
+    public:
+        AvatarEntityDataHash(uint32_t h) : hash(h) {};
+        uint32_t hash { 0 };
+        bool success { false };
+    };
+
+    using MapOfAvatarEntityDataHashes = QMap<QUuid, AvatarEntityDataHash>;
+    MapOfAvatarEntityDataHashes _avatarEntityDataHashes;
+
     std::vector<QUuid> _attachedAvatarEntities;
     std::shared_ptr<Sphere3DOverlay> _otherAvatarOrbMeshPlaceholder { nullptr };
     OverlayID _otherAvatarOrbMeshPlaceholderID { UNKNOWN_OVERLAY_ID };

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -305,11 +305,6 @@ void Avatar::setTargetScale(float targetScale) {
     }
 }
 
-void Avatar::setAvatarEntityDataChanged(bool value) {
-    AvatarData::setAvatarEntityDataChanged(value);
-    _avatarEntityDataHashes.clear();
-}
-
 void Avatar::removeAvatarEntitiesFromTree() {
     auto treeRenderer = DependencyManager::get<EntityTreeRenderer>();
     EntityTreePointer entityTree = treeRenderer ? treeRenderer->getTree() : nullptr;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -363,6 +363,13 @@ bool Avatar::applyGrabChanges() {
                 target->removeGrab(grab);
                 _avatarGrabs.erase(itr);
                 grabAddedOrRemoved = true;
+                if (isMyAvatar()) {
+                    const EntityItemPointer& entity = std::dynamic_pointer_cast<EntityItem>(target);
+                    if (entity && entity->getEntityHostType() == entity::HostType::AVATAR && entity->getSimulationOwner().getID() == getID()) {
+                        EntityItemProperties properties = entity->getProperties();
+                        sendPacket(entity->getID(), properties);
+                    }
+                }
             } else {
                 undeleted.push_back(id);
             }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -480,8 +480,6 @@ public:
     virtual void setModelScale(float scale) { _modelScale = scale; }
     virtual glm::vec3 scaleForChildren() const override { return glm::vec3(getModelScale()); }
 
-    virtual void setAvatarEntityDataChanged(bool value) override;
-
     // Show hide the model representation of the avatar
     virtual void setEnableMeshVisible(bool isEnabled);
     virtual bool getEnableMeshVisible() const;
@@ -647,8 +645,8 @@ protected:
         bool success { false };
     };
 
-    using MapOfAvatarEntityDataHashes = QMap<QUuid, AvatarEntityDataHash>;
-    MapOfAvatarEntityDataHashes _avatarEntityDataHashes;
+    //using MapOfAvatarEntityDataHashes = QMap<QUuid, AvatarEntityDataHash>;
+    //MapOfAvatarEntityDataHashes _avatarEntityDataHashes;
 
     uint64_t _lastRenderUpdateTime { 0 };
     int _leftPointerGeometryID { 0 };

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -25,6 +25,7 @@
 #include <render/Scene.h>
 #include <graphics-scripting/Forward.h>
 #include <GLMHelpers.h>
+#include <EntityItem.h>
 
 #include <Grab.h>
 #include <ThreadSafeValueCache.h>
@@ -601,6 +602,7 @@ protected:
 
     // protected methods...
     bool isLookingAtMe(AvatarSharedPointer avatar) const;
+    virtual void sendPacket(const QUuid& entityID, const EntityItemProperties& properties) const { }
     bool applyGrabChanges();
     void relayJointDataToChildren();
 
@@ -644,9 +646,6 @@ protected:
         uint32_t hash { 0 };
         bool success { false };
     };
-
-    //using MapOfAvatarEntityDataHashes = QMap<QUuid, AvatarEntityDataHash>;
-    //MapOfAvatarEntityDataHashes _avatarEntityDataHashes;
 
     uint64_t _lastRenderUpdateTime { 0 };
     int _leftPointerGeometryID { 0 };

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1147,7 +1147,7 @@ public:
      */
     Q_INVOKABLE virtual void setAvatarEntityData(const AvatarEntityMap& avatarEntityData);
 
-    virtual void setAvatarEntityDataChanged(bool value) { _avatarEntityDataChanged = value; }
+    void setAvatarEntityDataChanged(bool value) { _avatarEntityDataChanged = value; }
     AvatarEntityIDs getAndClearRecentlyRemovedIDs();
 
     /**jsdoc

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1897,7 +1897,7 @@ glm::vec3 EntityItem::getUnscaledDimensions() const {
 void EntityItem::setRotation(glm::quat rotation) {
     if (getLocalOrientation() != rotation) {
         setLocalOrientation(rotation);
-        markDirtyFlags(Simulation::DIRTY_ROTATION);
+        _flags |= Simulation::DIRTY_ROTATION;
         forEachDescendant([&](SpatiallyNestablePointer object) {
             if (object->getNestableType() == NestableType::Entity) {
                 EntityItemPointer entity = std::static_pointer_cast<EntityItem>(object);
@@ -1927,7 +1927,7 @@ void EntityItem::setVelocity(const glm::vec3& value) {
                     velocity = value;
                 }
                 setLocalVelocity(velocity);
-                markDirtyFlags(Simulation::DIRTY_LINEAR_VELOCITY);
+                _flags |= Simulation::DIRTY_LINEAR_VELOCITY;
             }
         }
     }
@@ -1982,7 +1982,7 @@ void EntityItem::setAngularVelocity(const glm::vec3& value) {
                     angularVelocity = value;
                 }
                 setLocalAngularVelocity(angularVelocity);
-                markDirtyFlags(Simulation::DIRTY_ANGULAR_VELOCITY);
+                _flags |= Simulation::DIRTY_ANGULAR_VELOCITY;
             }
         }
     }
@@ -2168,8 +2168,8 @@ bool EntityItem::addAction(EntitySimulationPointer simulation, EntityDynamicPoin
 
 void EntityItem::enableNoBootstrap() {
     if (!(bool)(_flags & Simulation::SPECIAL_FLAGS_NO_BOOTSTRAPPING)) {
-        markDirtyFlags(Simulation::DIRTY_COLLISION_GROUP);
-        markSpecialFlags(Simulation::SPECIAL_FLAGS_NO_BOOTSTRAPPING);
+        _flags |= Simulation::SPECIAL_FLAGS_NO_BOOTSTRAPPING;
+        _flags |= Simulation::DIRTY_COLLISION_GROUP; // may need to not collide with own avatar
 
         // NOTE: unlike disableNoBootstrap() below, we do not call simulation->changeEntity() here
         // because most enableNoBootstrap() cases are already correctly handled outside this scope
@@ -2188,8 +2188,8 @@ void EntityItem::enableNoBootstrap() {
 
 void EntityItem::disableNoBootstrap() {
     if (!stillHasGrabActions()) {
-        markDirtyFlags(Simulation::DIRTY_COLLISION_GROUP);
-        clearSpecialFlags(Simulation::SPECIAL_FLAGS_NO_BOOTSTRAPPING);
+        _flags &= ~Simulation::SPECIAL_FLAGS_NO_BOOTSTRAPPING;
+        _flags |= Simulation::DIRTY_COLLISION_GROUP; // may need to not collide with own avatar
 
         EntityTreePointer entityTree = getTree();
         assert(entityTree);
@@ -2588,7 +2588,7 @@ QList<EntityDynamicPointer> EntityItem::getActionsOfType(EntityDynamicType typeT
 void EntityItem::locationChanged(bool tellPhysics) {
     requiresRecalcBoxes();
     if (tellPhysics) {
-        markDirtyFlags(Simulation::DIRTY_TRANSFORM);
+        _flags |= Simulation::DIRTY_TRANSFORM;
         EntityTreePointer tree = getTree();
         if (tree) {
             tree->entityChanged(getThisPointer());


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21093/Non-dynamic-entities-with-exact-collision-stop-colliding-after-being-grabbed
https://highfidelity.manuscript.com/f/cases/21109/Avatar-entities-arranged-with-hands-in-VR-appear-to-observers-to-jump-to-different-positions

This PR fixes two bugs related to grabbing entities:
(1) After grabbing a non-dynamic model with concave shape the object no longer collides with Avatars
(2) When grabbing+moving non-dynamic attached AvatarEntities other observers will see them pop back to previous locations rather than their final resting place.