### PR TITLE
When adding new Node clear any dangling Connection objects

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -677,6 +677,9 @@ SharedNodePointer LimitedNodeList::addOrUpdateNode(const QUuid& uuid, NodeType_t
     // If there is a new node with the same socket, this is a reconnection, kill the old node
     removeOldNode(findNodeWithAddr(publicSocket));
     removeOldNode(findNodeWithAddr(localSocket));
+    // If there is an old Connection to the new node's address kill it
+    _nodeSocket.cleanupConnection(publicSocket);
+    _nodeSocket.cleanupConnection(localSocket);
 
     auto it = _connectionIDs.find(uuid);
     if (it == _connectionIDs.end()) {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21609/10-out-of-200-traits-bots-stayed-as-white-spheres-after-avatar-mixer-restart
Another approach to this issue: when a new Node is created remove any Connection objects that are for its address. This should clear any reliable connections for the AC's previous incarnation.
