### PR TITLE
Improve blendshape precision for small models

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1648,7 +1648,7 @@ using packBlendshapeOffsetTo = void(glm::uvec4& packed, const BlendshapeOffsetUn
 void packBlendshapeOffsetTo_Pos_F32_3xSN10_Nor_3xSN10_Tan_3xSN10(glm::uvec4& packed, const BlendshapeOffsetUnpacked& unpacked) {
     float len = glm::compMax(glm::abs(unpacked.positionOffset));
     glm::vec3 normalizedPos(unpacked.positionOffset);
-    if (len > 1.0f) {
+    if (len > 0.0f) {
         normalizedPos /= len;
     } else {
         len = 1.0f;


### PR DESCRIPTION
For avatars authored in meters, the max component length would often be less then 1.
In that case, the blendshape offset was not normalized before quantization, resulting in loss of precision.
This change will normalize the offset for all cases, except when the max component length is 0.

https://highfidelity.manuscript.com/f/cases/21923/Precision-loss-on-avatar-blendshape-rendering