### PR TITLE
case 21977: fix asan reported error when returning QString reference to refreshGroupsCache

### DIFF
--- a/domain-server/src/DomainGatekeeper.cpp
+++ b/domain-server/src/DomainGatekeeper.cpp
@@ -1010,7 +1010,7 @@ void DomainGatekeeper::refreshGroupsCache() {
     nodeList->eachNode([this](const SharedNodePointer& node) {
         if (!node->getPermissions().isAssignment) {
             // this node is an agent
-            const QString& verifiedUserName = node->getPermissions().getVerifiedUserName();
+            QString verifiedUserName = node->getPermissions().getVerifiedUserName();
             if (!verifiedUserName.isEmpty()) {
                 getGroupMemberships(verifiedUserName);
             }

--- a/libraries/networking/src/NodePermissions.h
+++ b/libraries/networking/src/NodePermissions.h
@@ -41,10 +41,10 @@ public:
     NodePermissions(const NodePermissionsKey& key) { _id = key.first.toLower(); _rankID = key.second; }
     NodePermissions(QMap<QString, QVariant> perms);
 
-    const QString& getID() const { return _id; } // a user-name or a group-name, not verified
+    QString getID() const { return _id; } // a user-name or a group-name, not verified
     void setID(const QString& id) { _id = id; }
     void setRankID(QUuid& rankID) { _rankID = rankID; }
-    const QUuid& getRankID() const { return _rankID; }
+    QUuid getRankID() const { return _rankID; }
     NodePermissionsKey getKey() const { return NodePermissionsKey(_id, _rankID); }
 
     // the _id member isn't authenticated/verified and _username is.
@@ -52,7 +52,7 @@ public:
     const QString& getVerifiedUserName() const { return _verifiedUserName; }
 
     void setGroupID(QUuid groupID) { _groupID = groupID; if (!groupID.isNull()) { _groupIDSet = true; }}
-    const QUuid& getGroupID() const { return _groupID; }
+    QUuid getGroupID() const { return _groupID; }
     bool isGroup() const { return _groupIDSet; }
 
     bool isAssignment { false };


### PR DESCRIPTION
- fix asan reported error when returning QString reference to refreshGroupsCache

https://highfidelity.fogbugz.com/f/cases/21977/stack-use-after-scope-in-DomainGatekeeper-refreshGroupsCache
