### PR TITLE
Case 21530: fix crash after uploading avatar asset - HERO

### DIFF
--- a/interface/src/avatar/AvatarProject.cpp
+++ b/interface/src/avatar/AvatarProject.cpp
@@ -250,11 +250,15 @@ void AvatarProject::openInInventory() const {
         DependencyManager::get<TabletScriptingInterface>()->getTablet("com.highfidelity.interface.tablet.system"));
     tablet->loadQMLSource("hifi/commerce/wallet/Wallet.qml");
     DependencyManager::get<HMDScriptingInterface>()->openTablet();
-    tablet->getTabletRoot()->forceActiveFocus();
-    auto name = getProjectName();
 
     // I'm not a fan of this, but it's the only current option.
+    auto name = getProjectName();
     QTimer::singleShot(TIME_TO_WAIT_FOR_INVENTORY_TO_OPEN_MS, [name, tablet]() {
         tablet->sendToQml(QVariantMap({ { "method", "updatePurchases" }, { "filterText", name } }));
     });
+
+    QQuickItem* root = tablet->getTabletRoot();
+    if (root) {
+        root->forceActiveFocus();
+    }
 }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21530/v-79-HERO-App-crashes-with-selecting-View-Inventory-after-adding-an-avatar-for-the-first-time

This PR fixes a crash bug after uploading new avatar asset