### PR TITLE
Don't drop saved reliable packets upon HandshakeReq

### DIFF
--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -116,7 +116,7 @@ SendQueue& Connection::getSendQueue() {
         QObject::connect(_sendQueue.get(), &SendQueue::packetRetransmitted, this, &Connection::recordRetransmission);
         QObject::connect(_sendQueue.get(), &SendQueue::queueInactive, this, &Connection::queueInactive);
         QObject::connect(_sendQueue.get(), &SendQueue::timeout, this, &Connection::queueTimeout);
-        QObject::connect(_sendQueue.get(), &SendQueue::clearHandshakeACK, this, &Connection::clearHandshakeACK);
+        QObject::connect(this, &Connection::clearHandshakeACK, _sendQueue.get(), &SendQueue::clearHandshakeACK);
 
         
         // set defaults on the send queue from our congestion control object and estimatedTimeout()

--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -27,8 +27,6 @@
 #include "Socket.h"
 #include <Trace.h>
 
-#define UDT_CONNECTION_DEBUG
-
 using namespace udt;
 using namespace std::chrono;
 

--- a/libraries/networking/src/udt/Connection.cpp
+++ b/libraries/networking/src/udt/Connection.cpp
@@ -27,6 +27,8 @@
 #include "Socket.h"
 #include <Trace.h>
 
+#define UDT_CONNECTION_DEBUG
+
 using namespace udt;
 using namespace std::chrono;
 
@@ -316,7 +318,6 @@ void Connection::processControl(ControlPacketPointer controlPacket) {
                 qCDebug(networking) << "Got HandshakeRequest from" << _destination << ", stopping SendQueue";
 #endif
                 _hasReceivedHandshakeACK = false;
-                //stopSendQueue();
                 emit clearHandshakeACK();
 
             }

--- a/libraries/networking/src/udt/Connection.h
+++ b/libraries/networking/src/udt/Connection.h
@@ -80,6 +80,8 @@ public:
 signals:
     void packetSent();
     void receiverHandshakeRequestComplete(const HifiSockAddr& sockAddr);
+    void clearHandshakeACK();
+
 
 private slots:
     void recordSentPackets(int wireSize, int payloadSize, SequenceNumber seqNum, p_high_resolution_clock::time_point timePoint);

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -293,6 +293,7 @@ void SendQueue::run() {
             // Keep processing events
             QCoreApplication::sendPostedEvents(this);
 
+            auto nextPacketTimestamp = p_high_resolution_clock::now();
             // Once we're here we've either received the handshake ACK or it's going to be time to re-send a handshake.
             // Either way let's continue processing - no packets will be sent if no handshake ACK has been received.
         }

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -291,7 +291,7 @@ void SendQueue::run() {
             // Keep processing events
             QCoreApplication::sendPostedEvents(this);
 
-            auto nextPacketTimestamp = p_high_resolution_clock::now();
+            nextPacketTimestamp = p_high_resolution_clock::now();
             // Once we're here we've either received the handshake ACK or it's going to be time to re-send a handshake.
             // Either way let's continue processing - no packets will be sent if no handshake ACK has been received.
         }

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -34,6 +34,8 @@
 
 #include "../NetworkLogging.h"
 
+#define UDT_CONNECTION_DEBUG
+
 using namespace udt;
 using namespace std::chrono;
 
@@ -280,21 +282,21 @@ void SendQueue::run() {
     
     _state = State::Running;
     
-    // Wait for handshake to be complete
-    while (_state == State::Running && !_hasReceivedHandshakeACK) {
-        sendHandshake();
-
-        // Keep processing events
-        QCoreApplication::sendPostedEvents(this);
-        
-        // Once we're here we've either received the handshake ACK or it's going to be time to re-send a handshake.
-        // Either way let's continue processing - no packets will be sent if no handshake ACK has been received.
-    }
-
     // Keep an HRC to know when the next packet should have been
     auto nextPacketTimestamp = p_high_resolution_clock::now();
 
     while (_state == State::Running) {
+        // Wait for handshake to be complete
+        while (_state == State::Running && !_hasReceivedHandshakeACK) {
+            sendHandshake();
+
+            // Keep processing events
+            QCoreApplication::sendPostedEvents(this);
+
+            // Once we're here we've either received the handshake ACK or it's going to be time to re-send a handshake.
+            // Either way let's continue processing - no packets will be sent if no handshake ACK has been received.
+        }
+
         bool attemptedToSendPacket = maybeResendPacket();
         
         // if we didn't find a packet to re-send AND we think we can fit a new packet on the wire

--- a/libraries/networking/src/udt/SendQueue.cpp
+++ b/libraries/networking/src/udt/SendQueue.cpp
@@ -34,8 +34,6 @@
 
 #include "../NetworkLogging.h"
 
-#define UDT_CONNECTION_DEBUG
-
 using namespace udt;
 using namespace std::chrono;
 

--- a/libraries/networking/src/udt/SendQueue.h
+++ b/libraries/networking/src/udt/SendQueue.h
@@ -75,6 +75,7 @@ public slots:
     void ack(SequenceNumber ack);
     void fastRetransmit(SequenceNumber ack);
     void handshakeACK();
+    void clearHandshakeACK();
 
 signals:
     void packetSent(int wireSize, int payloadSize, SequenceNumber seqNum, p_high_resolution_clock::time_point timePoint);

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -29,6 +29,8 @@
 #include "PacketList.h"
 #include <Trace.h>
 
+#define UDT_CONNECTION_DEBUG
+
 using namespace udt;
 
 Socket::Socket(QObject* parent, bool shouldChangeSocketOptions) :
@@ -200,7 +202,7 @@ void Socket::writeReliablePacket(Packet* packet, const HifiSockAddr& sockAddr) {
     }
 #ifdef UDT_CONNECTION_DEBUG
     else {
-        qCDebug(networking) << "Socket::writeReliablePacket refusing to send packet - no connection was created";
+        qCDebug(networking) << "Socket::writeReliablePacket refusing to send packet - no connection was created:" << sockAddr;
     }
 #endif
 
@@ -213,7 +215,7 @@ void Socket::writeReliablePacketList(PacketList* packetList, const HifiSockAddr&
     }
 #ifdef UDT_CONNECTION_DEBUG
     else {
-        qCDebug(networking) << "Socket::writeReliablePacketList refusing to send packet list - no connection was created";
+        qCDebug(networking) << "Socket::writeReliablePacketList refusing to send packet list - no connection was created:" << sockAddr;
     }
 #endif
 }

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -29,8 +29,6 @@
 #include "PacketList.h"
 #include <Trace.h>
 
-#define UDT_CONNECTION_DEBUG
-
 using namespace udt;
 
 Socket::Socket(QObject* parent, bool shouldChangeSocketOptions) :


### PR DESCRIPTION
Ticket: https://highfidelity.manuscript.com/f/cases/21609/10-out-of-200-traits-bots-stayed-as-white-spheres-after-avatar-mixer-restart

A HandshakeReq control packet is basically a connection reset when the state is out-of-sync. In the case where a SendQueue is active this PR recycles any unacknowledged packets and preserves queued-for-sending packets. Note that this may re-order packets.
