### PR TITLE
Case 22003: Reuse Blank Space from Volume Slider

### DIFF
--- a/interface/resources/qml/hifi/NameCard.qml
+++ b/interface/resources/qml/hifi/NameCard.qml
@@ -129,6 +129,7 @@ Item {
         height: 40
         // Anchors
         anchors.top: avatarImage.top
+        anchors.topMargin: avatarImage.visible ? 18 : 0;
         anchors.left: avatarImage.right
         anchors.leftMargin: avatarImage.visible ? 5 : 0;
         anchors.rightMargin: 5;


### PR DESCRIPTION
# TEST PLAN
- Launch Interface
- Open People App
- Your display name should be aligned with the availability text on the right of the screen
![image](https://user-images.githubusercontent.com/10539521/55351083-4dd01c00-5472-11e9-87e7-afa4583d582f.png)
https://highfidelity.manuscript.com/f/cases/22003/Move-the-name-card-display-name-header-in-the-People-app