### PR TITLE
Case 8064: Child of animated model brings collider with it

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1032,7 +1032,7 @@ void RenderableModelEntityItem::copyAnimationJointDataToModel() {
     });
 
     if (changed) {
-        locationChanged(false, true);
+        locationChanged(true, true);
     }
 }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/8064/Entities-that-are-children-of-animated-joints-do-not-impart-physics

Test plan:
- Run [this](https://gist.githubusercontent.com/SamGondelman/815e2c76da4c2379cbe112446293d541/raw/f5062212288d1d2bd5d67fab933c27bb65de92ea/AnimationTest2.js).
- You'll see a gesticulating mannequin with a box attached to its hand.
- If you walk up to the mannequin, the box will push you.  As the mannequin's hand moves around, the physical part of the box will move with it.
- You can see this by enabling Developer -> Physics -> Show Bullet Collisions.  In master, the box collider wouldn't move, but in this PR, it will follow the actual box.