### PR TITLE
Case 21846: Make JSDoc use "@returns {Signal}" instead of "@signal"

### DIFF
--- a/tools/jsdoc/hifi-jsdoc-template/tmpl/signalList.tmpl
+++ b/tools/jsdoc/hifi-jsdoc-template/tmpl/signalList.tmpl
@@ -13,8 +13,8 @@ var self = this;
                     <code><?js= (kind === 'class' ? 'new ' : '') + name + (data.signatureHead || '') ?></code></a>
                 </td>
                 <td>
-                <?js if (data.summary) { ?>
-                <?js= summary ?>
+                <?js if (data.description) { ?>
+                <?js= description ?>
                 <?js= this.partial('details.tmpl', data) ?>
                 <?js } else { ?>
                     <?js= this.partial('details.tmpl', data) ?>

--- a/tools/jsdoc/plugins/hifi.js
+++ b/tools/jsdoc/plugins/hifi.js
@@ -129,20 +129,6 @@ exports.handlers = {
     }
 };
 
-// Functions for adding @signal custom tag
-/** @private */
-function setDocletKindToTitle(doclet, tag) {
-    doclet.addTag( 'kind', tag.title );
-}
-
-function setDocletNameToValue(doclet, tag) {
-    if (tag.value && tag.value.description) { // as in a long tag
-        doclet.addTag('name', tag.value.description);
-    } else if (tag.text) { // or a short tag
-        doclet.addTag('name', tag.text);
-    }
-}
-
 // Define custom hifi tags here
 exports.defineTags = function (dictionary) {
 
@@ -171,15 +157,6 @@ exports.defineTags = function (dictionary) {
     dictionary.defineTag("hifi-server-entity", {
         onTagged: function (doclet, tag) {
             doclet.hifiServerEntity = true;
-        }
-    });
-    
-    // @signal
-    dictionary.defineTag("signal", {
-        mustHaveValue: true,
-        onTagged: function(doclet, tag) {
-            setDocletKindToTitle(doclet, tag);
-            setDocletNameToValue(doclet, tag);
         }
     });
 

--- a/tools/jsdoc/plugins/hifi.js
+++ b/tools/jsdoc/plugins/hifi.js
@@ -121,6 +121,11 @@ exports.handlers = {
                 e.doclet.description = (e.doclet.description ? e.doclet.description : "") + availableIn;
             }            
         }
+
+        if (e.doclet.kind === "function" && e.doclet.returns && e.doclet.returns[0].type
+                && e.doclet.returns[0].type.names[0] === "Signal") {
+            e.doclet.kind = "signal";
+        }
     }
 };
 


### PR DESCRIPTION
Updates the JSDoc processing to automatically detect signal functions from their return value rather than needing a new, custom "@signal" tag.

No change in Interface or server executable code.

https://highfidelity.manuscript.com/f/cases/21846/Make-JSDoc-template-use-returns-Signal-instead-of-signal