### PR TITLE
Case 21268: Avatar mouth blendshapes are not working correctly (RC80)

### DIFF
--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -27,8 +27,9 @@ QString Audio::HMD { "VR" };
 Setting::Handle<bool> enableNoiseReductionSetting { QStringList { Audio::AUDIO, "NoiseReduction" }, true };
 
 float Audio::loudnessToLevel(float loudness) {
-    float level = 6.02059991f * fastLog2f(loudness);    // level in dBFS
-    level = (level + 48.0f) * (1/39.0f);                // map [-48, -9] dBFS to [0, 1]
+    float level = loudness * (1/32768.0f);  // level in [0, 1]
+    level = 6.02059991f * fastLog2f(level); // convert to dBFS
+    level = (level + 48.0f) * (1/42.0f);    // map [-48, -6] dBFS to [0, 1]
     return glm::clamp(level, 0.0f, 1.0f);
 }
 

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -127,7 +127,7 @@ public:
 
     const QAudioFormat& getOutputFormat() const { return _outputFormat; }
 
-    float getLastInputLoudness() const { return _lastInputLoudness; }   // TODO: relative to noise floor?
+    float getLastInputLoudness() const { return _lastInputLoudness; }
 
     float getTimeSinceLastClip() const { return _timeSinceLastClip; }
     float getAudioAverageInputLoudness() const { return _lastInputLoudness; }
@@ -355,7 +355,9 @@ private:
 
     StDev _stdev;
     QElapsedTimer _timeSinceLastReceived;
-    float _lastInputLoudness;
+    float _lastRawInputLoudness;    // before mute/gate
+    float _lastSmoothedRawInputLoudness;
+    float _lastInputLoudness;       // after mute/gate
     float _timeSinceLastClip;
     int _totalInputAudioSamples;
 


### PR DESCRIPTION
Multiple bugs were caused by a change in mic loudness calculation in PR #14880.
Fixed by emulating the old behavior of _lastInputLoudness for these features.

See:

https://highfidelity.manuscript.com/f/cases/21268/Blendshapes-are-broken-in-master-9999

https://highfidelity.manuscript.com/f/cases/21330/Audio-loudness-bars-do-not-display-in-PAL

https://highfidelity.manuscript.com/f/cases/21346/Audio-levels-are-not-being-detected-correctly-from-microphone-input-as-a-result-Blendshapes-appear-broken-when-users-speak