### PR TITLE
case 21149: add a button to Avatar panel to lock or unlock wearables; allow others to grab unlocked wearables

### DIFF
--- a/interface/resources/qml/hifi/AvatarApp.qml
+++ b/interface/resources/qml/hifi/AvatarApp.qml
@@ -16,6 +16,8 @@ Rectangle {
     property bool keyboardRaised: false
     property bool punctuationMode: false
 
+    HifiConstants { id: hifi }
+
     HifiControls.Keyboard {
         id: keyboard
         z: 1000
@@ -48,6 +50,7 @@ Rectangle {
 
     property var jointNames: []
     property var currentAvatarSettings;
+    property bool wearablesLocked;
 
     function fetchAvatarModelName(marketId, avatar) {
         var xmlhttp = new XMLHttpRequest();
@@ -187,6 +190,8 @@ Rectangle {
             updateCurrentAvatarInBookmarks(currentAvatar);
         } else if (message.method === 'selectAvatarEntity') {
             adjustWearables.selectWearableByID(message.entityID);
+        } else if (message.method === 'wearablesLockedChanged') {
+            wearablesLocked = message.wearablesLocked;
         }
     }
 
@@ -507,12 +512,24 @@ Rectangle {
         }
 
         SquareLabel {
+            id: adjustLabel
             anchors.right: parent.right
             anchors.verticalCenter: wearablesLabel.verticalCenter
             glyphText: "\ue02e"
 
             onClicked: {
                 adjustWearables.open(currentAvatar);
+            }
+        }
+
+        SquareLabel {
+            anchors.right: adjustLabel.left
+            anchors.verticalCenter: wearablesLabel.verticalCenter
+            anchors.rightMargin: 15
+            glyphText: wearablesLocked ? hifi.glyphs.lock : hifi.glyphs.unlock;
+
+            onClicked: {
+                emitSendToScript({'method' : 'toggleWearablesLock'});
             }
         }
     }

--- a/interface/resources/qml/hifi/AvatarApp.qml
+++ b/interface/resources/qml/hifi/AvatarApp.qml
@@ -50,7 +50,7 @@ Rectangle {
 
     property var jointNames: []
     property var currentAvatarSettings;
-    property bool wearablesLocked;
+    property bool wearablesFrozen;
 
     function fetchAvatarModelName(marketId, avatar) {
         var xmlhttp = new XMLHttpRequest();
@@ -190,8 +190,8 @@ Rectangle {
             updateCurrentAvatarInBookmarks(currentAvatar);
         } else if (message.method === 'selectAvatarEntity') {
             adjustWearables.selectWearableByID(message.entityID);
-        } else if (message.method === 'wearablesLockedChanged') {
-            wearablesLocked = message.wearablesLocked;
+        } else if (message.method === 'wearablesFrozenChanged') {
+            wearablesFrozen = message.wearablesFrozen;
         }
     }
 
@@ -526,10 +526,10 @@ Rectangle {
             anchors.right: adjustLabel.left
             anchors.verticalCenter: wearablesLabel.verticalCenter
             anchors.rightMargin: 15
-            glyphText: wearablesLocked ? hifi.glyphs.lock : hifi.glyphs.unlock;
+            glyphText: wearablesFrozen ? hifi.glyphs.lock : hifi.glyphs.unlock;
 
             onClicked: {
-                emitSendToScript({'method' : 'toggleWearablesLock'});
+                emitSendToScript({'method' : 'toggleWearablesFrozen'});
             }
         }
     }

--- a/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
+++ b/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
@@ -113,6 +113,7 @@ Rectangle {
                 } else if (prop === 'dimensions') {
                     scalespinner.set(wearable[prop].x / wearable.naturalDimensions.x);
                 }
+                modified = true;
             }
         }
 

--- a/interface/resources/qml/stylesUit/+android_interface/HifiConstants.qml
+++ b/interface/resources/qml/stylesUit/+android_interface/HifiConstants.qml
@@ -344,6 +344,7 @@ Item {
         readonly property string stop_square: "\ue01e"
         readonly property string avatarTPose: "\ue01f"
         readonly property string lock: "\ue006"
+        readonly property string unlock: "\ue039"
         readonly property string checkmark: "\ue020"
         readonly property string leftRightArrows: "\ue021"
         readonly property string hfc: "\ue022"

--- a/interface/resources/qml/stylesUit/HifiConstants.qml
+++ b/interface/resources/qml/stylesUit/HifiConstants.qml
@@ -330,6 +330,7 @@ QtObject {
         readonly property string stop_square: "\ue01e"
         readonly property string avatarTPose: "\ue01f"
         readonly property string lock: "\ue006"
+        readonly property string unlock: "\ue039"
         readonly property string checkmark: "\ue020"
         readonly property string leftRightArrows: "\ue021"
         readonly property string hfc: "\ue022"

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2170,7 +2170,7 @@ private:
     bool getEnableStepResetRotation() const { return _stepResetRotationEnabled; }
     void setEnableDrawAverageFacing(bool drawAverage) { _drawAverageFacingEnabled = drawAverage; }
     bool getEnableDrawAverageFacing() const { return _drawAverageFacingEnabled; }
-    bool isMyAvatar() const override { return true; }
+    virtual bool isMyAvatar() const override { return true; }
     virtual int parseDataFromBuffer(const QByteArray& buffer) override;
     virtual glm::vec3 getSkeletonPosition() const override;
     int _skeletonModelChangeCount { 0 };

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -365,7 +365,7 @@ void OtherAvatar::handleChangedAvatarEntityData() {
     // AVATAR ENTITY UPDATE FLOW
     // - if queueEditEntityMessage() sees "AvatarEntity" HostType it calls _myAvatar->storeAvatarEntityDataPayload()
     // - storeAvatarEntityDataPayload() saves the payload and flags the trait instance for the entity as updated,
-    // - ClientTraitsHandler::sendChangedTraitsToMixea() sends the entity bytes to the mixer which relays them to other interfaces
+    // - ClientTraitsHandler::sendChangedTraitsToMixer() sends the entity bytes to the mixer which relays them to other interfaces
     // - AvatarHashMap::processBulkAvatarTraits() on other interfaces calls avatar->processTraitInstance()
     // - AvatarData::processTraitInstance() calls storeAvatarEntityDataPayload(), which sets _avatarEntityDataChanged = true
     // - (My)Avatar::simulate() calls handleChangedAvatarEntityData() every frame which checks _avatarEntityDataChanged

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -495,6 +495,18 @@ void OtherAvatar::handleChangedAvatarEntityData() {
                 const QUuid NULL_ID = QUuid("{00000000-0000-0000-0000-000000000005}");
                 entity->setParentID(NULL_ID);
                 entity->setParentID(oldParentID);
+
+                if (entity->stillHasMyGrabAction()) {
+                    // For this case: we want to ignore transform+velocities coming from authoritative OtherAvatar
+                    // because the MyAvatar is grabbing and we expect the local grab state
+                    // to have enough information to prevent simulation drift.
+                    //
+                    // Clever readers might realize this could cause problems.  For example,
+                    // if an ignored OtherAvagtar were to simultanously grab the object then there would be
+                    // a noticeable discrepancy between participants in the distributed physics simulation,
+                    // however the difference would be stable and would not drift.
+                    properties.clearTransformOrVelocityChanges();
+                }
                 if (entityTree->updateEntity(entityID, properties)) {
                     entity->updateLastEditedFromRemote();
                 } else {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -372,23 +372,6 @@ bool Avatar::applyGrabChanges() {
                 target->removeGrab(grab);
                 _avatarGrabs.erase(itr);
                 grabAddedOrRemoved = true;
-                const EntityItemPointer& entity = std::dynamic_pointer_cast<EntityItem>(target);
-                if (entity && entity->getEntityHostType() == entity::HostType::AVATAR) {
-                    // grabs are able to move avatar-entities which belong ot other avatars (assuming
-                    // the entities are grabbable, unlocked, etc).  Regardless of who released the grab
-                    // on this entity, the entity's owner needs to send off an update.
-                    QUuid entityOwnerID = entity->getOwningAvatarID();
-                    if (entityOwnerID == getMyAvatarID() || entityOwnerID == AVATAR_SELF_ID) {
-                        bool success;
-                        SpatiallyNestablePointer myAvatarSN = SpatiallyNestable::findByID(entityOwnerID, success);
-                        if (success) {
-                            std::shared_ptr<Avatar> myAvatar = std::dynamic_pointer_cast<Avatar>(myAvatarSN);
-                            if (myAvatar) {
-                                myAvatar->sendPacket(entity->getID());
-                            }
-                        }
-                    }
-                }
             } else {
                 undeleted.push_back(id);
             }
@@ -2112,13 +2095,4 @@ void Avatar::updateDescendantRenderIDs() {
             });
         }
     });
-}
-
-QUuid Avatar::getMyAvatarID() const  {
-    auto nodeList = DependencyManager::get<NodeList>();
-    if (nodeList) {
-        return nodeList->getSessionUUID();
-    } else {
-        return QUuid();
-    }
 }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -384,8 +384,7 @@ bool Avatar::applyGrabChanges() {
                         if (success) {
                             std::shared_ptr<Avatar> myAvatar = std::dynamic_pointer_cast<Avatar>(myAvatarSN);
                             if (myAvatar) {
-                                EntityItemProperties properties = entity->getProperties();
-                                myAvatar->sendPacket(entity->getID(), properties);
+                                myAvatar->sendPacket(entity->getID());
                             }
                         }
                     }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -372,11 +372,22 @@ bool Avatar::applyGrabChanges() {
                 target->removeGrab(grab);
                 _avatarGrabs.erase(itr);
                 grabAddedOrRemoved = true;
-                if (isMyAvatar()) {
-                    const EntityItemPointer& entity = std::dynamic_pointer_cast<EntityItem>(target);
-                    if (entity && entity->getEntityHostType() == entity::HostType::AVATAR && entity->getSimulationOwner().getID() == getID()) {
-                        EntityItemProperties properties = entity->getProperties();
-                        sendPacket(entity->getID());
+                const EntityItemPointer& entity = std::dynamic_pointer_cast<EntityItem>(target);
+                if (entity && entity->getEntityHostType() == entity::HostType::AVATAR) {
+                    // grabs are able to move avatar-entities which belong ot other avatars (assuming
+                    // the entities are grabbable, unlocked, etc).  Regardless of who released the grab
+                    // on this entity, the entity's owner needs to send off an update.
+                    QUuid entityOwnerID = entity->getOwningAvatarID();
+                    if (entityOwnerID == getMyAvatarID() || entityOwnerID == AVATAR_SELF_ID) {
+                        bool success;
+                        SpatiallyNestablePointer myAvatarSN = SpatiallyNestable::findByID(entityOwnerID, success);
+                        if (success) {
+                            std::shared_ptr<Avatar> myAvatar = std::dynamic_pointer_cast<Avatar>(myAvatarSN);
+                            if (myAvatar) {
+                                EntityItemProperties properties = entity->getProperties();
+                                myAvatar->sendPacket(entity->getID(), properties);
+                            }
+                        }
                     }
                 }
             } else {
@@ -2102,4 +2113,13 @@ void Avatar::updateDescendantRenderIDs() {
             });
         }
     });
+}
+
+QUuid Avatar::getMyAvatarID() const  {
+    auto nodeList = DependencyManager::get<NodeList>();
+    if (nodeList) {
+        return nodeList->getSessionUUID();
+    } else {
+        return QUuid();
+    }
 }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -180,7 +180,8 @@ public:
     /// Returns the distance to use as a LOD parameter.
     float getLODDistance() const;
 
-    virtual bool isMyAvatar() const override { return false; }
+    QUuid getMyAvatarID() const;
+
     virtual void createOrb() { }
 
     enum class LoadingStatus {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -180,8 +180,6 @@ public:
     /// Returns the distance to use as a LOD parameter.
     float getLODDistance() const;
 
-    QUuid getMyAvatarID() const;
-
     virtual void createOrb() { }
 
     enum class LoadingStatus {

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -124,8 +124,8 @@ public:
         { return (float)(usecTimestampNow() - getLastEdited()) / (float)USECS_PER_SECOND; }
 
     /// Last time we sent out an edit packet for this entity
-    quint64 getLastBroadcast() const;
-    void setLastBroadcast(quint64 lastBroadcast);
+    quint64 getLastBroadcast() const { return _lastBroadcast; }
+    void setLastBroadcast(quint64 lastBroadcast) { _lastBroadcast = lastBroadcast; }
 
     void markAsChangedOnServer();
     quint64 getLastChangedOnServer() const;
@@ -562,6 +562,8 @@ public:
     static void setPrimaryViewFrustumPositionOperator(std::function<glm::vec3()> getPrimaryViewFrustumPositionOperator) { _getPrimaryViewFrustumPositionOperator = getPrimaryViewFrustumPositionOperator; }
     static glm::vec3 getPrimaryViewFrustumPosition() { return _getPrimaryViewFrustumPositionOperator(); }
 
+    bool stillHasMyGrabAction() const;
+
 signals:
     void requestRenderUpdate();
     void spaceUpdate(std::pair<int32_t, glm::vec4> data);
@@ -574,7 +576,7 @@ protected:
     void setSimulated(bool simulated) { _simulated = simulated; }
 
     const QByteArray getDynamicDataInternal() const;
-    bool stillHasGrabActions() const;
+    bool stillHasGrabAction() const;
     void setDynamicDataInternal(QByteArray dynamicData);
 
     virtual void dimensionsChanged() override;

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -1101,13 +1101,13 @@ void EntityScriptingInterface::handleEntityScriptCallMethodPacket(QSharedPointer
 
 void EntityScriptingInterface::onAddingEntity(EntityItem* entity) {
     if (entity->isWearable()) {
-        emit addingWearable(entity->getEntityItemID());
+        QMetaObject::invokeMethod(this, "addingWearable", Q_ARG(QUuid, entity->getEntityItemID()));
     }
 }
 
 void EntityScriptingInterface::onDeletingEntity(EntityItem* entity) {
     if (entity->isWearable()) {
-        emit deletingWearable(entity->getEntityItemID());
+        QMetaObject::invokeMethod(this, "deletingWearable", Q_ARG(QUuid, entity->getEntityItemID()));
     }
 }
 

--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -77,7 +77,7 @@ function updateAvatarWearables(avatar, callback, wearablesOverride) {
         avatar[ENTRY_AVATAR_ENTITIES] = wearables;
 
         sendToQml({'method' : 'wearablesUpdated', 'wearables' : wearables});
-        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
 
         if(callback)
             callback();
@@ -179,26 +179,26 @@ var MARKETPLACE_PURCHASES_QML_PATH = "hifi/commerce/wallet/Wallet.qml";
 var MARKETPLACE_URL = Account.metaverseServerURL + "/marketplace";
 var MARKETPLACES_INJECT_SCRIPT_URL = Script.resolvePath("html/js/marketplacesInject.js");
 
-function getWearablesLocked() {
-    var wearablesLocked = true;
+function getWearablesFrozen() {
+    var wearablesFrozen = true;
     var wearablesArray = getMyAvatarWearables();
     wearablesArray.forEach(function(wearable) {
         if (isGrabbable(wearable.id)) {
-            wearablesLocked = false;
+            wearablesFrozen = false;
         }
     });
 
-    return wearablesLocked;
+    return wearablesFrozen;
 }
 
-function lockWearables() {
+function freezeWearables() {
     var wearablesArray = getMyAvatarWearables();
     wearablesArray.forEach(function(wearable) {
         setGrabbable(wearable.id, false);
     });
 }
 
-function unlockWearables() {
+function unfreezeWearables() {
     var wearablesArray = getMyAvatarWearables();
     wearablesArray.forEach(function(wearable) {
         setGrabbable(wearable.id, true);
@@ -237,7 +237,7 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
         AvatarBookmarks.loadBookmark(message.name);
         Entities.addingWearable.connect(onAddingWearable);
         Entities.deletingWearable.connect(onDeletingWearable);
-        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
         break;
     case 'deleteAvatar':
         AvatarBookmarks.removeBookmark(message.name);
@@ -262,7 +262,7 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
     case 'adjustWearablesOpened':
         currentAvatarWearablesBackup = getMyAvatarWearables();
         adjustWearables.setOpened(true);
-        unlockWearables();
+        unfreezeWearables();
 
         Entities.mousePressOnEntity.connect(onSelectedEntity);
         Messages.subscribe('Hifi-Object-Manipulation');
@@ -377,15 +377,15 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
 
         currentAvatarSettings = getMyAvatarSettings();
         break;
-    case 'toggleWearablesLock':
-        var wearablesLocked = getWearablesLocked();
-        wearablesLocked = !wearablesLocked;
-        if (wearablesLocked) {
-            lockWearables();
+    case 'toggleWearablesFrozen':
+        var wearablesFrozen = getWearablesFrozen();
+        wearablesFrozen = !wearablesFrozen;
+        if (wearablesFrozen) {
+            freezeWearables();
         } else {
-            unlockWearables();
+            unfreezeWearables();
         }
-        sendToQml({'method' : 'wearablesLockedChanged', 'wearablesLocked' : wearablesLocked});
+        sendToQml({'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : wearablesFrozen});
         break;
     default:
         print('Unrecognized message from AvatarApp.qml');
@@ -410,7 +410,7 @@ function setGrabbable(entityID, grabbable) {
     if (properties.avatarEntity && properties.grab.grabbable != grabbable) {
         var editProps = { grab: { grabbable: grabbable }};
         Entities.editEntity(entityID, editProps);
-        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
     }
 }
 
@@ -444,14 +444,14 @@ function onAddingWearable(entityID) {
     updateAvatarWearables(currentAvatar, function() {
         sendToQml({'method' : 'updateAvatarInBookmarks'});
     });
-    sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+    sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
 }
 
 function onDeletingWearable(entityID) {
     updateAvatarWearables(currentAvatar, function() {
         sendToQml({'method' : 'updateAvatarInBookmarks'});
     });
-    sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+    sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
 }
 
 function handleWearableMessages(channel, message, sender) {
@@ -635,7 +635,7 @@ function onTabletScreenChanged(type, url) {
 
     if(onAvatarAppScreenNow) {
         sendToQml({ 'method' : 'initialize', 'data' : { jointNames : MyAvatar.getJointNames() }});
-        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
     }
 }
 

--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -262,7 +262,7 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
     case 'adjustWearablesOpened':
         currentAvatarWearablesBackup = getMyAvatarWearables();
         adjustWearables.setOpened(true);
-        lockWearables();
+        unlockWearables();
 
         Entities.mousePressOnEntity.connect(onSelectedEntity);
         Messages.subscribe('Hifi-Object-Manipulation');

--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -16,7 +16,6 @@
 
 (function() { // BEGIN LOCAL_SCOPE
 
-// var request = Script.require('request').request;
 var AVATARAPP_QML_SOURCE = "hifi/AvatarApp.qml";
 Script.include("/~/system/libraries/controllers.js");
 
@@ -24,7 +23,6 @@ Script.include("/~/system/libraries/controllers.js");
 var ENTRY_AVATAR_URL = "avatarUrl";
 var ENTRY_AVATAR_ENTITIES = "avatarEntites";
 var ENTRY_AVATAR_SCALE = "avatarScale";
-// var ENTRY_VERSION = "version";
 
 function executeLater(callback) {
     Script.setTimeout(callback, 300);
@@ -79,7 +77,7 @@ function updateAvatarWearables(avatar, callback, wearablesOverride) {
         avatar[ENTRY_AVATAR_ENTITIES] = wearables;
 
         sendToQml({'method' : 'wearablesUpdated', 'wearables' : wearables});
-        sendToQml({ method : 'wearablesLockedChanged', wearablesLocked : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
 
         if(callback)
             callback();
@@ -174,7 +172,6 @@ function onAnimGraphUrlChanged(url) {
     }
 }
 
-var selectedAvatarEntityGrabbable = false;
 var selectedAvatarEntityID = null;
 var grabbedAvatarEntityChangeNotifier = null;
 
@@ -240,7 +237,7 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
         AvatarBookmarks.loadBookmark(message.name);
         Entities.addingWearable.connect(onAddingWearable);
         Entities.deletingWearable.connect(onDeletingWearable);
-        sendToQml({ method : 'wearablesLockedChanged', wearablesLocked : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
         break;
     case 'deleteAvatar':
         AvatarBookmarks.removeBookmark(message.name);
@@ -265,6 +262,7 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
     case 'adjustWearablesOpened':
         currentAvatarWearablesBackup = getMyAvatarWearables();
         adjustWearables.setOpened(true);
+        lockWearables();
 
         Entities.mousePressOnEntity.connect(onSelectedEntity);
         Messages.subscribe('Hifi-Object-Manipulation');
@@ -409,10 +407,10 @@ function isGrabbable(entityID) {
 
 function setGrabbable(entityID, grabbable) {
     var properties = Entities.getEntityProperties(entityID, ['avatarEntity', 'grab.grabbable']);
-    if (properties.avatarEntity && properties.grab.grabable != grabbable) {
+    if (properties.avatarEntity && properties.grab.grabbable != grabbable) {
         var editProps = { grab: { grabbable: grabbable }};
         Entities.editEntity(entityID, editProps);
-        sendToQml({ method : 'wearablesLockedChanged', wearablesLocked : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
     }
 }
 
@@ -422,18 +420,7 @@ function ensureWearableSelected(entityID) {
             Script.clearInterval(grabbedAvatarEntityChangeNotifier);
             grabbedAvatarEntityChangeNotifier = null;
         }
-
-        if(selectedAvatarEntityID !== null) {
-            setGrabbable(selectedAvatarEntityID, selectedAvatarEntityGrabbable);
-        }
-
         selectedAvatarEntityID = entityID;
-        selectedAvatarEntityGrabbable = isGrabbable(entityID);
-
-        if(selectedAvatarEntityID !== null) {
-            setGrabbable(selectedAvatarEntityID, true);
-        }
-
         return true;
     }
 
@@ -457,14 +444,14 @@ function onAddingWearable(entityID) {
     updateAvatarWearables(currentAvatar, function() {
         sendToQml({'method' : 'updateAvatarInBookmarks'});
     });
-    sendToQml({ method : 'wearablesLockedChanged', wearablesLocked : getWearablesLocked()});
+    sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
 }
 
 function onDeletingWearable(entityID) {
     updateAvatarWearables(currentAvatar, function() {
         sendToQml({'method' : 'updateAvatarInBookmarks'});
     });
-    sendToQml({ method : 'wearablesLockedChanged', wearablesLocked : getWearablesLocked()});
+    sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
 }
 
 function handleWearableMessages(channel, message, sender) {
@@ -647,8 +634,8 @@ function onTabletScreenChanged(type, url) {
     onAvatarAppScreen = onAvatarAppScreenNow;
 
     if(onAvatarAppScreenNow) {
-        sendToQml({ method : 'initialize', data : { jointNames : MyAvatar.getJointNames() }});
-        sendToQml({ method : 'wearablesLockedChanged', wearablesLocked : getWearablesLocked()});
+        sendToQml({ 'method' : 'initialize', 'data' : { jointNames : MyAvatar.getJointNames() }});
+        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
     }
 }
 

--- a/scripts/system/libraries/controllerDispatcherUtils.js
+++ b/scripts/system/libraries/controllerDispatcherUtils.js
@@ -341,8 +341,6 @@ entityIsGrabbable = function (eigProps) {
     var grabbable = getGrabbableData(eigProps).grabbable;
     if (!grabbable ||
         eigProps.locked ||
-        isAnothersAvatarEntity(eigProps) ||
-        isAnothersChildEntity(eigProps) ||
         FORBIDDEN_GRAB_TYPES.indexOf(eigProps.type) >= 0) {
         return false;
     }


### PR DESCRIPTION
- add a button to Avatar panel to lock or unlock wearables
- allow other avatars to grab / adjust your unlocked wearables


https://highfidelity.manuscript.com/f/cases/21149/Add-Grabbable-Checkbox-to-Wearables-in-Avatar-App
https://highfidelity.manuscript.com/f/cases/21882/v-82-Allow-user-to-adjust-try-on-wearables-on-other-avatars
https://highfidelity.manuscript.com/f/cases/21901/82-0-Multiple-crashes-on-the-Avatar-app-after-attachment-lock-merge

Also fixed in this PR was a problem AndrewMeadows noticed while trying to make some other changes here acceptable:

https://highfidelity.manuscript.com/f/cases/21945/Grabbing-someone-else-s-unattached-AvatarEntities-can-suffer-from-extrapolation-overshoot