### PR TITLE
Case 21309: don't corrupt workload system

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -219,7 +219,6 @@ void EntityTreeRenderer::clearNonLocalEntities() {
 
     std::unordered_map<EntityItemID, EntityRendererPointer> savedEntities;
     // remove all entities from the scene
-    _space->clear();
     auto scene = _viewState->getMain3DScene();
     if (scene) {
         render::Transaction transaction;

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -258,8 +258,6 @@ void EntityTreeRenderer::clear() {
         resetEntitiesScriptEngine();
     }
     // remove all entities from the scene
-
-    _space->clear();
     auto scene = _viewState->getMain3DScene();
     if (scene) {
         render::Transaction transaction;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21309/MyAvatar-physics-collisions-disabled-for-certain-avatar-orientations

This PR fixes a bug where sometimes non-local Entities are incorrectly culled from the physics simulation.