### PR TITLE
make placename consistent with hostname after domain reset

### DIFF
--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -834,6 +834,7 @@ bool AddressManager::setDomainInfo(const QUrl& domainURL, LookupTrigger trigger)
     }
 
     _domainURL = domainURL;
+    _shareablePlaceName.clear();
 
     // clear any current place information
     _rootPlaceID = QUuid();


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20598/Content-is-removed-due-to-Dynamic-Domain-Verification-if-the-content-was-added-shortly-after-Domain-ID-changed
and
https://highfidelity.manuscript.com/f/cases/20593/Content-removed-because-of-Dynamic-Domain-Verification-gets-continually-removed-when-it-is-added-again-by-DDV-check
