### PR TITLE
Case 21595: Oculus SDK Update

### DIFF
--- a/android/apps/questFramePlayer/src/main/cpp/RenderThread.cpp
+++ b/android/apps/questFramePlayer/src/main/cpp/RenderThread.cpp
@@ -117,7 +117,8 @@ void RenderThread::setup() {
     { std::unique_lock<std::mutex> lock(_frameLock); }
 
     ovr::VrHandler::initVr();
-    ovr::VrHandler::setHandler(this);
+    // Enable KHR_no_error for this context
+    ovr::VrHandler::setHandler(this, true);
 
     makeCurrent();
 

--- a/cmake/macros/TargetOculusMobile.cmake
+++ b/cmake/macros/TargetOculusMobile.cmake
@@ -1,6 +1,6 @@
 
 macro(target_oculus_mobile)
-    set(INSTALL_DIR ${HIFI_ANDROID_PRECOMPILED}/oculus/VrApi)
+    set(INSTALL_DIR ${HIFI_ANDROID_PRECOMPILED}/oculus_1.22/VrApi)
 
     # Mobile SDK
     set(OVR_MOBILE_INCLUDE_DIRS ${INSTALL_DIR}/Include)

--- a/hifi_android.py
+++ b/hifi_android.py
@@ -45,10 +45,10 @@ ANDROID_PACKAGES = {
         'sharedLibFolder': 'lib',
         'includeLibs': ['libnvtt.so', 'libnvmath.so', 'libnvimage.so', 'libnvcore.so']
     },
-    'oculus': {
-        'file': 'ovr_sdk_mobile_1.19.0.zip',
-        'versionId': 's_RN1vlEvUi3pnT7WPxUC4pQ0RJBs27y',
-        'checksum': '98f0afb62861f1f02dd8110b31ed30eb',
+    'oculus_1.22': {
+        'file': 'ovr_sdk_mobile_1.22.zip',
+        'versionId': 'InhomR5gwkzyiLAelH3X9k4nvV3iIpA_',
+        'checksum': '1ac3c5b0521e5406f287f351015daff8',
         'sharedLibFolder': 'VrApi/Libs/Android/arm64-v8a/Release',
         'includeLibs': ['libvrapi.so']
     },

--- a/libraries/oculusMobile/src/ovr/GLContext.cpp
+++ b/libraries/oculusMobile/src/ovr/GLContext.cpp
@@ -13,10 +13,7 @@
 #include <mutex>
 
 #include <android/log.h>
-
-#if !defined(EGL_OPENGL_ES3_BIT_KHR)
-#define EGL_OPENGL_ES3_BIT_KHR 0x0040
-#endif
+#include <EGL/eglext.h>
 
 using namespace ovr;
 
@@ -129,7 +126,7 @@ void GLContext::doneCurrent() {
     eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 }
 
-bool GLContext::create(EGLDisplay display, EGLContext shareContext) {
+bool GLContext::create(EGLDisplay display, EGLContext shareContext, bool noError) {
     this->display = display;
 
     auto config = findConfig(display);
@@ -139,7 +136,9 @@ bool GLContext::create(EGLDisplay display, EGLContext shareContext) {
         return false;
     }
 
-    EGLint contextAttribs[] = { EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE };
+    EGLint contextAttribs[] = { EGL_CONTEXT_CLIENT_VERSION, 3,
+                                noError ? EGL_CONTEXT_OPENGL_NO_ERROR_KHR : EGL_NONE, EGL_TRUE,
+                                EGL_NONE };
 
     context = eglCreateContext(display, config, shareContext, contextAttribs);
     if (context == EGL_NO_CONTEXT) {

--- a/libraries/oculusMobile/src/ovr/GLContext.h
+++ b/libraries/oculusMobile/src/ovr/GLContext.h
@@ -25,7 +25,7 @@ struct GLContext {
     static EGLConfig findConfig(EGLDisplay display);
     bool makeCurrent();
     void doneCurrent();
-    bool create(EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY), EGLContext shareContext = EGL_NO_CONTEXT);
+    bool create(EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY), EGLContext shareContext = EGL_NO_CONTEXT, bool noError = false);
     void destroy();
     operator bool() const { return context != EGL_NO_CONTEXT; }
     static void initModule();

--- a/libraries/oculusMobile/src/ovr/VrHandler.h
+++ b/libraries/oculusMobile/src/ovr/VrHandler.h
@@ -21,7 +21,7 @@ public:
     using HandlerTask = std::function<void(VrHandler*)>;
     using OvrMobileTask = std::function<void(ovrMobile*)>;
     using OvrJavaTask = std::function<void(const ovrJava*)>;
-    static void setHandler(VrHandler* handler);
+    static void setHandler(VrHandler* handler, bool noError = false);
     static bool withOvrMobile(const OvrMobileTask& task);
 
 protected:


### PR DESCRIPTION
[21595](https://highfidelity.manuscript.com/f/cases/edit/21595/Update-the-Oculus-Mobile-SDK-version)

* Update Oculus Mobile SDK from 1.19 to 1.22
* Support KHR_no_error for performance in the Oculus Mobile wrapper library
* Enable KHR_no_error in the questFramePlayer build

We can't currently enable KHR_no_error  in the main interface build because we have no way to enable it in the Qt created contexts we use, and you can't mix contexts with the feature enabled with ones without the feature.  

We _can_ enable it in the Quest version of the frame player app, and toggle it between enabled and not enabled in the code to compare the performance and see if it would be valuable to pursue enabling it in the main application.  