### PR TITLE
Case 21402: Don't send a KillAvatar packet on kick

### DIFF
--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -25,13 +25,13 @@
 
 #include <AccountManager.h>
 #include <Assignment.h>
+#include <AvatarData.h>
 #include <HifiConfigVariantMap.h>
 #include <HTTPConnection.h>
 #include <NLPacketList.h>
 #include <NumericalConstants.h>
 #include <SettingHandle.h>
 #include <SettingHelpers.h>
-#include <AvatarData.h> //for KillAvatarReason
 #include <FingerprintUtils.h>
 
 #include "DomainServerNodeData.h"
@@ -869,14 +869,6 @@ void DomainServerSettingsManager::processNodeKickRequestPacket(QSharedPointer<Re
                         }
                     }
                 }
-
-                // if we are here, then we kicked them, so send the KillAvatar message
-                auto packet = NLPacket::create(PacketType::KillAvatar, NUM_BYTES_RFC4122_UUID + sizeof(KillAvatarReason), true);
-                packet->write(nodeUUID.toRfc4122());
-                packet->writePrimitive(KillAvatarReason::NoReason);
-
-                // send to avatar mixer, it sends the kill to everyone else
-                limitedNodeList->broadcastToNodes(std::move(packet), NodeSet() << NodeType::AvatarMixer);
 
                 if (newPermissions) {
                     qDebug() << "Removing connect permission for node" << uuidStringWithoutCurlyBraces(matchingNode->getUUID())


### PR DESCRIPTION
[Manuscript Ticket](https://highfidelity.manuscript.com/f/cases/21402/Kicking-lock-the-reliable-traffic-between-the-DS-and-the-Avatar-Mixer)

The DS already takes cares of removing nodes no longer allowed when the permissions are updated.
So remove the KillAvatar logic and let the DS send the disconnect packets by itself.