### PR TITLE
Fixed MS21059: Avatar App Keyboard Raise in Desktop

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/Settings.qml
+++ b/interface/resources/qml/hifi/avatarapp/Settings.qml
@@ -21,7 +21,7 @@ Rectangle {
     HifiControlsUit.Keyboard {
         id: keyboard
         z: 1000
-        raised: parent.keyboardEnabled && parent.keyboardRaised
+        raised: parent.keyboardEnabled && parent.keyboardRaised && HMD.active
         numeric: parent.punctuationMode
         anchors {
             left: parent.left


### PR DESCRIPTION
This PR fixes [MS 21059](https://highfidelity.fogbugz.com/f/cases/21059/Avatar-menu-pops-up-keyboard-in-desktop-mode-when-clicking-in-Avatar-Animation-JSON-field-or-Avatar-collision-sound-URL)