### PR TITLE
Fix avatar multi-sphere bad scaling on some avatars

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1548,8 +1548,8 @@ void Avatar::rigReset() {
 
 void Avatar::computeMultiSphereShapes() {
     const Rig& rig = getSkeletonModel()->getRig();
-    glm::vec3 scale = extractScale(rig.getGeometryOffsetPose());
     const HFMModel& geometry = getSkeletonModel()->getHFMModel();
+    glm::vec3 geometryScale = extractScale(rig.getGeometryOffsetPose());
     int jointCount = rig.getJointStateCount();
     _multiSphereShapes.clear();
     _multiSphereShapes.reserve(jointCount);
@@ -1558,9 +1558,10 @@ void Avatar::computeMultiSphereShapes() {
         std::vector<btVector3> btPoints;
         int lineCount = (int)shapeInfo.debugLines.size();
         btPoints.reserve(lineCount);
+        glm::vec3 jointScale = rig.getJointPose(i).scale() / extractScale(rig.getGeometryToRigTransform());
         for (int j = 0; j < lineCount; j++) {
             const glm::vec3 &point = shapeInfo.debugLines[j];
-            auto rigPoint = scale * point;
+            auto rigPoint = jointScale * geometryScale * point;
             btVector3 btPoint = glmToBullet(rigPoint);
             btPoints.push_back(btPoint);
         }

--- a/libraries/physics/src/MultiSphereShape.h
+++ b/libraries/physics/src/MultiSphereShape.h
@@ -48,6 +48,7 @@ public:
     void extractSphereRegion(std::vector<std::pair<glm::vec3, glm::vec3>>& outLines);
     void extractEdges(bool reverseY = false);
     void translate(const glm::vec3& translation);
+    void scale(float scale);
     void dump(std::vector<std::pair<glm::vec3, glm::vec3>>& outLines);
     const glm::vec3& getDirection() const { return _direction; }
     const std::vector<glm::vec3>& getEdgesX() const { return _edgesX; }
@@ -94,7 +95,7 @@ private:
     void calculateSphereLines(std::vector<std::pair<glm::vec3, glm::vec3>>& outLines, const glm::vec3& center, const float& radius,
                               const int& subdivisions = DEFAULT_SPHERE_SUBDIVISIONS, const glm::vec3& direction = Vectors::UNIT_Y, 
                               const float& percentage = 1.0f, std::vector<glm::vec3>* edge = nullptr);
-    void calculateChamferBox(std::vector<std::pair<glm::vec3, glm::vec3>>& outLines, const float& radius, const std::vector<glm::vec3>& axes, const glm::vec3& translation);
+    void calculateChamferBox(std::vector<std::pair<glm::vec3, glm::vec3>>& outLines, const std::vector<float>& radiuses, const std::vector<glm::vec3>& axes, const glm::vec3& translation);
     void connectEdges(std::vector<std::pair<glm::vec3, glm::vec3>>& outLines, const std::vector<glm::vec3>& edge1, 
                       const std::vector<glm::vec3>& edge2, bool reverse = false);
     void connectSpheres(int index1, int index2, bool onlyEdges = false);


### PR DESCRIPTION
This PR fixes the computation of the multi-sphere shapes on some avatars with different joint scales.
It also fixes some visualization issues.
https://highfidelity.manuscript.com/f/cases/21526/Incorrect-Detailed-Collision-on-Cyberwolf-Avatar