### PR TITLE
Case 21391: Fix parent loop crash

### DIFF
--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -1422,7 +1422,7 @@ QUuid SpatiallyNestable::getEditSenderID() {
 
 void SpatiallyNestable::bumpAncestorChainRenderableVersion(int depth) const {
     if (depth > MAX_PARENTING_CHAIN_SIZE) {
-        breakParentingLoop();
+        // can't break the parent chain here, because it will call setParentID, which calls this
         return;
     }
 

--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -1420,11 +1420,16 @@ QUuid SpatiallyNestable::getEditSenderID() {
     return editSenderID;
 }
 
-void SpatiallyNestable::bumpAncestorChainRenderableVersion() const {
+void SpatiallyNestable::bumpAncestorChainRenderableVersion(int depth) const {
+    if (depth > MAX_PARENTING_CHAIN_SIZE) {
+        breakParentingLoop();
+        return;
+    }
+
     _ancestorChainRenderableVersion++;
     bool success = false;
     auto parent = getParentPointer(success);
     if (success && parent) {
-        parent->bumpAncestorChainRenderableVersion();
+        parent->bumpAncestorChainRenderableVersion(depth + 1);
     }
 }

--- a/libraries/shared/src/SpatiallyNestable.h
+++ b/libraries/shared/src/SpatiallyNestable.h
@@ -221,7 +221,7 @@ public:
     bool hasGrabs();
     virtual QUuid getEditSenderID();
 
-    void bumpAncestorChainRenderableVersion() const;
+    void bumpAncestorChainRenderableVersion(int depth = 0) const;
 
 protected:
     QUuid _id;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21391/parenting-loop-crash-for-81
Test plan:
- parent two entities to each other.  As in stable, you won't crash.