### PR TITLE
Case 22010: Bump protocol number to fix joint order mismatch

### DIFF
--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -38,10 +38,10 @@ PacketVersion versionForPacketType(PacketType packetType) {
             return static_cast<PacketVersion>(EntityQueryPacketVersion::ConicalFrustums);
         case PacketType::AvatarIdentity:
         case PacketType::AvatarData:
-            return static_cast<PacketVersion>(AvatarMixerPacketVersion::SendMaxTranslationDimension);
+            return static_cast<PacketVersion>(AvatarMixerPacketVersion::FBXJointOrderChange);
         case PacketType::BulkAvatarData:
         case PacketType::KillAvatar:
-            return static_cast<PacketVersion>(AvatarMixerPacketVersion::SendMaxTranslationDimension);
+            return static_cast<PacketVersion>(AvatarMixerPacketVersion::FBXJointOrderChange);
         case PacketType::MessagesData:
             return static_cast<PacketVersion>(MessageDataVersion::TextOrBinaryData);
         // ICE packets

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -328,7 +328,8 @@ enum class AvatarMixerPacketVersion : PacketVersion {
     CollisionFlag,
     AvatarTraitsAck,
     FasterAvatarEntities,
-    SendMaxTranslationDimension
+    SendMaxTranslationDimension,
+    FBXJointOrderChange
 };
 
 enum class DomainConnectRequestVersion : PacketVersion {


### PR DESCRIPTION
The joint order change was introduced in PR #15178, to fix an FBX Serializer bug.

https://highfidelity.manuscript.com/f/cases/22010/Avatars-appear-crumpled-and-distorted-in-Master