### PR TITLE
Case 21726 - Domain lost recent entity edits upon restart

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1766,14 +1766,14 @@ void DomainServer::processOctreeDataRequestMessage(QSharedPointer<ReceivedMessag
 
     bool remoteHasExistingData { false };
     QUuid id;
-    int version;
+    int dataVersion;
     message->readPrimitive(&remoteHasExistingData);
     if (remoteHasExistingData) {
         constexpr size_t UUID_SIZE_BYTES = 16;
         auto idData = message->read(UUID_SIZE_BYTES);
         id = QUuid::fromRfc4122(idData);
-        message->readPrimitive(&version);
-        qCDebug(domain_server) << "Entity server does have existing data: ID(" << id << ") DataVersion(" << version << ")";
+        message->readPrimitive(&dataVersion);
+        qCDebug(domain_server) << "Entity server does have existing data: ID(" << id << ") DataVersion(" << dataVersion << ")";
     } else {
         qCDebug(domain_server) << "Entity server does not have existing data";
     }
@@ -1782,11 +1782,11 @@ void DomainServer::processOctreeDataRequestMessage(QSharedPointer<ReceivedMessag
     auto reply = NLPacketList::create(PacketType::OctreeDataFileReply, QByteArray(), true, true);
     OctreeUtils::RawEntityData data;
     if (data.readOctreeDataInfoFromFile(entityFilePath)) {
-        if (data.id == id && data.version <= version) {
+        if (data.id == id && data.dataVersion <= dataVersion) {
             qCDebug(domain_server) << "ES has sufficient octree data, not sending data";
             reply->writePrimitive(false);
         } else {
-            qCDebug(domain_server) << "Sending newer octree data to ES: ID(" << data.id << ") DataVersion(" << data.version << ")";
+            qCDebug(domain_server) << "Sending newer octree data to ES: ID(" << data.id << ") DataVersion(" << data.dataVersion << ")";
             QFile file(entityFilePath);
             if (file.open(QIODevice::ReadOnly)) {
                 reply->writePrimitive(true);

--- a/libraries/octree/src/OctreePersistThread.cpp
+++ b/libraries/octree/src/OctreePersistThread.cpp
@@ -82,11 +82,11 @@ void OctreePersistThread::start() {
         }
 
         if (data.readOctreeDataInfoFromData(_cachedJSONData)) {
-            qCDebug(octree) << "Current octree data: ID(" << data.id << ") DataVersion(" << data.version << ")";
+            qCDebug(octree) << "Current octree data: ID(" << data.id << ") DataVersion(" << data.dataVersion << ")";
             packet->writePrimitive(true);
             auto id = data.id.toRfc4122();
             packet->write(id);
-            packet->writePrimitive(data.version);
+            packet->writePrimitive(data.dataVersion);
         } else {
             _cachedJSONData.clear();
             qCWarning(octree) << "No octree data found";
@@ -144,8 +144,8 @@ void OctreePersistThread::handleOctreeDataFileReply(QSharedPointer<ReceivedMessa
     quint64 loadStarted = usecTimestampNow();
 
     if (hasValidOctreeData) {
-        qDebug() << "Setting entity version info to: " << data.id << data.version;
-        _tree->setOctreeVersionInfo(data.id, data.version);
+        qDebug() << "Setting entity version info to: " << data.id << data.dataVersion;
+        _tree->setOctreeVersionInfo(data.id, data.dataVersion);
     }
 
     bool persistentFileRead;


### PR DESCRIPTION
When an entity server starts up, grabs the version of the models.json
file locally, and then queries the domain server for its copy of the
models.json file...iff the domain server version is newer.

There was a bug in this process in that the comparison was made between
the wrong version, specifically the 'file format version' which doesn't
change unless there was a protocol change...and not the data version,
which increments every time a change is made to a domain.

Therefore, the version of the models.json on the domain server was never
downloaded to the entity server, even when it was newer.

It would be newer if the entity server assignment was moved to a machine
with an old version of the models.json file, which was in fact the case
on distributed3 during this period of time.