### PR TITLE
ensure error message when marketplace update fails

### DIFF
--- a/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
+++ b/interface/resources/qml/hifi/commerce/checkout/Checkout.qml
@@ -180,7 +180,7 @@ Rectangle {
 
         onUpdateItemResult: {
             if (result.status !== 'success') {
-                failureErrorText.text = result.message;
+                failureErrorText.text = result.data ? (result.data.message || "Unknown Error") : JSON.stringify(result);
                 root.activeView = "checkoutFailure";
             } else {
                 root.itemHref = result.data.download_url;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21521/Updating-item-NFS-and-Sold-Out-spins-without-going-to-Thank-You-page-or-completing-update has a data-web bug at it's core, which is generating an error message. We're working on it.

However, the error message isn't being displayed, and we just spin. That's what this PR fixes.