### PR TITLE
case 21395: Adjust culling matrix 

### DIFF
--- a/libraries/oculusMobilePlugin/src/OculusMobileDisplayPlugin.cpp
+++ b/libraries/oculusMobilePlugin/src/OculusMobileDisplayPlugin.cpp
@@ -120,7 +120,10 @@ QRectF OculusMobileDisplayPlugin::getPlayAreaRect() {
 }
 
 glm::mat4 OculusMobileDisplayPlugin::getEyeProjection(Eye eye, const glm::mat4& baseProjection) const {
+    qDebug()<< "QQQ_ " << __FUNCTION__;
+
     glm::mat4 result = baseProjection;
+
     VrHandler::withOvrMobile([&](ovrMobile* session){
         auto trackingState = vrapi_GetPredictedTracking2(session, 0.0);
         result = ovr::Fov{ trackingState.Eye[eye].ProjectionMatrix }.withZ(baseProjection);
@@ -136,9 +139,13 @@ glm::mat4 OculusMobileDisplayPlugin::getCullingProjection(const glm::mat4& baseP
         for (size_t i = 0; i < 2; ++i) {
             fovs[i].extract(trackingState.Eye[i].ProjectionMatrix);
         }
+
         fovs[0].extend(fovs[1]);
-        return fovs[0].withZ(baseProjection);
+        result= glm::scale( fovs[0].withZ(baseProjection),glm::vec3(1.5f));
     });
+
+
+
     return result;
 }
 

--- a/libraries/oculusMobilePlugin/src/OculusMobileDisplayPlugin.cpp
+++ b/libraries/oculusMobilePlugin/src/OculusMobileDisplayPlugin.cpp
@@ -120,8 +120,6 @@ QRectF OculusMobileDisplayPlugin::getPlayAreaRect() {
 }
 
 glm::mat4 OculusMobileDisplayPlugin::getEyeProjection(Eye eye, const glm::mat4& baseProjection) const {
-    qDebug()<< "QQQ_ " << __FUNCTION__;
-
     glm::mat4 result = baseProjection;
 
     VrHandler::withOvrMobile([&](ovrMobile* session){
@@ -142,9 +140,8 @@ glm::mat4 OculusMobileDisplayPlugin::getCullingProjection(const glm::mat4& baseP
 
         fovs[0].extend(fovs[1]);
         result= glm::scale( fovs[0].withZ(baseProjection),glm::vec3(1.5f));
+        return result;
     });
-
-
 
     return result;
 }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21395/Adjust-culling-matrix-to-fix-vertical-culling

Adjust culling matrix so that items are not cut off from rendering at various pitch angles.  

Test:

Log into quest-demo domain
Go to the board room
Stand at end of table
Look up as far as you can while your eyes look at the table and chairs. 
The table should stay in view at all times, as well as the chairs
Look down, and repeat with the ceiling and lights. 

It should appear as if nothing is being dropped and recreated in the view based on the angle of your head. 