### PR TITLE
Case 21513: Keyboad doesn't scale to avatar after reloading content

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5847,7 +5847,9 @@ void Application::reloadResourceCaches() {
     DependencyManager::get<ScriptEngines>()->reloadAllScripts();
     getOffscreenUI()->clearCache();
 
-    DependencyManager::get<Keyboard>()->createKeyboard();
+    auto keyboard = DependencyManager::get<Keyboard>();
+    keyboard->createKeyboard();
+    keyboard->scaleKeyboard(getMyAvatar()->getSensorToWorldScale());
 
     getMyAvatar()->resetFullAvatarURL();
 }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5847,9 +5847,7 @@ void Application::reloadResourceCaches() {
     DependencyManager::get<ScriptEngines>()->reloadAllScripts();
     getOffscreenUI()->clearCache();
 
-    auto keyboard = DependencyManager::get<Keyboard>();
-    keyboard->createKeyboard();
-    keyboard->scaleKeyboard(getMyAvatar()->getSensorToWorldScale());
+    DependencyManager::get<Keyboard>()->createKeyboard();
 
     getMyAvatar()->resetFullAvatarURL();
 }

--- a/interface/src/ui/Keyboard.cpp
+++ b/interface/src/ui/Keyboard.cpp
@@ -910,6 +910,9 @@ void Keyboard::loadKeyboardFile(const QString& keyboardFile) {
         });
         _layerIndex = 0;
         addIncludeItemsToMallets();
+
+        auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
+        scaleKeyboard(myAvatar->getSensorToWorldScale());
     });
 
     request->send();

--- a/interface/src/ui/Keyboard.h
+++ b/interface/src/ui/Keyboard.h
@@ -98,6 +98,7 @@ public:
     bool isPassword() const;
     void setPassword(bool password);
     void enableRightMallet();
+    void scaleKeyboard(float sensorToWorldScale);
     void enableLeftMallet();
     void disableRightMallet();
     void disableLeftMallet();
@@ -122,7 +123,6 @@ public slots:
     void handleTriggerContinue(const QUuid& id, const PointerEvent& event);
     void handleHoverBegin(const QUuid& id, const PointerEvent& event);
     void handleHoverEnd(const QUuid& id, const PointerEvent& event);
-    void scaleKeyboard(float sensorToWorldScale);
 
 private:
     struct Anchor {


### PR DESCRIPTION
Ticket - https://highfidelity.manuscript.com/f/cases/21513/Keyboard-doesn-t-scale-to-avatar-after-reloading-content-with-a-different-size-of-avatar