### PR TITLE
case 21563: adding modelScale initialization so that it does not fail the validSc…

### DIFF
--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -40,6 +40,7 @@ ModelEntityItem::ModelEntityItem(const EntityItemID& entityItemID) : EntityItem(
     _type = EntityTypes::Model;
     _lastKnownCurrentFrame = -1;
     _visuallyReady = false;
+    _modelScale=glm::vec3(1.0f);
 }
 
 const QString ModelEntityItem::getTextures() const {

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -40,7 +40,6 @@ ModelEntityItem::ModelEntityItem(const EntityItemID& entityItemID) : EntityItem(
     _type = EntityTypes::Model;
     _lastKnownCurrentFrame = -1;
     _visuallyReady = false;
-    _modelScale=glm::vec3(1.0f);
 }
 
 const QString ModelEntityItem::getTextures() const {

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -164,7 +164,7 @@ protected:
     int _lastKnownCurrentFrame{-1};
 
     glm::u8vec3 _color;
-    glm::vec3 _modelScale {1.0f};
+    glm::vec3 _modelScale { 1.0f };
     QString _modelURL;
     bool _relayParentJoints;
     bool _groupCulled { false };

--- a/libraries/entities/src/ModelEntityItem.h
+++ b/libraries/entities/src/ModelEntityItem.h
@@ -164,7 +164,7 @@ protected:
     int _lastKnownCurrentFrame{-1};
 
     glm::u8vec3 _color;
-    glm::vec3 _modelScale;
+    glm::vec3 _modelScale {1.0f};
     QString _modelURL;
     bool _relayParentJoints;
     bool _groupCulled { false };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21563/2D-Android-Interface-crashes-on-start-up-splash-screen

Initializing _modelScale so that the validateScale check does not fail.

Test:

Android app should open without crashing. 
