### PR TITLE
Case 21596: Fix wearable scale on position change

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1868,7 +1868,7 @@ void EntityItem::setParentID(const QUuid& value) {
 
 glm::vec3 EntityItem::getScaledDimensions() const {
     glm::vec3 scale = getSNScale();
-    return _unscaledDimensions * scale;
+    return getUnscaledDimensions() * scale;
 }
 
 void EntityItem::setScaledDimensions(const glm::vec3& value) {

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -4177,7 +4177,7 @@ void EntityItemProperties::copySimulationRestrictedProperties(const EntityItemPo
         setAcceleration(entity->getAcceleration());
     }
     if (!_localDimensionsChanged && !_dimensionsChanged) {
-        setDimensions(entity->getScaledDimensions());
+        setLocalDimensions(entity->getScaledDimensions());
     }
 }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21596/wearable-scale-broken-on-position-change-for-81

Test plan:
- see https://highfidelity.manuscript.com/f/cases/21532/RC80-Wearables-break-when-the-user-attempts-to-edit-their-position-on-a-scaled-up-or-scaled-down-avatar