### PR TITLE
Read and apply the upVector parameter when importing FBX files

### DIFF
--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -484,7 +484,9 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
                                 constexpr int UP_AXIS_Y = 1;
                                 constexpr int UP_AXIS_Z = 2;
                                 int upAxis = subobject.properties.at(index).toInt();
-                                if (upAxis == UP_AXIS_Z) {
+                                if (upAxis == UP_AXIS_Y) {
+                                    // No update necessary, y up is the default
+                                } else if (upAxis == UP_AXIS_Z) {
                                     upAxisZRotation = glm::angleAxis(glm::radians(-90.0f), glm::vec3(1.0f, 0.0f, 0.0f));
                                     applyUpAxisZRotation = true;
                                 }

--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -167,7 +167,6 @@ glm::mat4 getGlobalTransform(const QMultiMap<QString, QString>& _connectionParen
             }
         }
     }
-
     return globalTransform;
 }
 
@@ -436,6 +435,8 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
     hfmModel.originalURL = url;
 
     float unitScaleFactor = 1.0f;
+    glm::quat upAxisZRotation;
+    bool applyUpAxisZRotation = false;
     glm::vec3 ambientColor;
     QString hifiGlobalNodeID;
     unsigned int meshIndex = 0;
@@ -473,11 +474,20 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
                         if (subobject.name == propertyName) {
                             static const QVariant UNIT_SCALE_FACTOR = QByteArray("UnitScaleFactor");
                             static const QVariant AMBIENT_COLOR = QByteArray("AmbientColor");
+                            static const QVariant UP_AXIS = QByteArray("UpAxis");
                             const auto& subpropName = subobject.properties.at(0);
                             if (subpropName == UNIT_SCALE_FACTOR) {
                                 unitScaleFactor = subobject.properties.at(index).toFloat();
                             } else if (subpropName == AMBIENT_COLOR) {
                                 ambientColor = getVec3(subobject.properties, index);
+                            } else if (subpropName == UP_AXIS) {
+                                constexpr int UP_AXIS_Y = 1;
+                                constexpr int UP_AXIS_Z = 2;
+                                int upAxis = subobject.properties.at(index).toInt();
+                                if (upAxis == UP_AXIS_Z) {
+                                    upAxisZRotation = glm::angleAxis(glm::radians(-90.0f), glm::vec3(1.0f, 0.0f, 0.0f));
+                                    applyUpAxisZRotation = true;
+                                }
                             }
                         }
                     }
@@ -1271,7 +1281,6 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
         hfmModel.hasSkeletonJoints = (hfmModel.hasSkeletonJoints || joint.isSkeletonJoint);
 
         glm::quat combinedRotation = joint.preRotation * joint.rotation * joint.postRotation;
-
         if (joint.parentIndex == -1) {
             joint.transform = hfmModel.offset * glm::translate(joint.translation) * joint.preTransform *
                 glm::mat4_cast(combinedRotation) * joint.postTransform;
@@ -1664,6 +1673,9 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
         }
     }
 
+    if (applyUpAxisZRotation) {
+        hfmModelPtr->bindExtents.rotate(upAxisZRotation);
+    }
     return hfmModelPtr;
 }
 

--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -1281,7 +1281,9 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
         joint.geometricScaling = fbxModel.geometricScaling;
         joint.isSkeletonJoint = fbxModel.isLimbNode;
         hfmModel.hasSkeletonJoints = (hfmModel.hasSkeletonJoints || joint.isSkeletonJoint);
-
+        if (applyUpAxisZRotation && joint.parentIndex == -1 && !joint.isSkeletonJoint) {
+            joint.rotation *= upAxisZRotation;
+        }
         glm::quat combinedRotation = joint.preRotation * joint.rotation * joint.postRotation;
         if (joint.parentIndex == -1) {
             joint.transform = hfmModel.offset * glm::translate(joint.translation) * joint.preTransform *
@@ -1676,6 +1678,7 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
     }
 
     if (applyUpAxisZRotation) {
+        hfmModelPtr->meshExtents.rotate(upAxisZRotation);
         hfmModelPtr->bindExtents.rotate(upAxisZRotation);
     }
     return hfmModelPtr;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20953/FBX-UpAxis-setting-is-being-ignored
This PR takes into account the upVector parameter from FBX files and apply a -90 rotation on the X axis when the upVector is Z (instead of the Y default value)