### PR TITLE
Fix crash on AvatarManager::findRayIntersectionVector when Avatar becomes null

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -719,7 +719,7 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersectionVector(const Pic
                 }
             }
 
-            if (rayAvatarResult._intersect && pickAgainstMesh) {
+            if (avatar && rayAvatarResult._intersect && pickAgainstMesh) {
                 glm::vec3 localRayOrigin = avatar->worldToJointPoint(ray.origin, rayAvatarResult._intersectWithJoint);
                 glm::vec3 localRayPoint = avatar->worldToJointPoint(ray.origin + rayAvatarResult._distance * rayDirection, rayAvatarResult._intersectWithJoint);
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21355/crash-in-Avatar-worldToJointPoint-AvatarManager-findRayIntersectionVector
This PR fix a crash that occurs when calling AvatarManager::findRayIntersectionVector function and the other avatar becomes null.
### How to repro the crash
Install a domain locally and start two interface instances. With two avatars on the same domain run [this script](https://gist.githubusercontent.com/SamGondelman/b2d93371a357fbf63ab817c4471b2a1b/raw/be54627071c8366dfa3ef5fe2bb67b01d9d97c36/AvatarIntersectionTest.js). A white sphere should appear on the intersection point with the avatar. Press "o" to get a precise picking (it should start logging precise information). Turn off the domain and keep picking on the other avatar until becomes null. At this point interface crash trying to call Avatar::worldToJointPoint on a null avatar.