### PR TITLE
Case 21675: removed redundant method.

### DIFF
--- a/interface/src/scripting/TestScriptingInterface.cpp
+++ b/interface/src/scripting/TestScriptingInterface.cpp
@@ -199,13 +199,3 @@ void TestScriptingInterface::setOtherAvatarsReplicaCount(int count) {
 int TestScriptingInterface::getOtherAvatarsReplicaCount() {
     return qApp->getOtherAvatarsReplicaCount();
 }
-
-QString TestScriptingInterface::getOperatingSystemType() {
-#ifdef Q_OS_WIN
-    return "WINDOWS";
-#elif defined Q_OS_MAC
-    return "MACOS";
-#else
-    return "UNKNOWN";
-#endif
-}

--- a/interface/src/scripting/TestScriptingInterface.h
+++ b/interface/src/scripting/TestScriptingInterface.h
@@ -163,13 +163,6 @@ public slots:
     */
     Q_INVOKABLE int getOtherAvatarsReplicaCount();
 
-    /**jsdoc
-    * Returns the Operating Sytem type
-    * @function Test.getOperatingSystemType
-    * @returns {string} "WINDOWS", "MACOS" or "UNKNOWN"
-    */
-    QString getOperatingSystemType();
-
 private:
     bool waitForCondition(qint64 maxWaitMs, std::function<bool()> condition);
     QString _testResultsLocation;


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/21675/Remove-getOperatingSystemType-from-Test-class

# Testing
Run full nitpick test suite.