### PR TITLE
Case 21227: don't enforce MOTION_TYPE_STATIC on mesh shapes

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1912,25 +1912,19 @@ void EntityItem::setRotation(glm::quat rotation) {
 void EntityItem::setVelocity(const glm::vec3& value) {
     glm::vec3 velocity = getLocalVelocity();
     if (velocity != value) {
-        if (getShapeType() == SHAPE_TYPE_STATIC_MESH) {
-            if (velocity != Vectors::ZERO) {
-                setLocalVelocity(Vectors::ZERO);
+        float speed = glm::length(value);
+        if (!glm::isnan(speed)) {
+            const float MIN_LINEAR_SPEED = 0.001f;
+            const float MAX_LINEAR_SPEED = 270.0f; // 3m per step at 90Hz
+            if (speed < MIN_LINEAR_SPEED) {
+                velocity = ENTITY_ITEM_ZERO_VEC3;
+            } else if (speed > MAX_LINEAR_SPEED) {
+                velocity = (MAX_LINEAR_SPEED / speed) * value;
+            } else {
+                velocity = value;
             }
-        } else {
-            float speed = glm::length(value);
-            if (!glm::isnan(speed)) {
-                const float MIN_LINEAR_SPEED = 0.001f;
-                const float MAX_LINEAR_SPEED = 270.0f; // 3m per step at 90Hz
-                if (speed < MIN_LINEAR_SPEED) {
-                    velocity = ENTITY_ITEM_ZERO_VEC3;
-                } else if (speed > MAX_LINEAR_SPEED) {
-                    velocity = (MAX_LINEAR_SPEED / speed) * value;
-                } else {
-                    velocity = value;
-                }
-                setLocalVelocity(velocity);
-                _flags |= Simulation::DIRTY_LINEAR_VELOCITY;
-            }
+            setLocalVelocity(velocity);
+            _flags |= Simulation::DIRTY_LINEAR_VELOCITY;
         }
     }
 }
@@ -1948,19 +1942,15 @@ void EntityItem::setDamping(float value) {
 void EntityItem::setGravity(const glm::vec3& value) {
     withWriteLock([&] {
         if (_gravity != value) {
-            if (getShapeType() == SHAPE_TYPE_STATIC_MESH) {
-                _gravity = Vectors::ZERO;
-            } else {
-                float magnitude = glm::length(value);
-                if (!glm::isnan(magnitude)) {
-                    const float MAX_ACCELERATION_OF_GRAVITY = 10.0f * 9.8f; // 10g
-                    if (magnitude > MAX_ACCELERATION_OF_GRAVITY) {
-                        _gravity = (MAX_ACCELERATION_OF_GRAVITY / magnitude) * value;
-                    } else {
-                        _gravity = value;
-                    }
-                    _flags |= Simulation::DIRTY_LINEAR_VELOCITY;
+            float magnitude = glm::length(value);
+            if (!glm::isnan(magnitude)) {
+                const float MAX_ACCELERATION_OF_GRAVITY = 10.0f * 9.8f; // 10g
+                if (magnitude > MAX_ACCELERATION_OF_GRAVITY) {
+                    _gravity = (MAX_ACCELERATION_OF_GRAVITY / magnitude) * value;
+                } else {
+                    _gravity = value;
                 }
+                _flags |= Simulation::DIRTY_LINEAR_VELOCITY;
             }
         }
     });
@@ -1969,23 +1959,19 @@ void EntityItem::setGravity(const glm::vec3& value) {
 void EntityItem::setAngularVelocity(const glm::vec3& value) {
     glm::vec3 angularVelocity = getLocalAngularVelocity();
     if (angularVelocity != value) {
-        if (getShapeType() == SHAPE_TYPE_STATIC_MESH) {
-            setLocalAngularVelocity(Vectors::ZERO);
-        } else {
-            float speed = glm::length(value);
-            if (!glm::isnan(speed)) {
-                const float MIN_ANGULAR_SPEED = 0.0002f;
-                const float MAX_ANGULAR_SPEED = 9.0f * TWO_PI; // 1/10 rotation per step at 90Hz
-                if (speed < MIN_ANGULAR_SPEED) {
-                    angularVelocity = ENTITY_ITEM_ZERO_VEC3;
-                } else if (speed > MAX_ANGULAR_SPEED) {
-                    angularVelocity = (MAX_ANGULAR_SPEED / speed) * value;
-                } else {
-                    angularVelocity = value;
-                }
-                setLocalAngularVelocity(angularVelocity);
-                _flags |= Simulation::DIRTY_ANGULAR_VELOCITY;
+        float speed = glm::length(value);
+        if (!glm::isnan(speed)) {
+            const float MIN_ANGULAR_SPEED = 0.0002f;
+            const float MAX_ANGULAR_SPEED = 9.0f * TWO_PI; // 1/10 rotation per step at 90Hz
+            if (speed < MIN_ANGULAR_SPEED) {
+                angularVelocity = ENTITY_ITEM_ZERO_VEC3;
+            } else if (speed > MAX_ANGULAR_SPEED) {
+                angularVelocity = (MAX_ANGULAR_SPEED / speed) * value;
+            } else {
+                angularVelocity = value;
             }
+            setLocalAngularVelocity(angularVelocity);
+            _flags |= Simulation::DIRTY_ANGULAR_VELOCITY;
         }
     }
 }

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -203,21 +203,6 @@ PhysicsMotionType EntityMotionState::computePhysicsMotionType() const {
     }
     assert(entityTreeIsLocked());
 
-    if (_entity->getShapeType() == SHAPE_TYPE_STATIC_MESH
-        || (_body && _body->getCollisionShape()->getShapeType() == TRIANGLE_MESH_SHAPE_PROXYTYPE)) {
-        if (_entity->isMoving()) {
-            // DANGER: Bullet doesn't support non-zero velocity for these shapes --> collision details may be wrong
-            // in ways that allow other DYNAMIC objects to tunnel/penetrate/snag.
-            // However, in practice low-velocity collisions work OK most of the time, and if we enforce these objects
-            // to be MOTION_TYPE_STATIC then some other bugs can be worse (e.g. when Grabbing --> Grab Action fails)
-            // so we're making a tradeoff here.
-            // TODO: The Correct Solution is to NOT use btBvhTriangleMesh shape for moving objects and instead compute the convex
-            // decomposition and build a btCompoundShape with convex sub-shapes.
-            return MOTION_TYPE_KINEMATIC;
-        }
-        return MOTION_TYPE_STATIC;
-    }
-
     if (_entity->getLocked()) {
         if (_entity->isMoving()) {
             return MOTION_TYPE_KINEMATIC;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/edit/21227/Near-grabbed-model-entities-with-exact-collision-do-not-update-for-observers

This PR fixes a bug where an Observer does not see the Grab effects on an ModelEntityItem that uses "Exact Collision" shape option.