### PR TITLE
Case 22014: Audio Mic Bar not muting/unmuting correctly

### DIFF
--- a/interface/resources/qml/hifi/audio/MicBar.qml
+++ b/interface/resources/qml/hifi/audio/MicBar.qml
@@ -87,7 +87,7 @@ Rectangle {
             if (pushToTalk) {
                 return;
             }
-            muted = !muted;
+            AudioScriptingInterface.muted = !muted;
             Tablet.playSound(TabletEnums.ButtonClick);
         }
         drag.target: dragTarget;


### PR DESCRIPTION
This PR fixes a bug that occurred when the previous PR for case 21892 was merged.

# TEST PLAN
- Launch Interface
- Use mic bar icon in desktop mode to mute/unmute yourself
- You should not be heard by others when muted and vice versa

https://highfidelity.manuscript.com/f/cases/22014