### PR TITLE
Case 21315, Case 21326, Case 21370

### DIFF
--- a/interface/resources/qml/hifi/commerce/marketplace/Marketplace.qml
+++ b/interface/resources/qml/hifi/commerce/marketplace/Marketplace.qml
@@ -41,6 +41,7 @@ Rectangle {
     property string searchScopeString: "Featured"
     property bool isLoggedIn: false
     property bool supports3DHTML: true
+    property bool pendingGetMarketplaceItemCall: false
 
     anchors.fill: (typeof parent === undefined) ? undefined : parent
 
@@ -100,7 +101,9 @@ Rectangle {
             getMarketplaceItems();
         }
         onGetMarketplaceItemsResult: {
-            marketBrowseModel.handlePage(result.status !== "success" && result.message, result);
+            if (!pendingGetMarketplaceItemCall) {
+                marketBrowseModel.handlePage(result.status !== "success" && result.message, result);
+            }
         }
         
         onGetMarketplaceItemResult: {
@@ -127,6 +130,7 @@ Rectangle {
                 marketplaceItemScrollView.contentHeight = marketplaceItemContent.height;
                 itemsList.visible = false;
                 marketplaceItemView.visible = true;
+                pendingGetMarketplaceItemCall = false;
             }
         }
     }
@@ -1224,6 +1228,7 @@ Rectangle {
                     console.log("A message with method 'updateMarketplaceQMLItem' was sent without an itemId!");
                     return;
                 }
+                pendingGetMarketplaceItemCall = true;
                 marketplaceItem.edition = message.params.edition ? message.params.edition : -1;
                 MarketplaceScriptingInterface.getMarketplaceItem(message.params.itemId);
                 break;

--- a/interface/resources/qml/hifi/commerce/marketplace/MarketplaceItem.qml
+++ b/interface/resources/qml/hifi/commerce/marketplace/MarketplaceItem.qml
@@ -52,13 +52,7 @@ Rectangle {
     }
     
     onDescriptionChanged: {
-
-        if(root.supports3DHTML) {
-            descriptionTextModel.clear();
-            descriptionTextModel.append({text: description});
-        } else {
-            descriptionText.text = description;
-        }
+        descriptionText.text = description;
     }
 
     onAttributionsChanged: {
@@ -250,7 +244,6 @@ Rectangle {
         
         function evalHeight() {
             height = categoriesList.y - buyButton.y + categoriesList.height;
-            console.log("HEIGHT: " + height);
         }
         
         HifiControlsUit.Button {
@@ -271,6 +264,9 @@ Rectangle {
             buttonGlyph: (enabled && !isUpdate && (price > 0)) ? hifi.glyphs.hfc : ""
             text: isUpdate ? "UPDATE FOR FREE" : (isStocking ? "FREE STOCK" : (enabled ? (price || "FREE") : availability))
             color: hifi.buttons.blue
+
+            buttonGlyphSize: 24
+            fontSize: 24
 
             onClicked: root.buy();
         }

--- a/interface/resources/qml/hifi/commerce/marketplace/MarketplaceListItem.qml
+++ b/interface/resources/qml/hifi/commerce/marketplace/MarketplaceListItem.qml
@@ -226,6 +226,7 @@ Rectangle {
                     top: parent.top
                     left: parent.left
                     leftMargin: 15
+                    topMargin: 10
                 }
                 width: paintedWidth
                 
@@ -241,7 +242,7 @@ Rectangle {
                 anchors {
                     top: creatorLabel.top;
                     left: creatorLabel.right;
-                    leftMargin: 15;
+                    leftMargin: 10;
                 }
                 width: paintedWidth;
 
@@ -273,7 +274,7 @@ Rectangle {
                 anchors {
                     top: categoryLabel.top
                     left: categoryLabel.right
-                    leftMargin: 15
+                    leftMargin: 10
                 }
                 width: paintedWidth
 
@@ -298,19 +299,21 @@ Rectangle {
                     topMargin:10
                     bottomMargin: 10
                 }
+                width: 180
 
                 property bool isNFS: availability === "not for sale" // Note: server will say "sold out" or "invalidated" before it says NFS
                 property bool isMine: creator === Account.username
                 property bool isUpgrade: root.edition >= 0
                 property int costToMe: ((isMine && isNFS) || isUpgrade) ? 0 : price
-                property bool isAvailable: costToMe >= 0
+                property bool isAvailable: availability === "available"
 
                 text: isUpgrade ? "UPGRADE FOR FREE" : (isAvailable ?  (costToMe || "FREE") : availability)
                 enabled: isAvailable
                 buttonGlyph: isAvailable ? (costToMe ? hifi.glyphs.hfc : "") : ""
 
                 color: hifi.buttons.blue;
-
+                buttonGlyphSize: 24
+                fontSize: 24
                 onClicked: root.buy();
             }
         }


### PR DESCRIPTION
Case 21315 - Clicking on item picture from Inventor Items list does not
always display the Marketplace item page.
Case 21326 - See All Markets page is missing its footer and the two
Explore buttons no longer work
Case 21370 - QML Marketplace - For unavailable items (no more editions
for sale), marketplace item list 'buy' button is not disabled

Also, a few minor font sizing and other graphics tweaks

https://highfidelity.manuscript.com/f/cases/21388/Clicking-an-item-picture-from-the-Inventory-Items-list-does-not-always-display-the-Marketplace-item-page

https://highfidelity.manuscript.com/f/cases/21387/See-All-Markets-page-is-missing-its-footer-and-the-two-Explore-buttons-no-longer-work

https://highfidelity.manuscript.com/f/cases/21375/v0-81-0-QML-Marketplace-For-unavailable-items-no-more-editions-for-sale-marketplace-item-list-buy-button-is-not-disabled