### PR TITLE
Case 21422: fix crash for nullptr deref when looking at recently uploaded avatar in inventory

### DIFF
--- a/interface/src/avatar/AvatarProject.cpp
+++ b/interface/src/avatar/AvatarProject.cpp
@@ -254,11 +254,15 @@ void AvatarProject::openInInventory() const {
         DependencyManager::get<TabletScriptingInterface>()->getTablet("com.highfidelity.interface.tablet.system"));
     tablet->loadQMLSource("hifi/commerce/wallet/Wallet.qml");
     DependencyManager::get<HMDScriptingInterface>()->openTablet();
-    tablet->getTabletRoot()->forceActiveFocus();
-    auto name = getProjectName();
 
     // I'm not a fan of this, but it's the only current option.
+    auto name = getProjectName();
     QTimer::singleShot(TIME_TO_WAIT_FOR_INVENTORY_TO_OPEN_MS, [name, tablet]() {
         tablet->sendToQml(QVariantMap({ { "method", "updatePurchases" }, { "filterText", name } }));
     });
+
+    QQuickItem* root = tablet->getTabletRoot();
+    if (root) {
+        root->forceActiveFocus();
+    }
 }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21422/Crash-when-trying-to-view-recently-uploaded-modified-avatar-in-inventory

This PR fixes a semi-reliable crash for nullptr deref.