### PR TITLE
loading jointRotationOffset2 from FST and deal with the shadow joints

### DIFF
--- a/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
+++ b/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
@@ -29,8 +29,14 @@ QMap<QString, QString> getJointNameMapping(const QVariantHash& mapping) {
 QMap<QString, glm::quat> getJointRotationOffsets(const QVariantHash& mapping) {
     QMap<QString, glm::quat> jointRotationOffsets;
     static const QString JOINT_ROTATION_OFFSET_FIELD = "jointRotationOffset";
-    if (!mapping.isEmpty() && mapping.contains(JOINT_ROTATION_OFFSET_FIELD) && mapping[JOINT_ROTATION_OFFSET_FIELD].type() == QVariant::Hash) {
-        auto offsets = mapping[JOINT_ROTATION_OFFSET_FIELD].toHash();
+    static const QString JOINT_ROTATION_OFFSET2_FIELD = "jointRotationOffset2";
+    if (!mapping.isEmpty() && ((mapping.contains(JOINT_ROTATION_OFFSET_FIELD) && mapping[JOINT_ROTATION_OFFSET_FIELD].type() == QVariant::Hash) || (mapping.contains(JOINT_ROTATION_OFFSET2_FIELD) && mapping[JOINT_ROTATION_OFFSET2_FIELD].type() == QVariant::Hash))) {
+        QHash<QString, QVariant> offsets;
+        if (mapping.contains(JOINT_ROTATION_OFFSET_FIELD)) {
+            offsets = mapping[JOINT_ROTATION_OFFSET_FIELD].toHash();
+        } else {
+            offsets = mapping[JOINT_ROTATION_OFFSET2_FIELD].toHash();
+        }
         for (auto itr = offsets.begin(); itr != offsets.end(); itr++) {
             QString jointName = itr.key();
             QString line = itr.value().toString();
@@ -57,6 +63,15 @@ void PrepareJointsTask::run(const baker::BakeContextPointer& context, const Inpu
     auto& jointRotationOffsets = output.edit1();
     auto& jointIndices = output.edit2();
 
+    bool newJointRot = false;
+    static const QString JOINT_ROTATION_OFFSET2_FIELD = "jointRotationOffset2";
+    QVariantHash fstHashMap = mapping.second;
+    if (fstHashMap.contains(JOINT_ROTATION_OFFSET2_FIELD)) {
+        newJointRot = true;
+    } else {
+        newJointRot = false;
+    }
+
     // Get joint renames
     auto jointNameMapping = getJointNameMapping(mapping.second);
     // Apply joint metadata from FST file mappings
@@ -64,11 +79,12 @@ void PrepareJointsTask::run(const baker::BakeContextPointer& context, const Inpu
         jointsOut.push_back(jointIn);
         auto& jointOut = jointsOut.back();
 
-        auto jointNameMapKey = jointNameMapping.key(jointIn.name);
-        if (jointNameMapping.contains(jointNameMapKey)) {
-            jointOut.name = jointNameMapKey;
+        if (!newJointRot) {
+            auto jointNameMapKey = jointNameMapping.key(jointIn.name);
+            if (jointNameMapping.contains(jointNameMapKey)) {
+                jointOut.name = jointNameMapKey;
+            }
         }
-
         jointIndices.insert(jointOut.name, (int)jointsOut.size());
     }
 
@@ -77,10 +93,33 @@ void PrepareJointsTask::run(const baker::BakeContextPointer& context, const Inpu
     for (auto itr = offsets.begin(); itr != offsets.end(); itr++) {
         QString jointName = itr.key();
         int jointIndex = jointIndices.value(jointName) - 1;
-        if (jointIndex != -1) {
+        if (jointIndex >= 0) {
             glm::quat rotationOffset = itr.value();
             jointRotationOffsets.insert(jointIndex, rotationOffset);
             qCDebug(model_baker) << "Joint Rotation Offset added to Rig._jointRotationOffsets : " << " jointName: " << jointName << " jointIndex: " << jointIndex << " rotation offset: " << rotationOffset;
+        }
+    }
+
+    if (newJointRot) {
+        for (const auto& jointIn : jointsIn) {
+
+            auto jointNameMapKey = jointNameMapping.key(jointIn.name);
+            int mappedIndex = jointIndices.value(jointIn.name);
+            if (jointNameMapping.contains(jointNameMapKey)) {
+
+                // delete and replace with hifi name
+                jointIndices.remove(jointIn.name);
+                jointIndices.insert(jointNameMapKey, mappedIndex);
+            } else {
+
+                // nothing mapped to this fbx joint name
+                if (jointNameMapping.contains(jointIn.name)) {
+                    // but the name is in the list of hifi names is mapped to a different joint
+                    int extraIndex = jointIndices.value(jointIn.name);
+                    jointIndices.remove(jointIn.name);
+                    jointIndices.insert("", extraIndex);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This pr addresses the bug that is created when shadow joint names exist. That is a joint in the skeleton has a Hifi name in the fbx file but it is not mapped to the same Hifi name in the FST.

https://highfidelity.manuscript.com/f/cases/21393/FST-FBX-shadowed-joint-issue

### Test Plan

1) open Interface and load the following avatars
http://hifi-content.s3.amazonaws.com/angus/shadowJoints/eng_newrot/avatar.fst
https://hifi-content.s3.us-west-1.amazonaws.com/davidback/avatars/PR15118/Savvalas/avatar.fst

Result: they should animate correctly, note there badly weighted poly in the back of the engineer
