### PR TITLE
Case 21910: Fix clashing hyperlinks in AvatarPackager project page

### DIFF
--- a/interface/resources/qml/hifi/avatarPackager/AvatarProject.qml
+++ b/interface/resources/qml/hifi/avatarPackager/AvatarProject.qml
@@ -339,8 +339,8 @@ Item {
         visible: AvatarPackagerCore.currentAvatarProject && AvatarPackagerCore.currentAvatarProject.hasErrors
 
         anchors {
-            top: notForSaleMessage.bottom
-            topMargin: 16
+            top: notForSaleMessage.visible ? notForSaleMessage.bottom : infoMessage .bottom
+            bottom: showFilesText.top
             horizontalCenter: parent.horizontalCenter
         }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21910/v0-82-Avatar-Packager-has-overlapping-hyperlinks-when-not-logged-in