### PR TITLE
Case 21344: Fix resource crash on invalid resource

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -353,16 +353,19 @@ QSharedPointer<Resource> ResourceCache::getResource(const QUrl& url, const QUrl&
             // We've seen this extra info before
             resource = resourcesWithExtraHashIter.value().lock();
         } else if (resourcesWithExtraHash.size() > 0.0f) {
-            // We haven't seen this extra info before, but we've already downloaded the resource.  We need a new copy of this object (with any old hash).
-            resource = createResourceCopy(resourcesWithExtraHash.begin().value().lock());
-            resource->setExtra(extra);
-            resource->setExtraHash(extraHash);
-            resource->setSelf(resource);
-            resource->setCache(this);
-            resource->moveToThread(qApp->thread());
-            connect(resource.data(), &Resource::updateSize, this, &ResourceCache::updateTotalSize);
-            resourcesWithExtraHash.insert(extraHash, resource);
-            resource->ensureLoading();
+            auto oldResource = resourcesWithExtraHash.begin().value().lock();
+            if (oldResource) {
+                // We haven't seen this extra info before, but we've already downloaded the resource.  We need a new copy of this object (with any old hash).
+                resource = createResourceCopy(oldResource);
+                resource->setExtra(extra);
+                resource->setExtraHash(extraHash);
+                resource->setSelf(resource);
+                resource->setCache(this);
+                resource->moveToThread(qApp->thread());
+                connect(resource.data(), &Resource::updateSize, this, &ResourceCache::updateTotalSize);
+                resourcesWithExtraHash.insert(extraHash, resource);
+                resource->ensureLoading();
+            }
         }
     }
     if (resource) {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21344/RC80-Crash-when-loading-Invalid-URL-maybe-because-of-the-Resource-Cache

Test plan:
- I couldn't reliably repro this crash.  You can try the methods described in the ticket, but likely we'll just have to merge it and monitor the crash frequency.