### PR TITLE
Case 21418: Allow flying in HMD if you would otherwise fall forever

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -932,7 +932,8 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
         bool isPhysicsEnabled = qApp->isPhysicsEnabled();
         bool zoneAllowsFlying = zoneInteractionProperties.first;
         bool collisionlessAllowed = zoneInteractionProperties.second;
-        _characterController.setFlyingAllowed((zoneAllowsFlying && _enableFlying) || !isPhysicsEnabled);
+        _characterController.setZoneFlyingAllowed(zoneAllowsFlying || !isPhysicsEnabled);
+        _characterController.setComfortFlyingAllowed(_enableFlying);
         _characterController.setCollisionlessAllowed(collisionlessAllowed);
     }
 

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -65,10 +65,10 @@ public:
     // overrides from btCharacterControllerInterface
     virtual void setWalkDirection(const btVector3 &walkDirection) override { assert(false); }
     virtual void setVelocityForTimeInterval(const btVector3 &velocity, btScalar timeInterval) override { assert(false); }
-    virtual void reset(btCollisionWorld* collisionWorld) override { }
-    virtual void warp(const btVector3& origin) override { }
-    virtual void debugDraw(btIDebugDraw* debugDrawer) override { }
-    virtual void setUpInterpolate(bool value) override { }
+    virtual void reset(btCollisionWorld* collisionWorld) override {}
+    virtual void warp(const btVector3& origin) override {}
+    virtual void debugDraw(btIDebugDraw* debugDrawer) override {}
+    virtual void setUpInterpolate(bool value) override {}
     virtual void updateAction(btCollisionWorld* collisionWorld, btScalar deltaTime) override;
     virtual void preStep(btCollisionWorld *collisionWorld) override;
     virtual void playerStep(btCollisionWorld *collisionWorld, btScalar dt) override;
@@ -90,7 +90,7 @@ public:
     void preSimulation();
     void postSimulation();
 
-    void setPositionAndOrientation( const glm::vec3& position, const glm::quat& orientation);
+    void setPositionAndOrientation(const glm::vec3& position, const glm::quat& orientation);
     void getPositionAndOrientation(glm::vec3& position, glm::quat& rotation) const;
 
     void setParentVelocity(const glm::vec3& parentVelocity);
@@ -129,7 +129,8 @@ public:
 
     bool getRigidBodyLocation(glm::vec3& avatarRigidBodyPosition, glm::quat& avatarRigidBodyRotation);
 
-    void setFlyingAllowed(bool value);
+    void setZoneFlyingAllowed(bool value) { _zoneFlyingAllowed = value; }
+    void setComfortFlyingAllowed(bool value) { _comfortFlyingAllowed = value; }
     void setCollisionlessAllowed(bool value);
 
     void setPendingFlagsUpdateCollisionMask(){ _pendingFlags |= PENDING_FLAG_UPDATE_COLLISION_MASK; }
@@ -212,7 +213,8 @@ protected:
     uint32_t _pendingFlags { 0 };
     uint32_t _previousFlags { 0 };
 
-    bool _flyingAllowed { true };
+    bool _zoneFlyingAllowed { true };
+    bool _comfortFlyingAllowed { true };
     bool _collisionlessAllowed { true };
     bool _collisionless { false };
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21418/hmd-falling-for-81

Test plan:
- Verify the following behavior:
- If you're in a zone with flying disabled, you can never fly.  You will continue to fall until you are in a zone with flying enabled, or the default zone.  This applies in HMD and desktop.
- If you're in a zone with flying enabled:
     - In desktop, you can jump and fly as in master.
     - In HMD with the "Flying and jumping" control setting enabled, you can jump and fly as in master.
     - In HMD with the "Flying and jumping" control setting disabled, you can't jump or fly.  However, if you walk off a surface so that there's nothing below you (or the thing is far below you), you'll start flying even though "Flying and jumping" is disabled.  If you fly over a surface (so that it's fairly close below you), you'll fall to the surface and go back to not being able to fly or jump.