### PR TITLE
Case 21887: Revert changes that impacted animation performance (RC81)

### DIFF
--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -178,7 +178,6 @@ void CauterizedModel::updateClusterMatrices() {
             }
         }
     }
-    computeMeshPartLocalBounds();
 
     // post the blender if we're not currently waiting for one to finish
     auto modelBlender = DependencyManager::get<ModelBlender>();

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1346,19 +1346,14 @@ void Model::updateRig(float deltaTime, glm::mat4 parentTransform) {
 }
 
 void Model::computeMeshPartLocalBounds() {
-    render::Transaction transaction;
-    auto meshStates = _meshStates;
-    for (auto renderItem : _modelMeshRenderItemIDs) {
-        transaction.updateItem<ModelMeshPartPayload>(renderItem, [this, meshStates](ModelMeshPartPayload& data) {
-            const Model::MeshState& state = meshStates.at(data._meshIndex);
-            if (_useDualQuaternionSkinning) {
-                data.computeAdjustedLocalBound(state.clusterDualQuaternions);
-            } else {
-                data.computeAdjustedLocalBound(state.clusterMatrices);
-            }
-        });
+    for (auto& part : _modelMeshRenderItems) {
+        const Model::MeshState& state = _meshStates.at(part->_meshIndex);
+        if (_useDualQuaternionSkinning) {
+            part->computeAdjustedLocalBound(state.clusterDualQuaternions);
+        } else {
+            part->computeAdjustedLocalBound(state.clusterMatrices);
+        }
     }
-    AbstractViewStateInterface::instance()->getMain3DScene()->enqueueTransaction(transaction);
 }
 
 // virtual
@@ -1391,7 +1386,6 @@ void Model::updateClusterMatrices() {
             }
         }
     }
-    computeMeshPartLocalBounds();
 
     // post the blender if we're not currently waiting for one to finish
     auto modelBlender = DependencyManager::get<ModelBlender>();


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21887/Fix-animations-performance-regression

Test plan:
- In domains with lots of animated entities, like industry40 (which might be on a different protocol, unfortunately), your game rate shouldn't tank immediately.  Things should still animate properly.
- Create an animating model:
```
var ANIMATION1 = "https://hifi-content.s3.amazonaws.com/jimi/animation/WS/Yelling.fbx";
var entity = Entities.addEntity({
    type: "Model",
    modelURL: "http://mpassets.highfidelity.com/ad348528-de38-420c-82bb-054cb22163f5-v1/mannequin.fst",
    position: Vec3.sum(MyAvatar.position, Vec3.multiply(4.0, Quat.getForward(MyAvatar.orientation))),
    rotation: MyAvatar.orientation,
    animation: {
        url: ANIMATION1,
        running: true,
        allowTranslation: false
    }
});
```
- Open luci.js and enable the Opaque, Transparent, and Meta checkboxes at the bottom.  You'll see various bounds around the model.
- Run this:
```
Entities.editEntity(entity, { modelScale: 0.5 });
```
- The model will shrink to be half the size.  The bounds will also update accordingly.