### PR TITLE
Fixed Bug For Old FBX Files That Have An Exported Pose Different From The Bind Pose

### DIFF
--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -466,7 +466,6 @@ HFMModel* FBXSerializer::extractHFMModel(const QVariantHash& mapping, const QStr
                     }
                 } else if (object.name == "FBXVersion") {
                     fbxVersionNumber = object.properties.at(0).toInt();
-                    qCDebug(modelformat) << "the fbx version number " << fbxVersionNumber;
                 }
             }
         } else if (child.name == "GlobalSettings") {


### PR DESCRIPTION
For FBX files that are earlier than version 7.5 (7500) there is a problem sometimes that avatars have a bind pose that is different from the intended exported pose.  When we imported FBX file we read the bind pose for the default but a connected animation file would have the intended poses.

The manuscript case is here:
https://highfidelity.manuscript.com/f/cases/21762/FBX-files-that-are-before-version-7-5-can-have-a-different-intended-pose-from-the-bind-pose

For those earlier avatars we now use the animation frame zero pose to override the bind pose.

This fixes several broken avatars like skater who have there feet in the ground.
### Test Plan
1) open interface and load skater
http://hifi-content.s3.amazonaws.com/angus/izzyRotationBug/skater_orig/skater_orig.fst
Expected result: it should animate normally and the feet should be on the ground.