### PR TITLE
Case 21132: Add "Avatar Script" classification to relevant JSDoc APIs

### DIFF
--- a/interface/src/AboutUtil.h
+++ b/interface/src/AboutUtil.h
@@ -20,7 +20,8 @@
  *
  * @hifi-interface
  * @hifi-client-entity
- * 
+ * @hifi-avatar
+ *
  * @property {string} buildDate
  * @property {string} buildVersion
  * @property {string} qtVersion

--- a/interface/src/AvatarBookmarks.h
+++ b/interface/src/AvatarBookmarks.h
@@ -21,6 +21,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  */
 

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -36,6 +36,7 @@ class AABox;
   *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {number} presentTime <em>Read-only.</em>
  * @property {number} engineRunTime <em>Read-only.</em>

--- a/interface/src/LocationBookmarks.h
+++ b/interface/src/LocationBookmarks.h
@@ -21,6 +21,7 @@
  *
  * @hifi-client-entity
  * @hifi-interface
+ * @hifi-avatar
  */
 
 class LocationBookmarks : public Bookmarks, public  Dependency  {

--- a/interface/src/SpeechRecognizer.h
+++ b/interface/src/SpeechRecognizer.h
@@ -27,6 +27,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 class SpeechRecognizer : public QObject, public Dependency {
     Q_OBJECT

--- a/interface/src/audio/AudioScope.h
+++ b/interface/src/audio/AudioScope.h
@@ -31,6 +31,7 @@ class AudioScope : public QObject, public Dependency {
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @property {number} scopeInput <em>Read-only.</em>
      * @property {number} scopeOutputLeft <em>Read-only.</em>

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -46,6 +46,7 @@ using SortedAvatar = std::pair<float, std::shared_ptr<Avatar>>;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @borrows AvatarList.getAvatarIdentifiers as getAvatarIdentifiers
  * @borrows AvatarList.getAvatarsInRange as getAvatarsInRange

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -66,6 +66,7 @@ class MyAvatar : public Avatar {
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @property {Vec3} qmlPosition - A synonym for <code>position</code> for use by QML.
      * @property {boolean} shouldRenderLocally=true - If <code>true</code> then your avatar is rendered for you in Interface,

--- a/interface/src/devices/DdeFaceTracker.h
+++ b/interface/src/devices/DdeFaceTracker.h
@@ -32,6 +32,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 
 class DdeFaceTracker : public FaceTracker, public Dependency {

--- a/interface/src/raypick/LaserPointerScriptingInterface.h
+++ b/interface/src/raypick/LaserPointerScriptingInterface.h
@@ -27,6 +27,7 @@ class LaserPointerScriptingInterface : public QObject, public Dependency {
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 public:
 

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -23,6 +23,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {number} PICK_ENTITIES A filter flag. Include domain and avatar entities when intersecting. <em>Read-only.</em>.  Deprecated.
  * @property {number} PICK_OVERLAYS A filter flag. Include local entities when intersecting. <em>Read-only.</em>. Deprecated.

--- a/interface/src/raypick/PointerScriptingInterface.h
+++ b/interface/src/raypick/PointerScriptingInterface.h
@@ -22,6 +22,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 
 class PointerScriptingInterface : public QObject, public Dependency {

--- a/interface/src/raypick/RayPickScriptingInterface.h
+++ b/interface/src/raypick/RayPickScriptingInterface.h
@@ -25,6 +25,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {number} PICK_ENTITIES <em>Read-only.</em>
  * @property {number} PICK_OVERLAYS <em>Read-only.</em>

--- a/interface/src/scripting/AccountServicesScriptingInterface.h
+++ b/interface/src/scripting/AccountServicesScriptingInterface.h
@@ -42,6 +42,7 @@ class AccountServicesScriptingInterface : public QObject {
      * 
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @namespace AccountServices
      * @property {string} username <em>Read-only.</em>

--- a/interface/src/scripting/Audio.h
+++ b/interface/src/scripting/Audio.h
@@ -32,6 +32,7 @@ class Audio : public AudioScriptingInterface, protected ReadWriteLockable {
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      * @hifi-server-entity
      * @hifi-assignment-client
      *

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -24,6 +24,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 class ClipboardScriptingInterface : public QObject {
     Q_OBJECT

--- a/interface/src/scripting/ControllerScriptingInterface.h
+++ b/interface/src/scripting/ControllerScriptingInterface.h
@@ -199,6 +199,7 @@ class ScriptEngine;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {Controller.Actions} Actions - Predefined actions on Interface and the user's avatar. These can be used as end
  *     points in a {@link RouteObject} mapping. A synonym for <code>Controller.Hardware.Actions</code>.

--- a/interface/src/scripting/DesktopScriptingInterface.h
+++ b/interface/src/scripting/DesktopScriptingInterface.h
@@ -24,7 +24,8 @@
  *
  * @hifi-interface
  * @hifi-client-entity
- * 
+ * @hifi-avatar
+ *
  * @property {number} width
  * @property {number} height
  * @property {number} ALWAYS_ON_TOP - InteractiveWindow flag for always showing a window on top

--- a/interface/src/scripting/GooglePolyScriptingInterface.h
+++ b/interface/src/scripting/GooglePolyScriptingInterface.h
@@ -21,6 +21,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 
 class GooglePolyScriptingInterface : public QObject, public Dependency {

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -31,6 +31,7 @@ class QScriptEngine;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {Vec3} position - The position of the HMD if currently in VR display mode, otherwise
  *     {@link Vec3(0)|Vec3.ZERO}. <em>Read-only.</em>

--- a/interface/src/scripting/KeyboardScriptingInterface.h
+++ b/interface/src/scripting/KeyboardScriptingInterface.h
@@ -24,6 +24,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {bool} raised - <code>true</code> If the keyboard is visible <code>false</code> otherwise
  * @property {bool} password - <code>true</code> Will show * instead of characters in the text display <code>false</code> otherwise

--- a/interface/src/scripting/MenuScriptingInterface.h
+++ b/interface/src/scripting/MenuScriptingInterface.h
@@ -35,6 +35,7 @@ class MenuItemProperties;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 
 /**

--- a/interface/src/scripting/SelectionScriptingInterface.h
+++ b/interface/src/scripting/SelectionScriptingInterface.h
@@ -88,6 +88,7 @@ protected:
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @example <caption>Outline an entity when it is grabbed by a controller.</caption>
  * // Create a box and copy the following text into the entity's "Script URL" field.

--- a/interface/src/scripting/SettingsScriptingInterface.h
+++ b/interface/src/scripting/SettingsScriptingInterface.h
@@ -21,6 +21,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 
 class SettingsScriptingInterface : public QObject {

--- a/interface/src/scripting/WalletScriptingInterface.h
+++ b/interface/src/scripting/WalletScriptingInterface.h
@@ -34,6 +34,7 @@ public:
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {number} walletStatus
  * @property {bool} limitedCommerce

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -31,6 +31,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {number} innerWidth - The width of the drawable area of the Interface window (i.e., without borders or other
  *     chrome), in pixels. <em>Read-only.</em>

--- a/interface/src/ui/AvatarInputs.h
+++ b/interface/src/ui/AvatarInputs.h
@@ -29,6 +29,7 @@ class AvatarInputs : public QObject {
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @property {boolean} cameraEnabled <em>Read-only.</em>
      * @property {boolean} cameraMuted <em>Read-only.</em>

--- a/interface/src/ui/Snapshot.h
+++ b/interface/src/ui/Snapshot.h
@@ -42,6 +42,7 @@ private:
  * 
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 
 class Snapshot : public QObject, public Dependency {

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -27,6 +27,7 @@ private: \
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -87,6 +87,7 @@ public:
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {Uuid} keyboardFocusOverlay - Get or set the {@link Overlays.OverlayType|web3d} overlay that has keyboard focus.
  *     If no overlay has keyboard focus, get returns <code>null</code>; set to <code>null</code> or {@link Uuid|Uuid.NULL} to 

--- a/libraries/animation/src/AnimationCache.h
+++ b/libraries/animation/src/AnimationCache.h
@@ -50,6 +50,7 @@ Q_DECLARE_METATYPE(AnimationPointer)
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/animation/src/AnimationCacheScriptingInterface.h
+++ b/libraries/animation/src/AnimationCacheScriptingInterface.h
@@ -30,6 +30,7 @@ class AnimationCacheScriptingInterface : public ScriptableResourceCache, public 
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      * @hifi-assignment-client
      *
      * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>

--- a/libraries/audio-client/src/AudioIOStats.h
+++ b/libraries/audio-client/src/AudioIOStats.h
@@ -44,6 +44,7 @@ class AudioStreamStatsInterface : public QObject {
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @property {number} lossRate <em>Read-only.</em>
      * @property {number} lossCount <em>Read-only.</em>
@@ -192,6 +193,7 @@ class AudioStatsInterface : public QObject {
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @property {number} pingMs <em>Read-only.</em>
      * @property {number} inputReadMsMax <em>Read-only.</em>

--- a/libraries/audio/src/AudioEffectOptions.h
+++ b/libraries/audio/src/AudioEffectOptions.h
@@ -25,6 +25,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/audio/src/Sound.h
+++ b/libraries/audio/src/Sound.h
@@ -132,6 +132,7 @@ typedef QSharedPointer<Sound> SharedSoundPointer;
  * 
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/audio/src/SoundCacheScriptingInterface.h
+++ b/libraries/audio/src/SoundCacheScriptingInterface.h
@@ -30,6 +30,7 @@ class SoundCacheScriptingInterface : public ScriptableResourceCache, public Depe
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      * @hifi-server-entity
      * @hifi-assignment-client
      *

--- a/libraries/controllers/src/controllers/impl/MappingBuilderProxy.h
+++ b/libraries/controllers/src/controllers/impl/MappingBuilderProxy.h
@@ -57,6 +57,7 @@ class UserInputMapper;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 
 /**jsdoc

--- a/libraries/controllers/src/controllers/impl/RouteBuilderProxy.h
+++ b/libraries/controllers/src/controllers/impl/RouteBuilderProxy.h
@@ -39,6 +39,7 @@ class ScriptingInterface;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 
 // TODO migrate functionality to a RouteBuilder class and make the proxy defer to that 

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.h
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.h
@@ -178,6 +178,7 @@ private:
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {boolean} allowMouseCapture
  * @property {number} depth

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -109,6 +109,7 @@ public:
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.h
@@ -27,6 +27,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 
 class GraphicsScriptingInterface : public QObject, public QScriptable, public Dependency {

--- a/libraries/midi/src/Midi.h
+++ b/libraries/midi/src/Midi.h
@@ -25,6 +25,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 
 class Midi : public QObject, public Dependency {

--- a/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.h
+++ b/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.h
@@ -30,6 +30,7 @@ class ModelCacheScriptingInterface : public ScriptableResourceCache, public Depe
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
      * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>

--- a/libraries/model-networking/src/model-networking/TextureCacheScriptingInterface.h
+++ b/libraries/model-networking/src/model-networking/TextureCacheScriptingInterface.h
@@ -30,6 +30,7 @@ class TextureCacheScriptingInterface : public ScriptableResourceCache, public De
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @property {number} numTotal - Total number of total resources. <em>Read-only.</em>
      * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -43,6 +43,7 @@ const QString GET_PLACE = "/api/v1/places/%1";
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-assignment-client
  *
  * @property {Uuid} domainID - A UUID uniquely identifying the domain you're visiting. Is {@link Uuid|Uuid.NULL} if you're not

--- a/libraries/networking/src/MessagesClient.h
+++ b/libraries/networking/src/MessagesClient.h
@@ -40,6 +40,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  */

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -95,6 +95,7 @@ class ScriptableResource : public QObject {
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      * @hifi-server-entity
      * @hifi-assignment-client
      *

--- a/libraries/networking/src/ResourceScriptingInterface.h
+++ b/libraries/networking/src/ResourceScriptingInterface.h
@@ -22,6 +22,7 @@
  * 
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  */

--- a/libraries/plugins/src/plugins/SteamClientPlugin.h
+++ b/libraries/plugins/src/plugins/SteamClientPlugin.h
@@ -45,6 +45,7 @@ public:
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {boolean} running - <em>Read-only.</em>
  */

--- a/libraries/pointers/src/Pick.h
+++ b/libraries/pointers/src/Pick.h
@@ -68,6 +68,7 @@ public:
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @property {number} Ray Ray picks intersect a ray with the nearest object in front of them, along a given direction.
      * @property {number} Stylus Stylus picks provide "tapping" functionality on/into flat surfaces.

--- a/libraries/script-engine/src/AssetScriptingInterface.h
+++ b/libraries/script-engine/src/AssetScriptingInterface.h
@@ -30,6 +30,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  */

--- a/libraries/script-engine/src/FileScriptingInterface.h
+++ b/libraries/script-engine/src/FileScriptingInterface.h
@@ -21,6 +21,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  */

--- a/libraries/script-engine/src/Mat4.h
+++ b/libraries/script-engine/src/Mat4.h
@@ -26,6 +26,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  */

--- a/libraries/script-engine/src/Quat.h
+++ b/libraries/script-engine/src/Quat.h
@@ -40,6 +40,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/script-engine/src/RecordingScriptingInterface.h
+++ b/libraries/script-engine/src/RecordingScriptingInterface.h
@@ -28,6 +28,7 @@ class QScriptValue;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-assignment-client
  */
 class RecordingScriptingInterface : public QObject, public Dependency {

--- a/libraries/script-engine/src/SceneScriptingInterface.h
+++ b/libraries/script-engine/src/SceneScriptingInterface.h
@@ -115,6 +115,7 @@ namespace SceneScripting {
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @property {string} backgroundMode
      * @property {Scene.Stage.KeyLight} keyLight
@@ -178,6 +179,7 @@ namespace SceneScripting {
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {boolean} shouldRenderAvatars
  * @property {boolean} shouldRenderEntities

--- a/libraries/script-engine/src/ScriptAudioInjector.h
+++ b/libraries/script-engine/src/ScriptAudioInjector.h
@@ -23,6 +23,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -588,6 +588,7 @@ static void scriptableResourceFromScriptValue(const QScriptValue& value, Scripta
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -104,6 +104,7 @@ public:
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/script-engine/src/ScriptEngines.h
+++ b/libraries/script-engine/src/ScriptEngines.h
@@ -32,6 +32,7 @@ class ScriptEngine;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {string} debugScriptUrl
  * @property {string} defaultScriptsPath

--- a/libraries/script-engine/src/ScriptUUID.h
+++ b/libraries/script-engine/src/ScriptUUID.h
@@ -27,6 +27,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/script-engine/src/ScriptsModel.h
+++ b/libraries/script-engine/src/ScriptsModel.h
@@ -71,6 +71,7 @@ public:
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 class ScriptsModel : public QAbstractItemModel {
     Q_OBJECT

--- a/libraries/script-engine/src/ScriptsModelFilter.h
+++ b/libraries/script-engine/src/ScriptsModelFilter.h
@@ -23,6 +23,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 class ScriptsModelFilter : public QSortFilterProxyModel {
     Q_OBJECT

--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -21,6 +21,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-assignment-client
  *
  * @property {boolean} canKick - <code>true</code> if the domain server allows the node or avatar to kick (ban) avatars,

--- a/libraries/script-engine/src/Vec3.h
+++ b/libraries/script-engine/src/Vec3.h
@@ -31,6 +31,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/shared/src/DebugDraw.h
+++ b/libraries/shared/src/DebugDraw.h
@@ -28,6 +28,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  */

--- a/libraries/shared/src/PathUtils.h
+++ b/libraries/shared/src/PathUtils.h
@@ -25,6 +25,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @deprecated The Paths API is deprecated. Use {@link Script.resolvePath} and {@link Script.resourcesPath} instead.
  * @readonly

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -645,6 +645,7 @@ using MeshPointer = std::shared_ptr<graphics::Mesh>;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @hifi-server-entity
  * @hifi-assignment-client
  *

--- a/libraries/shared/src/shared/Camera.h
+++ b/libraries/shared/src/shared/Camera.h
@@ -43,6 +43,7 @@ class Camera : public QObject {
      *
      * @hifi-interface
      * @hifi-client-entity
+     * @hifi-avatar
      *
      * @property {Vec3} position - The position of the camera. You can set this value only when the camera is in independent 
      *     mode.

--- a/libraries/task/src/task/Config.h
+++ b/libraries/task/src/task/Config.h
@@ -196,6 +196,7 @@ public:
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {number} cpuRunTime - <em>Read-only.</em>
  * @property {boolean} enabled

--- a/libraries/ui/src/InteractiveWindow.h
+++ b/libraries/ui/src/InteractiveWindow.h
@@ -44,7 +44,7 @@ using namespace InteractiveWindowEnums;
  * @class InteractiveWindow
  *
  * @hifi-interface
- * @hifi-client-en
+ * @hifi-client-entity
  * @hifi-avatar
  *
  * @property {string} title

--- a/libraries/ui/src/InteractiveWindow.h
+++ b/libraries/ui/src/InteractiveWindow.h
@@ -45,6 +45,7 @@ using namespace InteractiveWindowEnums;
  *
  * @hifi-interface
  * @hifi-client-en
+ * @hifi-avatar
  *
  * @property {string} title
  * @property {Vec2} position

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -36,6 +36,7 @@
  * 
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  * @property {boolean} navigationFocused
  * @property {boolean} navigationFocusDisabled
  */

--- a/libraries/ui/src/QmlWebWindowClass.h
+++ b/libraries/ui/src/QmlWebWindowClass.h
@@ -17,6 +17,7 @@
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {string} url - <em>Read-only.</em>
  * @property {Vec2} position

--- a/libraries/ui/src/QmlWindowClass.h
+++ b/libraries/ui/src/QmlWindowClass.h
@@ -24,7 +24,7 @@ class QScriptContext;
  * @param {OverlayWindow.Properties} [properties=null]
  *
  * @hifi-interface
- * @hifi-client-en
+ * @hifi-client-entity
  * @hifi-avatar
  *
  * @property {Vec2} position

--- a/libraries/ui/src/QmlWindowClass.h
+++ b/libraries/ui/src/QmlWindowClass.h
@@ -25,6 +25,7 @@ class QScriptContext;
  *
  * @hifi-interface
  * @hifi-client-en
+ * @hifi-avatar
  *
  * @property {Vec2} position
  * @property {Vec2} size

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -43,12 +43,14 @@ class OffscreenQmlSurface;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 /**jsdoc
  * @namespace tabletInterface
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @deprecated This API is deprecated and will be removed. Use {@link Tablet} instead.
  */
@@ -208,6 +210,7 @@ Q_DECLARE_METATYPE(TabletButtonsProxyModel*);
   *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {string} name - Name of this tablet. <em>Read-only.</em>
  * @property {boolean} toolbarMode - Used to transition this tablet into and out of toolbar mode.
@@ -456,6 +459,7 @@ Q_DECLARE_METATYPE(TabletProxy*);
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  *
  * @property {Uuid} uuid - Uniquely identifies this button. <em>Read-only.</em>
  * @property {TabletButtonProxy.ButtonProperties} properties

--- a/libraries/ui/src/ui/ToolbarScriptingInterface.h
+++ b/libraries/ui/src/ui/ToolbarScriptingInterface.h
@@ -24,6 +24,7 @@ class QQuickItem;
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 class ToolbarButtonProxy : public QmlWrapper {
     Q_OBJECT
@@ -83,6 +84,7 @@ Q_DECLARE_METATYPE(ToolbarButtonProxy*);
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 class ToolbarProxy : public QmlWrapper {
     Q_OBJECT
@@ -136,6 +138,7 @@ Q_DECLARE_METATYPE(ToolbarProxy*);
  *
  * @hifi-interface
  * @hifi-client-entity
+ * @hifi-avatar
  */
 class ToolbarScriptingInterface : public QObject, public Dependency {
     Q_OBJECT

--- a/tools/jsdoc/plugins/hifi.js
+++ b/tools/jsdoc/plugins/hifi.js
@@ -107,6 +107,9 @@ exports.handlers = {
             if (e.doclet.hifiClientEntity) {
                 rows.push("Client Entity Scripts");
             }
+            if (e.doclet.hifiAvatar) {
+                rows.push("Avatar Scripts");
+            }
             if (e.doclet.hifiServerEntity) {
                 rows.push("Server Entity Scripts");
             }
@@ -139,6 +142,14 @@ exports.defineTags = function (dictionary) {
             doclet.hifiAssignmentClient = true;
         }
     });
+
+    // @hifi-avatar-script
+    dictionary.defineTag("hifi-avatar", {
+        onTagged: function (doclet, tag) {
+            doclet.hifiAvatar = true;
+        }
+    });
+
 
     // @hifi-client-entity
     dictionary.defineTag("hifi-client-entity", {


### PR DESCRIPTION
Also fixes a couple of "Client Entity" classifications.

https://highfidelity.manuscript.com/f/cases/21132/JSDoc-Indicate-which-APIs-are-available-to-avatar-scripts