### PR TITLE
case 21447: fixed quest debug crash when a case of  _widths = 0 for polyline

### DIFF
--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -183,10 +183,6 @@ void PolyLineEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPo
 
 void PolyLineEntityRenderer::updateGeometry() {
     int maxNumVertices = std::min(_points.length(), _normals.length());
-
-    qDebug()<<"QQQ_ widths size: "<< _widths.size();
-    qDebug()<<"QQQ_ MaxNumbVertices: "<<maxNumVertices;
-
     bool doesStrokeWidthVary = false;
     if (_widths.size() > 0) {
         for (int i = 1; i < maxNumVertices; i++) {
@@ -215,8 +211,9 @@ void PolyLineEntityRenderer::updateGeometry() {
         glm::vec3 point = _points[i];
 
         float width=PolyLineEntityItem::DEFAULT_LINE_WIDTH;
-        if(_widths.size()>0 && i < _widths.size())
+        if(_widths.size()>0 && i < _widths.size()) {
             width = _widths[i];
+        }
 
         if (i > 0) { // First uCoord is 0.0f
             if (!_isUVModeStretch) {

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -184,8 +184,11 @@ void PolyLineEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPo
 void PolyLineEntityRenderer::updateGeometry() {
     int maxNumVertices = std::min(_points.length(), _normals.length());
 
+    qDebug()<<"QQQ_ widths size: "<< _widths.size();
+    qDebug()<<"QQQ_ MaxNumbVertices: "<<maxNumVertices;
+
     bool doesStrokeWidthVary = false;
-    if (_widths.size() >= 0) {
+    if (_widths.size() > 0) {
         for (int i = 1; i < maxNumVertices; i++) {
             float width = PolyLineEntityItem::DEFAULT_LINE_WIDTH;
             if (i < _widths.length()) {
@@ -206,12 +209,15 @@ void PolyLineEntityRenderer::updateGeometry() {
 
     std::vector<PolylineVertex> vertices;
     vertices.reserve(maxNumVertices);
+
     for (int i = 0; i < maxNumVertices; i++) {
         // Position
         glm::vec3 point = _points[i];
 
-        // uCoord
-        float width = i < _widths.size() ? _widths[i] : PolyLineEntityItem::DEFAULT_LINE_WIDTH;
+        float width=PolyLineEntityItem::DEFAULT_LINE_WIDTH;
+        if(_widths.size()>0 && i < _widths.size())
+            width = _widths[i];
+
         if (i > 0) { // First uCoord is 0.0f
             if (!_isUVModeStretch) {
                 accumulatedDistance += glm::distance(point, _points[i - 1]);

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -209,11 +209,7 @@ void PolyLineEntityRenderer::updateGeometry() {
     for (int i = 0; i < maxNumVertices; i++) {
         // Position
         glm::vec3 point = _points[i];
-
-        float width=PolyLineEntityItem::DEFAULT_LINE_WIDTH;
-        if(_widths.size()>0 && i < _widths.size()) {
-            width = _widths[i];
-        }
+        float width = i < _widths.size() ? _widths[i] : PolyLineEntityItem::DEFAULT_LINE_WIDTH;
 
         if (i > 0) { // First uCoord is 0.0f
             if (!_isUVModeStretch) {

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -185,15 +185,17 @@ void PolyLineEntityRenderer::updateGeometry() {
     int maxNumVertices = std::min(_points.length(), _normals.length());
     bool doesStrokeWidthVary = false;
     if (_widths.size() > 0) {
+        float prevWidth = _widths[0];
         for (int i = 1; i < maxNumVertices; i++) {
-            float width = PolyLineEntityItem::DEFAULT_LINE_WIDTH;
-            if (i < _widths.length()) {
-                width = _widths[i];
-            }
-            if (width != _widths[i - 1]) {
+            float width = i < _widths.length() ? _widths[i] : PolyLineEntityItem::DEFAULT_LINE_WIDTH;
+            if (width != prevWidth) {
                 doesStrokeWidthVary = true;
                 break;
             }
+            if (i > _widths.length() + 1) {
+                break;
+            }
+            prevWidth = width;
         }
     }
 
@@ -209,6 +211,7 @@ void PolyLineEntityRenderer::updateGeometry() {
     for (int i = 0; i < maxNumVertices; i++) {
         // Position
         glm::vec3 point = _points[i];
+        // uCoord
         float width = i < _widths.size() ? _widths[i] : PolyLineEntityItem::DEFAULT_LINE_WIDTH;
 
         if (i > 0) { // First uCoord is 0.0f


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21447/Quest-crashes-on-tablet-interaction-in-debugFixed issue where _widths index check was causing a crash in cases where _widths - =0l

Test::

Create a debug build
Start app,
Open tablet and point at it
Test that lasers render and the app does not crash