### PR TITLE
case 22190: Disable triggering away state when interface focus lost

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -962,6 +962,7 @@ const bool DEFAULT_PREFER_STYLUS_OVER_LASER = false;
 const bool DEFAULT_PREFER_AVATAR_FINGER_OVER_STYLUS = false;
 const QString DEFAULT_CURSOR_NAME = "DEFAULT";
 const bool DEFAULT_MINI_TABLET_ENABLED = true;
+const bool DEFAULT_AWAY_STATE_WHEN_FOCUS_LOST_IN_VR_ENABLED = true;
 
 QSharedPointer<OffscreenUi> getOffscreenUI() {
 #if !defined(DISABLE_QML)
@@ -992,6 +993,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     _preferStylusOverLaserSetting("preferStylusOverLaser", DEFAULT_PREFER_STYLUS_OVER_LASER),
     _preferAvatarFingerOverStylusSetting("preferAvatarFingerOverStylus", DEFAULT_PREFER_AVATAR_FINGER_OVER_STYLUS),
     _constrainToolbarPosition("toolbar/constrainToolbarToCenterX", true),
+    _awayStateWhenFocusLostInVREnabled("awayStateWhenFocusLostInVREnabled", DEFAULT_AWAY_STATE_WHEN_FOCUS_LOST_IN_VR_ENABLED),
     _preferredCursor("preferredCursor", DEFAULT_CURSOR_NAME),
     _miniTabletEnabledSetting("miniTabletEnabled", DEFAULT_MINI_TABLET_ENABLED),
     _scaleMirror(1.0f),
@@ -3560,6 +3562,11 @@ void Application::setPreferredCursor(const QString& cursorName) {
 void Application::setSettingConstrainToolbarPosition(bool setting) {
     _constrainToolbarPosition.set(setting);
     getOffscreenUI()->setConstrainToolbarToCenterX(setting);
+}
+
+void Application::setAwayStateWhenFocusLostInVREnabled(bool enabled) {
+    _awayStateWhenFocusLostInVREnabled.set(enabled);
+    emit awayStateWhenFocusLostInVRChanged(enabled);
 }
 
 void Application::setMiniTabletEnabled(bool enabled) {

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -236,6 +236,9 @@ public:
     float getSettingConstrainToolbarPosition() { return _constrainToolbarPosition.get(); }
     void setSettingConstrainToolbarPosition(bool setting);
 
+    float getAwayStateWhenFocusLostInVREnabled() { return _awayStateWhenFocusLostInVREnabled.get(); }
+    void setAwayStateWhenFocusLostInVREnabled(bool setting);
+
     Q_INVOKABLE void setMinimumGPUTextureMemStabilityCount(int stabilityCount) { _minimumGPUTextureMemSizeStabilityCount = stabilityCount; }
 
     NodeToOctreeSceneStats* getOcteeSceneStats() { return &_octreeServerSceneStats; }
@@ -357,6 +360,7 @@ signals:
     void loginDialogFocusDisabled();
 
     void miniTabletEnabledChanged(bool enabled);
+    void awayStateWhenFocusLostInVRChanged(bool enabled);
 
 public slots:
     QVector<EntityItemID> pasteEntities(float x, float y, float z);
@@ -660,6 +664,7 @@ private:
     Setting::Handle<bool> _preferStylusOverLaserSetting;
     Setting::Handle<bool> _preferAvatarFingerOverStylusSetting;
     Setting::Handle<bool> _constrainToolbarPosition;
+    Setting::Handle<bool> _awayStateWhenFocusLostInVREnabled;
     Setting::Handle<QString> _preferredCursor;
     Setting::Handle<bool> _miniTabletEnabledSetting;
     Setting::Handle<bool> _keepLogWindowOnTop { "keepLogWindowOnTop", false };

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -30,6 +30,9 @@ HMDScriptingInterface::HMDScriptingInterface() {
     connect(qApp, &Application::miniTabletEnabledChanged, [this](bool enabled) {
         emit miniTabletEnabledChanged(enabled);
     });
+    connect(qApp, &Application::awayStateWhenFocusLostInVRChanged, [this](bool enabled) {
+        emit awayStateWhenFocusLostInVRChanged(enabled);
+    });
 }
 
 glm::vec3 HMDScriptingInterface::calculateRayUICollisionPoint(const glm::vec3& position, const glm::vec3& direction) const {
@@ -135,6 +138,14 @@ void HMDScriptingInterface::setMiniTabletEnabled(bool enabled) {
 
 bool HMDScriptingInterface::getMiniTabletEnabled() {
     return qApp->getMiniTabletEnabled();
+}
+
+void HMDScriptingInterface::setAwayStateWhenFocusLostInVREnabled(bool enabled) {
+    qApp->setAwayStateWhenFocusLostInVREnabled(enabled);
+}
+
+bool HMDScriptingInterface::getAwayStateWhenFocusLostInVREnabled() {
+    return qApp->getAwayStateWhenFocusLostInVREnabled();
 }
 
 

--- a/interface/src/scripting/HMDScriptingInterface.h
+++ b/interface/src/scripting/HMDScriptingInterface.h
@@ -375,6 +375,14 @@ signals:
      */
     bool miniTabletEnabledChanged(bool enabled);
 
+    /**jsdoc
+     * Triggered when the altering the mode for going into an away state when the interface focus is lost in VR.
+     * @function HMD.awayStateWhenFocusLostInVRChanged
+     * @param {boolean} enabled - <code>true</code> if the setting to go into an away state in VR when the interface focus is lost is enabled, otherwise <code>false</code>.
+     * @returns {Signal}
+     */
+    bool awayStateWhenFocusLostInVRChanged(bool enabled);
+
 public:
     HMDScriptingInterface();
     static QScriptValue getHUDLookAtPosition2D(QScriptContext* context, QScriptEngine* engine);
@@ -410,6 +418,9 @@ public:
 
     void setMiniTabletEnabled(bool enabled);
     bool getMiniTabletEnabled();
+
+    void setAwayStateWhenFocusLostInVREnabled(bool enabled);
+    bool getAwayStateWhenFocusLostInVREnabled();
 
     QVariant getPlayAreaRect();
     QVector<glm::vec3> getSensorPositions();

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -89,6 +89,12 @@ void setupPreferences() {
         auto setter = [](bool value) { qApp->setSettingConstrainToolbarPosition(value); };
         preferences->addPreference(new CheckPreference(UI_CATEGORY, "Constrain Toolbar Position to Horizontal Center", getter, setter));
     }
+	
+    {
+        auto getter = []()->bool { return qApp->getAwayStateWhenFocusLostInVREnabled(); };
+        auto setter = [](bool value) { qApp->setAwayStateWhenFocusLostInVREnabled(value); };
+        preferences->addPreference(new CheckPreference(UI_CATEGORY, "Go into away state when interface window loses focus in VR", getter, setter));
+    }
 
     {
         auto getter = []()->float { return qApp->getDesktopTabletScale(); };

--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -285,10 +285,10 @@ function maybeGoAway() {
     if (Reticle.mouseCaptured !== wasMouseCaptured) {
         wasMouseCaptured = !wasMouseCaptured;
         if (!wasMouseCaptured) {
-			if (enterAwayStateWhenFocusLostInVR) {
-				goAway();
-				return;
-			}
+            if (enterAwayStateWhenFocusLostInVR) {
+                goAway();
+                return;
+            }
         }
     }
 
@@ -354,13 +354,13 @@ eventMapping.from(Controller.Standard.Start).peek().to(goActive);
 Controller.enableMapping(eventMappingName);
 
 function awayStateWhenFocusLostInVRChanged(enabled) {
-	enterAwayStateWhenFocusLostInVR = enabled;
+    enterAwayStateWhenFocusLostInVR = enabled;
 }
 
 Script.scriptEnding.connect(function () {
     Script.clearInterval(maybeIntervalTimer);
     goActive();
-	HMD.awayStateWhenFocusLostInVRChanged.disconnect(awayStateWhenFocusLostInVRChanged);
+    HMD.awayStateWhenFocusLostInVRChanged.disconnect(awayStateWhenFocusLostInVRChanged);
     Controller.disableMapping(eventMappingName);
     Controller.mousePressEvent.disconnect(goActive);
     Controller.keyPressEvent.disconnect(maybeGoActive);

--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -67,6 +67,8 @@ var avatarPosition = MyAvatar.position;
 var wasHmdMounted = HMD.mounted;
 var previousBubbleState = Users.getIgnoreRadiusEnabled();
 
+var enterAwayStateWhenFocusLostInVR = HMD.enterAwayStateWhenFocusLostInVR;
+
 // some intervals we may create/delete
 var avatarMovedInterval;
 
@@ -283,8 +285,10 @@ function maybeGoAway() {
     if (Reticle.mouseCaptured !== wasMouseCaptured) {
         wasMouseCaptured = !wasMouseCaptured;
         if (!wasMouseCaptured) {
-            goAway();
-            return;
+			if (enterAwayStateWhenFocusLostInVR) {
+				goAway();
+				return;
+			}
         }
     }
 
@@ -349,15 +353,22 @@ eventMapping.from(Controller.Standard.Back).peek().to(goActive);
 eventMapping.from(Controller.Standard.Start).peek().to(goActive);
 Controller.enableMapping(eventMappingName);
 
+function awayStateWhenFocusLostInVRChanged(enabled) {
+	enterAwayStateWhenFocusLostInVR = enabled;
+}
+
 Script.scriptEnding.connect(function () {
     Script.clearInterval(maybeIntervalTimer);
     goActive();
+	HMD.awayStateWhenFocusLostInVRChanged.disconnect(awayStateWhenFocusLostInVRChanged);
     Controller.disableMapping(eventMappingName);
     Controller.mousePressEvent.disconnect(goActive);
     Controller.keyPressEvent.disconnect(maybeGoActive);
     Messages.messageReceived.disconnect(handleMessage);
     Messages.unsubscribe(CHANNEL_AWAY_ENABLE);
 });
+
+HMD.awayStateWhenFocusLostInVRChanged.connect(awayStateWhenFocusLostInVRChanged);
 
 if (HMD.active && !HMD.mounted) {
     print("Starting script, while HMD is active and not mounted...");


### PR DESCRIPTION
This PR adds important functionality which I initially had in my PR before an alternative fix was merged instead for retaining hand-tracking in the Oculus Dash menu: a setting to prevent being forced into an away state when mouse focus was lost on the interface window. This is necessary because the main point of the Oculus Dash fix was to allow people to visibly operate other external software such as Discord for messaging while allowing their hands to be shown visibly typing, which was based on user preference from users who use this functionality a lot in other similar social VR software.

This version also adds an option to toggle this from the general settings menu under the setting 'Go into away state when interface window loses focus in VR'. The setting is on by default, will retain current behavior unless otherwise turned off, and setting persists across sessions. When turned off, it will be possible when bringing up the new Oculus Dash to navigate to other windows via the virtual desktop without being forced into an away state.

https://highfidelity.fogbugz.com/f/cases/22190/Disable-triggering-away-state-when-interface-focus-lost
