### PR TITLE
case 21982: Allow logging-in with an email that contains a '+' sign

### DIFF
--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -536,7 +536,7 @@ void AccountManager::requestAccessToken(const QString& login, const QString& pas
 
     QByteArray postData;
     postData.append("grant_type=password&");
-    postData.append("username=" + login + "&");
+    postData.append("username=" + QUrl::toPercentEncoding(login) + "&");
     postData.append("password=" + QUrl::toPercentEncoding(password) + "&");
     postData.append("scope=" + ACCOUNT_MANAGER_REQUESTED_SCOPE);
 


### PR DESCRIPTION
Right now, if a user signs up with an email address that contains the character '+' then they won't be able to login by entering their email address. That's because the username field isn't currently encoded when it's sent to the server, so the '+' character is changed to a space.

This pull request encodes the login field (same as the password field).

https://highfidelity.fogbugz.com/f/cases/21982/can-t-log-in-with-an-email-that-contains-a-sign
