### PR TITLE
Fix/dominant hand changed

### DIFF
--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -335,8 +335,6 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
         currentAvatar.avatarScale = message.avatarScale;
         break;
     case 'saveSettings':
-        
-        
         MyAvatar.setAvatarScale(message.avatarScale);
         currentAvatar.avatarScale = message.avatarScale;
 

--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -335,10 +335,15 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
         currentAvatar.avatarScale = message.avatarScale;
         break;
     case 'saveSettings':
+        
+        
         MyAvatar.setAvatarScale(message.avatarScale);
         currentAvatar.avatarScale = message.avatarScale;
 
-        MyAvatar.setDominantHand(message.settings.dominantHand);
+        if (currentAvatarSettings.dominantHand !== message.settings.dominantHand) {
+            MyAvatar.setDominantHand(message.settings.dominantHand);
+        }
+
         MyAvatar.setHmdAvatarAlignmentType(message.settings.hmdAvatarAlignmentType);
         MyAvatar.setOtherAvatarsCollisionsEnabled(message.settings.otherAvatarsCollisionsEnabled);
         MyAvatar.setCollisionsEnabled(message.settings.collisionsEnabled);


### PR DESCRIPTION
case: 21306 https://highfidelity.fogbugz.com/f/cases/21306/Clicking-Save-in-Avatar-Menu-emits-dominantHandChanged-signal

When saving avatar settings in the app, a dominant hand changed signal is emitted even if there isn't one.
This makes sure the dominant hand was changed.

Test Plan:
Open console
function domainhc(){console.log("emitted")};
MyAvatar.dominantHandChanged.connect(domainhc);

Go to the avatar app and save the settings. There should be nothing emitted.
Change the dominant hand and save.
You should now see the log above.