### PR TITLE
Case 21500: Keyboard handle appears huge when scaling down avatar

### DIFF
--- a/interface/src/ui/Keyboard.cpp
+++ b/interface/src/ui/Keyboard.cpp
@@ -375,6 +375,12 @@ void Keyboard::scaleKeyboard(float sensorToWorldScale) {
 
     {
         EntityItemProperties properties;
+        properties.setDimensions(_anchor.originalDimensions * sensorToWorldScale);
+        entityScriptingInterface->editEntity(_anchor.entityID, properties);
+    }
+
+    {
+        EntityItemProperties properties;
         properties.setLocalPosition(_backPlate.localPosition * sensorToWorldScale);
         properties.setDimensions(_backPlate.dimensions * sensorToWorldScale);
         entityScriptingInterface->editEntity(_backPlate.entityID, properties);


### PR DESCRIPTION
Ticket - https://highfidelity.manuscript.com/f/cases/21500/Keyboard-handle-appears-huge-when-scaling-down-avatar