### PR TITLE
Case 21687: Unable to create new profile during steam login

### DIFF
--- a/interface/resources/qml/LoginDialog/CompleteProfileBody.qml
+++ b/interface/resources/qml/LoginDialog/CompleteProfileBody.qml
@@ -510,7 +510,7 @@ Item {
             console.log("Create Failed: " + error);
             if (completeProfileBody.withSteam || completeProfileBody.withOculus) {
                 if (completeProfileBody.loginDialogPoppedUp) {
-                    action = completeProfileBody.withSteam ? "Steam" : "Oculus";
+                    var action = completeProfileBody.withSteam ? "Steam" : "Oculus";
                     var data = {
                         "action": "user failed to create a profile with " + action + " from the complete profile screen"
                     }


### PR DESCRIPTION
# TEST PLAN
1) Launch Steam build (put attached files [1](https://highfidelity.manuscript.com/default.asp?ixAttachment=11618&pg=pgDownload&pgType=pgFile&sFilename=steam_appid.txt) and [2](https://highfidelity.manuscript.com/default.asp?ixAttachment=11619&pg=pgDownload&pgType=pgFile&sFilename=interface.exe+-+Steam.bat) into program files folder and launch while steam is running)
2) Make sure your steam account is not linked to an existing HiFi account (unlink if it is)
3) Click Continue with Steam
4) Choose CREATE YOUR PROFILE button
5) Should get to screen showing to choose a username if creating your profile fails
![image](https://user-images.githubusercontent.com/10539521/54245609-b6b91980-44ee-11e9-8a22-a5295b6d2fec.png)

https://highfidelity.manuscript.com/f/cases/21687/Unable-to-create-new-profile-during-steam-login