### PR TITLE
Fix mixer crash with Zones that have compound shapes

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -35,6 +35,8 @@
 #include <TryLocker.h>
 #include "../AssignmentDynamicFactory.h"
 #include "../entities/AssignmentParentFinder.h"
+#include <model-networking/ModelCache.h>
+#include <hfm/ModelFormatRegistry.h>
 
 const QString AVATAR_MIXER_LOGGING_NAME = "avatar-mixer";
 
@@ -47,7 +49,10 @@ AvatarMixer::AvatarMixer(ReceivedMessage& message) :
 {
     DependencyManager::registerInheritance<EntityDynamicFactoryInterface, AssignmentDynamicFactory>();
     DependencyManager::set<AssignmentDynamicFactory>();
-
+    DependencyManager::set<ModelFormatRegistry>();
+    DependencyManager::set<ModelCache>();
+    DependencyManager::set<ResourceCacheSharedItems>();
+    DependencyManager::set<ResourceManager>();
     // make sure we hear about node kills so we can tell the other nodes
     connect(DependencyManager::get<NodeList>().data(), &NodeList::nodeKilled, this, &AvatarMixer::handleAvatarKilled);
 
@@ -1025,6 +1030,10 @@ void AvatarMixer::handleOctreePacket(QSharedPointer<ReceivedMessage> message, Sh
 }
 
 void AvatarMixer::aboutToFinish() {
+    DependencyManager::destroy<ResourceManager>();
+    DependencyManager::destroy<ResourceCacheSharedItems>();
+    DependencyManager::destroy<ModelCache>();
+    DependencyManager::destroy<ModelFormatRegistry>();
     DependencyManager::destroy<AssignmentDynamicFactory>();
     DependencyManager::destroy<AssignmentParentFinder>();
 


### PR DESCRIPTION
Ticket: https://highfidelity.manuscript.com/f/cases/21614/

To handle downloading the mesh URLs the avatar mixer requires the ModelCache singleton plus a bunch of others.
