### PR TITLE
Case 21499: Lasers are offset in front of hands after scaling avatar down then relaunching

### DIFF
--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1122,6 +1122,7 @@ public:
     float getUserEyeHeight() const;
 
     virtual SpatialParentTree* getParentTree() const override;
+    virtual glm::vec3 scaleForChildren() const override { return glm::vec3(getSensorToWorldScale()); }
 
     const QUuid& getSelfID() const { return AVATAR_SELF_ID; }
 

--- a/libraries/shared/src/NestableTransformNode.h
+++ b/libraries/shared/src/NestableTransformNode.h
@@ -20,8 +20,10 @@ public:
         _jointIndex(jointIndex) {
         auto nestablePointer = _spatiallyNestable.lock();
         if (nestablePointer) {
-            glm::vec3 nestableDimensions = getActualScale(nestablePointer);
-            _baseScale = glm::max(glm::vec3(0.001f), nestableDimensions);
+            if (nestablePointer->getNestableType() != NestableType::Avatar) {
+                glm::vec3 nestableDimensions = getActualScale(nestablePointer);
+                _baseScale = glm::max(glm::vec3(0.001f), nestableDimensions);
+            }
         }
     }
 


### PR DESCRIPTION
Ticket - https://highfidelity.manuscript.com/f/cases/21499/Lasers-are-offset-in-front-of-hands-after-scaling-avatar-down-then-relaunching