### PR TITLE
Case 20991: more correct collision group during grabs

### DIFF
--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -448,7 +448,7 @@ public:
     bool clearActions(EntitySimulationPointer simulation);
     void setDynamicData(QByteArray dynamicData);
     const QByteArray getDynamicData() const;
-    bool hasActions() const { return !_objectActions.empty(); }
+    bool hasActions() const { return !_objectActions.empty() || !_grabActions.empty(); }
     QList<QUuid> getActionIDs() const { return _objectActions.keys(); }
     QVariantMap getActionArguments(const QUuid& actionID) const;
     void deserializeActions();

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -217,9 +217,8 @@ PhysicsMotionType EntityMotionState::computePhysicsMotionType() const {
         }
         return MOTION_TYPE_DYNAMIC;
     }
-    if (_entity->isMovingRelativeToParent() ||
-        _entity->hasActions() ||
-        _entity->hasGrabs() ||
+    if (_entity->hasActions() ||
+        _entity->isMovingRelativeToParent() ||
         _entity->hasAncestorOfType(NestableType::Avatar)) {
         return MOTION_TYPE_KINEMATIC;
     }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20991/Dynamic-entities-that-don-t-collide-with-kinematic-entities-don-t-agree-on-whether-a-held-non-dynamic-entity-is-kinematic

This PR fixes a bug where when a static object is grabbed it becomes **kinematic** and its collision group was being left as **static**.