### PR TITLE
[MS#21495] Enable Bubble/Shield on Away

### DIFF
--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -65,7 +65,7 @@ var eventMappingName = "io.highfidelity.away"; // goActive on hand controller bu
 var eventMapping = Controller.newMapping(eventMappingName);
 var avatarPosition = MyAvatar.position;
 var wasHmdMounted = HMD.mounted;
-
+var previousBubbleState = Users.getIgnoreRadiusEnabled();
 
 // some intervals we may create/delete
 var avatarMovedInterval;
@@ -166,7 +166,12 @@ function goAway(fromStartup) {
             avatarMovedInterval = Script.setInterval(ifAvatarMovedGoActive, BASIC_TIMER_INTERVAL);
         }, WAIT_FOR_MOVE_ON_STARTUP);
     }
-    
+
+    previousBubbleState = Users.getIgnoreRadiusEnabled();
+    if (!previousBubbleState) {
+        Users.toggleIgnoreRadius();
+    }
+    UserActivityLogger.bubbleToggled(Users.getIgnoreRadiusEnabled());
     UserActivityLogger.toggledAway(true);
     MyAvatar.isAway = true;
 }
@@ -178,6 +183,11 @@ function goActive() {
 
     UserActivityLogger.toggledAway(false);
     MyAvatar.isAway = false;
+
+    if (Users.getIgnoreRadiusEnabled() !== previousBubbleState) {
+        Users.toggleIgnoreRadius();
+        UserActivityLogger.bubbleToggled(Users.getIgnoreRadiusEnabled());
+    }
 
     if (!Window.hasFocus()) {
         Window.setFocus();


### PR DESCRIPTION
Manuscript Ticket [here](https://highfidelity.fogbugz.com/f/cases/21495/Enable-Bubble-on-Away).

Given the amount of harassment that has been known to occur when a user enters away mode (especially on our platform, as they enter a kneeling position), it's a good idea we enable the protective Bubble (soon to be re-branded 'Shield') when a user enters AFK, automatically.

When the user returns from AFK, their bubble's state should be restored to what it was before they entered AFK, i.e.:

_**Case A:**_

1.) User had bubble **on**, entered AFK, bubble turns **on**.

2.) User returns from AFK, bubble should remain **on**.

_**Case B:**_

1.) User had bubble **off**, entered AFK, bubble turns **on**.

2.) User returns from AFK, bubble turns **off** again.