### PR TITLE
Case 20993: Fix AO

### DIFF
--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -205,7 +205,7 @@ gpu::TexturePointer AmbientOcclusionFramebuffer::getNormalTexture() {
 }
 
 AmbientOcclusionEffectConfig::AmbientOcclusionEffectConfig() :
-    render::GPUJobConfig::Persistent(QStringList() << "Render" << "Engine" << "Ambient Occlusion", false),
+    render::GPUJobConfig::Persistent(QStringList() << "Render" << "Engine" << "Ambient Occlusion"),
     perspectiveScale{ 1.0f },
     edgeSharpness{ 1.0f },
     blurRadius{ 4 },

--- a/libraries/render-utils/src/LightingModel.h
+++ b/libraries/render-utils/src/LightingModel.h
@@ -118,7 +118,7 @@ protected:
         float enableSkinning{ 1.0f };
         float enableBlendshape{ 1.0f };
 
-        float enableAmbientOcclusion{ 0.0f };
+        float enableAmbientOcclusion{ 0.0f }; // false by default
         float enableShadow{ 1.0f };
         float spare1{ 1.0f };
         float spare2{ 1.0f };
@@ -196,15 +196,13 @@ public:
     bool enableSkinning{ true };
     bool enableBlendshape{ true };
 
-    bool enableAmbientOcclusion{ true };
+    bool enableAmbientOcclusion{ false }; // false by default
     bool enableShadow{ true };
 
 
     void setAmbientOcclusion(bool enable) { enableAmbientOcclusion = enable; emit dirty();}
     bool isAmbientOcclusionEnabled() const { return enableAmbientOcclusion; }
-    void setShadow(bool enable) { 
-        enableShadow = enable; emit dirty();
-     }
+    void setShadow(bool enable) { enableShadow = enable; emit dirty(); }
     bool isShadowEnabled() const { return enableShadow; }
 
 signals:

--- a/scripts/developer/utilities/render/deferredLighting.qml
+++ b/scripts/developer/utilities/render/deferredLighting.qml
@@ -47,7 +47,7 @@ Rectangle {
                          "Lightmap:LightingModel:enableLightmap",
                          "Background:LightingModel:enableBackground",      
                          "Haze:LightingModel:enableHaze",                        
-                         "ssao:LightingModel:enableAmbientOcclusion",
+                         "AO:LightingModel:enableAmbientOcclusion",
                          "Textures:LightingModel:enableMaterialTexturing"                     
                     ]
                     HifiControls.CheckBox {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20993/SSAO-does-not-seem-to-work-in-78

Test plan:
- Open luci and enable AO.
- Create a zone with a skybox.  Enabled the ambient map and copy it from the skybox.  Increase the ambient intensity until the ambient map is noticeable.  You should see AO.