### PR TITLE
Case 11775: Don't clear my avatar entities on domain switch

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6948,7 +6948,7 @@ void Application::clearDomainOctreeDetails(bool clearAll) {
     });
 
     // reset the model renderer
-    clearAll ? getEntities()->clear() : getEntities()->clearNonLocalEntities();
+    clearAll ? getEntities()->clear() : getEntities()->clearDomainAndNonOwnedEntities();
 
     auto skyStage = DependencyManager::get<SceneScriptingInterface>()->getSkyStage();
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -87,7 +87,7 @@ public:
     virtual void init() override;
 
     /// clears the tree
-    virtual void clearNonLocalEntities() override;
+    virtual void clearDomainAndNonOwnedEntities() override;
     virtual void clear() override;
 
     /// reloads the entity scripts, calling unload and preload
@@ -170,7 +170,7 @@ private:
     bool findBestZoneAndMaybeContainingEntities(QVector<EntityItemID>* entitiesContainingAvatar = nullptr);
 
     bool applyLayeredZones();
-    void stopNonLocalEntityScripts();
+    void stopDomainAndNonOwnedEntities();
 
     void checkAndCallPreload(const EntityItemID& entityID, bool reload = false, bool unloadFirst = false);
 
@@ -179,7 +179,7 @@ private:
 
     QScriptValueList createEntityArgs(const EntityItemID& entityID);
     bool checkEnterLeaveEntities();
-    void leaveNonLocalEntities();
+    void leaveDomainAndNonOwnedEntities();
     void leaveAllEntities();
     void forceRecheckEntities();
 

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -75,7 +75,7 @@ public:
     }
 
 
-    virtual void eraseNonLocalEntities() override;
+    virtual void eraseDomainAndNonOwnedEntities() override;
     virtual void eraseAllOctreeElements(bool createNewRoot = true) override;
 
     virtual void readBitstreamToTree(const unsigned char* bitstream,
@@ -255,6 +255,7 @@ public:
     QByteArray computeNonce(const QString& certID, const QString ownerKey);
     bool verifyNonce(const QString& certID, const QString& nonce, EntityItemID& id);
 
+    QUuid getMyAvatarSessionUUID() { return _myAvatar ? _myAvatar->getSessionUUID() : QUuid(); }
     void setMyAvatar(std::shared_ptr<AvatarData> myAvatar) { _myAvatar = myAvatar; }
 
     void swapStaleProxies(std::vector<int>& proxies) { proxies.swap(_staleProxies); }

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -697,11 +697,11 @@ EntityItemPointer EntityTreeElement::getEntityWithEntityItemID(const EntityItemI
     return foundEntity;
 }
 
-void EntityTreeElement::cleanupNonLocalEntities() {
+void EntityTreeElement::cleanupDomainAndNonOwnedEntities() {
     withWriteLock([&] {
         EntityItems savedEntities;
         foreach(EntityItemPointer entity, _entityItems) {
-            if (!entity->isLocalEntity()) {
+            if (!(entity->isLocalEntity() || (entity->isAvatarEntity() && entity->getOwningAvatarID() == getTree()->getMyAvatarSessionUUID()))) {
                 entity->preDelete();
                 entity->_element = NULL;
             } else {

--- a/libraries/entities/src/EntityTreeElement.h
+++ b/libraries/entities/src/EntityTreeElement.h
@@ -190,7 +190,7 @@ public:
     EntityItemPointer getEntityWithEntityItemID(const EntityItemID& id) const;
     void getEntitiesInside(const AACube& box, QVector<EntityItemPointer>& foundEntities);
 
-    void cleanupNonLocalEntities();
+    void cleanupDomainAndNonOwnedEntities();
     void cleanupEntities(); /// called by EntityTree on cleanup this will free all entities
     bool removeEntityItem(EntityItemPointer entity, bool deletion = false);
 

--- a/libraries/octree/src/Octree.h
+++ b/libraries/octree/src/Octree.h
@@ -149,7 +149,7 @@ public:
 
     OctreeElementPointer getRoot() { return _rootElement; }
 
-    virtual void eraseNonLocalEntities() { _isDirty = true; };
+    virtual void eraseDomainAndNonOwnedEntities() { _isDirty = true; };
     virtual void eraseAllOctreeElements(bool createNewRoot = true);
 
     virtual void readBitstreamToTree(const unsigned char* bitstream,  uint64_t bufferSizeBytes, ReadBitstreamToTreeParams& args);

--- a/libraries/octree/src/OctreeProcessor.cpp
+++ b/libraries/octree/src/OctreeProcessor.cpp
@@ -198,10 +198,10 @@ void OctreeProcessor::processDatagram(ReceivedMessage& message, SharedNodePointe
 }
 
 
-void OctreeProcessor::clearNonLocalEntities() {
+void OctreeProcessor::clearDomainAndNonOwnedEntities() {
     if (_tree) {
         _tree->withWriteLock([&] {
-            _tree->eraseNonLocalEntities();
+            _tree->eraseDomainAndNonOwnedEntities();
         });
     }
 }

--- a/libraries/octree/src/OctreeProcessor.h
+++ b/libraries/octree/src/OctreeProcessor.h
@@ -43,7 +43,7 @@ public:
     virtual void init();
 
     /// clears the tree
-    virtual void clearNonLocalEntities();
+    virtual void clearDomainAndNonOwnedEntities();
     virtual void clear();
 
     float getAverageElementsPerPacket() const { return _elementsPerPacket.getAverage(); }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/11775/Avatar-Entity-does-not-persist-when-local-sandbox-is-shutdown

Test plan:
- Go to a domain with other people running this PR.  Both of you should make some avatar entities.  You can run this a few times in the console:
```
Entities.addEntity({
    type: "Box",
    dimensions: 0.1,
    position: MyAvatar.position,
    parentID: MyAvatar.SELF_ID,
    collisionless: true,
    localPosition: {
        x: 2.0 * (Math.random() - 0.5),
        y: 2.0 * (Math.random() - 0.5),
        z: 2.0 * (Math.random() - 0.5)
    }
}, "avatar");
```
- Switch domains.  The other person's boxes should disappear.  Your boxes should persist.
- Go to your local sandbox and shut it down, as described in the ticket.  Your boxes should persist.