### PR TITLE
(case 21585) Fix crash when FST model used as both graphics and physics model

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -394,7 +394,11 @@ QSharedPointer<Resource> ModelCache::createResource(const QUrl& url) {
 }
 
 QSharedPointer<Resource> ModelCache::createResourceCopy(const QSharedPointer<Resource>& resource) {
-    return QSharedPointer<Resource>(new GeometryDefinitionResource(*resource.staticCast<GeometryDefinitionResource>()), &Resource::deleter);
+    if (resource->getURL().path().toLower().endsWith(".fst")) {
+        return QSharedPointer<Resource>(new GeometryMappingResource(*resource.staticCast<GeometryMappingResource>()), &Resource::deleter);
+    } else {
+        return QSharedPointer<Resource>(new GeometryDefinitionResource(*resource.staticCast<GeometryDefinitionResource>()), &Resource::deleter);
+    }
 }
 
 GeometryResource::Pointer ModelCache::getGeometryResource(const QUrl& url,


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21585/CRASH-Good-Submesh-FST-model-used-RC81

The crash fixed in this PR was caused by a bad static cast in the ModelCache.

This is the master version of https://github.com/highfidelity/hifi/pull/15110