### PR TITLE
Case 21721: Fix wearable duplication on domain switch

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5772,6 +5772,7 @@ void Application::reloadResourceCaches() {
 
     queryOctree(NodeType::EntityServer, PacketType::EntityQuery);
 
+    getMyAvatar()->prepareAvatarEntityDataForReload();
     // Clear the entities and their renderables
     getEntities()->clear();
 
@@ -6947,9 +6948,6 @@ void Application::updateWindowTitle() const {
 }
 
 void Application::clearDomainOctreeDetails(bool clearAll) {
-    // before we delete all entities get MyAvatar's AvatarEntityData ready
-    getMyAvatar()->prepareAvatarEntityDataForReload();
-
     // if we're about to quit, we really don't need to do the rest of these things...
     if (_aboutToQuit) {
         return;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1213,6 +1213,12 @@ public:
 
 public slots:
 
+   /**jsdoc
+    * @function MyAvatar.setSessionUUID
+    * @param {Uuid} sessionUUID
+    */
+    virtual void setSessionUUID(const QUuid& sessionUUID) override;
+
     /**jsdoc
      * Increase the avatar's scale by five percent, up to a minimum scale of <code>1000</code>.
      * @function MyAvatar.increaseSize

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -1646,11 +1646,9 @@ bool EntityScriptingInterface::actionWorker(const QUuid& entityID,
     auto nodeList = DependencyManager::get<NodeList>();
     const QUuid myNodeID = nodeList->getSessionUUID();
 
-    EntityItemProperties properties;
-
     EntityItemPointer entity;
     bool doTransmit = false;
-    _entityTree->withWriteLock([this, &entity, entityID, myNodeID, &doTransmit, actor, &properties] {
+    _entityTree->withWriteLock([this, &entity, entityID, myNodeID, &doTransmit, actor] {
         EntitySimulationPointer simulation = _entityTree->getSimulation();
         entity = _entityTree->findEntityByEntityItemID(entityID);
         if (!entity) {
@@ -1669,16 +1667,12 @@ bool EntityScriptingInterface::actionWorker(const QUuid& entityID,
 
         doTransmit = actor(simulation, entity);
         _entityTree->entityChanged(entity);
-        if (doTransmit) {
-            properties.setEntityHostType(entity->getEntityHostType());
-            properties.setOwningAvatarID(entity->getOwningAvatarID());
-        }
     });
 
     // transmit the change
     if (doTransmit) {
-        _entityTree->withReadLock([&] {
-            properties = entity->getProperties();
+        EntityItemProperties properties = _entityTree->resultWithReadLock<EntityItemProperties>([&] {
+            return entity->getProperties();
         });
 
         properties.setActionDataDirty();


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21721/wearables-clone-themselves-on-domain-switch

Test plan:
- Put on some wearables.  The problem is easiest to see if one of them is animated:
```
var entity = Entities.addEntity({
    type: "Model",
    modelURL: "http://mpassets.highfidelity.com/ad348528-de38-420c-82bb-054cb22163f5-v1/mannequin.fst",
    rotation: MyAvatar.orientation,
    animation: {
        url: "https://hifi-content.s3.amazonaws.com/jimi/animation/WS/Yelling.fbx",
        running: true,
        allowTranslation: false
    },
    parentID: MyAvatar.SELF_ID
}, "avatar");
```
- When you switch domains, your wearables will stay with you.  They shouldn't disappear or duplicate.  You should be able to delete them once you get to the new domain.