### PR TITLE
case 21896: avoid a deadlock in code invoked by onAddingEntity or onDeletingEntity

### DIFF
--- a/interface/resources/qml/hifi/AvatarApp.qml
+++ b/interface/resources/qml/hifi/AvatarApp.qml
@@ -50,7 +50,7 @@ Rectangle {
 
     property var jointNames: []
     property var currentAvatarSettings;
-    property bool wearablesLocked;
+    property bool wearablesFrozen;
 
     function fetchAvatarModelName(marketId, avatar) {
         var xmlhttp = new XMLHttpRequest();
@@ -190,8 +190,8 @@ Rectangle {
             updateCurrentAvatarInBookmarks(currentAvatar);
         } else if (message.method === 'selectAvatarEntity') {
             adjustWearables.selectWearableByID(message.entityID);
-        } else if (message.method === 'wearablesLockedChanged') {
-            wearablesLocked = message.wearablesLocked;
+        } else if (message.method === 'wearablesFrozenChanged') {
+            wearablesFrozen = message.wearablesFrozen;
         }
     }
 
@@ -526,10 +526,10 @@ Rectangle {
             anchors.right: adjustLabel.left
             anchors.verticalCenter: wearablesLabel.verticalCenter
             anchors.rightMargin: 15
-            glyphText: wearablesLocked ? hifi.glyphs.lock : hifi.glyphs.unlock;
+            glyphText: wearablesFrozen ? hifi.glyphs.lock : hifi.glyphs.unlock;
 
             onClicked: {
-                emitSendToScript({'method' : 'toggleWearablesLock'});
+                emitSendToScript({'method' : 'toggleWearablesFrozen'});
             }
         }
     }

--- a/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
+++ b/interface/resources/qml/hifi/avatarapp/AdjustWearables.qml
@@ -113,6 +113,7 @@ Rectangle {
                 } else if (prop === 'dimensions') {
                     scalespinner.set(wearable[prop].x / wearable.naturalDimensions.x);
                 }
+                modified = true;
             }
         }
 

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -1101,13 +1101,13 @@ void EntityScriptingInterface::handleEntityScriptCallMethodPacket(QSharedPointer
 
 void EntityScriptingInterface::onAddingEntity(EntityItem* entity) {
     if (entity->isWearable()) {
-        emit addingWearable(entity->getEntityItemID());
+        QMetaObject::invokeMethod(this, "addingWearable", Q_ARG(QUuid, entity->getEntityItemID()));
     }
 }
 
 void EntityScriptingInterface::onDeletingEntity(EntityItem* entity) {
     if (entity->isWearable()) {
-        emit deletingWearable(entity->getEntityItemID());
+        QMetaObject::invokeMethod(this, "deletingWearable", Q_ARG(QUuid, entity->getEntityItemID()));
     }
 }
 

--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -77,7 +77,7 @@ function updateAvatarWearables(avatar, callback, wearablesOverride) {
         avatar[ENTRY_AVATAR_ENTITIES] = wearables;
 
         sendToQml({'method' : 'wearablesUpdated', 'wearables' : wearables});
-        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
 
         if(callback)
             callback();
@@ -179,26 +179,26 @@ var MARKETPLACE_PURCHASES_QML_PATH = "hifi/commerce/wallet/Wallet.qml";
 var MARKETPLACE_URL = Account.metaverseServerURL + "/marketplace";
 var MARKETPLACES_INJECT_SCRIPT_URL = Script.resolvePath("html/js/marketplacesInject.js");
 
-function getWearablesLocked() {
-    var wearablesLocked = true;
+function getWearablesFrozen() {
+    var wearablesFrozen = true;
     var wearablesArray = getMyAvatarWearables();
     wearablesArray.forEach(function(wearable) {
         if (isGrabbable(wearable.id)) {
-            wearablesLocked = false;
+            wearablesFrozen = false;
         }
     });
 
-    return wearablesLocked;
+    return wearablesFrozen;
 }
 
-function lockWearables() {
+function freezeWearables() {
     var wearablesArray = getMyAvatarWearables();
     wearablesArray.forEach(function(wearable) {
         setGrabbable(wearable.id, false);
     });
 }
 
-function unlockWearables() {
+function unfreezeWearables() {
     var wearablesArray = getMyAvatarWearables();
     wearablesArray.forEach(function(wearable) {
         setGrabbable(wearable.id, true);
@@ -237,7 +237,7 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
         AvatarBookmarks.loadBookmark(message.name);
         Entities.addingWearable.connect(onAddingWearable);
         Entities.deletingWearable.connect(onDeletingWearable);
-        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
         break;
     case 'deleteAvatar':
         AvatarBookmarks.removeBookmark(message.name);
@@ -262,7 +262,7 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
     case 'adjustWearablesOpened':
         currentAvatarWearablesBackup = getMyAvatarWearables();
         adjustWearables.setOpened(true);
-        unlockWearables();
+        unfreezeWearables();
 
         Entities.mousePressOnEntity.connect(onSelectedEntity);
         Messages.subscribe('Hifi-Object-Manipulation');
@@ -377,15 +377,15 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
 
         currentAvatarSettings = getMyAvatarSettings();
         break;
-    case 'toggleWearablesLock':
-        var wearablesLocked = getWearablesLocked();
-        wearablesLocked = !wearablesLocked;
-        if (wearablesLocked) {
-            lockWearables();
+    case 'toggleWearablesFrozen':
+        var wearablesFrozen = getWearablesFrozen();
+        wearablesFrozen = !wearablesFrozen;
+        if (wearablesFrozen) {
+            freezeWearables();
         } else {
-            unlockWearables();
+            unfreezeWearables();
         }
-        sendToQml({'method' : 'wearablesLockedChanged', 'wearablesLocked' : wearablesLocked});
+        sendToQml({'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : wearablesFrozen});
         break;
     default:
         print('Unrecognized message from AvatarApp.qml');
@@ -410,7 +410,7 @@ function setGrabbable(entityID, grabbable) {
     if (properties.avatarEntity && properties.grab.grabbable != grabbable) {
         var editProps = { grab: { grabbable: grabbable }};
         Entities.editEntity(entityID, editProps);
-        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
     }
 }
 
@@ -444,14 +444,14 @@ function onAddingWearable(entityID) {
     updateAvatarWearables(currentAvatar, function() {
         sendToQml({'method' : 'updateAvatarInBookmarks'});
     });
-    sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+    sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
 }
 
 function onDeletingWearable(entityID) {
     updateAvatarWearables(currentAvatar, function() {
         sendToQml({'method' : 'updateAvatarInBookmarks'});
     });
-    sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+    sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
 }
 
 function handleWearableMessages(channel, message, sender) {
@@ -635,7 +635,7 @@ function onTabletScreenChanged(type, url) {
 
     if(onAvatarAppScreenNow) {
         sendToQml({ 'method' : 'initialize', 'data' : { jointNames : MyAvatar.getJointNames() }});
-        sendToQml({ 'method' : 'wearablesLockedChanged', 'wearablesLocked' : getWearablesLocked()});
+        sendToQml({ 'method' : 'wearablesFrozenChanged', 'wearablesFrozen' : getWearablesFrozen()});
     }
 }
 

--- a/scripts/system/avatarapp.js
+++ b/scripts/system/avatarapp.js
@@ -262,7 +262,7 @@ function fromQml(message) { // messages are {method, params}, like json-rpc. See
     case 'adjustWearablesOpened':
         currentAvatarWearablesBackup = getMyAvatarWearables();
         adjustWearables.setOpened(true);
-        lockWearables();
+        unlockWearables();
 
         Entities.mousePressOnEntity.connect(onSelectedEntity);
         Messages.subscribe('Hifi-Object-Manipulation');


### PR DESCRIPTION
avoid a deadlock when code invoked by onAddingEntity or onDeletingEntity runs more code that locks the entity tree


https://highfidelity.manuscript.com/f/cases/21896/Multiple-crashes-on-the-Avatar-app-after-attachment-lock-merge
