### PR TITLE
Case 21259: Pal textures don't change

### DIFF
--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -358,6 +358,17 @@ EntityItemProperties Overlays::convertOverlayToEntityProperties(QVariantMap& ove
         return "none";
     });
 
+    RENAME_PROP_CONVERT(textures, textures, [](const QVariant& v) {
+        auto map = v.toMap();
+        if (!map.isEmpty()) {
+            auto json = QJsonDocument::fromVariant(map);
+            if (!json.isNull()) {
+                return QVariant(QString(json.toJson()));
+            }
+        }
+        return v;
+    });
+
     if (type == "Shape" || type == "Box" || type == "Sphere" || type == "Gizmo") {
         RENAME_PROP(solid, isSolid);
         RENAME_PROP(isFilled, isSolid);

--- a/libraries/material-networking/src/material-networking/TextureCache.h
+++ b/libraries/material-networking/src/material-networking/TextureCache.h
@@ -64,7 +64,7 @@ public:
 
     Q_INVOKABLE void setOriginalDescriptor(ktx::KTXDescriptor* descriptor) { _originalKtxDescriptor.reset(descriptor); }
 
-    void setExtra(void* extra, bool isNewExtra) override;
+    void setExtra(void* extra) override;
 
 signals:
     void networkTextureCreated(const QWeakPointer<NetworkTexture>& self);
@@ -136,12 +136,12 @@ private:
     // mip offsets to change.
     ktx::KTXDescriptorPointer _originalKtxDescriptor;
 
-
     int _originalWidth { 0 };
     int _originalHeight { 0 };
     int _width { 0 };
     int _height { 0 };
     int _maxNumPixels { ABSOLUTE_MAX_TEXTURE_NUM_PIXELS };
+    QByteArray _content;
 
     friend class TextureCache;
 };

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -309,7 +309,7 @@ public:
 
     virtual void downloadFinished(const QByteArray& data) override;
 
-    void setExtra(void* extra, bool isNewExtra) override;
+    void setExtra(void* extra) override;
 
 protected:
     Q_INVOKABLE void setGeometryDefinition(HFMModel::Pointer hfmModel, QVariantHash mapping);
@@ -320,7 +320,7 @@ private:
     bool _combineParts;
 };
 
-void GeometryDefinitionResource::setExtra(void* extra, bool isNewExtra) {
+void GeometryDefinitionResource::setExtra(void* extra) {
     const GeometryExtra* geometryExtra = static_cast<const GeometryExtra*>(extra);
     _mapping = geometryExtra ? geometryExtra->mapping : QVariantHash();
     _textureBaseUrl = geometryExtra ? resolveTextureBaseUrl(_url, geometryExtra->textureBaseUrl) : QUrl();

--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -355,7 +355,7 @@ QSharedPointer<Resource> ResourceCache::getResource(const QUrl& url, const QUrl&
         } else if (resourcesWithExtraHash.size() > 0.0f) {
             // We haven't seen this extra info before, but we've already downloaded the resource.  We need a new copy of this object (with any old hash).
             resource = createResourceCopy(resourcesWithExtraHash.begin().value().lock());
-            resource->setExtra(extra, true);
+            resource->setExtra(extra);
             resource->setExtraHash(extraHash);
             resource->setSelf(resource);
             resource->setCache(this);
@@ -375,7 +375,7 @@ QSharedPointer<Resource> ResourceCache::getResource(const QUrl& url, const QUrl&
 
     if (!resource) {
         resource = createResource(url);
-        resource->setExtra(extra, false);
+        resource->setExtra(extra);
         resource->setExtraHash(extraHash);
         resource->setSelf(resource);
         resource->setCache(this);

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -417,7 +417,7 @@ public:
     unsigned int getDownloadAttempts() { return _attempts; }
     unsigned int getDownloadAttemptsRemaining() { return _attemptsRemaining; }
 
-    virtual void setExtra(void* extra, bool isNewExtra) {};
+    virtual void setExtra(void* extra) {};
     void setExtraHash(size_t extraHash) { _extraHash = extraHash; }
     size_t getExtraHash() const { return _extraHash; }
 

--- a/libraries/shared/src/RegisteredMetaTypes.cpp
+++ b/libraries/shared/src/RegisteredMetaTypes.cpp
@@ -1269,7 +1269,14 @@ QVariantMap parseTexturesToMap(QString newTextures, const QVariantMap& defaultTe
     QVariantMap newTexturesMap = newTexturesJson.toVariant().toMap();
     QVariantMap toReturn = defaultTextures;
     for (auto& texture : newTexturesMap.keys()) {
-        toReturn[texture] = newTexturesMap[texture];
+        auto newURL = newTexturesMap[texture];
+        if (newURL.canConvert<QUrl>()) {
+            toReturn[texture] = newURL.toUrl();
+        } else if (newURL.canConvert<QString>()) {
+            toReturn[texture] = QUrl(newURL.toString());
+        } else {
+            toReturn[texture] = newURL;
+        }
     }
 
     return toReturn;

--- a/libraries/shared/src/VariantMapToScriptValue.cpp
+++ b/libraries/shared/src/VariantMapToScriptValue.cpp
@@ -26,10 +26,10 @@ QScriptValue variantToScriptValue(QVariant& qValue, QScriptEngine& scriptEngine)
         case QVariant::Double:
             return qValue.toDouble();
             break;
-        case QVariant::String: {
+        case QVariant::String:
+        case QVariant::Url:
             return scriptEngine.newVariant(qValue);
             break;
-        }
         case QVariant::Map: {
             QVariantMap childMap = qValue.toMap();
             return variantMapToScriptValue(childMap, scriptEngine);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21259/Pal-textures-don-t-switch-when-you-click-on-someone

Test plan:
- Find someone else.  Open pal.  Click on them.  The glow should change from blue to orange.
- Run this test: https://github.com/highfidelity/hifi_tests/tree/master/tests/content/entity/model/modelReaders/gltfReader/gltfTestSuite/boomBox