### PR TITLE
Case 21797: Fix vanishing avatar entities for 0.81.0

### DIFF
--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1918,7 +1918,7 @@ private:
     bool didTeleport();
     bool getIsAway() const { return _isAway; }
     void setAway(bool value);
-    void sendPacket(const QUuid& entityID, const EntityItemProperties& properties) const override;
+    void sendPacket(const QUuid& entityID) const override;
 
     std::mutex _pinnedJointsMutex;
     std::vector<int> _pinnedJoints;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -376,7 +376,7 @@ bool Avatar::applyGrabChanges() {
                     const EntityItemPointer& entity = std::dynamic_pointer_cast<EntityItem>(target);
                     if (entity && entity->getEntityHostType() == entity::HostType::AVATAR && entity->getSimulationOwner().getID() == getID()) {
                         EntityItemProperties properties = entity->getProperties();
-                        sendPacket(entity->getID(), properties);
+                        sendPacket(entity->getID());
                     }
                 }
             } else {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -605,7 +605,7 @@ protected:
 
     // protected methods...
     bool isLookingAtMe(AvatarSharedPointer avatar) const;
-    virtual void sendPacket(const QUuid& entityID, const EntityItemProperties& properties) const { }
+    virtual void sendPacket(const QUuid& entityID) const { }
     bool applyGrabChanges();
     void relayJointDataToChildren();
 

--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -39,9 +39,7 @@ void EntityEditPacketSender::adjustEditPacketForClockSkew(PacketType type, QByte
     }
 }
 
-void EntityEditPacketSender::queueEditAvatarEntityMessage(EntityTreePointer entityTree,
-                                                          EntityItemID entityItemID,
-                                                          const EntityItemProperties& properties) {
+void EntityEditPacketSender::queueEditAvatarEntityMessage(EntityTreePointer entityTree, EntityItemID entityItemID) {
     assert(_myAvatar);
     if (!entityTree) {
         qCDebug(entities) << "EntityEditPacketSender::queueEditAvatarEntityMessage null entityTree.";
@@ -53,11 +51,6 @@ void EntityEditPacketSender::queueEditAvatarEntityMessage(EntityTreePointer enti
         return;
     }
     entity->setLastBroadcast(usecTimestampNow());
-
-    // serialize ALL properties in an "AvatarEntity" packet
-    // rather than just the ones being edited.
-    EntityItemProperties entityProperties = entity->getProperties();
-    entityProperties.merge(properties);
 
     OctreePacketData packetData(false, AvatarTraits::MAXIMUM_TRAIT_SIZE);
     EncodeBitstreamParams params;
@@ -82,7 +75,7 @@ void EntityEditPacketSender::queueEditEntityMessage(PacketType type,
             qCWarning(entities) << "Suppressing entity edit message: cannot send avatar entity edit with no myAvatar";
         } else if (properties.getOwningAvatarID() == _myAvatar->getID()) {
             // this is an avatar-based entity --> update our avatar-data rather than sending to the entity-server
-            queueEditAvatarEntityMessage(entityTree, entityItemID, properties);
+            queueEditAvatarEntityMessage(entityTree, entityItemID);
         } else {
             qCWarning(entities) << "Suppressing entity edit message: cannot send avatar entity edit for another avatar";
         }

--- a/libraries/entities/src/EntityEditPacketSender.h
+++ b/libraries/entities/src/EntityEditPacketSender.h
@@ -50,8 +50,8 @@ public slots:
     void processEntityEditNackPacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer sendingNode);
 
 private:
-    void queueEditAvatarEntityMessage(EntityTreePointer entityTree,
-                                      EntityItemID entityItemID, const EntityItemProperties& properties);
+    friend class MyAvatar;
+    void queueEditAvatarEntityMessage(EntityTreePointer entityTree, EntityItemID entityItemID);
 
 private:
     std::mutex _mutex;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21797/Avatar-entities-are-not-seen-by-observers-when-the-wearer-joins-a-domain-until-they-are-edited

This PR fixes a regression problem where attached AvatarEntities vanish for others after changing domains.