### PR TITLE
Updated engine code to not emit if dominant hand isn't actually changed

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -324,8 +324,11 @@ QString MyAvatar::getDominantHand() const {
 
 void MyAvatar::setDominantHand(const QString& hand) {
     if (hand == DOMINANT_LEFT_HAND || hand == DOMINANT_RIGHT_HAND) {
-        _dominantHand.set(hand);
-        emit dominantHandChanged(hand);
+        bool changed = (hand != _dominantHand.get());
+        if (changed) {
+            _dominantHand.set(hand);
+            emit dominantHandChanged(hand);
+        }
     }
 }
 


### PR DESCRIPTION
case: 21306 https://highfidelity.fogbugz.com/f/cases/21306/Clicking-Save-in-Avatar-Menu-emits-dominantHandChanged-signal

When saving avatar settings in the app, a dominant hand changed signal is emitted even if there isn't one.
This makes sure the dominant hand was changed.

Test Plan:
Open console
function domainhc(){console.log("emitted")};
MyAvatar.dominantHandChanged.connect(domainhc);

Go to the avatar app and save the settings. There should be nothing emitted.
Change the dominant hand and save.
You should now see the log above.