### PR TITLE
Case 21653: Fix User is not able to update input fields and scroll past selected object in Create Tools [master]

### DIFF
--- a/scripts/system/html/js/entityList.js
+++ b/scripts/system/html/js/entityList.js
@@ -459,7 +459,7 @@ function loaded() {
                 isRenameFieldBeingMoved = true;
                 document.body.appendChild(elRenameInput);
                 // keep the focus
-                elRenameInput.select();
+                elRenameInput.focus();
             }
         }
 
@@ -475,7 +475,7 @@ function loaded() {
             elCell.innerHTML = "";
             elCell.appendChild(elRenameInput);
             // keep the focus
-            elRenameInput.select();
+            elRenameInput.focus();
             isRenameFieldBeingMoved = false;
         }
 

--- a/scripts/system/html/js/entityProperties.js
+++ b/scripts/system/html/js/entityProperties.js
@@ -3325,6 +3325,13 @@ function loaded() {
                         }
 
                         let hasSelectedEntityChanged = lastEntityID !== '"' + selectedEntityProperties.id + '"';
+
+                        if (!hasSelectedEntityChanged && document.hasFocus()) {
+                            // in case the selection has not changed and we still have focus on the properties page,
+                            // we will ignore the event.
+                            return;
+                        }
+
                         let doSelectElement = !hasSelectedEntityChanged;
 
                         // the event bridge and json parsing handle our avatar id string differently.


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21722/v82-0-User-is-not-able-to-update-input-fields-and-scroll-past-selected-object-in-Create-Tools