### PR TITLE
case 21978: Eliminated some JavaScript warnings due to missing commas

### DIFF
--- a/scripts/tutorials/makeBlocks.js
+++ b/scripts/tutorials/makeBlocks.js
@@ -56,7 +56,7 @@
                 grab: { grabbable: true },
                 cloneable: true,
                 cloneLifetime: LIFETIME,
-                cloneLimit: 9999
+                cloneLimit: 9999,
                 position: Vec3.sum(MyAvatar.position, Vec3.sum(forwardOffset, forwardVector)),
                 color: newColor(),
                 script: SCRIPT_URL

--- a/unpublishedScripts/DomainContent/Toybox/basketball/createHoop.js
+++ b/unpublishedScripts/DomainContent/Toybox/basketball/createHoop.js
@@ -38,6 +38,6 @@ var hoop = Entities.addEntity({
         grabbableKey: {
             grabbable: false
         }
-    })
+    }),
     compoundShapeURL: hoopCollisionHullURL
 });


### PR DESCRIPTION
These warnings appear in Visual Studio. I got tired of seeing them, so here's a fix.

This only leaves a couple of warnings in syntax-error.js. Apparently they're intentional. Nevertheless, if you could remove that file so that the project can become warning-free then that would be great...

https://highfidelity.fogbugz.com/f/cases/21978/JavaScript-warnings-due-to-missing-commas
