### PR TITLE
(case 21231) Fix GLTF materials

### DIFF
--- a/libraries/material-networking/src/material-networking/TextureCache.cpp
+++ b/libraries/material-networking/src/material-networking/TextureCache.cpp
@@ -368,16 +368,17 @@ static bool isLocalUrl(const QUrl& url) {
     return (scheme == HIFI_URL_SCHEME_FILE || scheme == URL_SCHEME_QRC || scheme == RESOURCE_SCHEME);
 }
 
-void NetworkTexture::setExtra(void* extra) {
+void NetworkTexture::setExtra(void* extra, bool isNewExtra) {
     const TextureExtra* textureExtra = static_cast<const TextureExtra*>(extra);
     _type = textureExtra ? textureExtra->type : image::TextureUsage::DEFAULT_TEXTURE;
     _maxNumPixels = textureExtra ? textureExtra->maxNumPixels : ABSOLUTE_MAX_TEXTURE_NUM_PIXELS;
     _sourceChannel = textureExtra ? textureExtra->sourceChannel : image::ColorChannel::NONE;
 
-    if (_textureSource) {
-        _textureSource->setUrl(_url);
-        _textureSource->setType((int)_type);
-    } else {
+    if (isNewExtra && !_loaded) {
+        _startedLoading = false;
+    }
+
+    if (!_textureSource || isNewExtra) {
         _textureSource = std::make_shared<gpu::TextureSource>(_url, (int)_type);
     }
     _lowestRequestedMipLevel = 0;

--- a/libraries/material-networking/src/material-networking/TextureCache.h
+++ b/libraries/material-networking/src/material-networking/TextureCache.h
@@ -64,7 +64,7 @@ public:
 
     Q_INVOKABLE void setOriginalDescriptor(ktx::KTXDescriptor* descriptor) { _originalKtxDescriptor.reset(descriptor); }
 
-    void setExtra(void* extra) override;
+    void setExtra(void* extra, bool isNewExtra) override;
 
 signals:
     void networkTextureCreated(const QWeakPointer<NetworkTexture>& self);

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -309,7 +309,7 @@ public:
 
     virtual void downloadFinished(const QByteArray& data) override;
 
-    void setExtra(void* extra) override;
+    void setExtra(void* extra, bool isNewExtra) override;
 
 protected:
     Q_INVOKABLE void setGeometryDefinition(HFMModel::Pointer hfmModel, QVariantHash mapping);
@@ -320,7 +320,7 @@ private:
     bool _combineParts;
 };
 
-void GeometryDefinitionResource::setExtra(void* extra) {
+void GeometryDefinitionResource::setExtra(void* extra, bool isNewExtra) {
     const GeometryExtra* geometryExtra = static_cast<const GeometryExtra*>(extra);
     _mapping = geometryExtra ? geometryExtra->mapping : QVariantHash();
     _textureBaseUrl = geometryExtra ? resolveTextureBaseUrl(_url, geometryExtra->textureBaseUrl) : QUrl();

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -355,7 +355,7 @@ QSharedPointer<Resource> ResourceCache::getResource(const QUrl& url, const QUrl&
         } else if (resourcesWithExtraHash.size() > 0.0f) {
             // We haven't seen this extra info before, but we've already downloaded the resource.  We need a new copy of this object (with any old hash).
             resource = createResourceCopy(resourcesWithExtraHash.begin().value().lock());
-            resource->setExtra(extra);
+            resource->setExtra(extra, true);
             resource->setExtraHash(extraHash);
             resource->setSelf(resource);
             resource->setCache(this);
@@ -375,7 +375,7 @@ QSharedPointer<Resource> ResourceCache::getResource(const QUrl& url, const QUrl&
 
     if (!resource) {
         resource = createResource(url);
-        resource->setExtra(extra);
+        resource->setExtra(extra, false);
         resource->setExtraHash(extraHash);
         resource->setSelf(resource);
         resource->setCache(this);

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -417,7 +417,7 @@ public:
     unsigned int getDownloadAttempts() { return _attempts; }
     unsigned int getDownloadAttemptsRemaining() { return _attemptsRemaining; }
 
-    virtual void setExtra(void* extra) {};
+    virtual void setExtra(void* extra, bool isNewExtra) {};
     void setExtraHash(size_t extraHash) { _extraHash = extraHash; }
     size_t getExtraHash() const { return _extraHash; }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21231/GLTF-Materials-are-no-longer-working-in-master

This PR fixes a bug which caused the new GLTF occlusion/roughness/metallic textures to break, while being careful to preserve existing same-url-different-material functionality such as the transparency of the avatar spheres in the People app.

Please note there is currently a known bug with the People app in master where the glow around the orange sphere is the wrong color (and only the wrong color), which this PR does not affect.