### PR TITLE
Fixed Memory Corruption in AnimClip.cpp

### DIFF
--- a/libraries/animation/src/AnimClip.cpp
+++ b/libraries/animation/src/AnimClip.cpp
@@ -124,40 +124,44 @@ void AnimClip::copyFromNetworkAnim() {
     _anim.resize(animFrameCount);
 
     // find the size scale factor for translation in the animation.
-    const int avatarHipsParentIndex = avatarSkeleton->getParentIndex(avatarSkeleton->nameToJointIndex("Hips"));
-    const int animHipsParentIndex = animSkeleton.getParentIndex(animSkeleton.nameToJointIndex("Hips"));
-    const AnimPose& avatarHipsAbsoluteDefaultPose = avatarSkeleton->getAbsoluteDefaultPose(avatarSkeleton->nameToJointIndex("Hips"));
-    const AnimPose& animHipsAbsoluteDefaultPose = animSkeleton.getAbsoluteDefaultPose(animSkeleton.nameToJointIndex("Hips"));
-
-    // the get the units and the heights for the animation and the avatar
-    const float avatarUnitScale = extractScale(avatarSkeleton->getGeometryOffset()).y;
-    const float animationUnitScale = extractScale(animModel.offset).y;
-    const float avatarHeightInMeters = avatarUnitScale * avatarHipsAbsoluteDefaultPose.trans().y;
-    const float animHeightInMeters = animationUnitScale * animHipsAbsoluteDefaultPose.trans().y;
-
-    // get the parent scales for the avatar and the animation
-    float avatarHipsParentScale = 1.0f;
-    if (avatarHipsParentIndex >= 0) {
-        const AnimPose& avatarHipsParentAbsoluteDefaultPose = avatarSkeleton->getAbsoluteDefaultPose(avatarHipsParentIndex);
-        avatarHipsParentScale = avatarHipsParentAbsoluteDefaultPose.scale().y;
-    }
-    float animHipsParentScale = 1.0f;
-    if (animHipsParentIndex >= 0) {
-        const AnimPose& animationHipsParentAbsoluteDefaultPose = animSkeleton.getAbsoluteDefaultPose(animHipsParentIndex);
-        animHipsParentScale = animationHipsParentAbsoluteDefaultPose.scale().y;
-    }
-
-    const float EPSILON = 0.0001f;
     float boneLengthScale = 1.0f;
-    // compute the ratios for the units, the heights in meters, and the parent scales
-    if ((fabsf(animHeightInMeters) > EPSILON) && (animationUnitScale > EPSILON) && (animHipsParentScale > EPSILON)) {
-        const float avatarToAnimationHeightRatio = avatarHeightInMeters / animHeightInMeters;
-        const float unitsRatio = 1.0f / (avatarUnitScale / animationUnitScale);
-        const float parentScaleRatio = 1.0f / (avatarHipsParentScale / animHipsParentScale);
+    const int avatarHipsIndex = avatarSkeleton->nameToJointIndex("Hips");
+    const int animHipsIndex = animSkeleton.nameToJointIndex("Hips");
+    if (avatarHipsIndex != -1 && animHipsIndex != -1) {
+        const int avatarHipsParentIndex = avatarSkeleton->getParentIndex(avatarHipsIndex);
+        const int animHipsParentIndex = animSkeleton.getParentIndex(animHipsIndex);
 
-        boneLengthScale = avatarToAnimationHeightRatio * unitsRatio * parentScaleRatio;
+        const AnimPose& avatarHipsAbsoluteDefaultPose = avatarSkeleton->getAbsoluteDefaultPose(avatarHipsIndex);
+        const AnimPose& animHipsAbsoluteDefaultPose = animSkeleton.getAbsoluteDefaultPose(animHipsIndex);
+
+        // the get the units and the heights for the animation and the avatar
+        const float avatarUnitScale = extractScale(avatarSkeleton->getGeometryOffset()).y;
+        const float animationUnitScale = extractScale(animModel.offset).y;
+        const float avatarHeightInMeters = avatarUnitScale * avatarHipsAbsoluteDefaultPose.trans().y;
+        const float animHeightInMeters = animationUnitScale * animHipsAbsoluteDefaultPose.trans().y;
+
+        // get the parent scales for the avatar and the animation
+        float avatarHipsParentScale = 1.0f;
+        if (avatarHipsParentIndex != -1) {
+            const AnimPose& avatarHipsParentAbsoluteDefaultPose = avatarSkeleton->getAbsoluteDefaultPose(avatarHipsParentIndex);
+            avatarHipsParentScale = avatarHipsParentAbsoluteDefaultPose.scale().y;
+        }
+        float animHipsParentScale = 1.0f;
+        if (animHipsParentIndex != -1) {
+            const AnimPose& animationHipsParentAbsoluteDefaultPose = animSkeleton.getAbsoluteDefaultPose(animHipsParentIndex);
+            animHipsParentScale = animationHipsParentAbsoluteDefaultPose.scale().y;
+        }
+
+        const float EPSILON = 0.0001f;
+        // compute the ratios for the units, the heights in meters, and the parent scales
+        if ((fabsf(animHeightInMeters) > EPSILON) && (animationUnitScale > EPSILON) && (animHipsParentScale > EPSILON)) {
+            const float avatarToAnimationHeightRatio = avatarHeightInMeters / animHeightInMeters;
+            const float unitsRatio = 1.0f / (avatarUnitScale / animationUnitScale);
+            const float parentScaleRatio = 1.0f / (avatarHipsParentScale / animHipsParentScale);
+
+            boneLengthScale = avatarToAnimationHeightRatio * unitsRatio * parentScaleRatio;
+        }
     }
-
 
     for (int frame = 0; frame < animFrameCount; frame++) {
         const HFMAnimationFrame& animFrame = animModel.animationFrames[frame];


### PR DESCRIPTION
This pr fixes a memory corruption caused by not checking if the hips joint existed.

The case is here
https://highfidelity.manuscript.com/f/cases/21734/Crash-Memory-Corruption-in-AnimClip-copyFromNetworkAnim

### TEST PLAN
1)open interface.  load Matthew.  
Expected: no crash.