### PR TITLE
Case 21769 - updatable items not showing up as updatable after clicking 'show updates' button.

### DIFF
--- a/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/PurchasedItem.qml
@@ -49,7 +49,7 @@ Item {
     property string wornEntityID;
     property string updatedItemId;
     property string upgradeTitle;
-    property bool updateAvailable: root.updateItemId && root.updateItemId !== "";
+    property bool updateAvailable: root.updateItemId !== "";
     property bool valid;
     property bool standaloneOptimized;
     property bool standaloneIncompatible;

--- a/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
+++ b/interface/resources/qml/hifi/commerce/purchases/Purchases.qml
@@ -523,9 +523,9 @@ Rectangle {
                     item.cardBackVisible = false;
                     item.isInstalled = root.installedApps.indexOf(item.id) > -1;
                     item.wornEntityID = '';
+                    item.upgrade_id = item.upgrade_id ? item.upgrade_id : "";
                 });
                 sendToScript({ method: 'purchases_updateWearables' });
-
                 return data.assets;
             }
         }
@@ -545,7 +545,7 @@ Rectangle {
             delegate: PurchasedItem {
                 itemName: title;
                 itemId: id;
-                updateItemId: model.upgrade_id ? model.upgrade_id : "";
+                updateItemId: model.upgrade_id
                 itemPreviewImageUrl: preview;
                 itemHref: download_url;
                 certificateId: certificate_id;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21769/After-one-item-is-updated-any-other-updated-items-no-longer-show-the-Update-button-in-the-three-dot-context-menu