### PR TITLE
Case 21514: Lasers scale with avatar

### DIFF
--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -172,7 +172,10 @@ void LaserPointer::RenderState::update(const glm::vec3& origin, const glm::vec3&
         properties.setVisible(true);
         properties.setIgnorePickIntersection(doesPathIgnorePicks());
         QVector<float> widths;
-        widths.append(getLineWidth() * parentScale);
+        float width = getLineWidth() * parentScale;
+        widths.append(width);
+        widths.append(width);
+        properties.setStrokeWidths(widths);
         DependencyManager::get<EntityScriptingInterface>()->editEntity(getPathID(), properties);
     }
 }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21514/Laser-size-does-not-scale-with-avatar-appearing-unusually-large-when-user-is-small-and-vice-versa

Test plan:
- Hand laser width should scale with your avatar.