### PR TITLE
FarGrab Entity Rotation with Off-Hand

### DIFF
--- a/scripts/system/controllers/controllerModules/farGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farGrabEntity.js
@@ -88,7 +88,7 @@ Script.include("/~/system/libraries/controllers.js");
 
         this.getOtherModule = function () {
             // Used to fetch other module.
-            return getEnabledModuleByName(this.hand === RIGHT_HAND ? ("RightFarGrabEntity") : ("LeftFarGrabEntity"));
+            return getEnabledModuleByName(this.hand === RIGHT_HAND ? ("LeftFarGrabEntity") : ("RightFarGrabEntity"));
         };
 
         this.getTargetRotation = function () {
@@ -105,7 +105,7 @@ Script.include("/~/system/libraries/controllers.js");
         }
 
         this.getOffhandTrigger = function () {
-            return (_this.hand === RIGHT_HAND ? _this.rightTrigger : _this.leftTrigger);
+            return (_this.hand === RIGHT_HAND ? _this.leftTrigger : _this.rightTrigger);
         }
 
         this.shouldManipulateTarget = function () {

--- a/scripts/system/controllers/controllerModules/farGrabEntity.js
+++ b/scripts/system/controllers/controllerModules/farGrabEntity.js
@@ -83,14 +83,11 @@ Script.include("/~/system/libraries/controllers.js");
             100,
             makeLaserParams(this.hand, false));
 
-        //enableDispatcherModule("LeftFarGrabEntity", leftFarGrabEntity);
-        //enableDispatcherModule("RightFarGrabEntity", rightFarGrabEntity);
-
         this.getOtherModule = function () {
-            // Used to fetch other module.
             return getEnabledModuleByName(this.hand === RIGHT_HAND ? ("LeftFarGrabEntity") : ("RightFarGrabEntity"));
         };
 
+        // Get the rotation of the fargrabbed entity.
         this.getTargetRotation = function () {
             if (this.targetIsNull()) {
                 return null;
@@ -108,10 +105,12 @@ Script.include("/~/system/libraries/controllers.js");
             return (_this.hand === RIGHT_HAND ? _this.leftTrigger : _this.rightTrigger);
         }
 
+        // Activation criteria for rotating a fargrabbed entity. If we're changing the mapping, this is where to do it.
         this.shouldManipulateTarget = function () {
             return (_this.getOffhandTrigger() > TRIGGER_ON_VALUE) ? true : false;
         };
 
+        // Get the delta between the current rotation and where the controller was when manipulation started.
         this.calculateEntityRotationManipulation = function (controllerRotation) {
             return Quat.multiply(controllerRotation, Quat.inverse(this.initialControllerRotation));
         };
@@ -303,11 +302,14 @@ Script.include("/~/system/libraries/controllers.js");
                 this.lastJointRotation = Quat.multiply(doubleRot, this.initialEntityRotation);
                 this.setJointRotation(this.lastJointRotation);
             } else {
+                // If we were manipulating but the user isn't currently expressing this intent, we want to know so we preserve the rotation
+                // between manipulations without ending the fargrab.
                 if (this.manipulating) {
                     this.initialEntityRotation = this.lastJointRotation;
                     this.wasManipulating = true;
                 }
                 this.manipulating = false;
+                // Reset the inital controller position.
                 this.initialControllerRotation = Quat.IDENTITY;
             }
             this.setJointTranslation(newTargetPosLocal);


### PR DESCRIPTION
Experiment involving the ability to rotate the entity that you're fargrabbing with your off hand. In order to test:

1.) FarGrab an entity with either hand.
2.) On your offhand controller (i.e. the one that is _not_ performing a FarGrab) pull the trigger.
3.) Rotate your wrist to rotate the object. Release the offhand controller trigger when done.

ticket is found here https://highfidelity.fogbugz.com/f/cases/21487/Feature-Manipulate-Rotate-FarGrabbed-Item-with-Off-Hand