### PR TITLE
Case 21930: Don't change OpenGL context state every frame

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3961,6 +3961,15 @@ static void dumpEventQueue(QThread* thread) {
 }
 #endif // DEBUG_EVENT_QUEUE
 
+bool Application::notify(QObject * object, QEvent * event) {
+    if (thread() == QThread::currentThread()) {
+        PROFILE_RANGE_IF_LONGER(app, "notify", 2)
+        return QApplication::notify(object, event);
+    } 
+        
+    return QApplication::notify(object, event);
+}
+
 bool Application::event(QEvent* event) {
 
     if (_aboutToQuit) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -156,6 +156,7 @@ public:
     void updateCamera(RenderArgs& renderArgs, float deltaTime);
     void resizeGL();
 
+    bool notify(QObject *, QEvent *) override;
     bool event(QEvent* event) override;
     bool eventFilter(QObject* object, QEvent* event) override;
 

--- a/libraries/shared/src/Profile.h
+++ b/libraries/shared/src/Profile.h
@@ -37,17 +37,31 @@ Q_DECLARE_LOGGING_CATEGORY(trace_startup)
 Q_DECLARE_LOGGING_CATEGORY(trace_workload)
 Q_DECLARE_LOGGING_CATEGORY(trace_baker)
 
-class Duration {
+class DurationBase {
+
+protected:
+    DurationBase(const QLoggingCategory& category, const QString& name);
+    const QString _name;
+    const QLoggingCategory& _category;
+};
+
+class Duration : public DurationBase {
 public:
     Duration(const QLoggingCategory& category, const QString& name, uint32_t argbColor = 0xff0000ff, uint64_t payload = 0, const QVariantMap& args = QVariantMap());
     ~Duration();
 
     static uint64_t beginRange(const QLoggingCategory& category, const char* name, uint32_t argbColor);
     static void endRange(const QLoggingCategory& category, uint64_t rangeId);
+};
+
+class ConditionalDuration : public DurationBase {
+public:
+    ConditionalDuration(const QLoggingCategory& category, const QString& name, uint32_t minTime);
+    ~ConditionalDuration();
 
 private:
-    QString _name;
-    const QLoggingCategory& _category;
+    const int64_t _startTime;
+    const int64_t _minTime;
 };
 
 
@@ -95,6 +109,7 @@ inline void metadata(const QString& metadataType, const QVariantMap& args) {
 }
 
 #define PROFILE_RANGE(category, name) Duration profileRangeThis(trace_##category(), name);
+#define PROFILE_RANGE_IF_LONGER(category, name, ms) ConditionalDuration profileRangeThis(trace_##category(), name, ms);
 #define PROFILE_RANGE_EX(category, name, argbColor, payload, ...) Duration profileRangeThis(trace_##category(), name, argbColor, (uint64_t)payload, ##__VA_ARGS__);
 #define PROFILE_RANGE_BEGIN(category, rangeId, name, argbColor) rangeId = Duration::beginRange(trace_##category(), name, argbColor)
 #define PROFILE_RANGE_END(category, rangeId) Duration::endRange(trace_##category(), rangeId)

--- a/libraries/shared/src/Trace.cpp
+++ b/libraries/shared/src/Trace.cpp
@@ -176,6 +176,10 @@ void Tracer::serialize(const QString& filename) {
 #endif
 }
 
+int64_t Tracer::now() {
+    return std::chrono::duration_cast<std::chrono::microseconds>(p_high_resolution_clock::now().time_since_epoch()).count();
+}
+
 void Tracer::traceEvent(const QLoggingCategory& category,
     const QString& name, EventType type,
     qint64 timestamp, qint64 processID, qint64 threadID,
@@ -226,9 +230,17 @@ void Tracer::traceEvent(const QLoggingCategory& category,
         return;
     }
 
-    auto timestamp = std::chrono::duration_cast<std::chrono::microseconds>(p_high_resolution_clock::now().time_since_epoch()).count();
+    traceEvent(category, name, type, now(), id, args, extra);
+}
+
+void Tracer::traceEvent(const QLoggingCategory& category, 
+    const QString& name, EventType type, int64_t timestamp, const QString& id, 
+    const QVariantMap& args, const QVariantMap& extra) {
+    if (!_enabled && type != Metadata) {
+        return;
+    }
+
     auto processID = QCoreApplication::applicationPid();
     auto threadID = int64_t(QThread::currentThreadId());
-
     traceEvent(category, name, type, timestamp, processID, threadID, id, args, extra);
 }

--- a/libraries/shared/src/Trace.h
+++ b/libraries/shared/src/Trace.h
@@ -78,8 +78,15 @@ struct TraceEvent {
 
 class Tracer : public Dependency {
 public:
+    static int64_t now();
     void traceEvent(const QLoggingCategory& category, 
         const QString& name, EventType type,
+        const QString& id = "", 
+        const QVariantMap& args = QVariantMap(), const QVariantMap& extra = QVariantMap());
+
+    void traceEvent(const QLoggingCategory& category, 
+        const QString& name, EventType type,
+        int64_t timestamp,
         const QString& id = "", 
         const QVariantMap& args = QVariantMap(), const QVariantMap& extra = QVariantMap());
 
@@ -100,6 +107,16 @@ private:
     std::list<TraceEvent> _metadataEvents;
     std::mutex _eventsMutex;
 };
+
+inline void traceEvent(const QLoggingCategory& category, int64_t timestamp, const QString& name, EventType type, const QString& id = "", const QVariantMap& args = {}, const QVariantMap& extra = {}) {
+    if (!DependencyManager::isSet<Tracer>()) {
+        return;
+    }
+    const auto& tracer = DependencyManager::get<Tracer>();
+    if (tracer) {
+        tracer->traceEvent(category, name, type, timestamp, id, args, extra);
+    }
+}
 
 inline void traceEvent(const QLoggingCategory& category, const QString& name, EventType type, const QString& id = "", const QVariantMap& args = {}, const QVariantMap& extra = {}) {
     if (!DependencyManager::isSet<Tracer>()) {


### PR DESCRIPTION
[21930](https://highfidelity.manuscript.com/f/cases/21930/Keep-GL-context-current-on-present-thread-at-all-times)

Adds some new tracing functionality and changes how we manage the OpenGL context on the present thread.  