### PR TITLE
case 21932: the test-audio button causes a local audio-loopback rather than a server one

### DIFF
--- a/interface/resources/qml/hifi/audio/LoopbackAudio.qml
+++ b/interface/resources/qml/hifi/audio/LoopbackAudio.qml
@@ -17,7 +17,7 @@ import stylesUit 1.0
 import controlsUit 1.0 as HifiControlsUit
 
 RowLayout {
-    property bool audioLoopedBack: AudioScriptingInterface.getServerEcho();
+    property bool audioLoopedBack: AudioScriptingInterface.getLocalEcho();
     function startAudioLoopback() {
         if (!audioLoopedBack) {
             audioLoopedBack = true;

--- a/interface/resources/qml/hifi/audio/LoopbackAudio.qml
+++ b/interface/resources/qml/hifi/audio/LoopbackAudio.qml
@@ -21,13 +21,13 @@ RowLayout {
     function startAudioLoopback() {
         if (!audioLoopedBack) {
             audioLoopedBack = true;
-            AudioScriptingInterface.setServerEcho(true);
+            AudioScriptingInterface.setLocalEcho(true);
         }
     }
     function stopAudioLoopback() {
         if (audioLoopedBack) {
             audioLoopedBack = false;
-            AudioScriptingInterface.setServerEcho(false);
+            AudioScriptingInterface.setLocalEcho(false);
         }
     }
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1052,7 +1052,7 @@ void AudioClient::setReverbOptions(const AudioEffectOptions* options) {
 void AudioClient::handleLocalEchoAndReverb(QByteArray& inputByteArray) {
     // If there is server echo, reverb will be applied to the recieved audio stream so no need to have it here.
     bool hasReverb = _reverb || _receivedAudioStream.hasReverb();
-    if (_muted || !_audioOutput || (!_shouldEchoLocally && !hasReverb)) {
+    if ((_muted && !_shouldEchoLocally) || !_audioOutput || (!_shouldEchoLocally && !hasReverb)) {
         return;
     }
 


### PR DESCRIPTION
- the test-audio button causes a local audio-loopback rather than a server one


https://highfidelity.fogbugz.com/f/cases/21932/Test-your-voice-button-isn-t-working-correctly-when-Muted-or-in-Push-to-talk-mode