### PR TITLE
Case 21876: New procedural uniforms for time, iEntityTime and iLocalCreatedTime

### DIFF
--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -261,7 +261,7 @@ void ShapeEntityRenderer::doRender(RenderArgs* args) {
         if (_procedural.isReady()) {
             outColor = _procedural.getColor(outColor);
             outColor.a *= _procedural.isFading() ? Interpolate::calculateFadeRatio(_procedural.getFadeStartTime()) : 1.0f;
-            _procedural.prepare(batch, _position, _dimensions, _orientation, ProceduralProgramKey(outColor.a < 1.0f));
+            _procedural.prepare(batch, _position, _dimensions, _orientation, _created, ProceduralProgramKey(outColor.a < 1.0f));
             proceduralRender = true;
         }
     });

--- a/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableZoneEntityItem.cpp
@@ -33,7 +33,7 @@ using namespace render::entities;
 
 ZoneEntityRenderer::ZoneEntityRenderer(const EntityItemPointer& entity)
     : Parent(entity) {
-    _background->setSkybox(std::make_shared<ProceduralSkybox>());
+    _background->setSkybox(std::make_shared<ProceduralSkybox>(entity->getCreated()));
 }
 
 void ZoneEntityRenderer::onRemoveFromSceneTyped(const TypedEntityPointer& entity) {

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -225,11 +225,13 @@ void Procedural::prepare(gpu::Batch& batch,
                          const glm::vec3& position,
                          const glm::vec3& size,
                          const glm::quat& orientation,
+                         const quint64& created,
                          const ProceduralProgramKey key) {
     std::lock_guard<std::mutex> lock(_mutex);
     _entityDimensions = size;
     _entityPosition = position;
     _entityOrientation = glm::mat3_cast(orientation);
+    _entityCreated = created;
     if (!_shaderPath.isEmpty()) {
         auto lastModified = (quint64)QFileInfo(_shaderPath).lastModified().toMSecsSinceEpoch();
         if (lastModified > _shaderModified) {
@@ -278,7 +280,10 @@ void Procedural::prepare(gpu::Batch& batch,
 
         _proceduralPipelines[key] = gpu::Pipeline::create(program, key.isTransparent() ? _transparentState : _opaqueState);
 
-        _start = usecTimestampNow();
+        _lastCompile = usecTimestampNow();
+        if (_firstCompile == 0) {
+            _firstCompile = _lastCompile;
+        }
         _frameCount = 0;
         recompiledShader = true;
     }
@@ -371,7 +376,11 @@ void Procedural::setupUniforms() {
     _uniforms.push_back([=](gpu::Batch& batch) {
         _standardInputs.position = vec4(_entityPosition, 1.0f);
         // Minimize floating point error by doing an integer division to milliseconds, before the floating point division to seconds
-        _standardInputs.time = (float)((usecTimestampNow() - _start) / USECS_PER_MSEC) / MSECS_PER_SECOND;
+        auto now = usecTimestampNow();
+        _standardInputs.timeSinceLastCompile = (float)((now - _lastCompile) / USECS_PER_MSEC) / MSECS_PER_SECOND;
+        _standardInputs.timeSinceFirstCompile = (float)((now - _firstCompile) / USECS_PER_MSEC) / MSECS_PER_SECOND;
+        _standardInputs.timeSinceEntityCreation = (float)((now - _entityCreated) / USECS_PER_MSEC) / MSECS_PER_SECOND;
+
 
         // Date
         {

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -225,7 +225,7 @@ void Procedural::prepare(gpu::Batch& batch,
                          const glm::vec3& position,
                          const glm::vec3& size,
                          const glm::quat& orientation,
-                         const quint64& created,
+                         const uint64_t& created,
                          const ProceduralProgramKey key) {
     std::lock_guard<std::mutex> lock(_mutex);
     _entityDimensions = size;
@@ -233,7 +233,7 @@ void Procedural::prepare(gpu::Batch& batch,
     _entityOrientation = glm::mat3_cast(orientation);
     _entityCreated = created;
     if (!_shaderPath.isEmpty()) {
-        auto lastModified = (quint64)QFileInfo(_shaderPath).lastModified().toMSecsSinceEpoch();
+        auto lastModified = (uint64_t)QFileInfo(_shaderPath).lastModified().toMSecsSinceEpoch();
         if (lastModified > _shaderModified) {
             QFile file(_shaderPath);
             file.open(QIODevice::ReadOnly);

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -83,10 +83,10 @@ public:
     bool isReady() const;
     bool isEnabled() const { return _enabled; }
     void prepare(gpu::Batch& batch, const glm::vec3& position, const glm::vec3& size, const glm::quat& orientation,
-                 const quint64& created, const ProceduralProgramKey key = ProceduralProgramKey());
+                 const uint64_t& created, const ProceduralProgramKey key = ProceduralProgramKey());
 
     glm::vec4 getColor(const glm::vec4& entityColor) const;
-    quint64 getFadeStartTime() const { return _fadeStartTime; }
+    uint64_t getFadeStartTime() const { return _fadeStartTime; }
     bool isFading() const { return _doesFade && _isFading; }
     void setIsFading(bool isFading) { _isFading = isFading; }
     void setDoesFade(bool doesFade) { _doesFade = doesFade; }
@@ -136,7 +136,7 @@ protected:
     // Rendering object descriptions, from userData
     QString _shaderSource;
     QString _shaderPath;
-    quint64 _shaderModified { 0 };
+    uint64_t _shaderModified { 0 };
     NetworkShaderPointer _networkShader;
     bool _shaderDirty { true };
     bool _uniformsDirty { true };
@@ -156,12 +156,12 @@ protected:
     glm::vec3 _entityDimensions;
     glm::vec3 _entityPosition;
     glm::mat3 _entityOrientation;
-    quint64 _entityCreated;
+    uint64_t _entityCreated;
 
 private:
     void setupUniforms();
 
-    mutable quint64 _fadeStartTime { 0 };
+    mutable uint64_t _fadeStartTime { 0 };
     mutable bool _hasStartedFade { false };
     mutable bool _isFading { false };
     bool _doesFade { true };

--- a/libraries/procedural/src/procedural/Procedural.h
+++ b/libraries/procedural/src/procedural/Procedural.h
@@ -82,7 +82,8 @@ public:
 
     bool isReady() const;
     bool isEnabled() const { return _enabled; }
-    void prepare(gpu::Batch& batch, const glm::vec3& position, const glm::vec3& size, const glm::quat& orientation, const ProceduralProgramKey key = ProceduralProgramKey());
+    void prepare(gpu::Batch& batch, const glm::vec3& position, const glm::vec3& size, const glm::quat& orientation,
+                 const quint64& created, const ProceduralProgramKey key = ProceduralProgramKey());
 
     glm::vec4 getColor(const glm::vec4& entityColor) const;
     quint64 getFadeStartTime() const { return _fadeStartTime; }
@@ -106,9 +107,10 @@ protected:
         vec4 date;
         vec4 position; 
         vec4 scale;
-        float time;
+        float timeSinceLastCompile;
+        float timeSinceFirstCompile;
+        float timeSinceEntityCreation;
         int frameCount;
-        vec2 _spare1;
         vec4 resolution[4];
         mat4 orientation;
     };
@@ -116,9 +118,10 @@ protected:
     static_assert(0 == offsetof(StandardInputs, date), "ProceduralOffsets");
     static_assert(16 == offsetof(StandardInputs, position), "ProceduralOffsets");
     static_assert(32 == offsetof(StandardInputs, scale), "ProceduralOffsets");
-    static_assert(48 == offsetof(StandardInputs, time), "ProceduralOffsets");
-    static_assert(52 == offsetof(StandardInputs, frameCount), "ProceduralOffsets");
-    static_assert(56 == offsetof(StandardInputs, _spare1), "ProceduralOffsets");
+    static_assert(48 == offsetof(StandardInputs, timeSinceLastCompile), "ProceduralOffsets");
+    static_assert(52 == offsetof(StandardInputs, timeSinceFirstCompile), "ProceduralOffsets");
+    static_assert(56 == offsetof(StandardInputs, timeSinceEntityCreation), "ProceduralOffsets");
+    static_assert(60 == offsetof(StandardInputs, frameCount), "ProceduralOffsets");
     static_assert(64 == offsetof(StandardInputs, resolution), "ProceduralOffsets");
     static_assert(128 == offsetof(StandardInputs, orientation), "ProceduralOffsets");
 
@@ -126,7 +129,8 @@ protected:
     ProceduralData _data;
 
     bool _enabled { false };
-    uint64_t _start { 0 };
+    uint64_t _lastCompile { 0 };
+    uint64_t _firstCompile { 0 };
     int32_t _frameCount { 0 };
 
     // Rendering object descriptions, from userData
@@ -152,6 +156,7 @@ protected:
     glm::vec3 _entityDimensions;
     glm::vec3 _entityPosition;
     glm::mat3 _entityOrientation;
+    quint64 _entityCreated;
 
 private:
     void setupUniforms();

--- a/libraries/procedural/src/procedural/ProceduralCommon.slh
+++ b/libraries/procedural/src/procedural/ProceduralCommon.slh
@@ -36,9 +36,11 @@ LAYOUT_STD140(binding=0) uniform standardInputsBuffer {
     // Offset 48
     float globalTime;
     // Offset 52
-    int frameCount;
+    float localCreatedTime;
     // Offset 56
-    vec2 _spare1;
+    float entityTime;
+    // Offset 60
+    int frameCount;
     // Offset 64, acts as vec4[4] for alignment purposes
     vec3 channelResolution[4];
     // Offset 128, acts as vec4[3] for alignment purposes
@@ -52,6 +54,8 @@ LAYOUT_STD140(binding=0) uniform standardInputsBuffer {
 #define iWorldPosition standardInputs.worldPosition
 #define iWorldScale standardInputs.worldScale
 #define iGlobalTime standardInputs.globalTime
+#define iLocalCreatedTime standardInputs.localCreatedTime
+#define iEntityTime standardInputs.entityTime
 #define iFrameCount standardInputs.frameCount
 #define iChannelResolution standardInputs.channelResolution
 #define iWorldOrientation standardInputs.worldOrientation

--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -17,7 +17,7 @@
 #include <ViewFrustum.h>
 #include <shaders/Shaders.h>
 
-ProceduralSkybox::ProceduralSkybox() : graphics::Skybox() {
+ProceduralSkybox::ProceduralSkybox(quint64 created) : graphics::Skybox(), _created(created) {
     _procedural._vertexSource = gpu::Shader::createVertex(shader::graphics::vertex::skybox)->getSource();
     _procedural._opaqueFragmentSource = shader::Source::get(shader::procedural::fragment::proceduralSkybox);
     // Adjust the pipeline state for background using the stencil test
@@ -59,7 +59,7 @@ void ProceduralSkybox::render(gpu::Batch& batch, const ViewFrustum& viewFrustum,
     batch.setModelTransform(Transform()); // only for Mac
 
     auto& procedural = skybox._procedural;
-    procedural.prepare(batch, glm::vec3(0), glm::vec3(1), glm::quat());
+    procedural.prepare(batch, glm::vec3(0), glm::vec3(1), glm::quat(), skybox.getCreated());
     skybox.prepare(batch);
     batch.draw(gpu::TRIANGLE_STRIP, 4);
 }

--- a/libraries/procedural/src/procedural/ProceduralSkybox.cpp
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.cpp
@@ -17,7 +17,7 @@
 #include <ViewFrustum.h>
 #include <shaders/Shaders.h>
 
-ProceduralSkybox::ProceduralSkybox(quint64 created) : graphics::Skybox(), _created(created) {
+ProceduralSkybox::ProceduralSkybox(uint64_t created) : graphics::Skybox(), _created(created) {
     _procedural._vertexSource = gpu::Shader::createVertex(shader::graphics::vertex::skybox)->getSource();
     _procedural._opaqueFragmentSource = shader::Source::get(shader::procedural::fragment::proceduralSkybox);
     // Adjust the pipeline state for background using the stencil test

--- a/libraries/procedural/src/procedural/ProceduralSkybox.h
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.h
@@ -19,7 +19,7 @@
 
 class ProceduralSkybox: public graphics::Skybox {
 public:
-    ProceduralSkybox();
+    ProceduralSkybox(quint64 created = 0);
     
     void parse(const QString& userData) { _procedural.setProceduralData(ProceduralData::parse(userData)); }
 
@@ -29,8 +29,11 @@ public:
     void render(gpu::Batch& batch, const ViewFrustum& frustum) const override;
     static void render(gpu::Batch& batch, const ViewFrustum& frustum, const ProceduralSkybox& skybox);
 
+    quint64 getCreated() const { return _created; }
+
 protected:
     mutable Procedural _procedural;
+    quint64 _created;
 };
 typedef std::shared_ptr< ProceduralSkybox > ProceduralSkyboxPointer;
 

--- a/libraries/procedural/src/procedural/ProceduralSkybox.h
+++ b/libraries/procedural/src/procedural/ProceduralSkybox.h
@@ -19,7 +19,7 @@
 
 class ProceduralSkybox: public graphics::Skybox {
 public:
-    ProceduralSkybox(quint64 created = 0);
+    ProceduralSkybox(uint64_t created = 0);
     
     void parse(const QString& userData) { _procedural.setProceduralData(ProceduralData::parse(userData)); }
 
@@ -29,11 +29,11 @@ public:
     void render(gpu::Batch& batch, const ViewFrustum& frustum) const override;
     static void render(gpu::Batch& batch, const ViewFrustum& frustum, const ProceduralSkybox& skybox);
 
-    quint64 getCreated() const { return _created; }
+    uint64_t getCreated() const { return _created; }
 
 protected:
     mutable Procedural _procedural;
-    quint64 _created;
+    uint64_t _created;
 };
 typedef std::shared_ptr< ProceduralSkybox > ProceduralSkyboxPointer;
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21876/Expose-iEntityTime-and-iLocalCreatedTime-for-procedurals

Test plan:
- Go to a domain and run this:
```
var entity = Entities.addEntity({
	type: "Sphere",
             position: Vec3.sum(MyAvatar.position, Vec3.multiply(2, Quat.getFront(MyAvatar.orientation))),
             dimensions: 0.5,
             collisionless: true,
             userData: JSON.stringify({
                  "ProceduralEntity": {
                       "version": 2,
                       "shaderUrl": "https://hifi-content.s3.amazonaws.com/samuel/ProceduralTime.fs”
                  }
             })
});
```
- You'll see a sphere split into 3 sections: red, green, and blue.  They should all be pulsing, but could be slightly off from each other.
- Red corresponds to iGlobalTime, which is the time since the shader last compiled.  If you change the shaderURL or uniforms, etc., the shader will be recompiled, and the red will restart.
- Green corresponds to iLocalCreatedTime, the time since the first shader for this object was compiled.  If you do something to cause the shader to recompile, this will not restart.
- Blue corresponds to iEntityTime, the time since the entity creation.  This is shared across clients and can't change, so you can create shader effects that are synced across clients.
- Have someone else running this PR join you.  They'll see the sphere too, but the timing of the pulses will be slightly off.  The blue pulses should pretty closely match.
- Run this:
```
Entities.editEntity(entity, {
     userData: JSON.stringify({
          "ProceduralEntity": {
               "version": 2,
               "uniforms": {
                    "_shininess": 1
               },
               "shaderUrl": "https://hifi-content.s3.amazonaws.com/samuel/ProceduralTime.fs?8"
          }
     })
});
```
Immediately after you run that, the red pulses should restart for both of you, but the other pulses shouldn't be affected.  This will only happen the first time you run that snippet, if you don't catch it, you can run the first snippet again and try again.