### PR TITLE
case 22001: Fixed calls to addingWearable() and deletingWearable()

### DIFF
--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -1101,13 +1101,13 @@ void EntityScriptingInterface::handleEntityScriptCallMethodPacket(QSharedPointer
 
 void EntityScriptingInterface::onAddingEntity(EntityItem* entity) {
     if (entity->isWearable()) {
-        QMetaObject::invokeMethod(this, "addingWearable", Q_ARG(QUuid, entity->getEntityItemID()));
+        QMetaObject::invokeMethod(this, "addingWearable", Q_ARG(EntityItemID, entity->getEntityItemID()));
     }
 }
 
 void EntityScriptingInterface::onDeletingEntity(EntityItem* entity) {
     if (entity->isWearable()) {
-        QMetaObject::invokeMethod(this, "deletingWearable", Q_ARG(QUuid, entity->getEntityItemID()));
+        QMetaObject::invokeMethod(this, "deletingWearable", Q_ARG(EntityItemID, entity->getEntityItemID()));
     }
 }
 


### PR DESCRIPTION
The calls used a parameter type of QUuid instead of EntityItemID. This resulted in the following warnings in the log:

[04/01 18:16:11.012] [WARNING] [default] [53296] QMetaObject::invokeMethod: No such method EntityScriptingInterface::addingWearable(QUuid)
[04/01 18:16:11.012] [WARNING] [default] [53296] Candidates are:
[04/01 18:16:11.012] [WARNING] [default] [53296]     addingWearable(EntityItemID)

https://highfidelity.fogbugz.com/f/cases/22001/addingWearable-causes-log-spam