### PR TITLE
Case 21640: RC80: Adding Hero support in simulation of avatars

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -130,11 +130,15 @@ int AvatarMixerClientData::parseData(ReceivedMessage& message, const SlaveShared
     }
     _lastReceivedSequenceNumber = sequenceNumber;
     glm::vec3 oldPosition = getPosition();
+    bool oldHasPriority = _avatar->getHasPriority();
 
     // compute the offset to the data payload
     if (!_avatar->parseDataFromBuffer(message.readWithoutCopy(message.getBytesLeftToRead()))) {
         return false;
     }
+
+    // Regardless of what the client says, restore the priority as we know it without triggering any update.
+    _avatar->setHasPriorityWithoutTimestampReset(oldHasPriority);
 
     auto newPosition = getPosition();
     if (newPosition != oldPosition) {

--- a/assignment-client/src/avatars/MixerAvatar.h
+++ b/assignment-client/src/avatars/MixerAvatar.h
@@ -19,11 +19,8 @@
 
 class MixerAvatar : public AvatarData {
 public:
-    bool getHasPriority() const { return  _hasPriority; }
-    void setHasPriority(bool hasPriority) { _hasPriority = hasPriority; }
 
 private:
-    bool _hasPriority { false };
 };
 
 using MixerAvatarSharedPointer = std::shared_ptr<MixerAvatar>;

--- a/interface/resources/qml/+android_interface/Stats.qml
+++ b/interface/resources/qml/+android_interface/Stats.qml
@@ -115,6 +115,10 @@ Item {
                     }
                     StatText {
                         visible: root.expanded
+                        text: "Heroes Count/Updated: " + root.heroAvatarCount + "/" + root.updatedHeroAvatarCount
+                    }
+                    StatText {
+                        visible: root.expanded
                         text: "Avatars NOT Updated: " + root.notUpdatedAvatarCount
                     }
                 }

--- a/interface/resources/qml/Stats.qml
+++ b/interface/resources/qml/Stats.qml
@@ -117,6 +117,10 @@ Item {
                     }
                     StatText {
                         visible: root.expanded
+                        text: "Heroes Count/Updated: " + root.heroAvatarCount + "/" + root.updatedHeroAvatarCount
+                    }
+                    StatText {
+                        visible: root.expanded
                         text: "Avatars NOT Updated: " + root.notUpdatedAvatarCount
                     }
                     StatText {

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -232,93 +232,138 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
     auto avatarMap = getHashCopy();
 
     const auto& views = qApp->getConicalViews();
-    PrioritySortUtil::PriorityQueue<SortableAvatar> sortedAvatars(views,
-            AvatarData::_avatarSortCoefficientSize,
-            AvatarData::_avatarSortCoefficientCenter,
-            AvatarData::_avatarSortCoefficientAge);
-    sortedAvatars.reserve(avatarMap.size() - 1); // don't include MyAvatar
+    // Prepare 2 queues for heros and for crowd avatars
+    using AvatarPriorityQueue = PrioritySortUtil::PriorityQueue<SortableAvatar>;
+    // Keep two independent queues, one for heroes and one for the riff-raff.
+    enum PriorityVariants
+    {
+        kHero = 0,
+        kNonHero,
+        NumVariants
+    };
+    AvatarPriorityQueue avatarPriorityQueues[NumVariants] = {
+             { views,
+               AvatarData::_avatarSortCoefficientSize,
+               AvatarData::_avatarSortCoefficientCenter,
+               AvatarData::_avatarSortCoefficientAge },
+             { views,
+               AvatarData::_avatarSortCoefficientSize,
+               AvatarData::_avatarSortCoefficientCenter,
+               AvatarData::_avatarSortCoefficientAge } };
+    // Reserve space
+    //avatarPriorityQueues[kHero].reserve(10);  // just few
+    avatarPriorityQueues[kNonHero].reserve(avatarMap.size() - 1);  // don't include MyAvatar
 
     // Build vector and compute priorities
     auto nodeList = DependencyManager::get<NodeList>();
     AvatarHash::iterator itr = avatarMap.begin();
     while (itr != avatarMap.end()) {
-        const auto& avatar = std::static_pointer_cast<Avatar>(*itr);
+        auto avatar = std::static_pointer_cast<Avatar>(*itr);
         // DO NOT update _myAvatar!  Its update has already been done earlier in the main loop.
         // DO NOT update or fade out uninitialized Avatars
         if (avatar != _myAvatar && avatar->isInitialized() && !nodeList->isPersonalMutingNode(avatar->getID())) {
-            sortedAvatars.push(SortableAvatar(avatar));
+            if (avatar->getHasPriority()) {
+                avatarPriorityQueues[kHero].push(SortableAvatar(avatar));
+            } else {
+                avatarPriorityQueues[kNonHero].push(SortableAvatar(avatar));
+            }
         }
         ++itr;
     }
-    // Sort
-    const auto& sortedAvatarVector = sortedAvatars.getSortedVector();
+
+    _numHeroAvatars = (int)avatarPriorityQueues[kHero].size();
 
     // process in sorted order
     uint64_t startTime = usecTimestampNow();
-    uint64_t updateExpiry = startTime + MAX_UPDATE_AVATARS_TIME_BUDGET;
+
+    const uint64_t MAX_UPDATE_HEROS_TIME_BUDGET = uint64_t(0.8 * MAX_UPDATE_AVATARS_TIME_BUDGET);
+
+    uint64_t updatePriorityExpiries[NumVariants] = { startTime + MAX_UPDATE_HEROS_TIME_BUDGET, startTime + MAX_UPDATE_AVATARS_TIME_BUDGET };
+    int numHerosUpdated = 0;
     int numAvatarsUpdated = 0;
-    int numAVatarsNotUpdated = 0;
+    int numAvatarsNotUpdated = 0;
 
     render::Transaction renderTransaction;
     workload::Transaction workloadTransaction;
-    for (auto it = sortedAvatarVector.begin(); it != sortedAvatarVector.end(); ++it) {
-        const SortableAvatar& sortData = *it;
-        const auto avatar = std::static_pointer_cast<OtherAvatar>(sortData.getAvatar());
-        if (!avatar->_isClientAvatar) {
-            avatar->setIsClientAvatar(true);
-        }
-        // TODO: to help us scale to more avatars it would be nice to not have to poll this stuff every update
-        if (avatar->getSkeletonModel()->isLoaded()) {
-            // remove the orb if it is there
-            avatar->removeOrb();
-            if (avatar->needsPhysicsUpdate()) {
-                _avatarsToChangeInPhysics.insert(avatar);
-            }
-        } else {
-            avatar->updateOrbPosition();
-        }
+ 
+    for (int p = kHero; p < NumVariants; p++) {
+        auto& priorityQueue = avatarPriorityQueues[p];
+        // Sorting the current queue HERE as part of the measured timing.
+        const auto& sortedAvatarVector = priorityQueue.getSortedVector();
 
-        // for ALL avatars...
-        if (_shouldRender) {
-            avatar->ensureInScene(avatar, qApp->getMain3DScene());
-        }
-        avatar->animateScaleChanges(deltaTime);
+        auto passExpiry = updatePriorityExpiries[p];
 
-        uint64_t now = usecTimestampNow();
-        if (now < updateExpiry) {
-            // we're within budget
-            bool inView = sortData.getPriority() > OUT_OF_VIEW_THRESHOLD;
-            if (inView && avatar->hasNewJointData()) {
-                numAvatarsUpdated++;
+        for (auto it = sortedAvatarVector.begin(); it != sortedAvatarVector.end(); ++it) {
+            const SortableAvatar& sortData = *it;
+            const auto avatar = std::static_pointer_cast<OtherAvatar>(sortData.getAvatar());
+            if (!avatar->_isClientAvatar) {
+                avatar->setIsClientAvatar(true);
             }
-            auto transitStatus = avatar->_transit.update(deltaTime, avatar->_serverPosition, _transitConfig);
-            if (avatar->getIsNewAvatar() && (transitStatus == AvatarTransit::Status::START_TRANSIT || transitStatus == AvatarTransit::Status::ABORT_TRANSIT)) {
-                avatar->_transit.reset();
-                avatar->setIsNewAvatar(false);
-            }
-            avatar->simulate(deltaTime, inView);
-            avatar->updateRenderItem(renderTransaction);
-            avatar->updateSpaceProxy(workloadTransaction);
-            avatar->setLastRenderUpdateTime(startTime);
-        } else {
-            // we've spent our full time budget --> bail on the rest of the avatar updates
-            // --> more avatars may freeze until their priority trickles up
-            // --> some scale animations may glitch
-            // --> some avatar velocity measurements may be a little off
-
-            // no time to simulate, but we take the time to count how many were tragically missed
-            while (it != sortedAvatarVector.end()) {
-                const SortableAvatar& newSortData = *it;
-                const auto& newAvatar = newSortData.getAvatar();
-                bool inView = newSortData.getPriority() > OUT_OF_VIEW_THRESHOLD;
-                // Once we reach an avatar that's not in view, all avatars after it will also be out of view
-                if (!inView) {
-                    break;
+            // TODO: to help us scale to more avatars it would be nice to not have to poll this stuff every update
+            if (avatar->getSkeletonModel()->isLoaded()) {
+                // remove the orb if it is there
+                avatar->removeOrb();
+                if (avatar->needsPhysicsUpdate()) {
+                    _avatarsToChangeInPhysics.insert(avatar);
                 }
-                numAVatarsNotUpdated += (int)(newAvatar->hasNewJointData());
-                ++it;
+            } else {
+                avatar->updateOrbPosition();
             }
-            break;
+
+            // for ALL avatars...
+            if (_shouldRender) {
+                avatar->ensureInScene(avatar, qApp->getMain3DScene());
+            }
+            avatar->animateScaleChanges(deltaTime);
+
+            uint64_t now = usecTimestampNow();
+            if (now < passExpiry) {
+                // we're within budget
+                bool inView = sortData.getPriority() > OUT_OF_VIEW_THRESHOLD;
+                if (inView && avatar->hasNewJointData()) {
+                    numAvatarsUpdated++;
+                }
+                auto transitStatus = avatar->_transit.update(deltaTime, avatar->_serverPosition, _transitConfig);
+                if (avatar->getIsNewAvatar() && (transitStatus == AvatarTransit::Status::START_TRANSIT ||
+                                                 transitStatus == AvatarTransit::Status::ABORT_TRANSIT)) {
+                    avatar->_transit.reset();
+                    avatar->setIsNewAvatar(false);
+                }
+                avatar->simulate(deltaTime, inView);
+                avatar->updateRenderItem(renderTransaction);
+                avatar->updateSpaceProxy(workloadTransaction);
+                avatar->setLastRenderUpdateTime(startTime);
+            } else {
+                // we've spent our time budget for this priority bucket
+                // let's deal with the reminding avatars if this pass and BREAK from the for loop
+
+                if (p == kHero) {
+                    // Hero,
+                    // --> put them back in the non hero queue
+
+                    auto& crowdQueue = avatarPriorityQueues[kNonHero];
+                    while (it != sortedAvatarVector.end()) {
+                        crowdQueue.push(SortableAvatar((*it).getAvatar()));
+                        ++it;
+                    }
+                } else {
+                    // Non Hero
+                    // --> bail on the rest of the avatar updates
+                    // --> more avatars may freeze until their priority trickles up
+                    // --> some scale animations may glitch
+                    // --> some avatar velocity measurements may be a little off
+
+                    // no time to simulate, but we take the time to count how many were tragically missed
+                    numAvatarsNotUpdated = sortedAvatarVector.end() - it;
+                }
+
+                // We had to cut short this pass, we must break out of the for loop here
+                break;
+            }
+        }
+
+        if (p == kHero) {
+            numHerosUpdated = numAvatarsUpdated;
         }
     }
 
@@ -334,7 +379,8 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
     _space->enqueueTransaction(workloadTransaction);
 
     _numAvatarsUpdated = numAvatarsUpdated;
-    _numAvatarsNotUpdated = numAVatarsNotUpdated;
+    _numAvatarsNotUpdated = numAvatarsNotUpdated;
+    _numHeroAvatarsUpdated = numHerosUpdated;
 
     simulateAvatarFades(deltaTime);
 

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -90,6 +90,8 @@ public:
 
     int getNumAvatarsUpdated() const { return _numAvatarsUpdated; }
     int getNumAvatarsNotUpdated() const { return _numAvatarsNotUpdated; }
+    int getNumHeroAvatars() const { return _numHeroAvatars; }
+    int getNumHeroAvatarsUpdated() const { return _numHeroAvatarsUpdated; }
     float getAvatarSimulationTime() const { return _avatarSimulationTime; }
 
     void updateMyAvatar(float deltaTime);
@@ -242,6 +244,8 @@ private:
     RateCounter<> _myAvatarSendRate;
     int _numAvatarsUpdated { 0 };
     int _numAvatarsNotUpdated { 0 };
+    int _numHeroAvatars{ 0 };
+    int _numHeroAvatarsUpdated{ 0 };
     float _avatarSimulationTime { 0.0f };
     bool _shouldRender { true };
     bool _myAvatarDataPacketsPaused { false };

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -200,17 +200,6 @@ void OtherAvatar::resetDetailedMotionStates() {
 
 void OtherAvatar::setWorkloadRegion(uint8_t region) {
     _workloadRegion = region;
-    QString printRegion = "";
-    if (region == workload::Region::R1) {
-        printRegion = "R1";
-    } else if (region == workload::Region::R2) {
-        printRegion = "R2";
-    } else if (region == workload::Region::R3) {
-        printRegion = "R3";
-    } else {
-        printRegion = "invalid";
-    }
-    qCDebug(avatars) << "Setting workload region to " << printRegion;
     computeShapeLOD();
 }
 
@@ -235,7 +224,6 @@ void OtherAvatar::computeShapeLOD() {
     if (newLOD != _bodyLOD) {
         _bodyLOD = newLOD;
         if (isInPhysicsSimulation()) {
-            qCDebug(avatars) << "Changing to body LOD " << newLOD;
             _needsReinsertion = true;
         }
     }

--- a/interface/src/ui/Stats.cpp
+++ b/interface/src/ui/Stats.cpp
@@ -125,8 +125,10 @@ void Stats::updateStats(bool force) {
     auto avatarManager = DependencyManager::get<AvatarManager>();
     // we need to take one avatar out so we don't include ourselves
     STAT_UPDATE(avatarCount, avatarManager->size() - 1);
+    STAT_UPDATE(heroAvatarCount, avatarManager->getNumHeroAvatars());
     STAT_UPDATE(physicsObjectCount, qApp->getNumCollisionObjects());
     STAT_UPDATE(updatedAvatarCount, avatarManager->getNumAvatarsUpdated());
+    STAT_UPDATE(updatedHeroAvatarCount, avatarManager->getNumHeroAvatarsUpdated());
     STAT_UPDATE(notUpdatedAvatarCount, avatarManager->getNumAvatarsNotUpdated());
     STAT_UPDATE(serverCount, (int)nodeList->size());
     STAT_UPDATE_FLOAT(renderrate, qApp->getRenderLoopRate(), 0.1f);

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -49,8 +49,10 @@ private: \
  * @property {number} presentdroprate - <em>Read-only.</em>
  * @property {number} gameLoopRate - <em>Read-only.</em>
  * @property {number} avatarCount - <em>Read-only.</em>
+ * @property {number} heroAvatarCount - <em>Read-only.</em>
  * @property {number} physicsObjectCount - <em>Read-only.</em>
  * @property {number} updatedAvatarCount - <em>Read-only.</em>
+ * @property {number} updatedHeroAvatarCount - <em>Read-only.</em>
  * @property {number} notUpdatedAvatarCount - <em>Read-only.</em>
  * @property {number} packetInCount - <em>Read-only.</em>
  * @property {number} packetOutCount - <em>Read-only.</em>
@@ -203,8 +205,10 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(float, presentdroprate, 0)
     STATS_PROPERTY(int, gameLoopRate, 0)
     STATS_PROPERTY(int, avatarCount, 0)
+    STATS_PROPERTY(int, heroAvatarCount, 0)
     STATS_PROPERTY(int, physicsObjectCount, 0)
     STATS_PROPERTY(int, updatedAvatarCount, 0)
+    STATS_PROPERTY(int, updatedHeroAvatarCount, 0)
     STATS_PROPERTY(int, notUpdatedAvatarCount, 0)
     STATS_PROPERTY(int, packetInCount, 0)
     STATS_PROPERTY(int, packetOutCount, 0)
@@ -437,11 +441,25 @@ signals:
     void avatarCountChanged();
 
     /**jsdoc
+     * Triggered when the value of the <code>heroAvatarCount</code> property changes.
+     * @function Stats.heroAvatarCountChanged
+     * @returns {Signal}
+     */
+    void heroAvatarCountChanged();
+
+    /**jsdoc
      * Triggered when the value of the <code>updatedAvatarCount</code> property changes.
      * @function Stats.updatedAvatarCountChanged
      * @returns {Signal}
      */
     void updatedAvatarCountChanged();
+
+    /**jsdoc
+     * Triggered when the value of the <code>updatedHeroAvatarCount</code> property changes.
+     * @function Stats.updatedHeroAvatarCountChanged
+     * @returns {Signal}
+     */
+    void updatedHeroAvatarCountChanged();
 
     /**jsdoc
      * Triggered when the value of the <code>notUpdatedAvatarCount</code> property changes.

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -564,6 +564,11 @@ QByteArray AvatarData::toByteArray(AvatarDataDetail dataDetail, quint64 lastSent
             setAtBit16(flags, COLLIDE_WITH_OTHER_AVATARS);
         }
 
+        // Avatar has hero priority
+        if (getHasPriority()) {
+            setAtBit16(flags, HAS_HERO_PRIORITY);
+        }
+
         data->flags = flags;
         destinationBuffer += sizeof(AvatarDataPacket::AdditionalFlags);
 
@@ -1152,7 +1157,8 @@ int AvatarData::parseDataFromBuffer(const QByteArray& buffer) {
         auto newHasProceduralEyeFaceMovement = oneAtBit16(bitItems, PROCEDURAL_EYE_FACE_MOVEMENT);
         auto newHasProceduralBlinkFaceMovement = oneAtBit16(bitItems, PROCEDURAL_BLINK_FACE_MOVEMENT);
         auto newCollideWithOtherAvatars = oneAtBit16(bitItems, COLLIDE_WITH_OTHER_AVATARS);
-        
+        auto newHasPriority = oneAtBit16(bitItems, HAS_HERO_PRIORITY);        
+
         bool keyStateChanged = (_keyState != newKeyState);
         bool handStateChanged = (_handState != newHandState);
         bool faceStateChanged = (_headData->_isFaceTrackerConnected != newFaceTrackerConnected);
@@ -1161,8 +1167,10 @@ int AvatarData::parseDataFromBuffer(const QByteArray& buffer) {
         bool proceduralEyeFaceMovementChanged = (_headData->getHasProceduralEyeFaceMovement() != newHasProceduralEyeFaceMovement);
         bool proceduralBlinkFaceMovementChanged = (_headData->getHasProceduralBlinkFaceMovement() != newHasProceduralBlinkFaceMovement);
         bool collideWithOtherAvatarsChanged = (_collideWithOtherAvatars != newCollideWithOtherAvatars);
+        bool hasPriorityChanged = (getHasPriority() != newHasPriority);
         bool somethingChanged = keyStateChanged || handStateChanged || faceStateChanged || eyeStateChanged || audioEnableFaceMovementChanged || 
-                                proceduralEyeFaceMovementChanged || proceduralBlinkFaceMovementChanged || collideWithOtherAvatarsChanged;
+                                proceduralEyeFaceMovementChanged ||
+                                proceduralBlinkFaceMovementChanged || collideWithOtherAvatarsChanged || hasPriorityChanged;
 
         _keyState = newKeyState;
         _handState = newHandState;
@@ -1172,6 +1180,7 @@ int AvatarData::parseDataFromBuffer(const QByteArray& buffer) {
         _headData->setHasProceduralEyeFaceMovement(newHasProceduralEyeFaceMovement);
         _headData->setHasProceduralBlinkFaceMovement(newHasProceduralBlinkFaceMovement);
         _collideWithOtherAvatars = newCollideWithOtherAvatars;
+        setHasPriorityWithoutTimestampReset(newHasPriority);
 
         sourceBuffer += sizeof(AvatarDataPacket::AdditionalFlags);
 

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -100,6 +100,9 @@ const quint32 AVATAR_MOTION_SCRIPTABLE_BITS =
 // Procedural audio to mouth movement is enabled 8th bit
 // Procedural Blink is enabled 9th bit
 // Procedural Eyelid is enabled 10th bit
+// Procedural PROCEDURAL_BLINK_FACE_MOVEMENT is enabled 11th bit
+// Procedural Collide with other avatars is enabled 12th bit
+// Procedural Has Hero Priority is enabled 13th bit
 
 const int KEY_STATE_START_BIT = 0; // 1st and 2nd bits
 const int HAND_STATE_START_BIT = 2; // 3rd and 4th bits
@@ -111,7 +114,7 @@ const int AUDIO_ENABLED_FACE_MOVEMENT = 8; // 9th bit
 const int PROCEDURAL_EYE_FACE_MOVEMENT = 9; // 10th bit
 const int PROCEDURAL_BLINK_FACE_MOVEMENT = 10; // 11th bit
 const int COLLIDE_WITH_OTHER_AVATARS = 11; // 12th bit
-
+const int HAS_HERO_PRIORITY = 12; // 13th bit  (be scared)
 
 const char HAND_STATE_NULL = 0;
 const char LEFT_HAND_POINTING_FLAG = 1;
@@ -1121,6 +1124,18 @@ public:
     int getAverageBytesReceivedPerSecond() const;
     int getReceiveRate() const;
 
+    // An Avatar can be set Priority from the AvatarMixer side.
+    bool getHasPriority() const { return _hasPriority; }
+    // regular setHasPriority does a check of state changed and if true reset 'additionalFlagsChanged' timestamp
+    void setHasPriority(bool hasPriority) {
+        if (_hasPriority != hasPriority) {
+            _additionalFlagsChanged = usecTimestampNow();
+            _hasPriority = hasPriority;
+        }
+    }
+    // In some cases, we want to assign the hasPRiority flag without reseting timestamp
+    void setHasPriorityWithoutTimestampReset(bool hasPriority) { _hasPriority = hasPriority; }
+
     const glm::vec3& getTargetVelocity() const { return _targetVelocity; }
 
     void clearRecordingBasis();
@@ -1498,6 +1513,7 @@ protected:
     bool _isNewAvatar { true };
     bool _isClientAvatar { false };
     bool _collideWithOtherAvatars { true };
+    bool _hasPriority{ false };
 
     // null unless MyAvatar or ScriptableAvatar sending traits data to mixer
     std::unique_ptr<ClientTraitsHandler, LaterDeleter> _clientTraitsHandler;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21640/v80-Add-the-Hero-avatars-simulation-prioritization-on-the-client-side-rc80

same as PR15129

This pr introduces the "hasPriority" flag to the AvatarData
The hasPriority flag is set from the AvatarMixer (never read from the data sent TO the mixer) based on the position  relative to a "hero" zone.

On the client engine side, we do the same logic as in the Mixer, during simulation of OtherAvatars we make 2 queues of avatars to simulate, one for Heroes, one for the rest of the crowd avatars.
We process first the Heroes with a budget of 80% of the OtherAvatars budget, then the rest of the crowd in the remaining time.
THe client just read the hasPriority status of the avatars, it doesn't evaluate it.

## TEST PLAN

Use this script : https://gist.githubusercontent.com/samcake/40769fe82ea1eae54ccfe9ab61a54b34/raw/e7e5e2d6f064534f428c70d04ada92a26ccc988b/debugAvatarCrowd.js
and visualize the simulation rate vs the network rate.
the color of the indicator per avatar is green at simulation of 30Hz, red at 0hz

