### PR TITLE
Case 21305: Fix text overlay color property

### DIFF
--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -375,6 +375,8 @@ EntityItemProperties Overlays::convertOverlayToEntityProperties(QVariantMap& ove
         RENAME_PROP(animationSettings, animation);
     } else if (type == "Image") {
         RENAME_PROP(url, imageURL);
+    } else if (type == "Text") {
+        RENAME_PROP(color, textColor);
     } else if (type == "Web") {
         RENAME_PROP(url, sourceUrl);
         RENAME_PROP_CONVERT(inputMode, inputMode, [](const QVariant& v) { return v.toString() == "Mouse" ? "mouse" : "touch"; });
@@ -675,6 +677,8 @@ QVariantMap Overlays::convertEntityToOverlayProperties(const EntityItemPropertie
         RENAME_PROP(animation, animationSettings);
     } else if (type == "Image") {
         RENAME_PROP(imageURL, url);
+    } else if (type == "Text") {
+        RENAME_PROP(textColor, color);
     } else if (type == "Web") {
         RENAME_PROP(sourceUrl, url);
         RENAME_PROP_CONVERT(inputMode, inputMode, [](const QVariant& v) { return v.toString() == "mouse" ? "Mouse" : "Touch"; });


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21305/text-overlay-color-property-for-81

Test plan:
- Run this from the console:
```
Overlays.addOverlay("text3d", {
          name: "Muted-Warning",
          localPosition: { x: 0.2, y: -0.35, z: -1.0 },
          localOrientation: Quat.fromVec3Degrees({ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }),
          dimensions: 0.5,
          text: "Warning: you are muted",
          textAlpha: 1,
          color: { red: 226, green: 51, blue: 77 },
          backgroundAlpha: 0,
          lineHeight: 0.042,
          visible: true,
          ignoreRayIntersection: true,
          drawInFront: true,
          grabbable: false,
          parentID: MyAvatar.SELF_ID,
          parentJointIndex: MyAvatar.getJointIndex("_CAMERA_MATRIX")
      });
```
- Some text will appear on the screen.  It should be reddish, not white, as in master.