### PR TITLE
Case 20928: Fix some URLs with query params not working with model baker

### DIFF
--- a/libraries/baking/src/baking/BakerLibrary.cpp
+++ b/libraries/baking/src/baking/BakerLibrary.cpp
@@ -26,11 +26,10 @@ QUrl getBakeableModelURL(const QUrl& url) {
         GLTF_EXTENSION
     };
 
-    QUrl cleanURL = url.adjusted(QUrl::RemoveQuery | QUrl::RemoveFragment);
-    QString cleanURLString = cleanURL.fileName();
+    QString filename = url.fileName();
     for (auto& extension : extensionsToBake) {
-        if (cleanURLString.endsWith(extension, Qt::CaseInsensitive)) {
-            return cleanURL;
+        if (filename.endsWith(extension, Qt::CaseInsensitive)) {
+            return url;
         }
     }
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/20928/Oven-tool-fails-on-dropbox-hosted-fails-to-report-invalid-FBX

After talking with Sabrina, we decided that we could safely leave the
query param and fragment intact for a URL in the model baker.