### PR TITLE
Case 21684: Microphone is still live after reopening Interface

### DIFF
--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -228,6 +228,9 @@ void Audio::loadData() {
     _hmdMuted = _hmdMutedSetting.get();
     _pttDesktop = _pttDesktopSetting.get();
     _pttHMD = _pttHMDSetting.get();
+
+    auto client = DependencyManager::get<AudioClient>().data();
+    QMetaObject::invokeMethod(client, "setMuted", Q_ARG(bool, isMuted()), Q_ARG(bool, false));
 }
 
 bool Audio::getPTTHMD() const {


### PR DESCRIPTION
# TEST PLAN

1) Mute microphone with button in top left
2) Close Interface
3) Re-Open Interface
4) UI displays muted state
5) Speak to another user
6) Microphone is should be muted

https://highfidelity.manuscript.com/f/cases/21684/Microphone-is-still-live-after-reopening-Interface