### PR TITLE
Case 21755: Allow Web Entities to use alpha from html/qml textures

### DIFF
--- a/libraries/render-utils/src/simple_opaque_web_browser.slf
+++ b/libraries/render-utils/src/simple_opaque_web_browser.slf
@@ -28,7 +28,7 @@ layout(location=RENDER_UTILS_ATTR_TEXCOORD01) in vec4 _texCoord01;
 #define _texCoord1 _texCoord01.zw
 
 void main(void) {
-    vec4 texel = texture(originalTexture, _texCoord0.st);
+    vec4 texel = texture(originalTexture, _texCoord0);
     texel = color_sRGBAToLinear(texel);
     packDeferredFragmentUnlit(normalize(_normalWS), 1.0, _color.rgb * texel.rgb);
 }

--- a/libraries/render-utils/src/simple_transparent_web_browser.slf
+++ b/libraries/render-utils/src/simple_transparent_web_browser.slf
@@ -28,11 +28,11 @@ layout(location=RENDER_UTILS_ATTR_TEXCOORD01) in vec4 _texCoord01;
 #define _texCoord1 _texCoord01.zw
 
 void main(void) {
-    vec4 texel = texture(originalTexture, _texCoord0.st);
+    vec4 texel = texture(originalTexture, _texCoord0);
     texel = color_sRGBAToLinear(texel);
     packDeferredFragmentTranslucent(
         normalize(_normalWS),
-        _color.a,
+        _color.a * texel.a,
         _color.rgb * texel.rgb,
         DEFAULT_ROUGHNESS);
 }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21755/Allow-web-entities-to-render-the-alpha-from-the-html-qml-pages

In order to enable this, you must set the alpha on the web entity to be < 1.

Test plan:
- Open the stats with "/".
- Run this:
```
var entity = Entities.addEntity({
     type: "Web",
     sourceUrl: "Stats.qml",
     position: MyAvatar.position,
     dimensions: 1.0
});
```
- You'll see this:
![image](https://user-images.githubusercontent.com/7650116/54465620-48b46280-4739-11e9-8627-5dfbe114b599.png)
- Move around and run this:
```
var entity = Entities.addEntity({
     type: "Web",
     sourceUrl: "Stats.qml",
     position: MyAvatar.position,
     dimensions: 1.0,
     alpha: 0.9
});
```
- You'll see this:
![image](https://user-images.githubusercontent.com/7650116/54465631-5964d880-4739-11e9-8c04-3bcbcc52d4a1.png)
