### PR TITLE
Case 21883: Fix safe landing code improperly finding local entities

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -3742,7 +3742,8 @@ bool MyAvatar::requiresSafeLanding(const glm::vec3& positionIn, glm::vec3& bette
         // See https://highfidelity.fogbugz.com/f/cases/5003/findRayIntersection-has-option-to-use-collidableOnly-but-doesn-t-actually-use-colliders
         QVariantMap extraInfo;
         EntityItemID entityID = entityTree->evalRayIntersection(startPointIn, directionIn, include, ignore,
-            PickFilter(PickFilter::getBitMask(PickFilter::FlagBit::COLLIDABLE) | PickFilter::getBitMask(PickFilter::FlagBit::PRECISE)),
+            PickFilter(PickFilter::getBitMask(PickFilter::FlagBit::COLLIDABLE) | PickFilter::getBitMask(PickFilter::FlagBit::PRECISE)
+            | PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES)),    // exclude Local entities
             element, distance, face, normalOut, extraInfo, lockType, accurateResult);
         if (entityID.isNull()) {
             return false;

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -148,13 +148,20 @@ bool EntityTreeElement::checkFilterSettings(const EntityItemPointer& entity, Pic
         (!searchFilter.doesPickLocalEntities() && hostType == entity::HostType::LOCAL)) {
         return false;
     }
-    // We only check the collidable filters for non-local entities, because local entities are always collisionless
-    bool collidable = !entity->getCollisionless() && (entity->getShapeType() != SHAPE_TYPE_NONE);
-    if (hostType != entity::HostType::LOCAL) {
-        if ((collidable && !searchFilter.doesPickCollidable()) || (!collidable && !searchFilter.doesPickNonCollidable())) {
-            return false;
-        }
+
+    bool collidable;
+    if (hostType == entity::HostType::LOCAL) {
+        // Local entities are always collisionless
+        collidable = false;
     }
+    else {
+        collidable = !entity->getCollisionless() && (entity->getShapeType() != SHAPE_TYPE_NONE);
+    }
+
+    if ((collidable && !searchFilter.doesPickCollidable()) || (!collidable && !searchFilter.doesPickNonCollidable())) {
+        return false;
+    }
+
     return true;
 }
 

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -148,20 +148,17 @@ bool EntityTreeElement::checkFilterSettings(const EntityItemPointer& entity, Pic
         (!searchFilter.doesPickLocalEntities() && hostType == entity::HostType::LOCAL)) {
         return false;
     }
-
-    bool collidable;
-    if (hostType == entity::HostType::LOCAL) {
-        // Local entities are always collisionless
-        collidable = false;
+    // We only check the collidable filters for non-local entities, because local entities are always collisionless,
+    // but picks always include COLLIDABLE (see PickScriptingInterface::getPickFilter()), so if we were to respect
+    // the getCollisionless() property of Local entities then we would *never* intersect them in a pick.
+    // An unfortunate side effect of the following code is that Local entities are intersected even if the
+    // pick explicitly requested only COLLIDABLE entities (but, again, Local entities are always collisionless).
+    if (hostType != entity::HostType::LOCAL) {
+        bool collidable = !entity->getCollisionless() && (entity->getShapeType() != SHAPE_TYPE_NONE);
+        if ((collidable && !searchFilter.doesPickCollidable()) || (!collidable && !searchFilter.doesPickNonCollidable())) {
+            return false;
+        }
     }
-    else {
-        collidable = !entity->getCollisionless() && (entity->getShapeType() != SHAPE_TYPE_NONE);
-    }
-
-    if ((collidable && !searchFilter.doesPickCollidable()) || (!collidable && !searchFilter.doesPickNonCollidable())) {
-        return false;
-    }
-
     return true;
 }
 


### PR DESCRIPTION
Previously, rays **always** intersected with Local entities, regardless of whether the pick filter requested
to hit on collidable or noncollidable entities. But Local entities are always collisionless, so a pick filter
for collidable entities shouldn't intersect with Local entities.

I saw this bug manifest in the following way: I was using the nametags script, which puts an Overlay with the avatar name above the avatar's head. This overlay is now implemented as a Local Entity. Because of the bug, the Safe Landing code thought that the avatar's head is touching a collidable entity, so it moved the avatar up to try to get away from it. So often, when I entered a world or teleported inside it, my avatar was moved several meters above the intended position. Curiously, this process stopped after a few iterations; I'm not sure why (it seems like it should have gone on forever, shooting my avatar to the moon).

https://highfidelity.manuscript.com/f/cases/21883/Avatar-shows-up-on-the-roof-of-help-welcome-and-thespot-domains-when-using-the-goto