### PR TITLE
Case 21356:Fine tune the LOD manager max render target and world detail default for Quest / Tier Low

### DIFF
--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -19,7 +19,6 @@
 #include <SimpleMovingAverage.h>
 #include <render/Args.h>
 
-#include <QtCore/QGlobal.h>
 
 #ifdef Q_OS_ANDROID
 const float LOD_DEFAULT_QUALITY_LEVEL = 0.2; // default quality level setting is High (lower framerate)

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -19,13 +19,20 @@
 #include <SimpleMovingAverage.h>
 #include <render/Args.h>
 
+#include <QtCore/QGlobal.h>
+
 #ifdef Q_OS_ANDROID
-const float LOD_DEFAULT_QUALITY_LEVEL = 0.75f; // default quality level setting is High (lower framerate)
+const float LOD_DEFAULT_QUALITY_LEVEL = 0.2; // default quality level setting is High (lower framerate)
 #else
 const float LOD_DEFAULT_QUALITY_LEVEL = 0.5f; // default quality level setting is Mid
 #endif
 const float LOD_MAX_LIKELY_DESKTOP_FPS = 60.0f; // this is essentially, V-synch fps
+#ifdef Q_OS_ANDROID
+const float LOD_MAX_LIKELY_HMD_FPS = 36.0f; // this is essentially, V-synch fps
+#else
 const float LOD_MAX_LIKELY_HMD_FPS = 90.0f; // this is essentially, V-synch fps
+#endif
+
 const float LOD_OFFSET_FPS = 5.0f; // offset of FPS to add for computing the target framerate
 
 class AABox;

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -21,7 +21,7 @@
 
 
 #ifdef Q_OS_ANDROID
-const float LOD_DEFAULT_QUALITY_LEVEL = 0.2; // default quality level setting is High (lower framerate)
+const float LOD_DEFAULT_QUALITY_LEVEL = 0.2f; // default quality level setting is High (lower framerate)
 #else
 const float LOD_DEFAULT_QUALITY_LEVEL = 0.5f; // default quality level setting is Mid
 #endif


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21356/Fine-tune-the-LOD-manager-max-render-target-and-world-detail-default-for-Quest-Tier-Low

Assigning the default world detail and max render rate target in vr quest

we set the defaults to:
Max REnder Target is 36Hz (because that is the vsync we picked for quest build at the moment)
World Detaiil is set to "Max details" (0.25)

