### PR TITLE
Case 21372: don't corrupt workload system on 80

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -219,7 +219,6 @@ void EntityTreeRenderer::clearNonLocalEntities() {
 
     std::unordered_map<EntityItemID, EntityRendererPointer> savedEntities;
     // remove all entities from the scene
-    _space->clear();
     auto scene = _viewState->getMain3DScene();
     if (scene) {
         render::Transaction transaction;
@@ -259,8 +258,6 @@ void EntityTreeRenderer::clear() {
         resetEntitiesScriptEngine();
     }
     // remove all entities from the scene
-
-    _space->clear();
     auto scene = _viewState->getMain3DScene();
     if (scene) {
         render::Transaction transaction;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21372/Some-EntityItems-incorrectly-removed-from-physics-simulation

TI assume the release crew want this fix in 0.80 so I created this PR which fixes a bug where: sometimes MyAvatar doesn't collide with the floor.
