### PR TITLE
RC79-HERO: Detailed picking if avatar is not null

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -720,7 +720,7 @@ RayToAvatarIntersectionResult AvatarManager::findRayIntersectionVector(const Pic
                     }
                 }
             }
-            if (pickAgainstMesh) {
+            if (avatar && pickAgainstMesh) {
                 glm::vec3 localRayOrigin = avatar->worldToJointPoint(ray.origin, rayAvatarResult._intersectWithJoint);
                 glm::vec3 localRayPoint = avatar->worldToJointPoint(ray.origin + rayDirection, rayAvatarResult._intersectWithJoint);
 


### PR DESCRIPTION
(cherry picked from commit 6afb1b46987dfcd2401c9200aeaf5cdfeb5d6bdc)

See PR #14987 

https://highfidelity.manuscript.com/f/cases/21538/v0-79-HERO-crash-in-Avatar-worldToJointPoint-AvatarManager-findRayIntersectionVector