### PR TITLE
Prevent HUD and Web Surface lasers from interrupting FarGrab.

### DIFF
--- a/scripts/system/controllers/controllerModules/hudOverlayPointer.js
+++ b/scripts/system/controllers/controllerModules/hudOverlayPointer.js
@@ -30,6 +30,20 @@
             100,
             makeLaserParams((this.hand + HUD_LASER_OFFSET), false));
 
+        this.getFarGrab = function () {
+            return getEnabledModuleByName(this.hand === RIGHT_HAND ? ("RightFarGrabEntity") : ("LeftFarGrabEntity"));
+        }
+
+        this.farGrabActive = function () {
+            var farGrab = this.getFarGrab();
+            // farGrab will be null if module isn't loaded.
+            if (farGrab) {
+                return farGrab.targetIsNull();
+            } else {
+                return false;
+            }
+        };
+
         this.getOtherHandController = function() {
             return (this.hand === RIGHT_HAND) ? Controller.Standard.LeftHand : Controller.Standard.RightHand;
         };
@@ -79,7 +93,7 @@
 
         this.isReady = function (controllerData) {
             var otherModuleRunning = this.getOtherModule().running;
-            if (!otherModuleRunning && HMD.active) {
+            if (!otherModuleRunning && HMD.active && !this.farGrabActive()) {
                 if (this.processLaser(controllerData)) {
                     this.running = true;
                     return ControllerDispatcherUtils.makeRunningValues(true, [], []);

--- a/scripts/system/controllers/controllerModules/webSurfaceLaserInput.js
+++ b/scripts/system/controllers/controllerModules/webSurfaceLaserInput.js
@@ -37,6 +37,20 @@ Script.include("/~/system/libraries/controllers.js");
             100,
             makeLaserParams(hand, true));
 
+        this.getFarGrab = function () {
+            return getEnabledModuleByName(this.hand === RIGHT_HAND ? ("RightFarGrabEntity") : ("LeftFarGrabEntity"));
+        };
+
+        this.farGrabActive = function () {
+            var farGrab = this.getFarGrab();
+            // farGrab will be null if module isn't loaded.
+            if (farGrab) {
+                return farGrab.targetIsNull();
+            } else {
+                return false;
+            }
+        };
+
         this.grabModuleWantsNearbyOverlay = function(controllerData) {
             if (controllerData.triggerValues[this.hand] > TRIGGER_ON_VALUE || controllerData.secondaryValues[this.hand] > BUMPER_ON_VALUE) {
                 var nearGrabName = this.hand === RIGHT_HAND ? "RightNearParentingGrabOverlay" : "LeftNearParentingGrabOverlay";
@@ -184,7 +198,12 @@ Script.include("/~/system/libraries/controllers.js");
 
         this.dominantHandOverride = false;
 
-        this.isReady = function(controllerData) {
+        this.isReady = function (controllerData) {
+            // Trivial rejection for when FarGrab is active.
+            if (this.farGrabActive()) {
+                return makeRunningValues(false, [], []);
+            }
+
             var isTriggerPressed = controllerData.triggerValues[this.hand] > TRIGGER_OFF_VALUE &&
                                    controllerData.triggerValues[this.otherHand] <= TRIGGER_OFF_VALUE;
             var type = this.getInteractableType(controllerData, isTriggerPressed, false);


### PR DESCRIPTION
As it stands, when FarGrabbing an entity, it can be interrupted if the pointer intersects the HUD or a web entity. This behavior is undesirable as it leaves users confused or annoyed.

Manuscript ticket [here](https://highfidelity.fogbugz.com/f/cases/21519/Stop-HUD-and-Web-Entity-Pointers-from-Interrupting-FarGrab).

Test Plan:
1.) Spawn a cube.
2.) Spawn a web entity.
3.) FarGrab the cube.
4.) Move the cube so that it is between you and the web entity, where your laser would normally intersect it if you weren't holding the cube.
5.) FarGrab should continue like normal without engaging the web entity.
6.) Do the same with the cube and the mic mute gem at the top-left corner of your in-HMD HUD.