### PR TITLE
Fixes Bug that Prevented Eye Rotation Override When Procedural Eye Movement is Disabled

### DIFF
--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -334,7 +334,9 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     eyeParams.leftEyeJointIndex = _rig.indexOfJoint("LeftEye");
     eyeParams.rightEyeJointIndex = _rig.indexOfJoint("RightEye");
 
-    _rig.updateFromEyeParameters(eyeParams);
+    if (_owningAvatar->getHasProceduralEyeFaceMovement()) {
+        _rig.updateFromEyeParameters(eyeParams);
+    }
 
     updateFingers();
 }


### PR DESCRIPTION
This pr fixes the bug in case https://highfidelity.manuscript.com/f/cases/21962/Can-t-override-the-eye-joint-rotations-when-procedural-eye-movement-is-turned-off

When you call MyAvatar.setJointRotation(eyeJointID, eyeRotation) in script, the eye joint is unaffected, even when you have procedural eye movement disabled.

If MyAvatar.hasProceduralEyeFaceMovement == false then you should be able to override the rotation.

### TEST PLAN
1) open interface
2) run the following script that overrides the right eye rotation.
https://hifi-content.s3.amazonaws.com/angus/eyetest/testEyeJointOverride.js
3) expected result:  nothing should happen
4) open the script console and set MyAvatar.hasProceduralEyeFaceMovement == false
5) expected result:  the right eye should roll back in the head 