### PR TITLE
bug fix: Ik is on by default in desktop mode

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1064,28 +1064,30 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
 
         t += deltaTime;
 
-        if (_enableInverseKinematics) {
-            _animVars.set("ikOverlayAlpha", 1.0f);
-            _animVars.set("splineIKEnabled", true);
-            _animVars.set("leftHandIKEnabled", true);
-            _animVars.set("rightHandIKEnabled", true);
-            _animVars.set("leftFootIKEnabled", true);
-            _animVars.set("rightFootIKEnabled", true);
-            _animVars.set("leftFootPoleVectorEnabled", true);
-            _animVars.set("rightFootPoleVectorEnabled", true);
-        } else {
-            _animVars.set("ikOverlayAlpha", 0.0f);
-            _animVars.set("splineIKEnabled", false);
-            _animVars.set("leftHandIKEnabled", false);
-            _animVars.set("rightHandIKEnabled", false);
-            _animVars.set("leftFootIKEnabled", false);
-            _animVars.set("rightFootIKEnabled", false);
-            _animVars.set("leftHandPoleVectorEnabled", false);
-            _animVars.set("rightHandPoleVectorEnabled", false);
-            _animVars.set("leftFootPoleVectorEnabled", false);
-            _animVars.set("rightFootPoleVectorEnabled", false);
+        if (_enableInverseKinematics != _lastEnableInverseKinematics) {
+            if (_enableInverseKinematics) {
+                _animVars.set("ikOverlayAlpha", 1.0f);
+                _animVars.set("splineIKEnabled", true);
+                _animVars.set("leftHandIKEnabled", true);
+                _animVars.set("rightHandIKEnabled", true);
+                _animVars.set("leftFootIKEnabled", true);
+                _animVars.set("rightFootIKEnabled", true);
+                _animVars.set("leftFootPoleVectorEnabled", true);
+                _animVars.set("rightFootPoleVectorEnabled", true);
+            } else {
+                _animVars.set("ikOverlayAlpha", 0.0f);
+                _animVars.set("splineIKEnabled", false);
+                _animVars.set("leftHandIKEnabled", false);
+                _animVars.set("rightHandIKEnabled", false);
+                _animVars.set("leftFootIKEnabled", false);
+                _animVars.set("rightFootIKEnabled", false);
+                _animVars.set("leftHandPoleVectorEnabled", false);
+                _animVars.set("rightHandPoleVectorEnabled", false);
+                _animVars.set("leftFootPoleVectorEnabled", false);
+                _animVars.set("rightFootPoleVectorEnabled", false);
+            }
+            _lastEnableInverseKinematics = _enableInverseKinematics;
         }
-        _lastEnableInverseKinematics = _enableInverseKinematics;
     }
     _lastForward = forward;
     _lastPosition = worldPosition;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1064,28 +1064,19 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
 
         t += deltaTime;
 
-        if (_enableInverseKinematics != _lastEnableInverseKinematics) {
-            if (_enableInverseKinematics) {
-                _animVars.set("ikOverlayAlpha", 1.0f);
-                _animVars.set("splineIKEnabled", true);
-                _animVars.set("leftHandIKEnabled", true);
-                _animVars.set("rightHandIKEnabled", true);
-                _animVars.set("leftFootIKEnabled", true);
-                _animVars.set("rightFootIKEnabled", true);
-                _animVars.set("leftFootPoleVectorEnabled", true);
-                _animVars.set("rightFootPoleVectorEnabled", true);
-            } else {
-                _animVars.set("ikOverlayAlpha", 0.0f);
-                _animVars.set("splineIKEnabled", false);
-                _animVars.set("leftHandIKEnabled", false);
-                _animVars.set("rightHandIKEnabled", false);
-                _animVars.set("leftFootIKEnabled", false);
-                _animVars.set("rightFootIKEnabled", false);
-                _animVars.set("leftHandPoleVectorEnabled", false);
-                _animVars.set("rightHandPoleVectorEnabled", false);
-                _animVars.set("leftFootPoleVectorEnabled", false);
-                _animVars.set("rightFootPoleVectorEnabled", false);
-            }
+        if (_enableInverseKinematics) {
+            _animVars.set("ikOverlayAlpha", 1.0f);
+        } else {
+            _animVars.set("ikOverlayAlpha", 0.0f);
+            _animVars.set("splineIKEnabled", false);
+            _animVars.set("leftHandIKEnabled", false);
+            _animVars.set("rightHandIKEnabled", false);
+            _animVars.set("leftFootIKEnabled", false);
+            _animVars.set("rightFootIKEnabled", false);
+            _animVars.set("leftHandPoleVectorEnabled", false);
+            _animVars.set("rightHandPoleVectorEnabled", false);
+            _animVars.set("leftFootPoleVectorEnabled", false);
+            _animVars.set("rightFootPoleVectorEnabled", false);
         }
         _lastEnableInverseKinematics = _enableInverseKinematics;
     }

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1086,8 +1086,8 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
                 _animVars.set("leftFootPoleVectorEnabled", false);
                 _animVars.set("rightFootPoleVectorEnabled", false);
             }
-            _lastEnableInverseKinematics = _enableInverseKinematics;
         }
+        _lastEnableInverseKinematics = _enableInverseKinematics;
     }
     _lastForward = forward;
     _lastPosition = worldPosition;


### PR DESCRIPTION
This pr addresses the ik being on by default in desktop mode.
https://highfidelity.manuscript.com/f/cases/21419/ik-is-on-by-default-in-desktop-mode

### Test Plan
1) open interface in desktop mode
2) hold down shift and an arrow key to strafe left and or right
Result: Strafing should look normal
3) go into hmd mode and the ik on the spine and arms and legs should be enabled.
4) take off the headset and try the strafing from step 2 again.  it should look normal, ie no ik interference.
5) finally make sure that you can disable ik in hmd mode.  go into hmd mode, go to developer/avatar/enable Inverse Kinematics  make sure that it is not checked.  then your arms should go to your sides, and knees will not bend when you bend your knees in real life