### PR TITLE
case 21374 : Away mode on Quest when device is paused

### DIFF
--- a/android/apps/questInterface/src/main/cpp/native.cpp
+++ b/android/apps/questInterface/src/main/cpp/native.cpp
@@ -61,7 +61,7 @@ extern "C" {
     Java_io_highfidelity_oculus_OculusMobileActivity_nativeInitOculusPlatform(JNIEnv *env, jobject obj){
         initOculusPlatform(env, obj);
     }
-QAndroidJniObject __interfaceActivity;
+    QAndroidJniObject __interfaceActivity;
 
     JNIEXPORT void JNICALL
     Java_io_highfidelity_oculus_OculusMobileActivity_questNativeOnCreate(JNIEnv *env, jobject obj) {
@@ -80,6 +80,10 @@ QAndroidJniObject __interfaceActivity;
         });
     }
 
+    JNIEXPORT void JNICALL
+    Java_io_highfidelity_oculus_OculusMobileActivity_questNativeAwayMode(JNIEnv *env, jobject obj) {
+            AndroidHelper::instance().toggleAwayMode();
+    }
 
 
 JNIEXPORT void Java_io_highfidelity_oculus_OculusMobileActivity_questOnAppAfterLoad(JNIEnv* env, jobject obj) {

--- a/android/libraries/oculus/src/main/java/io/highfidelity/oculus/OculusMobileActivity.java
+++ b/android/libraries/oculus/src/main/java/io/highfidelity/oculus/OculusMobileActivity.java
@@ -51,15 +51,13 @@ public class OculusMobileActivity extends QtActivity implements SurfaceHolder.Ca
         nativeOnCreate();
         questNativeOnCreate();
     }
+
     public void onAppLoadedComplete() {
         Log.w(TAG, "QQQ Load Completed");
         runOnUiThread(() -> {
             setContentView(mView);
             questOnAppAfterLoad();
-
         });
-
-
     }
 
     @Override
@@ -93,7 +91,6 @@ public class OculusMobileActivity extends QtActivity implements SurfaceHolder.Ca
         questNativeOnPause();
         nativeOnPause();
         isPausing=true;
-
     }
 
     @Override

--- a/android/libraries/oculus/src/main/java/io/highfidelity/oculus/OculusMobileActivity.java
+++ b/android/libraries/oculus/src/main/java/io/highfidelity/oculus/OculusMobileActivity.java
@@ -34,6 +34,7 @@ public class OculusMobileActivity extends QtActivity implements SurfaceHolder.Ca
     private native void questNativeOnResume();
     private native void questOnAppAfterLoad();
 
+    private native void questNativeAwayMode();
     private SurfaceView mView;
     private SurfaceHolder mSurfaceHolder;
 
@@ -55,6 +56,7 @@ public class OculusMobileActivity extends QtActivity implements SurfaceHolder.Ca
         runOnUiThread(() -> {
             setContentView(mView);
             questOnAppAfterLoad();
+
         });
 
 
@@ -91,12 +93,14 @@ public class OculusMobileActivity extends QtActivity implements SurfaceHolder.Ca
         questNativeOnPause();
         nativeOnPause();
         isPausing=true;
+
     }
 
     @Override
     protected void onStop(){
         super.onStop();
         Log.w(TAG, "QQQ_ Onstop called");
+        questNativeAwayMode();
     }
 
     @Override
@@ -104,6 +108,7 @@ public class OculusMobileActivity extends QtActivity implements SurfaceHolder.Ca
         super.onRestart();
         Log.w(TAG, "QQQ_ onRestart called ****");
         questOnAppAfterLoad();
+        questNativeAwayMode();
     }
 
     @Override
@@ -123,8 +128,7 @@ public class OculusMobileActivity extends QtActivity implements SurfaceHolder.Ca
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
         Log.w(TAG, "QQQ_ surfaceDestroyed ***************************************************");
-      //  nativeOnSurfaceChanged(null);
-       // mSurfaceHolder = null;
-
+        nativeOnSurfaceChanged(null);
+        mSurfaceHolder = null;
     }
 }

--- a/interface/src/AndroidHelper.cpp
+++ b/interface/src/AndroidHelper.cpp
@@ -45,6 +45,10 @@ void AndroidHelper::notifyBeforeEnterBackground() {
     emit beforeEnterBackground();
 }
 
+void AndroidHelper::notifyToggleAwayMode() {
+    emit toggleAwayMode();
+}
+
 void AndroidHelper::notifyEnterBackground() {
     emit enterBackground();
 }

--- a/interface/src/AndroidHelper.h
+++ b/interface/src/AndroidHelper.h
@@ -31,6 +31,7 @@ public:
     void notifyEnterForeground();
     void notifyBeforeEnterBackground();
     void notifyEnterBackground();
+    void notifyToggleAwayMode();
 
     void performHapticFeedback(int duration);
     void processURL(const QString &url);
@@ -55,7 +56,7 @@ signals:
     void enterForeground();
     void beforeEnterBackground();
     void enterBackground();
-
+    void toggleAwayMode();
     void hapticFeedbackRequested(int duration);
 
     void handleSignupCompleted();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1756,6 +1756,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
 #endif
     });
 
+
     // Setup the _keyboardMouseDevice, _touchscreenDevice, _touchscreenVirtualPadDevice and the user input mapper with the default bindings
     userInputMapper->registerDevice(_keyboardMouseDevice->getInputDevice());
     // if the _touchscreenDevice is not supported it will not be registered
@@ -9162,12 +9163,15 @@ void Application::enterForeground() {
     auto nodeList = DependencyManager::get<NodeList>();
     nodeList->setSendDomainServerCheckInEnabled(true);
 }
-#endif
+
 
 void Application::toggleAwayMode(){
-   auto key = QKeyEvent(QEvent::KeyPress,Qt::Key_Escape,Qt::NoModifier);
-    _keyboardMouseDevice->keyPressEvent(&key);
-    qDebug()<<"QQQ_ AWAY MODE ";
+   QKeyEvent event = QKeyEvent (QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    QCoreApplication::sendEvent (this, &event);
 }
+
+
+#endif
+
 
 #include "Application.moc"

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2411,6 +2411,8 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     connect(&AndroidHelper::instance(), &AndroidHelper::beforeEnterBackground, this, &Application::beforeEnterBackground);
     connect(&AndroidHelper::instance(), &AndroidHelper::enterBackground, this, &Application::enterBackground);
     connect(&AndroidHelper::instance(), &AndroidHelper::enterForeground, this, &Application::enterForeground);
+    connect(&AndroidHelper::instance(), &AndroidHelper::toggleAwayMode, this, &Application::toggleAwayMode);
+
     AndroidHelper::instance().notifyLoadComplete();
 #endif
     pauseUntilLoginDetermined();
@@ -9135,6 +9137,8 @@ void Application::beforeEnterBackground() {
     clearDomainOctreeDetails();
 }
 
+
+
 void Application::enterBackground() {
     QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(),
                               "stop", Qt::BlockingQueuedConnection);
@@ -9159,5 +9163,11 @@ void Application::enterForeground() {
     nodeList->setSendDomainServerCheckInEnabled(true);
 }
 #endif
+
+void Application::toggleAwayMode(){
+   auto key = QKeyEvent(QEvent::KeyPress,Qt::Key_Escape,Qt::NoModifier);
+    _keyboardMouseDevice->keyPressEvent(&key);
+    qDebug()<<"QQQ_ AWAY MODE ";
+}
 
 #include "Application.moc"

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -9166,7 +9166,7 @@ void Application::enterForeground() {
 
 
 void Application::toggleAwayMode(){
-   QKeyEvent event = QKeyEvent (QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    QKeyEvent event = QKeyEvent (QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
     QCoreApplication::sendEvent (this, &event);
 }
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -338,7 +338,8 @@ public:
     void beforeEnterBackground();
     void enterBackground();
     void enterForeground();
-#endif
+    void toggleAwayMode();
+    #endif
 
 signals:
     void svoImportRequested(const QString& url);

--- a/libraries/oculusMobile/src/ovr/VrHandler.cpp
+++ b/libraries/oculusMobile/src/ovr/VrHandler.cpp
@@ -140,7 +140,11 @@ struct VrSurface : public TaskQueue {
         if (vrReady != vrRunning) {
             if (vrRunning) {
                 __android_log_write(ANDROID_LOG_WARN, "QQQ_OVR", "vrapi_LeaveVrMode");
+                vrapi_SetClockLevels(session, 1, 1);
+                vrapi_SetExtraLatencyMode(session, VRAPI_EXTRA_LATENCY_MODE_OFF);
+                vrapi_SetDisplayRefreshRate(session, 60);
                 vrapi_LeaveVrMode(session);
+
                 session = nullptr;
                 oculusActivity = nullptr;
             } else {

--- a/scripts/+android_questInterface/defaultScripts.js
+++ b/scripts/+android_questInterface/defaultScripts.js
@@ -14,8 +14,8 @@
 var DEFAULT_SCRIPTS_COMBINED = [
     "system/request-service.js",
     "system/progress.js",
-    //"system/away.js",
-    "system/hmd.js",
+    "system/away.js",
+    //"system/hmd.js",
     "system/menu.js",
     "system/bubble.js",
     "system/pal.js", // "system/mod.js", // older UX, if you prefer

--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -154,7 +154,7 @@ function goAway(fromStartup) {
     if (!isEnabled || isAway) {
         return;
     }
-    console.warn('QQQ_ JS going away);
+ 
     // If we're entering away mode from some other state than startup, then we create our move timer immediately.
     // However if we're just stating up, we need to delay this process so that we don't think the initial teleport
     // is actually a move.
@@ -176,7 +176,6 @@ function goActive() {
         return;
     }
 
-    console.warn('QQQ_ JS going active); 
     UserActivityLogger.toggledAway(false);
     MyAvatar.isAway = false;
 

--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -154,7 +154,7 @@ function goAway(fromStartup) {
     if (!isEnabled || isAway) {
         return;
     }
-    
+    console.warn('QQQ_ JS going away);
     // If we're entering away mode from some other state than startup, then we create our move timer immediately.
     // However if we're just stating up, we need to delay this process so that we don't think the initial teleport
     // is actually a move.
@@ -176,6 +176,7 @@ function goActive() {
         return;
     }
 
+    console.warn('QQQ_ JS going active); 
     UserActivityLogger.toggledAway(false);
     MyAvatar.isAway = false;
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21374/

Setting away mode when user enters pause state on the device by either taking it off their head or hitting the oculus button.

Test:

1. Enter domain with PC or other device
2. Enter the same domain as the device above using the quest
3.  Make sure the avatars can see each other
4. Press Oculus button on the quest to enter pause mode
5. On the pc, observe the avatar go into kneel animation
6. On Quest hit resume.
5. Observe the avatar (using the other device) go back to active (non away mode)