### PR TITLE
Case 20943: Animations should preserve avatar joint scale

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1878,13 +1878,15 @@ void Rig::updateFromControllerParameters(const ControllerParameters& params, flo
     };
 
     std::shared_ptr<AnimInverseKinematics> ikNode = getAnimInverseKinematicsNode();
-    for (int i = 0; i < (int)NumSecondaryControllerTypes; i++) {
-        int index = indexOfJoint(secondaryControllerJointNames[i]);
-        if ((index >= 0) && (ikNode)) {
-            if (params.secondaryControllerFlags[i] & (uint8_t)ControllerFlags::Enabled) {
-                ikNode->setSecondaryTargetInRigFrame(index, params.secondaryControllerPoses[i]);
-            } else {
-                ikNode->clearSecondaryTarget(index);
+    if (ikNode) {
+        for (int i = 0; i < (int)NumSecondaryControllerTypes; i++) {
+            int index = indexOfJoint(secondaryControllerJointNames[i]);
+            if (index >= 0) {
+                if (params.secondaryControllerFlags[i] & (uint8_t)ControllerFlags::Enabled) {
+                    ikNode->setSecondaryTargetInRigFrame(index, params.secondaryControllerPoses[i]);
+                } else {
+                    ikNode->clearSecondaryTarget(index);
+                }
             }
         }
     }


### PR DESCRIPTION
This PR will preserve uniform scale on joints in the avatar when custom animations are played.  This gives users the ability apply a scale factor to the FBX hips joint in Blender/Maya to increase/decrease total avatar size. It also allows scale on selected joints to achieve effects such as "huge-head" avatars.