### PR TITLE
Case 19748: Audio loss statistic occasionally displays a huge number

### DIFF
--- a/libraries/networking/src/SequenceNumberStats.cpp
+++ b/libraries/networking/src/SequenceNumberStats.cpp
@@ -142,8 +142,10 @@ SequenceNumberStats::ArrivalInfo SequenceNumberStats::sequenceNumberReceived(qui
                 if (wantExtraDebugging) {
                     qCDebug(networking) << "found it in _missingSet";
                 }
-                _stats._lost--;
-                _stats._recovered++;
+                if (_stats._lost > 0) {
+                    _stats._lost--;
+                    _stats._recovered++;
+                }
             } else {
                 // this late seq num is not in our missing set.  it is possibly a duplicate, or possibly a late
                 // packet that should have arrived before our first received packet.  we'll count these


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19748/Audio-loss-occasionally-jumps-to-around-145-million-percent-and-reported-audio-loss

A possible explanation for this hard-to-reproduce bug is that the unsigned _lost counter is getting decremented below zero, causing network stats to temporarily display an absurdly large loss percentage.

This PR sanitizes the only place where that might occur. It is otherwise harmless.