### PR TITLE
Agent requires the ModelCache singleton for zone entities with meshes

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -52,6 +52,8 @@
 #include <WebSocketServerClass.h>
 #include <EntityScriptingInterface.h> // TODO: consider moving to scriptengine.h
 
+#include <hfm/ModelFormatRegistry.h>
+
 #include "entities/AssignmentParentFinder.h"
 #include "AssignmentDynamicFactory.h"
 #include "RecordingScriptingInterface.h"
@@ -98,6 +100,9 @@ Agent::Agent(ReceivedMessage& message) :
 
     DependencyManager::set<RecordingScriptingInterface>();
     DependencyManager::set<UsersScriptingInterface>();
+
+    DependencyManager::set<ModelFormatRegistry>();
+    DependencyManager::set<ModelCache>();
 
     // Needed to ensure the creation of the DebugDraw instance on the main thread
     DebugDraw::getInstance();
@@ -818,6 +823,9 @@ void Agent::aboutToFinish() {
     DependencyManager::get<EntityScriptingInterface>()->setEntityTree(nullptr);
 
     DependencyManager::get<ResourceManager>()->cleanup();
+
+    DependencyManager::destroy<ModelFormatRegistry>();
+    DependencyManager::destroy<ModelCache>();
 
     DependencyManager::destroy<PluginManager>();
 


### PR DESCRIPTION
Ticket: https://highfidelity.manuscript.com/f/cases/21654

Agent may crash if a zone entity with a collision hull (arbitrary mesh) is supplied by the entity server.