### PR TITLE
Check that destination Node is still valid for reliable-packet service

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -497,7 +497,8 @@ qint64 LimitedNodeList::sendPacketList(std::unique_ptr<NLPacketList> packetList,
 
 qint64 LimitedNodeList::sendPacketList(std::unique_ptr<NLPacketList> packetList, const Node& destinationNode) {
     auto activeSocket = destinationNode.getActiveSocket();
-    if (activeSocket) {
+    if (activeSocket
+        && (!packetList->isReliable() || _nodeHash.find(destinationNode.getUUID()) != _nodeHash.end()) ) {
         // close the last packet in the list
         packetList->closeCurrentPacket();
 
@@ -508,7 +509,7 @@ qint64 LimitedNodeList::sendPacketList(std::unique_ptr<NLPacketList> packetList,
 
         return _nodeSocket.writePacketList(std::move(packetList), *activeSocket);
     } else {
-        qCDebug(networking) << "LimitedNodeList::sendPacketList called without active socket for node "
+        qCDebug(networking) << "LimitedNodeList::sendPacketList called without active socket or valid node for node "
                             << destinationNode.getUUID() << ". Not sending.";
         return ERROR_SENDING_PACKET_BYTES;
     }

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -423,10 +423,11 @@ qint64 LimitedNodeList::sendPacket(std::unique_ptr<NLPacket> packet, const Node&
     Q_ASSERT(!packet->isPartOfMessage());
     auto activeSocket = destinationNode.getActiveSocket();
 
-    if (activeSocket) {
+    if (activeSocket
+        && (!packet->isReliable() || _nodeHash.find(destinationNode.getUUID()) != _nodeHash.end()) ) {
         return sendPacket(std::move(packet), *activeSocket, destinationNode.getAuthenticateHash());
     } else {
-        qCDebug(networking) << "LimitedNodeList::sendPacket called without active socket for node" << destinationNode << "- not sending";
+        qCDebug(networking) << "LimitedNodeList::sendPacket called without active socket or valid node for node" << destinationNode << "- not sending";
         return ERROR_SENDING_PACKET_BYTES;
     }
 }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21609/10-out-of-200-traits-bots-stayed-as-white-spheres-after-avatar-mixer-restart

Where a Node is supplied as the destination for reliable service check that it's still in the nodelist, in case it's been removed by the domain but still exists due to, e.g., SharedNodePointer. Possible fix for race condition in restarting ACs.

Ideally the check would be on the NodeList thread, where the Node is removed, but that would require moving the jump-to-NodeList up from the Socket class to the LimitedNodeList class.
