### PR TITLE
Case 19188: Potential 2D overlay + Tablet threading fixes

### DIFF
--- a/interface/src/ui/overlays/Overlay.cpp
+++ b/interface/src/ui/overlays/Overlay.cpp
@@ -16,8 +16,7 @@
 #include "Application.h"
 
 Overlay::Overlay() :
-    _renderItemID(render::Item::INVALID_ITEM_ID),
-    _visible(true)
+    _renderItemID(render::Item::INVALID_ITEM_ID)
 {
 }
 
@@ -32,20 +31,6 @@ void Overlay::setProperties(const QVariantMap& properties) {
         bool visible = properties["visible"].toBool();
         setVisible(visible);
     }
-}
-
-QVariant Overlay::getProperty(const QString& property) {
-    if (property == "type") {
-        return QVariant(getType());
-    }
-    if (property == "id") {
-        return getID();
-    }
-    if (property == "visible") {
-        return _visible;
-    }
-
-    return QVariant();
 }
 
 bool Overlay::addToScene(Overlay::Pointer overlay, const render::ScenePointer& scene, render::Transaction& transaction) {
@@ -65,7 +50,7 @@ render::ItemKey Overlay::getKey() {
     builder.withViewSpace();
     builder.withLayer(render::hifi::LAYER_2D);
 
-    if (!getVisible()) {
+    if (!_visible) {
         builder.withInvisible();
     }
 

--- a/interface/src/ui/overlays/Overlay.h
+++ b/interface/src/ui/overlays/Overlay.h
@@ -31,7 +31,6 @@ public:
 
     virtual render::ItemKey getKey();
     virtual AABox getBounds() const = 0;
-    virtual bool supportsGetProperty() const { return true; }
 
     virtual bool addToScene(Overlay::Pointer overlay, const render::ScenePointer& scene, render::Transaction& transaction);
     virtual void removeFromScene(Overlay::Pointer overlay, const render::ScenePointer& scene, render::Transaction& transaction);
@@ -42,17 +41,15 @@ public:
 
     // getters
     virtual QString getType() const = 0;
-    bool isLoaded() { return true; }
     bool getVisible() const { return _visible; }
 
     // setters
-    virtual void setVisible(bool visible) { _visible = visible; }
+    void setVisible(bool visible) { _visible = visible; }
     unsigned int getStackOrder() const { return _stackOrder; }
     void setStackOrder(unsigned int stackOrder) { _stackOrder = stackOrder; }
 
-    Q_INVOKABLE virtual void setProperties(const QVariantMap& properties);
+    Q_INVOKABLE virtual void setProperties(const QVariantMap& properties) = 0;
     Q_INVOKABLE virtual Overlay* createClone() const = 0;
-    Q_INVOKABLE virtual QVariant getProperty(const QString& property);
 
     render::ItemID getRenderItemID() const { return _renderItemID; }
     void setRenderItemID(render::ItemID renderItemID) { _renderItemID = renderItemID; }
@@ -60,7 +57,7 @@ public:
 protected:
     render::ItemID _renderItemID { render::Item::INVALID_ITEM_ID };
 
-    bool _visible;
+    bool _visible { true };
     unsigned int _stackOrder { 0 };
 
 private:

--- a/interface/src/ui/overlays/Overlay2D.cpp
+++ b/interface/src/ui/overlays/Overlay2D.cpp
@@ -66,23 +66,3 @@ void Overlay2D::setProperties(const QVariantMap& properties) {
         setBounds(newBounds);
     }
 }
-
-QVariant Overlay2D::getProperty(const QString& property) {
-    if (property == "bounds") {
-        return qRectToVariant(_bounds);
-    }
-    if (property == "x") {
-        return _bounds.x();
-    }
-    if (property == "y") {
-        return _bounds.y();
-    }
-    if (property == "width") {
-        return _bounds.width();
-    }
-    if (property == "height") {
-        return _bounds.height();
-    }
-
-    return Overlay::getProperty(property);
-}

--- a/interface/src/ui/overlays/Overlay2D.h
+++ b/interface/src/ui/overlays/Overlay2D.h
@@ -26,10 +26,6 @@ public:
     virtual uint32_t fetchMetaSubItems(render::ItemIDs& subItems) const override { subItems.push_back(getRenderItemID()); return 1; }
 
     // getters
-    int getX() const { return _bounds.x(); }
-    int getY() const { return _bounds.y(); }
-    int getWidth() const { return _bounds.width(); }
-    int getHeight() const { return _bounds.height(); }
     const QRect& getBoundingRect() const { return _bounds; }
 
     // setters
@@ -40,7 +36,6 @@ public:
     void setBounds(const QRect& bounds) { _bounds = bounds; }
 
     void setProperties(const QVariantMap& properties) override;
-    QVariant getProperty(const QString& property) override;
 
 protected:
     QRect _bounds; // where on the screen to draw

--- a/interface/src/ui/overlays/QmlOverlay.cpp
+++ b/interface/src/ui/overlays/QmlOverlay.cpp
@@ -57,29 +57,15 @@ QmlOverlay::~QmlOverlay() {
 
 // QmlOverlay replaces Overlay's properties with those defined in the QML file used but keeps Overlay2D's properties.
 void QmlOverlay::setProperties(const QVariantMap& properties) {
-    if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "setProperties", Q_ARG(QVariantMap, properties));
-        return;
-    }
-
     Overlay2D::setProperties(properties);
-    auto bounds = _bounds;
+
     // check to see if qmlElement still exists
     if (_qmlElement) {
-        _qmlElement->setX(bounds.left());
-        _qmlElement->setY(bounds.top());
-        _qmlElement->setWidth(bounds.width());
-        _qmlElement->setHeight(bounds.height());
-        QMetaObject::invokeMethod(_qmlElement, "updatePropertiesFromScript", Qt::DirectConnection, Q_ARG(QVariant, properties));
-    }
-}
-
-void QmlOverlay::render(RenderArgs* args) {
-    if (!_qmlElement) {
-        return;
-    }
-
-    if (_visible != _qmlElement->isVisible()) {
+        _qmlElement->setX(_bounds.left());
+        _qmlElement->setY(_bounds.top());
+        _qmlElement->setWidth(_bounds.width());
+        _qmlElement->setHeight(_bounds.height());
         _qmlElement->setVisible(_visible);
+        QMetaObject::invokeMethod(_qmlElement, "updatePropertiesFromScript", Qt::DirectConnection, Q_ARG(QVariant, properties));
     }
 }

--- a/interface/src/ui/overlays/QmlOverlay.h
+++ b/interface/src/ui/overlays/QmlOverlay.h
@@ -25,10 +25,8 @@ public:
     QmlOverlay(const QUrl& url, const QmlOverlay* overlay);
     ~QmlOverlay();
 
-    bool supportsGetProperty() const override { return false; }
-
     void setProperties(const QVariantMap& properties) override;
-    void render(RenderArgs* args) override;
+    void render(RenderArgs* args) override {}
 
 private:
     Q_INVOKABLE void qmlElementDestroyed();

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -458,6 +458,11 @@ void TabletProxy::emitWebEvent(const QVariant& msg) {
 }
 
 void TabletProxy::onTabletShown() {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "onTabletShown");
+        return;
+    }
+
     if (_tabletShown) {
         Setting::Handle<bool> notificationSounds{ QStringLiteral("play_notification_sounds"), true};
         Setting::Handle<bool> notificationSoundTablet{ QStringLiteral("play_notification_sounds_tablet"), true};
@@ -485,7 +490,11 @@ bool TabletProxy::isPathLoaded(const QVariant& path) {
 }
 
 void TabletProxy::setQmlTabletRoot(OffscreenQmlSurface* qmlOffscreenSurface) {
-    Q_ASSERT(QThread::currentThread() == qApp->thread());
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "setQmlTabletRoot", Q_ARG(OffscreenQmlSurface*, qmlOffscreenSurface));
+        return;
+    }
+
     _qmlOffscreenSurface = qmlOffscreenSurface;
     _qmlTabletRoot = qmlOffscreenSurface ? qmlOffscreenSurface->getRootItem() : nullptr;
     if (_qmlTabletRoot && _qmlOffscreenSurface) {
@@ -654,6 +663,11 @@ void TabletProxy::loadQMLSource(const QVariant& path, bool resizable) {
 }
 
 void TabletProxy::stopQMLSource() {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "stopQMLSource");
+        return;
+    }
+
     // For desktop toolbar mode dialogs.
     if (!_toolbarMode || !_desktopWindow) {
         qCDebug(uiLogging) << "tablet cannot clear QML because not desktop toolbar mode";
@@ -879,6 +893,12 @@ void TabletProxy::sendToQml(const QVariant& msg) {
 
 
 OffscreenQmlSurface* TabletProxy::getTabletSurface() {
+    if (QThread::currentThread() != thread()) {
+        OffscreenQmlSurface* result = nullptr;
+        BLOCKING_INVOKE_METHOD(this, "getTabletSurface", Q_RETURN_ARG(OffscreenQmlSurface*, result));
+        return result;
+    }
+
     return _qmlOffscreenSurface;
 }
 
@@ -888,6 +908,11 @@ void TabletProxy::desktopWindowClosed() {
 }
 
 void TabletProxy::unfocus() {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "unfocus");
+        return;
+    }
+
     if (_qmlOffscreenSurface) {
         _qmlOffscreenSurface->lowerKeyboard();
     }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19188/click-on-PAL-crash

Test plan:
- Click the tablet buttons a lot.  Go to different domains.  Click em more.  You shouldn't crash.
- Notifications should still work.
- Run [this](https://gist.githubusercontent.com/SamGondelman/a339b6aa11336ea254936f26592685fa/raw/6b3a1ac5ce2c7b9a6666545d30510527a4a3580b/QMLThreadTest.js).  You'll see a text overlay flashing around your screen super quickly, and a flashing button on your toolbar (or tablet in HMD).  You shouldn't crash.
- I think we should merge this and then monitor the crashes in the ticket after 80 is released.