### PR TITLE
case 21981: Fix startup race conditions in Interface

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5414,6 +5414,13 @@ void Application::pauseUntilLoginDetermined() {
         return;
     }
 
+    if (_resumeAfterLoginDialogActionTakenWasCalled) {
+        // This happens occasionally (though not often): resumeAfterLoginDialogActionTaken() has already been called.
+        // We must abort this method, otherwise Interface will remain in the "Paused" state permanently.
+        // E.g., the menus "Edit", "View", etc. will not appear.
+        return;
+    }
+
     auto myAvatar = getMyAvatar();
     _previousAvatarTargetScale = myAvatar->getTargetScale();
     _previousAvatarSkeletonModel = myAvatar->getSkeletonModelURL().toString();
@@ -5528,6 +5535,8 @@ void Application::resumeAfterLoginDialogActionTaken() {
     menu->getMenu("Developer")->setVisible(_developerMenuVisible);
     _myCamera.setMode(_previousCameraMode);
     cameraModeChanged();
+
+    _resumeAfterLoginDialogActionTakenWasCalled = true;
 }
 
 void Application::loadAvatarScripts(const QVector<QString>& urls) {

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1446,6 +1446,34 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     _overlays.init(); // do this before scripts load
     DependencyManager::set<ContextOverlayInterface>();
 
+    auto offscreenUi = getOffscreenUI();
+    connect(offscreenUi.data(), &OffscreenUi::desktopReady, []() {
+        // Now that we've loaded the menu and thus switched to the previous display plugin
+        // we can unlock the desktop repositioning code, since all the positions will be
+        // relative to the desktop size for this plugin
+        auto offscreenUi = getOffscreenUI();
+        auto desktop = offscreenUi->getDesktop();
+        if (desktop) {
+            desktop->setProperty("repositionLocked", false);
+        }
+    });
+
+    connect(offscreenUi.data(), &OffscreenUi::keyboardFocusActive, [this]() {
+#if !defined(Q_OS_ANDROID) && !defined(DISABLE_QML)
+        // Do not show login dialog if requested not to on the command line
+        QString hifiNoLoginCommandLineKey = QString("--").append(HIFI_NO_LOGIN_COMMAND_LINE_KEY);
+        int index = arguments().indexOf(hifiNoLoginCommandLineKey);
+        if (index != -1) {
+            resumeAfterLoginDialogActionTaken();
+            return;
+        }
+
+        showLoginScreen();
+#else
+        resumeAfterLoginDialogActionTaken();
+#endif
+    });
+
     // Initialize the user interface and menu system
     // Needs to happen AFTER the render engine initialization to access its configuration
     initializeUi();
@@ -1790,34 +1818,6 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     loadSettings();
 
     updateVerboseLogging();
-
-    // Now that we've loaded the menu and thus switched to the previous display plugin
-    // we can unlock the desktop repositioning code, since all the positions will be
-    // relative to the desktop size for this plugin
-    auto offscreenUi = getOffscreenUI();
-    connect(offscreenUi.data(), &OffscreenUi::desktopReady, []() {
-        auto offscreenUi = getOffscreenUI();
-        auto desktop = offscreenUi->getDesktop();
-        if (desktop) {
-            desktop->setProperty("repositionLocked", false);
-        }
-    });
-
-    connect(offscreenUi.data(), &OffscreenUi::keyboardFocusActive, [this]() {
-#if !defined(Q_OS_ANDROID) && !defined(DISABLE_QML)
-        // Do not show login dialog if requested not to on the command line
-        QString hifiNoLoginCommandLineKey = QString("--").append(HIFI_NO_LOGIN_COMMAND_LINE_KEY);
-        int index = arguments().indexOf(hifiNoLoginCommandLineKey);
-        if (index != -1) {
-            resumeAfterLoginDialogActionTaken();
-            return;
-        }
-
-        showLoginScreen();
-#else
-        resumeAfterLoginDialogActionTaken();
-#endif
-    });
 
     // Make sure we don't time out during slow operations at startup
     updateHeartbeat();

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -802,5 +802,8 @@ private:
 
     bool _showTrackedObjects { false };
     bool _prevShowTrackedObjects { false };
+
+    // Whether resumeAfterLoginDialogActionTaken() has been called
+    bool _resumeAfterLoginDialogActionTakenWasCalled { false };
 };
 #endif // hifi_Application_h

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -1,4 +1,4 @@
-//
+﻿//
 //  Application.h
 //  interface/src
 //
@@ -803,7 +803,7 @@ private:
     bool _showTrackedObjects { false };
     bool _prevShowTrackedObjects { false };
 
-    // Whether resumeAfterLoginDialogActionTaken() has been called
-    bool _resumeAfterLoginDialogActionTakenWasCalled { false };
+    bool _resumeAfterLoginDialogActionTaken_WasPostponed { false };
+    bool _resumeAfterLoginDialogActionTaken_SafeToRun { false };
 };
 #endif // hifi_Application_h


### PR DESCRIPTION
When Interface starts it carries out a great many operations. Some of these operations must be carried out in a specific order, otherwise Interface won't function correctly. But due to asynchronous operations, the desired order doesn't always happen.

This pull request fixes a couple of these problems (which I've actually encountered). Before fixing these problems I occasionally encountered errors when starting Interface. For example, in one type of error, the program remained "stuck" in the state of waiting for login to complete (even if it did complete). In another type of error, the scripts started running before the Keyboard had been initialized. This caused edit.js to fail, which means that the Create app didn't work.

https://highfidelity.fogbugz.com/f/cases/21981/startup-race-conditions-in-Interface
