### PR TITLE
Remove deleteBookmark function call from AvatarBookmarks

### DIFF
--- a/interface/src/AvatarBookmarks.cpp
+++ b/interface/src/AvatarBookmarks.cpp
@@ -149,6 +149,9 @@ void AvatarBookmarks::removeBookmark(const QString& bookmarkName) {
     emit bookmarkDeleted(bookmarkName);
 }
 
+void AvatarBookmarks::deleteBookmark() {
+}
+
 void AvatarBookmarks::updateAvatarEntities(const QVariantList &avatarEntities) {
     auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
     auto currentAvatarEntities = myAvatar->getAvatarEntityData();

--- a/interface/src/AvatarBookmarks.h
+++ b/interface/src/AvatarBookmarks.h
@@ -76,6 +76,9 @@ protected:
     void readFromFile() override;
     QVariantMap getAvatarDataToBookmark();
 
+protected slots: 
+    void deleteBookmark() override;
+
 private:
     const QString AVATARBOOKMARKS_FILENAME = "avatarbookmarks.json";
     const QString ENTRY_AVATAR_URL = "avatarUrl";

--- a/interface/src/Bookmarks.h
+++ b/interface/src/Bookmarks.h
@@ -52,12 +52,9 @@ protected:
 
 protected slots:
     /**jsdoc
-     * @function AvatarBookmarks.deleteBookmark
-     */
-    /**jsdoc
      * @function LocationBookmarks.deleteBookmark
      */
-    void deleteBookmark();
+    virtual void deleteBookmark();
 
 private:
     static bool sortOrder(QAction* a, QAction* b);


### PR DESCRIPTION
Removes automatic interface crash when running AvatarBookmarks.deleteBookmark();
Will remove deleteBookmark function call from the AvatarBookmarks documentation.