### PR TITLE
Case 21232: avoid entity update storm from entity-server

### DIFF
--- a/assignment-client/src/octree/OctreeSendThread.cpp
+++ b/assignment-client/src/octree/OctreeSendThread.cpp
@@ -324,12 +324,6 @@ int OctreeSendThread::packetDistributor(SharedNodePointer node, OctreeQueryNode*
     if (isFullScene) {
         // we're forcing a full scene, clear the force in OctreeQueryNode so we don't force it next time again
         nodeData->setShouldForceFullScene(false);
-    } else {
-        // we aren't forcing a full scene, check if something else suggests we should
-        isFullScene = nodeData->haveJSONParametersChanged() ||
-                      (nodeData->hasConicalViews() &&
-                       (nodeData->getViewFrustumJustStoppedChanging() ||
-                        nodeData->hasLodChanged()));
     }
 
     if (nodeData->isPacketWaiting()) {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21232/entity-server-constantly-resends-data-in-view

This PR to avoid a situation where the entity-server constantly re-sends data for entities in view.