### PR TITLE
case 21980: Allow copying grandchild entities

### DIFF
--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -1620,7 +1620,7 @@ function recursiveDelete(entities, childrenList, deletedIDs, entityHostType) {
         if (entityHostTypes[i].entityHostType !== entityHostType) {
             if (wantDebug) {
                 console.log("Skipping deletion of entity " + entityID + " with conflicting entityHostType: " +
-                    entityHostTypes[i].entityHostType);
+                    entityHostTypes[i].entityHostType + ", expected: " + entityHostType);
             }
             continue;
         }

--- a/scripts/system/libraries/entitySelectionTool.js
+++ b/scripts/system/libraries/entitySelectionTool.js
@@ -206,7 +206,7 @@ SelectionManager = (function() {
             if (entityHostTypes[i].entityHostType !== entityHostType) {
                 if (wantDebug) {
                     console.log("Skipping addition of entity " + childID + " with conflicting entityHostType: " +
-                        entityHostTypes[i].entityHostType);
+                        entityHostTypes[i].entityHostType + ", expected: " + entityHostType);
                 }
                 continue;
             }
@@ -398,15 +398,15 @@ SelectionManager = (function() {
 
                 if (entityHostTypes[i].entityHostType !== entityHostType) {
                     if (wantDebug) {
-                        console.warn("Skipping deletion of entity " + id + " with conflicting entityHostType: " +
-                            entityHostTypes[i].entityHostType);
+                        console.warn("Skipping addition of entity " + id + " with conflicting entityHostType: " +
+                            entityHostTypes[i].entityHostType + ", expected: " + entityHostType);
                     }
                     continue;
                 }
 
                 if (!(id in entities)) {
                     entities[id] = Entities.getEntityProperties(id); 
-                    appendChildren(id, entities);
+                    appendChildren(id, entities, entityHostType);
                 }
             }
         }


### PR DESCRIPTION
In Create mode, users can select entities, and then use Copy and Paste to duplicate them. This is supposed to be recursive, i.e. when an entity is copied all of its descendants are copied as well. However, there was a bug: only an entity's direct children were copied, but not *their* children. This pull request fixes that. (Also, it makes the logging consistent wherever the error "conflicting entityHostType" occurs.)


https://highfidelity.fogbugz.com/f/cases/21980/in-CREATE-app-copy-and-paste-doesn-t-copy-grandchildren
