### PR TITLE
Case 21756: Entities.emitScriptEvent works now

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1985,6 +1985,13 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         return nullptr;
     });
 
+    EntityTree::setEmitScriptEventOperator([this](const QUuid& id, const QVariant& message) {
+        auto entities = getEntities();
+        if (auto entity = entities->renderableForEntityId(id)) {
+            entity->emitScriptEvent(message);
+        }
+    });
+
     EntityTree::setTextSizeOperator([this](const QUuid& id, const QString& text) {
         auto entities = getEntities();
         if (auto entity = entities->renderableForEntityId(id)) {

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -40,6 +40,7 @@ public:
     virtual bool wantsKeyboardFocus() const { return false; }
     virtual void setProxyWindow(QWindow* proxyWindow) {}
     virtual QObject* getEventHandler() { return nullptr; }
+    virtual void emitScriptEvent(const QVariant& message) {}
     const EntityItemPointer& getEntity() const { return _entity; }
     const ItemID& getRenderItemID() const { return _renderItemID; }
 

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.h
@@ -106,7 +106,7 @@ private:
     static std::function<void(QSharedPointer<OffscreenQmlSurface>&, bool&, std::vector<QMetaObject::Connection>&)> _releaseWebSurfaceOperator;
 
 public slots:
-    void emitScriptEvent(const QVariant& scriptMessage);
+    void emitScriptEvent(const QVariant& scriptMessage) override;
 
 signals:
     void scriptEventReceived(const QVariant& message);

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -511,8 +511,6 @@ public:
     virtual void setProxyWindow(QWindow* proxyWindow) {}
     virtual QObject* getEventHandler() { return nullptr; }
 
-    virtual void emitScriptEvent(const QVariant& message) {}
-
     QUuid getLastEditedBy() const { return _lastEditedBy; }
     void setLastEditedBy(QUuid value) { _lastEditedBy = value; }
 

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -2202,14 +2202,7 @@ bool EntityScriptingInterface::wantsHandControllerPointerEvents(const QUuid& id)
 }
 
 void EntityScriptingInterface::emitScriptEvent(const EntityItemID& entityID, const QVariant& message) {
-    if (_entityTree) {
-        _entityTree->withReadLock([&] {
-            EntityItemPointer entity = _entityTree->findEntityByEntityItemID(EntityItemID(entityID));
-            if (entity) {
-                entity->emitScriptEvent(message);
-            }
-        });
-    }
+    EntityTree::emitScriptEvent(entityID, message);
 }
 
 // TODO move this someplace that makes more sense...

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -1529,7 +1529,6 @@ public slots:
      * @function Entities.emitScriptEvent
      * @param {Uuid} entityID - The ID of the {@link Entities.EntityType|Web} entity.
      * @param {string} message - The message to send.
-     * @todo <em>This function is currently not implemented.</em>
      */
     Q_INVOKABLE void emitScriptEvent(const EntityItemID& entityID, const QVariant& message);
 

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -2978,6 +2978,7 @@ QStringList EntityTree::getJointNames(const QUuid& entityID) const {
 std::function<QObject*(const QUuid&)> EntityTree::_getEntityObjectOperator = nullptr;
 std::function<QSizeF(const QUuid&, const QString&)> EntityTree::_textSizeOperator = nullptr;
 std::function<bool()> EntityTree::_areEntityClicksCapturedOperator = nullptr;
+std::function<void(const QUuid&, const QVariant&)> EntityTree::_emitScriptEventOperator = nullptr;
 
 QObject* EntityTree::getEntityObject(const QUuid& id) {
     if (_getEntityObjectOperator) {
@@ -2998,6 +2999,12 @@ bool EntityTree::areEntityClicksCaptured() {
         return _areEntityClicksCapturedOperator();
     }
     return false;
+}
+
+void EntityTree::emitScriptEvent(const QUuid& id, const QVariant& message) {
+    if (_emitScriptEventOperator) {
+        _emitScriptEventOperator(id, message);
+    }
 }
 
 void EntityTree::updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -272,6 +272,9 @@ public:
     static void setEntityClicksCapturedOperator(std::function<bool()> areEntityClicksCapturedOperator) { _areEntityClicksCapturedOperator = areEntityClicksCapturedOperator; }
     static bool areEntityClicksCaptured();
 
+    static void setEmitScriptEventOperator(std::function<void(const QUuid&, const QVariant&)> emitScriptEventOperator) { _emitScriptEventOperator = emitScriptEventOperator; }
+    static void emitScriptEvent(const QUuid& id, const QVariant& message);
+
     std::map<QString, QString> getNamedPaths() const { return _namedPaths; }
 
     void updateEntityQueryAACube(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,
@@ -383,6 +386,7 @@ private:
     static std::function<QObject*(const QUuid&)> _getEntityObjectOperator;
     static std::function<QSizeF(const QUuid&, const QString&)> _textSizeOperator;
     static std::function<bool()> _areEntityClicksCapturedOperator;
+    static std::function<void(const QUuid&, const QVariant&)> _emitScriptEventOperator;
 
     std::vector<int32_t> _staleProxies;
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21756/Entities-emitScriptEvent-doesn-t-work-on-web-entities

Test plan:
- In desktop, enable the desktop tablet.  Open the snap app.
- Run this in the console:
```
Entities.emitScriptEvent(HMD.tabletScreenID, JSON.stringify({
     type: "snapshot",
     action: "showSetupInstructions"
}));
```
- The tablet will update to show the setup instructions.