### PR TITLE
Case 21877: [CreateApp] give onWebEventReceived the correct context in VR [RC82]

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -2524,7 +2524,7 @@ var PropertiesTool = function (opts) {
 
     createToolsWindow.webEventReceived.addListener(this, onWebEventReceived);
 
-    webView.webEventReceived.connect(onWebEventReceived);
+    webView.webEventReceived.connect(this, onWebEventReceived);
 
     return that;
 };


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21877/v82-0-In-VR-only-properties-tab-does-not-update-when-locking-unlocking-an-entity-or-changing-skybox-properties