### PR TITLE
Case 21291, Case 21292, Case 21293: Working on overlay bugs

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2282,7 +2282,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 
     // Setup the mouse ray pick and related operators
     {
-        auto mouseRayPick = std::make_shared<RayPick>(Vectors::ZERO, Vectors::UP, PickFilter(PickScriptingInterface::PICK_ENTITIES()), 0.0f, true);
+        auto mouseRayPick = std::make_shared<RayPick>(Vectors::ZERO, Vectors::UP, PickFilter(PickScriptingInterface::PICK_ENTITIES() | PickScriptingInterface::PICK_LOCAL_ENTITIES()), 0.0f, true);
         mouseRayPick->parentTransform = std::make_shared<MouseTransformNode>();
         mouseRayPick->setJointState(PickQuery::JOINT_STATE_MOUSE);
         auto mouseRayPickID = DependencyManager::get<PickManager>()->addPick(PickQuery::Ray, mouseRayPick);

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -65,7 +65,6 @@ public slots:
     bool createOrDestroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
     bool destroyContextOverlay(const EntityItemID& entityItemID, const PointerEvent& event);
     bool destroyContextOverlay(const EntityItemID& entityItemID);
-    void contextOverlays_mousePressOnOverlay(const QUuid& id, const PointerEvent& event);
     void contextOverlays_hoverEnterOverlay(const QUuid& id, const PointerEvent& event);
     void contextOverlays_hoverLeaveOverlay(const QUuid& id, const PointerEvent& event);
     void contextOverlays_hoverEnterEntity(const EntityItemID& entityID, const PointerEvent& event);

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -79,15 +79,7 @@ void Overlays::cleanupAllOverlays() {
     cleanupOverlaysToDelete();
 }
 
-void Overlays::init() {
-    auto entityScriptingInterface = DependencyManager::get<EntityScriptingInterface>();
-    connect(this, &Overlays::hoverEnterOverlay, entityScriptingInterface.data(), &EntityScriptingInterface::hoverEnterEntity);
-    connect(this, &Overlays::hoverOverOverlay, entityScriptingInterface.data(), &EntityScriptingInterface::hoverOverEntity);
-    connect(this, &Overlays::hoverLeaveOverlay, entityScriptingInterface.data(), &EntityScriptingInterface::hoverLeaveEntity);
-    connect(this, &Overlays::mousePressOnOverlay, entityScriptingInterface.data(), &EntityScriptingInterface::mousePressOnEntity);
-    connect(this, &Overlays::mouseMoveOnOverlay, entityScriptingInterface.data(), &EntityScriptingInterface::mouseMoveOnEntity);
-    connect(this, &Overlays::mouseReleaseOnOverlay, entityScriptingInterface.data(), &EntityScriptingInterface::mouseReleaseOnEntity);
-}
+void Overlays::init() {}
 
 void Overlays::update(float deltatime) {
     cleanupOverlaysToDelete();

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -63,13 +63,6 @@ Overlays::Overlays() {
     ADD_TYPE_MAP(PolyLine, line3d);
     ADD_TYPE_MAP(Grid, grid);
     ADD_TYPE_MAP(Gizmo, circle3d);
-
-    auto mouseRayPick = std::make_shared<RayPick>(Vectors::ZERO, Vectors::UP,
-                                                  PickFilter(PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES) |
-                                                             PickFilter::getBitMask(PickFilter::FlagBit::VISIBLE)), 0.0f, true);
-    mouseRayPick->parentTransform = std::make_shared<MouseTransformNode>();
-    mouseRayPick->setJointState(PickQuery::JOINT_STATE_MOUSE);
-    _mouseRayPickID = DependencyManager::get<PickManager>()->addPick(PickQuery::Ray, mouseRayPick);
 }
 
 void Overlays::cleanupAllOverlays() {
@@ -1228,12 +1221,12 @@ static PointerEvent::Button toPointerButton(const QMouseEvent& event) {
     }
 }
 
-RayToOverlayIntersectionResult getPrevPickResult(unsigned int mouseRayPickID) {
+RayToOverlayIntersectionResult getPrevPickResult() {
     RayToOverlayIntersectionResult overlayResult;
     overlayResult.intersects = false;
-    auto pickResult = DependencyManager::get<PickManager>()->getPrevPickResultTyped<RayPickResult>(mouseRayPickID);
+    auto pickResult = DependencyManager::get<PickManager>()->getPrevPickResultTyped<RayPickResult>(DependencyManager::get<EntityTreeRenderer>()->getMouseRayPickID());
     if (pickResult) {
-        overlayResult.intersects = pickResult->type != IntersectionType::NONE;
+        overlayResult.intersects = pickResult->type == IntersectionType::LOCAL_ENTITY;
         if (overlayResult.intersects) {
             overlayResult.intersection = pickResult->intersection;
             overlayResult.distance = pickResult->distance;
@@ -1281,7 +1274,7 @@ std::pair<float, QUuid> Overlays::mousePressEvent(QMouseEvent* event) {
     PerformanceTimer perfTimer("Overlays::mousePressEvent");
 
     PickRay ray = qApp->computePickRay(event->x(), event->y());
-    RayToOverlayIntersectionResult rayPickResult = getPrevPickResult(_mouseRayPickID);
+    RayToOverlayIntersectionResult rayPickResult = getPrevPickResult();
     if (rayPickResult.intersects) {
         _currentClickingOnOverlayID = rayPickResult.overlayID;
 
@@ -1305,7 +1298,7 @@ bool Overlays::mouseDoublePressEvent(QMouseEvent* event) {
     PerformanceTimer perfTimer("Overlays::mouseDoublePressEvent");
 
     PickRay ray = qApp->computePickRay(event->x(), event->y());
-    RayToOverlayIntersectionResult rayPickResult = getPrevPickResult(_mouseRayPickID);
+    RayToOverlayIntersectionResult rayPickResult = getPrevPickResult();
     if (rayPickResult.intersects) {
         _currentClickingOnOverlayID = rayPickResult.overlayID;
 
@@ -1321,7 +1314,7 @@ bool Overlays::mouseReleaseEvent(QMouseEvent* event) {
     PerformanceTimer perfTimer("Overlays::mouseReleaseEvent");
 
     PickRay ray = qApp->computePickRay(event->x(), event->y());
-    RayToOverlayIntersectionResult rayPickResult = getPrevPickResult(_mouseRayPickID);
+    RayToOverlayIntersectionResult rayPickResult = getPrevPickResult();
     if (rayPickResult.intersects) {
         auto pointerEvent = calculateOverlayPointerEvent(rayPickResult.overlayID, ray, rayPickResult, event, PointerEvent::Release);
         mouseReleasePointerEvent(rayPickResult.overlayID, pointerEvent);
@@ -1343,7 +1336,7 @@ bool Overlays::mouseMoveEvent(QMouseEvent* event) {
     PerformanceTimer perfTimer("Overlays::mouseMoveEvent");
 
     PickRay ray = qApp->computePickRay(event->x(), event->y());
-    RayToOverlayIntersectionResult rayPickResult = getPrevPickResult(_mouseRayPickID);
+    RayToOverlayIntersectionResult rayPickResult = getPrevPickResult();
     if (rayPickResult.intersects) {
         auto pointerEvent = calculateOverlayPointerEvent(rayPickResult.overlayID, ray, rayPickResult, event, PointerEvent::Move);
         mouseMovePointerEvent(rayPickResult.overlayID, pointerEvent);

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -719,7 +719,6 @@ private:
     PointerEvent calculateOverlayPointerEvent(const QUuid& id, const PickRay& ray, const RayToOverlayIntersectionResult& rayPickResult,
         QMouseEvent* event, PointerEvent::EventType eventType);
 
-    unsigned int _mouseRayPickID;
     QUuid _currentClickingOnOverlayID;
     QUuid _currentHoverOverOverlayID;
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -86,7 +86,7 @@ EntityTreeRenderer::EntityTreeRenderer(bool wantScripts, AbstractViewStateInterf
     auto handlePointerEvent = [&](const QUuid& entityID, const PointerEvent& event) {
         std::shared_ptr<render::entities::WebEntityRenderer> thisEntity;
         auto entity = getEntity(entityID);
-        if (entity && entity->getType() == EntityTypes::Web) {
+        if (entity && entity->isVisible() && entity->getType() == EntityTypes::Web) {
             thisEntity = std::static_pointer_cast<render::entities::WebEntityRenderer>(renderableForEntityId(entityID));
         }
         if (thisEntity) {
@@ -99,7 +99,7 @@ EntityTreeRenderer::EntityTreeRenderer(bool wantScripts, AbstractViewStateInterf
     connect(entityScriptingInterface.data(), &EntityScriptingInterface::hoverEnterEntity, this, [&](const QUuid& entityID, const PointerEvent& event) {
         std::shared_ptr<render::entities::WebEntityRenderer> thisEntity;
         auto entity = getEntity(entityID);
-        if (entity && entity->getType() == EntityTypes::Web) {
+        if (entity && entity->isVisible() && entity->getType() == EntityTypes::Web) {
             thisEntity = std::static_pointer_cast<render::entities::WebEntityRenderer>(renderableForEntityId(entityID));
         }
         if (thisEntity) {
@@ -110,7 +110,7 @@ EntityTreeRenderer::EntityTreeRenderer(bool wantScripts, AbstractViewStateInterf
     connect(entityScriptingInterface.data(), &EntityScriptingInterface::hoverLeaveEntity, this, [&](const QUuid& entityID, const PointerEvent& event) {
         std::shared_ptr<render::entities::WebEntityRenderer> thisEntity;
         auto entity = getEntity(entityID);
-        if (entity && entity->getType() == EntityTypes::Web) {
+        if (entity && entity->isVisible() && entity->getType() == EntityTypes::Web) {
             thisEntity = std::static_pointer_cast<render::entities::WebEntityRenderer>(renderableForEntityId(entityID));
         }
         if (thisEntity) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -73,6 +73,7 @@ public:
     static void setEntityLoadingPriorityFunction(CalculateEntityLoadingPriority fn) { _calculateEntityLoadingPriorityFunc = fn; }
 
     void setMouseRayPickID(unsigned int rayPickID) { _mouseRayPickID = rayPickID; }
+    unsigned int getMouseRayPickID() { return _mouseRayPickID; }
     void setMouseRayPickResultOperator(std::function<RayToEntityIntersectionResult(unsigned int)> getPrevRayPickResultOperator) { _getPrevRayPickResultOperator = getPrevRayPickResultOperator;  }
     void setSetPrecisionPickingOperator(std::function<void(unsigned int, bool)> setPrecisionPickingOperator) { _setPrecisionPickingOperator = setPrecisionPickingOperator; }
 

--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -45,7 +45,8 @@ var OVERLAY_DATA_HMD = {
     emissive: true,
     drawInFront: true,
     parentID: MyAvatar.SELF_ID,
-    parentJointIndex: CAMERA_MATRIX
+    parentJointIndex: CAMERA_MATRIX,
+    ignorePickIntersection: true
 };
 
 var AWAY_INTRO = {

--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -196,14 +196,14 @@ Script.include("/~/system/libraries/controllers.js");
 
             var playAreaOverlayProperties = {
                 dimensions:
-                    Vec3.multiply(this.teleportScaleFactor * avatarScale, {
-                        x: this.playArea.width,
-                        y: this.PLAY_AREA_OVERLAY_MODEL_DIMENSIONS.y,
-                        z: this.playArea.height
+                    Vec3.multiply(_this.teleportScaleFactor * avatarScale, {
+                        x: _this.playArea.width,
+                        y: _this.PLAY_AREA_OVERLAY_MODEL_DIMENSIONS.y,
+                        z: _this.playArea.height
                     })
             };
 
-            if (this.teleportScaleFactor < 1) {
+            if (_this.teleportScaleFactor < 1) {
                 // Adjust position of playAreOverlay so that its base is at correct height.
                 // Always parenting to teleport target is good enough for this.
                 var sensorToWorldMatrix = MyAvatar.sensorToWorldMatrix;
@@ -212,37 +212,37 @@ Script.include("/~/system/libraries/controllers.js");
                 var avatarSensorPosition = Mat4.transformPoint(worldToSensorMatrix, MyAvatar.position);
                 avatarSensorPosition.y = 0;
 
-                var targetRotation = Overlays.getProperty(this.targetOverlayID, "rotation");
+                var targetRotation = Overlays.getProperty(_this.targetOverlayID, "rotation");
                 var relativePlayAreaCenterOffset =
-                    Vec3.sum(this.playAreaCenterOffset, { x: 0, y: -TARGET_MODEL_DIMENSIONS.y / 2, z: 0 });
+                    Vec3.sum(_this.playAreaCenterOffset, { x: 0, y: -TARGET_MODEL_DIMENSIONS.y / 2, z: 0 });
                 var localPosition = Vec3.multiplyQbyV(Quat.inverse(targetRotation),
                     Vec3.multiplyQbyV(sensorToWorldRotation,
                         Vec3.multiply(avatarScale, Vec3.subtract(relativePlayAreaCenterOffset, avatarSensorPosition))));
-                localPosition.y = this.teleportScaleFactor * localPosition.y;
+                localPosition.y = _this.teleportScaleFactor * localPosition.y;
 
-                playAreaOverlayProperties.parentID = this.targetOverlayID;
+                playAreaOverlayProperties.parentID = _this.targetOverlayID;
                 playAreaOverlayProperties.localPosition = localPosition;
             }
 
-            Overlays.editOverlay(this.playAreaOverlay, playAreaOverlayProperties);
+            Overlays.editOverlay(_this.playAreaOverlay, playAreaOverlayProperties);
 
-            for (var i = 0; i < this.playAreaSensorPositionOverlays.length; i++) {
-                localPosition = this.playAreaSensorPositions[i];
+            for (var i = 0; i < _this.playAreaSensorPositionOverlays.length; i++) {
+                localPosition = _this.playAreaSensorPositions[i];
                 localPosition = Vec3.multiply(avatarScale, localPosition);
                 // Position relative to the play area.
-                localPosition.y = avatarScale * (this.PLAY_AREA_SENSOR_OVERLAY_DIMENSIONS.y / 2
-                    - this.PLAY_AREA_OVERLAY_MODEL_DIMENSIONS.y / 2);
-                Overlays.editOverlay(this.playAreaSensorPositionOverlays[i], {
-                    dimensions: Vec3.multiply(this.teleportScaleFactor * avatarScale, this.PLAY_AREA_SENSOR_OVERLAY_DIMENSIONS),
-                    parentID: this.playAreaOverlay,
+                localPosition.y = avatarScale * (_this.PLAY_AREA_SENSOR_OVERLAY_DIMENSIONS.y / 2
+                    - _this.PLAY_AREA_OVERLAY_MODEL_DIMENSIONS.y / 2);
+                Overlays.editOverlay(_this.playAreaSensorPositionOverlays[i], {
+                    dimensions: Vec3.multiply(_this.teleportScaleFactor * avatarScale, _this.PLAY_AREA_SENSOR_OVERLAY_DIMENSIONS),
+                    parentID: _this.playAreaOverlay,
                     localPosition: localPosition
                 });
             }
         };
 
         this.updatePlayAreaScale = function () {
-            if (this.isPlayAreaAvailable) {
-                this.setPlayAreaDimensions();
+            if (_this.isPlayAreaAvailable) {
+                _this.setPlayAreaDimensions();
             }
         };
 
@@ -265,7 +265,7 @@ Script.include("/~/system/libraries/controllers.js");
             for (var i = 0, length = teleportRenderStates.length; i < length; i++) {
                 var state = properties.renderStates[teleportRenderStates[i].name];
                 if (state && state.end) {
-                    Selection.addToSelectedItemsList(this.teleporterSelectionName, "overlay", state.end);
+                    Selection.addToSelectedItemsList(_this.teleporterSelectionName, "overlay", state.end);
                 }
             }
         };
@@ -448,34 +448,34 @@ Script.include("/~/system/libraries/controllers.js");
         this.translateZAction = Controller.findAction("TranslateZ");
 
         this.setPlayAreaVisible = function (visible, targetOverlayID, fade) {
-            if (!this.isPlayAreaAvailable || this.isPlayAreaVisible === visible) {
+            if (!_this.isPlayAreaAvailable || _this.isPlayAreaVisible === visible) {
                 return;
             }
 
-            this.wasPlayAreaVisible = this.isPlayAreaVisible;
-            this.isPlayAreaVisible = visible;
-            this.targetOverlayID = targetOverlayID;
+            _this.wasPlayAreaVisible = _this.isPlayAreaVisible;
+            _this.isPlayAreaVisible = visible;
+            _this.targetOverlayID = targetOverlayID;
 
-            if (this.teleportedFadeTimer !== null) {
-                Script.clearTimeout(this.teleportedFadeTimer);
-                this.teleportedFadeTimer = null;
+            if (_this.teleportedFadeTimer !== null) {
+                Script.clearTimeout(_this.teleportedFadeTimer);
+                _this.teleportedFadeTimer = null;
             }
             if (visible || !fade) {
                 // Immediately make visible or invisible.
-                this.isPlayAreaVisible = visible;
-                Overlays.editOverlay(this.playAreaOverlay, {
+                _this.isPlayAreaVisible = visible;
+                Overlays.editOverlay(_this.playAreaOverlay, {
                     dimensions: Vec3.ZERO,
-                    alpha: this.PLAY_AREA_BOX_ALPHA,
+                    alpha: _this.PLAY_AREA_BOX_ALPHA,
                     visible: visible
                 });
-                for (var i = 0; i < this.playAreaSensorPositionOverlays.length; i++) {
-                    Overlays.editOverlay(this.playAreaSensorPositionOverlays[i], {
+                for (var i = 0; i < _this.playAreaSensorPositionOverlays.length; i++) {
+                    Overlays.editOverlay(_this.playAreaSensorPositionOverlays[i], {
                         dimensions: Vec3.ZERO,
-                        alpha: this.PLAY_AREA_SENSOR_ALPHA,
+                        alpha: _this.PLAY_AREA_SENSOR_ALPHA,
                         visible: visible
                     });
                 }
-                Overlays.editOverlay(this.teleportedTargetOverlay, { visible: false });
+                Overlays.editOverlay(_this.teleportedTargetOverlay, { visible: false });
             } else {
                 // Fading out of overlays is initiated in setTeleportVisible().
             }
@@ -494,22 +494,22 @@ Script.include("/~/system/libraries/controllers.js");
             var MIN_PARENTING_DISTANCE = 0.2; // Parenting under this distance results in the play area's rotation jittering.
             if (Vec3.distance(targetXZPosition, avatarXZPosition) < MIN_PARENTING_DISTANCE) {
                 // Set play area position and rotation in world coordinates with no parenting.
-                Overlays.editOverlay(this.playAreaOverlay, {
+                Overlays.editOverlay(_this.playAreaOverlay, {
                     parentID: Uuid.NULL,
                     position: Vec3.sum(position,
                         Vec3.multiplyQbyV(sensorToWorldRotation,
                             Vec3.multiply(MyAvatar.sensorToWorldScale,
-                                Vec3.subtract(this.playAreaCenterOffset, avatarSensorPosition)))),
+                                Vec3.subtract(_this.playAreaCenterOffset, avatarSensorPosition)))),
                     rotation: sensorToWorldRotation
                 });
             } else {
                 // Set play area position and rotation in local coordinates with parenting.
-                var targetRotation = Overlays.getProperty(this.targetOverlayID, "rotation");
+                var targetRotation = Overlays.getProperty(_this.targetOverlayID, "rotation");
                 var sensorToTargetRotation = Quat.multiply(Quat.inverse(targetRotation), sensorToWorldRotation);
                 var relativePlayAreaCenterOffset =
-                    Vec3.sum(this.playAreaCenterOffset, { x: 0, y: -TARGET_MODEL_DIMENSIONS.y / 2, z: 0 });
-                Overlays.editOverlay(this.playAreaOverlay, {
-                    parentID: this.targetOverlayID,
+                    Vec3.sum(_this.playAreaCenterOffset, { x: 0, y: -TARGET_MODEL_DIMENSIONS.y / 2, z: 0 });
+                Overlays.editOverlay(_this.playAreaOverlay, {
+                    parentID: _this.targetOverlayID,
                     localPosition: Vec3.multiplyQbyV(Quat.inverse(targetRotation),
                         Vec3.multiplyQbyV(sensorToWorldRotation,
                             Vec3.multiply(MyAvatar.sensorToWorldScale,
@@ -585,26 +585,26 @@ Script.include("/~/system/libraries/controllers.js");
         this.cancelFade = function () {
             // Other hand may call this to immediately hide fading overlays.
             var i, length;
-            if (this.teleportedFadeTimer) {
-                Overlays.editOverlay(this.teleportedTargetOverlay, { visible: false });
-                if (this.wasPlayAreaVisible) {
-                    Overlays.editOverlay(this.playAreaOverlay, { visible: false });
-                    for (i = 0, length = this.playAreaSensorPositionOverlays.length; i < length; i++) {
-                        Overlays.editOverlay(this.playAreaSensorPositionOverlays[i], { visible: false });
+            if (_this.teleportedFadeTimer) {
+                Overlays.editOverlay(_this.teleportedTargetOverlay, { visible: false });
+                if (_this.wasPlayAreaVisible) {
+                    Overlays.editOverlay(_this.playAreaOverlay, { visible: false });
+                    for (i = 0, length = _this.playAreaSensorPositionOverlays.length; i < length; i++) {
+                        Overlays.editOverlay(_this.playAreaSensorPositionOverlays[i], { visible: false });
                     }
                 }
-                this.teleportedFadeTimer = null;
+                _this.teleportedFadeTimer = null;
             }
         };
 
         this.setTeleportVisible = function (visible, mode, fade) {
             // Scales in teleport target and play area when start displaying them.
-            if (visible === this.isTeleportVisible) {
+            if (visible === _this.isTeleportVisible) {
                 return;
             }
 
             if (visible) {
-                this.teleportScaleMode = mode;
+                _this.teleportScaleMode = mode;
                 Pointers.editRenderState(
                     mode === "head" ? _this.teleportParabolaHeadVisuals : _this.teleportParabolaHandVisuals,
                     "teleport",
@@ -613,42 +613,42 @@ Script.include("/~/system/libraries/controllers.js");
                         end: { dimensions: Vec3.ZERO }
                     }
                 );
-                this.getOtherModule().cancelFade();
-                this.teleportScaleStart = Date.now();
-                this.teleportScaleFactor = 0;
-                this.scaleInTeleport();
-                Selection.enableListHighlight(this.teleporterSelectionName, this.TELEPORTER_SELECTION_STYLE);
+                _this.getOtherModule().cancelFade();
+                _this.teleportScaleStart = Date.now();
+                _this.teleportScaleFactor = 0;
+                _this.scaleInTeleport();
+                Selection.enableListHighlight(_this.teleporterSelectionName, _this.TELEPORTER_SELECTION_STYLE);
             } else {
-                if (this.teleportScaleTimer !== null) {
-                    Script.clearTimeout(this.teleportScaleTimer);
-                    this.teleportScaleTimer = null;
+                if (_this.teleportScaleTimer !== null) {
+                    Script.clearTimeout(_this.teleportScaleTimer);
+                    _this.teleportScaleTimer = null;
                 }
 
                 if (fade) {
                     // Copy of target at teleported position for fading.
                     var avatarScale = MyAvatar.sensorToWorldScale;
-                    Overlays.editOverlay(this.teleportedTargetOverlay, {
-                        position: Vec3.sum(this.teleportedPosition, {
+                    Overlays.editOverlay(_this.teleportedTargetOverlay, {
+                        position: Vec3.sum(_this.teleportedPosition, {
                             x: 0,
                             y: -getAvatarFootOffset() + avatarScale * TARGET_MODEL_DIMENSIONS.y / 2,
                             z: 0
                         }),
-                        rotation: Quat.multiply(this.TELEPORTED_TARGET_ROTATION, MyAvatar.orientation),
+                        rotation: Quat.multiply(_this.TELEPORTED_TARGET_ROTATION, MyAvatar.orientation),
                         dimensions: Vec3.multiply(avatarScale, TARGET_MODEL_DIMENSIONS),
-                        alpha: this.TELEPORTED_TARGET_ALPHA,
+                        alpha: _this.TELEPORTED_TARGET_ALPHA,
                         visible: true
                     });
 
                     // Fade out over time.
-                    this.teleportedFadeDelayFactor = 1.0;
-                    this.teleportedFadeFactor = 1.0;
-                    this.teleportedFadeTimer = Script.setTimeout(this.fadeOutTeleport, this.TELEPORTED_FADE_DELAY);
+                    _this.teleportedFadeDelayFactor = 1.0;
+                    _this.teleportedFadeFactor = 1.0;
+                    _this.teleportedFadeTimer = Script.setTimeout(_this.fadeOutTeleport, _this.TELEPORTED_FADE_DELAY);
                 } else {
-                    Selection.disableListHighlight(this.teleporterSelectionName);
+                    Selection.disableListHighlight(_this.teleporterSelectionName);
                 }
             }
 
-            this.isTeleportVisible = visible;
+            _this.isTeleportVisible = visible;
         };
 
 
@@ -697,7 +697,7 @@ Script.include("/~/system/libraries/controllers.js");
             100);
 
         this.enterTeleport = function() {
-            this.state = TELEPORTER_STATES.TARGETTING;
+            _this.state = TELEPORTER_STATES.TARGETTING;
         };
 
         this.isReady = function(controllerData, deltaTime) {
@@ -761,23 +761,23 @@ Script.include("/~/system/libraries/controllers.js");
 
             if (teleportLocationType === TARGET.NONE) {
                 // Use the cancel default state
-                this.setTeleportState(mode, "cancel", "");
+                _this.setTeleportState(mode, "cancel", "");
             } else if (teleportLocationType === TARGET.INVALID) {
-                this.setTeleportState(mode, "", "cancel");
+                _this.setTeleportState(mode, "", "cancel");
             } else if (teleportLocationType === TARGET.COLLIDES) {
-                this.setTeleportState(mode, "cancel", "collision");
+                _this.setTeleportState(mode, "cancel", "collision");
             } else if (teleportLocationType === TARGET.SURFACE || teleportLocationType === TARGET.DISCREPANCY) {
-                this.setTeleportState(mode, "teleport", "collision");
-                this.updatePlayArea(result.intersection);
+                _this.setTeleportState(mode, "teleport", "collision");
+                _this.updatePlayArea(result.intersection);
             } else if (teleportLocationType === TARGET.SEAT) {
-                this.setTeleportState(mode, "collision", "seat");
+                _this.setTeleportState(mode, "collision", "seat");
             }
-            return this.teleport(result, teleportLocationType);
+            return _this.teleport(result, teleportLocationType);
         };
 
         this.teleport = function(newResult, target) {
             var result = newResult;
-            this.teleportedPosition = newResult.intersection;
+            _this.teleportedPosition = newResult.intersection;
             if (_this.buttonValue !== 0) {
                 return makeRunningValues(true, [], []);
             }
@@ -795,14 +795,14 @@ Script.include("/~/system/libraries/controllers.js");
                 MyAvatar.centerBody();
             }
 
-            this.disableLasers();
-            this.active = false;
+            _this.disableLasers();
+            _this.active = false;
             return makeRunningValues(false, [], []);
         };
 
         this.disableLasers = function() {
-            this.setPlayAreaVisible(false, null, true);
-            this.setTeleportVisible(false, null, true);
+            _this.setPlayAreaVisible(false, null, true);
+            _this.setTeleportVisible(false, null, true);
             Pointers.disablePointer(_this.teleportParabolaHandVisuals);
             Pointers.disablePointer(_this.teleportParabolaHandCollisions);
             Pointers.disablePointer(_this.teleportParabolaHeadVisuals);
@@ -815,10 +815,10 @@ Script.include("/~/system/libraries/controllers.js");
 
         this.setTeleportState = function (mode, visibleState, invisibleState) {
             var teleportState = mode + visibleState + invisibleState;
-            if (teleportState === this.teleportState) {
+            if (teleportState === _this.teleportState) {
                 return;
             }
-            this.teleportState = teleportState;
+            _this.teleportState = teleportState;
 
             var pointerID;
             if (mode === 'head') {
@@ -831,16 +831,16 @@ Script.include("/~/system/libraries/controllers.js");
                 pointerID = _this.teleportParabolaHandVisuals;
             }
             var visible = visibleState === "teleport";
-            this.setPlayAreaVisible(visible && MyAvatar.showPlayArea,
+            _this.setPlayAreaVisible(visible && MyAvatar.showPlayArea,
                 Pointers.getPointerProperties(pointerID).renderStates.teleport.end, false);
-            this.setTeleportVisible(visible, mode, false);
+            _this.setTeleportVisible(visible, mode, false);
         };
 
         this.setIgnoreEntities = function(entitiesToIgnore) {
-            Pointers.setIgnoreItems(this.teleportParabolaHandVisuals, entitiesToIgnore);
-            Pointers.setIgnoreItems(this.teleportParabolaHandCollisions, entitiesToIgnore);
-            Pointers.setIgnoreItems(this.teleportParabolaHeadVisuals, entitiesToIgnore);
-            Pointers.setIgnoreItems(this.teleportParabolaHeadCollisions, entitiesToIgnore);
+            Pointers.setIgnoreItems(_this.teleportParabolaHandVisuals, entitiesToIgnore);
+            Pointers.setIgnoreItems(_this.teleportParabolaHandCollisions, entitiesToIgnore);
+            Pointers.setIgnoreItems(_this.teleportParabolaHeadVisuals, entitiesToIgnore);
+            Pointers.setIgnoreItems(_this.teleportParabolaHeadCollisions, entitiesToIgnore);
             Picks.setIgnoreItems(_this.teleportHeadCollisionPick, entitiesToIgnore);
             Picks.setIgnoreItems(_this.teleportHandCollisionPick, entitiesToIgnore);
         };

--- a/scripts/system/controllers/controllerModules/teleport.js
+++ b/scripts/system/controllers/controllerModules/teleport.js
@@ -578,7 +578,7 @@ Script.include("/~/system/libraries/controllers.js");
                     }
                 }
                 _this.teleportedFadeTimer = null;
-                Selection.disableListHighlight(this.teleporterSelectionName);
+                Selection.disableListHighlight(_this.teleporterSelectionName);
             }
         };
 

--- a/scripts/system/pal.js
+++ b/scripts/system/pal.js
@@ -161,7 +161,8 @@ ExtendedOverlay.unHover = function () { // calls hover(false) on lastHoveringId 
 // hit(overlay) on the one overlay intersected by pickRay, if any.
 // noHit() if no ExtendedOverlay was intersected (helps with hover)
 ExtendedOverlay.applyPickRay = function (pickRay, hit, noHit) {
-    var pickedOverlay = Overlays.findRayIntersection(pickRay); // Depends on nearer coverOverlays to extend closer to us than farther ones.
+    // TODO: this could just include the necessary overlays for better performance
+    var pickedOverlay = Overlays.findRayIntersection(pickRay, true); // Depends on nearer coverOverlays to extend closer to us than farther ones.
     if (!pickedOverlay.intersects) {
         if (noHit) {
             return noHit();

--- a/scripts/system/tablet-ui/tabletUI.js
+++ b/scripts/system/tablet-ui/tabletUI.js
@@ -137,11 +137,11 @@
                 UIWebTablet.calculateTabletAttachmentProperties(activeHand, true, tabletProperties);
             }
             tabletProperties.visible = true;
+            tabletProperties.ignorePickIntersection = false;
             Overlays.editOverlay(HMD.tabletID, tabletProperties);
-            Overlays.editOverlay(HMD.homeButtonID, { visible: true });
-            Overlays.editOverlay(HMD.homeButtonHighlightID, { visible: true });
-            Overlays.editOverlay(HMD.tabletScreenID, { visible: true });
-            Overlays.editOverlay(HMD.tabletScreenID, { maxFPS: 90 });
+            Overlays.editOverlay(HMD.homeButtonID, { visible: true, ignorePickIntersection: false });
+            Overlays.editOverlay(HMD.homeButtonHighlightID, { visible: true, ignorePickIntersection: false });
+            Overlays.editOverlay(HMD.tabletScreenID, { visible: true, ignorePickIntersection: false, maxFPS: 90 });
             updateTabletWidthFromSettings(true);
         }
         gTablet.tabletShown = true;
@@ -158,11 +158,10 @@
             print("TABLET hide");
         }
 
-        Overlays.editOverlay(HMD.tabletID, { visible: false });
-        Overlays.editOverlay(HMD.homeButtonID, { visible: false });
-        Overlays.editOverlay(HMD.homeButtonHighlightID, { visible: false });
-        Overlays.editOverlay(HMD.tabletScreenID, { visible: false });
-        Overlays.editOverlay(HMD.tabletScreenID, { maxFPS: 1 });
+        Overlays.editOverlay(HMD.tabletID, { visible: false, ignorePickIntersection: true });
+        Overlays.editOverlay(HMD.homeButtonID, { visible: false, ignorePickIntersection: true });
+        Overlays.editOverlay(HMD.homeButtonHighlightID, { visible: false, ignorePickIntersection: true });
+        Overlays.editOverlay(HMD.tabletScreenID, { visible: false, ignorePickIntersection: true, maxFPS: 1 });
     }
 
     function closeTabletUI() {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21291/teleport-highlight-bug-for-81
https://highfidelity.manuscript.com/f/cases/21292/can-t-click-pal-spheres-for-81
https://highfidelity.manuscript.com/f/cases/21293/context-overlay-clicking-bug-for-81

Test plan:
- Rez a certified item from the marketplace.  Right click on it.  The context overlay will appear.  Orient your view so the context overlay is in front of an entity.  Left click the context overlay.  The QML certificate thing will open.
- Repeat but orient your view so the context overlay is in front of nothing.  Left click the context overlay and the QML thing will still appear.
- Pal spheres should be clickable (depends on https://github.com/highfidelity/hifi/pull/14942 and https://github.com/highfidelity/hifi/pull/14937)
- Verify that the problem described in case 21274 doesn't happen anymore