### PR TITLE
Case 21911: Fix stutter/strobe effect on OpenVR

### DIFF
--- a/interface/src/raypick/PointerScriptingInterface.cpp
+++ b/interface/src/raypick/PointerScriptingInterface.cpp
@@ -37,6 +37,7 @@ unsigned int PointerScriptingInterface::createPointer(const PickQuery::PickType&
         BLOCKING_INVOKE_METHOD(this, "createPointer", Q_RETURN_ARG(unsigned int, result), Q_ARG(PickQuery::PickType, type), Q_ARG(QVariant, properties));
         return result;
     }
+                return PointerEvent::INVALID_POINTER_ID;
 
     switch (type) {
         case PickQuery::PickType::Ray:

--- a/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.cpp
@@ -109,7 +109,7 @@ bool Basic2DWindowOpenGLDisplayPlugin::internalActivate() {
     return Parent::internalActivate();
 }
 
-void Basic2DWindowOpenGLDisplayPlugin::compositeExtra(const gpu::FramebufferPointer& compositeFramebuffer) {
+void Basic2DWindowOpenGLDisplayPlugin::compositeExtra() {
 #if defined(Q_OS_ANDROID)
     auto& virtualPadManager = VirtualPad::Manager::instance();
     if(virtualPadManager.getLeftVirtualPad()->isShown()) {
@@ -140,7 +140,7 @@ void Basic2DWindowOpenGLDisplayPlugin::compositeExtra(const gpu::FramebufferPoin
         });
     }
 #endif
-    Parent::compositeExtra(compositeFramebuffer);
+    Parent::compositeExtra();
 }
 
 static const uint32_t MIN_THROTTLE_CHECK_FRAMES = 60;

--- a/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.h
@@ -33,7 +33,7 @@ public:
 
     virtual bool isThrottled() const override;
 
-    virtual void compositeExtra(const gpu::FramebufferPointer&) override;
+    virtual void compositeExtra() override;
 
     virtual void pluginUpdate() override {};
 

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -94,10 +94,12 @@ protected:
     // is not populated
     virtual bool alwaysPresent() const { return false; }
 
+    virtual const gpu::FramebufferPointer& getCompositeFramebuffer();
     virtual QThread::Priority getPresentPriority() { return QThread::HighPriority; }
-    virtual void compositeLayers(const gpu::FramebufferPointer&);
-    virtual void compositePointer(const gpu::FramebufferPointer&);
-    virtual void compositeExtra(const gpu::FramebufferPointer&) {};
+    virtual void compositeLayers();
+    virtual void compositeScene();
+    virtual void compositePointer();
+    virtual void compositeExtra() {}
 
     // These functions must only be called on the presentation thread
     virtual void customizeContext();
@@ -112,7 +114,7 @@ protected:
     virtual void deactivateSession() {}
 
     // Plugin specific functionality to send the composed scene to the output window or device
-    virtual void internalPresent(const gpu::FramebufferPointer&);
+    virtual void internalPresent();
 
     
     void renderFromTexture(gpu::Batch& batch, const gpu::TexturePointer& texture, const glm::ivec4& viewport, const glm::ivec4& scissor, const gpu::FramebufferPointer& destFbo = nullptr, const gpu::FramebufferPointer& copyFbo = nullptr);
@@ -178,6 +180,7 @@ protected:
 
 private:
     gpu::PipelinePointer _presentPipeline;
+    gpu::PipelinePointer _simplePipeline;
 
 };
 

--- a/libraries/display-plugins/src/display-plugins/hmd/DebugHmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/DebugHmdDisplayPlugin.h
@@ -24,7 +24,7 @@ public:
 
 protected:
     void updatePresentPose() override;
-    void hmdPresent(const gpu::FramebufferPointer&) override {}
+    void hmdPresent() override {}
     bool isHmdMounted() const override { return true; }
     bool internalActivate() override;
 private:

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -177,11 +177,11 @@ float HmdDisplayPlugin::getLeftCenterPixel() const {
     return leftCenterPixel;
 }
 
-void HmdDisplayPlugin::internalPresent(const gpu::FramebufferPointer& compositeFramebuffer) {
+void HmdDisplayPlugin::internalPresent() {
     PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)presentCount())
 
     // Composite together the scene, hud and mouse cursor
-    hmdPresent(compositeFramebuffer);
+    hmdPresent();
 
     if (_displayTexture) {
         // Note: _displayTexture must currently be the same size as the display.
@@ -263,7 +263,7 @@ void HmdDisplayPlugin::internalPresent(const gpu::FramebufferPointer& compositeF
 
                 viewport.z *= 2;
             }
-            renderFromTexture(batch, compositeFramebuffer->getRenderBuffer(0), viewport, scissor, nullptr, fbo);
+            renderFromTexture(batch, getCompositeFramebuffer()->getRenderBuffer(0), viewport, scissor, nullptr, fbo);
         });
         swapBuffers();
 
@@ -450,7 +450,7 @@ DisplayPlugin::HUDOperator HmdDisplayPlugin::HUDRenderer::build() {
     };
 }
 
-void HmdDisplayPlugin::compositePointer(const gpu::FramebufferPointer& compositeFramebuffer) {
+void HmdDisplayPlugin::compositePointer() {
     auto& cursorManager = Cursor::Manager::instance();
     const auto& cursorData = _cursorsData[cursorManager.getCursor()->getIcon()];
     auto compositorHelper = DependencyManager::get<CompositorHelper>();
@@ -459,7 +459,7 @@ void HmdDisplayPlugin::compositePointer(const gpu::FramebufferPointer& composite
     render([&](gpu::Batch& batch) {
         // FIXME use standard gpu stereo rendering for this.
         batch.enableStereo(false);
-        batch.setFramebuffer(compositeFramebuffer);
+        batch.setFramebuffer(getCompositeFramebuffer());
         batch.setPipeline(_cursorPipeline);
         batch.setResourceTexture(0, cursorData.texture);
         batch.resetViewTransform();

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -53,15 +53,15 @@ signals:
     void hmdVisibleChanged(bool visible);
 
 protected:
-    virtual void hmdPresent(const gpu::FramebufferPointer&) = 0;
+    virtual void hmdPresent() = 0;
     virtual bool isHmdMounted() const = 0;
     virtual void postPreview() {};
     virtual void updatePresentPose();
 
     bool internalActivate() override;
     void internalDeactivate() override;
-    void compositePointer(const gpu::FramebufferPointer&) override;
-    void internalPresent(const gpu::FramebufferPointer&) override;
+    void compositePointer() override;
+    void internalPresent() override;
     void customizeContext() override;
     void uncustomizeContext() override;
     void updateFrameData() override;

--- a/libraries/display-plugins/src/display-plugins/stereo/InterleavedStereoDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/stereo/InterleavedStereoDisplayPlugin.cpp
@@ -37,13 +37,13 @@ glm::uvec2 InterleavedStereoDisplayPlugin::getRecommendedRenderSize() const {
     return result;
 }
 
-void InterleavedStereoDisplayPlugin::internalPresent(const gpu::FramebufferPointer& compositeFramebuffer) {
+void InterleavedStereoDisplayPlugin::internalPresent() {
     render([&](gpu::Batch& batch) {
         batch.enableStereo(false);
         batch.resetViewTransform();
         batch.setFramebuffer(gpu::FramebufferPointer());
         batch.setViewportTransform(ivec4(uvec2(0), getSurfacePixels()));
-        batch.setResourceTexture(0, compositeFramebuffer->getRenderBuffer(0));
+        batch.setResourceTexture(0, getCompositeFramebuffer()->getRenderBuffer(0));
         batch.setPipeline(_interleavedPresentPipeline);
         batch.draw(gpu::TRIANGLE_STRIP, 4);
     });

--- a/libraries/display-plugins/src/display-plugins/stereo/InterleavedStereoDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/stereo/InterleavedStereoDisplayPlugin.h
@@ -21,7 +21,7 @@ protected:
     // initialize OpenGL context settings needed by the plugin
     void customizeContext() override;
     void uncustomizeContext() override;
-    void internalPresent(const gpu::FramebufferPointer&) override;
+    void internalPresent() override;
 
 private:
     static const QString NAME;

--- a/plugins/oculus/src/OculusDebugDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDebugDisplayPlugin.h
@@ -16,7 +16,7 @@ public:
     bool isSupported() const override;
 
 protected:
-    void hmdPresent(const gpu::FramebufferPointer&) override {}
+    void hmdPresent() override {}
     bool isHmdMounted() const override { return true; }
 
 private:

--- a/plugins/oculus/src/OculusDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusDisplayPlugin.cpp
@@ -130,7 +130,7 @@ void OculusDisplayPlugin::uncustomizeContext() {
 static const uint64_t FRAME_BUDGET = (11 * USECS_PER_MSEC);
 static const uint64_t FRAME_OVER_BUDGET = (15 * USECS_PER_MSEC);
 
-void OculusDisplayPlugin::hmdPresent(const gpu::FramebufferPointer& compositeFramebuffer) {
+void OculusDisplayPlugin::hmdPresent() {
     static uint64_t lastSubmitEnd = 0;
 
     if (!_customized) {
@@ -147,6 +147,7 @@ void OculusDisplayPlugin::hmdPresent(const gpu::FramebufferPointer& compositeFra
 
     PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
 
+    const auto& compositeFramebuffer = getCompositeFramebuffer();
     {
         PROFILE_RANGE_EX(render, "Oculus Blit", 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
         int curIndex;

--- a/plugins/oculus/src/OculusDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDisplayPlugin.h
@@ -28,7 +28,7 @@ protected:
     QThread::Priority getPresentPriority() override { return QThread::TimeCriticalPriority; }
 
     bool internalActivate() override;
-    void hmdPresent(const gpu::FramebufferPointer&) override;
+    void hmdPresent() override;
     bool isHmdMounted() const override;
     void customizeContext() override;
     void uncustomizeContext() override;

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
@@ -237,7 +237,7 @@ void OculusLegacyDisplayPlugin::uncustomizeContext() {
     Parent::uncustomizeContext();
 }
 
-void OculusLegacyDisplayPlugin::hmdPresent(const gpu::FramebufferPointer& compositeFramebuffer) {
+void OculusLegacyDisplayPlugin::hmdPresent() {
     if (!_hswDismissed) {
         ovrHSWDisplayState hswState;
         ovrHmd_GetHSWDisplayState(_hmd, &hswState);
@@ -252,6 +252,7 @@ void OculusLegacyDisplayPlugin::hmdPresent(const gpu::FramebufferPointer& compos
     memset(eyePoses, 0, sizeof(ovrPosef) * 2);
     eyePoses[0].Orientation = eyePoses[1].Orientation = ovrRotation;
     
+    const auto& compositeFramebuffer = getCompositeFramebuffer();
     GLint texture = getGLBackend()->getTextureID(compositeFramebuffer->getRenderBuffer(0));
     auto sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
     glFlush();

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
@@ -39,7 +39,7 @@ protected:
 
     void customizeContext() override;
     void uncustomizeContext() override;
-    void hmdPresent(const gpu::FramebufferPointer&) override;
+    void hmdPresent() override;
     bool isHmdMounted() const override { return true; }
 
 private:

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -49,300 +49,6 @@ bool _openVrDisplayActive{ false };
 static vr::VRTextureBounds_t OPENVR_TEXTURE_BOUNDS_LEFT{ 0, 0, 0.5f, 1 };
 static vr::VRTextureBounds_t OPENVR_TEXTURE_BOUNDS_RIGHT{ 0.5f, 0, 1, 1 };
 
-#define REPROJECTION_BINDING 1
-
-static const char* HMD_REPROJECTION_VERT = R"SHADER(
-#version 450 core
-
-out vec3 vPosition;
-out vec2 vTexCoord;
-
-void main(void) {
-    const float depth = 0.0;
-    const vec4 UNIT_QUAD[4] = vec4[4](
-        vec4(-1.0, -1.0, depth, 1.0),
-        vec4(1.0, -1.0, depth, 1.0),
-        vec4(-1.0, 1.0, depth, 1.0),
-        vec4(1.0, 1.0, depth, 1.0)
-    );
-    vec4 pos = UNIT_QUAD[gl_VertexID];
-
-    gl_Position = pos;
-    vPosition = pos.xyz;
-    vTexCoord = (pos.xy + 1.0) * 0.5;
-}
-)SHADER";
-
-static const char* HMD_REPROJECTION_FRAG = R"SHADER(
-#version 450 core
-
-uniform sampler2D sampler;
-layout(binding = 1, std140) uniform Reprojection
-{
-    mat4 projections[2];
-    mat4 inverseProjections[2];
-    mat4 reprojection;
-};
-
-in vec3 vPosition;
-in vec2 vTexCoord;
-
-out vec4 FragColor;
-
-void main() {
-    vec2 uv = vTexCoord;
-    
-    mat4 eyeInverseProjection;
-    mat4 eyeProjection;
-    
-    float xoffset = 1.0;
-    vec2 uvmin = vec2(0.0);
-    vec2 uvmax = vec2(1.0);
-    // determine the correct projection and inverse projection to use.
-    if (vTexCoord.x < 0.5) {
-        uvmax.x = 0.5;
-        eyeInverseProjection = inverseProjections[0];
-        eyeProjection = projections[0];
-    } else {
-        xoffset = -1.0;
-        uvmin.x = 0.5;
-        uvmax.x = 1.0;
-        eyeInverseProjection = inverseProjections[1];
-        eyeProjection = projections[1];
-    }
-
-    // Account for stereo in calculating the per-eye NDC coordinates
-    vec4 ndcSpace = vec4(vPosition, 1.0);
-    ndcSpace.x *= 2.0;
-    ndcSpace.x += xoffset;
-    
-    // Convert from NDC to eyespace
-    vec4 eyeSpace = eyeInverseProjection * ndcSpace;
-    eyeSpace /= eyeSpace.w;
-
-    // Convert to a noramlized ray 
-    vec3 ray = eyeSpace.xyz;
-    ray = normalize(ray);
-
-    // Adjust the ray by the rotation
-    ray = mat3(reprojection) * ray;
-
-    // Project back on to the texture plane
-    ray *= eyeSpace.z / ray.z;
-
-    // Update the eyespace vector
-    eyeSpace.xyz = ray;
-
-    // Reproject back into NDC
-    ndcSpace = eyeProjection * eyeSpace;
-    ndcSpace /= ndcSpace.w;
-    ndcSpace.x -= xoffset;
-    ndcSpace.x /= 2.0;
-    
-    // Calculate the new UV coordinates
-    uv = (ndcSpace.xy / 2.0) + 0.5;
-    if (any(greaterThan(uv, uvmax)) || any(lessThan(uv, uvmin))) {
-        FragColor = vec4(0.0, 0.0, 0.0, 1.0);
-    } else {
-        FragColor = texture(sampler, uv);
-    }
-}
-)SHADER";
-
-struct Reprojection {
-    mat4 projections[2];
-    mat4 inverseProjections[2];
-    mat4 reprojection;
-};
-
-class OpenVrSubmitThread : public QThread, public Dependency {
-public:
-    using Mutex = std::mutex;
-    using Condition = std::condition_variable;
-    using Lock = std::unique_lock<Mutex>;
-    friend class OpenVrDisplayPlugin;
-    std::shared_ptr<gl::OffscreenContext> _canvas;
-
-    OpenVrSubmitThread(OpenVrDisplayPlugin& plugin) : _plugin(plugin) { setObjectName("OpenVR Submit Thread"); }
-
-    void updateSource() {
-        _plugin.withNonPresentThreadLock([&] {
-            while (!_queue.empty()) {
-                auto& front = _queue.front();
-
-                auto result = glClientWaitSync((GLsync)front.fence, 0, 0);
-
-                if (GL_TIMEOUT_EXPIRED == result || GL_WAIT_FAILED == result) {
-                    break;
-                } else if (GL_CONDITION_SATISFIED == result || GL_ALREADY_SIGNALED == result) {
-                    glDeleteSync((GLsync)front.fence);
-                } else {
-                    assert(false);
-                }
-
-                front.fence = 0;
-                _current = front;
-                _queue.pop();
-            }
-        });
-    }
-
-    GLuint _program{ 0 };
-
-    void updateProgram() {
-        if (!_program) {
-            std::string vsSource = HMD_REPROJECTION_VERT;
-            std::string fsSource = HMD_REPROJECTION_FRAG;
-            GLuint vertexShader{ 0 }, fragmentShader{ 0 };
-            std::string error;
-            ::gl::compileShader(GL_VERTEX_SHADER, vsSource, vertexShader, error);
-            ::gl::compileShader(GL_FRAGMENT_SHADER, fsSource, fragmentShader, error);
-            _program = ::gl::buildProgram({ { vertexShader, fragmentShader } });
-            ::gl::linkProgram(_program, error);
-            glDeleteShader(vertexShader);
-            glDeleteShader(fragmentShader);
-            qDebug() << "Rebuild proigram";
-        }
-    }
-
-#define COLOR_BUFFER_COUNT 4
-
-    void run() override {
-        GLuint _framebuffer{ 0 };
-        std::array<GLuint, COLOR_BUFFER_COUNT> _colors;
-        size_t currentColorBuffer{ 0 };
-        size_t globalColorBufferCount{ 0 };
-        GLuint _uniformBuffer{ 0 };
-        GLuint _vao{ 0 };
-        GLuint _depth{ 0 };
-        Reprojection _reprojection;
-
-        QThread::currentThread()->setPriority(QThread::Priority::TimeCriticalPriority);
-        _canvas->makeCurrent();
-
-        glCreateBuffers(1, &_uniformBuffer);
-        glNamedBufferStorage(_uniformBuffer, sizeof(Reprojection), 0, GL_DYNAMIC_STORAGE_BIT);
-        glCreateVertexArrays(1, &_vao);
-        glBindVertexArray(_vao);
-
-        glCreateFramebuffers(1, &_framebuffer);
-        {
-            glCreateRenderbuffers(1, &_depth);
-            glNamedRenderbufferStorage(_depth, GL_DEPTH24_STENCIL8, _plugin._renderTargetSize.x, _plugin._renderTargetSize.y);
-            glNamedFramebufferRenderbuffer(_framebuffer, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depth);
-            glCreateTextures(GL_TEXTURE_2D, COLOR_BUFFER_COUNT, &_colors[0]);
-            for (size_t i = 0; i < COLOR_BUFFER_COUNT; ++i) {
-                glTextureStorage2D(_colors[i], 1, GL_RGBA8, _plugin._renderTargetSize.x, _plugin._renderTargetSize.y);
-            }
-        }
-
-        glDisable(GL_DEPTH_TEST);
-        glViewport(0, 0, _plugin._renderTargetSize.x, _plugin._renderTargetSize.y);
-        _canvas->doneCurrent();
-        while (!_quit) {
-            _canvas->makeCurrent();
-            updateSource();
-            if (!_current.texture) {
-                _canvas->doneCurrent();
-                QThread::usleep(1);
-                continue;
-            }
-
-            updateProgram();
-            {
-                auto presentRotation = glm::mat3(_nextRender.poses[0]);
-                auto renderRotation = glm::mat3(_current.pose);
-                for (size_t i = 0; i < 2; ++i) {
-                    _reprojection.projections[i] = _plugin._eyeProjections[i];
-                    _reprojection.inverseProjections[i] = _plugin._eyeInverseProjections[i];
-                }
-                _reprojection.reprojection = glm::inverse(renderRotation) * presentRotation;
-                glNamedBufferSubData(_uniformBuffer, 0, sizeof(Reprojection), &_reprojection);
-                glNamedFramebufferTexture(_framebuffer, GL_COLOR_ATTACHMENT0, _colors[currentColorBuffer], 0);
-                glBindFramebuffer(GL_DRAW_FRAMEBUFFER, _framebuffer);
-                {
-                    glClearColor(1, 1, 0, 1);
-                    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-                    glTextureParameteri(_current.textureID, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-                    glTextureParameteri(_current.textureID, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-                    glUseProgram(_program);
-                    glBindBufferBase(GL_UNIFORM_BUFFER, REPROJECTION_BINDING, _uniformBuffer);
-                    glBindTexture(GL_TEXTURE_2D, _current.textureID);
-                    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-                }
-
-                glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-                static const vr::VRTextureBounds_t leftBounds{ 0, 0, 0.5f, 1 };
-                static const vr::VRTextureBounds_t rightBounds{ 0.5f, 0, 1, 1 };
-
-                vr::Texture_t texture{ (void*)(uintptr_t)_colors[currentColorBuffer], vr::TextureType_OpenGL,
-                                       vr::ColorSpace_Auto };
-                vr::VRCompositor()->Submit(vr::Eye_Left, &texture, &leftBounds);
-                vr::VRCompositor()->Submit(vr::Eye_Right, &texture, &rightBounds);
-                _plugin._presentRate.increment();
-                PoseData nextRender, nextSim;
-                nextRender.frameIndex = _plugin.presentCount();
-                vr::VRCompositor()->WaitGetPoses(nextRender.vrPoses, vr::k_unMaxTrackedDeviceCount, nextSim.vrPoses,
-                                                 vr::k_unMaxTrackedDeviceCount);
-
-                // Copy invalid poses in nextSim from nextRender
-                for (uint32_t i = 0; i < vr::k_unMaxTrackedDeviceCount; ++i) {
-                    if (!nextSim.vrPoses[i].bPoseIsValid) {
-                        nextSim.vrPoses[i] = nextRender.vrPoses[i];
-                    }
-                }
-
-                mat4 sensorResetMat;
-                _plugin.withNonPresentThreadLock([&] { sensorResetMat = _plugin._sensorResetMat; });
-
-                nextRender.update(sensorResetMat);
-                nextSim.update(sensorResetMat);
-                _plugin.withNonPresentThreadLock([&] {
-                    _nextRender = nextRender;
-                    _nextSim = nextSim;
-                    ++_presentCount;
-                    _presented.notify_one();
-                });
-
-                ++globalColorBufferCount;
-                currentColorBuffer = globalColorBufferCount % COLOR_BUFFER_COUNT;
-            }
-            _canvas->doneCurrent();
-        }
-
-        _canvas->makeCurrent();
-        glDeleteBuffers(1, &_uniformBuffer);
-        glDeleteFramebuffers(1, &_framebuffer);
-        CHECK_GL_ERROR();
-        glDeleteTextures(4, &_colors[0]);
-        glDeleteProgram(_program);
-        glBindVertexArray(0);
-        glDeleteVertexArrays(1, &_vao);
-        _canvas->doneCurrent();
-        _canvas->moveToThread(_plugin.thread());
-    }
-
-    void update(const CompositeInfo& newCompositeInfo) { _queue.push(newCompositeInfo); }
-
-    void waitForPresent() {
-        auto lastCount = _presentCount.load();
-        Lock lock(_plugin._presentMutex);
-        _presented.wait(lock, [&]() -> bool { return _presentCount.load() > lastCount; });
-        _nextSimPoseData = _nextSim;
-        _nextRenderPoseData = _nextRender;
-    }
-
-    CompositeInfo _current;
-    CompositeInfo::Queue _queue;
-
-    PoseData _nextRender, _nextSim;
-    bool _quit{ false };
-    GLuint _currentTexture{ 0 };
-    std::atomic<uint32_t> _presentCount{ 0 };
-    Condition _presented;
-    OpenVrDisplayPlugin& _plugin;
-};
-
 bool OpenVrDisplayPlugin::isSupported() const {
     return openVrSupported();
 }
@@ -433,12 +139,10 @@ bool OpenVrDisplayPlugin::internalActivate() {
     auto usingOpenVRForOculus = oculusViaOpenVR();
     _asyncReprojectionActive = (timing.m_nReprojectionFlags & VRCompositor_ReprojectionAsync) || usingOpenVRForOculus;
 
-    _threadedSubmit = !_asyncReprojectionActive;
     if (usingOpenVRForOculus) {
         qDebug() << "Oculus active via OpenVR:  " << usingOpenVRForOculus;
     }
     qDebug() << "OpenVR Async Reprojection active:  " << _asyncReprojectionActive;
-    qDebug() << "OpenVR Threaded submit enabled:  " << _threadedSubmit;
 
     _openVrDisplayActive = true;
     _system->GetRecommendedRenderTargetSize(&_renderTargetSize.x, &_renderTargetSize.y);
@@ -477,18 +181,6 @@ bool OpenVrDisplayPlugin::internalActivate() {
 #endif
     }
 
-    if (_threadedSubmit) {
-        _submitThread = std::make_shared<OpenVrSubmitThread>(*this);
-        if (!_submitCanvas) {
-            withOtherThreadContext([&] {
-                _submitCanvas = std::make_shared<gl::OffscreenContext>();
-                _submitCanvas->create();
-                _submitCanvas->doneCurrent();
-            });
-        }
-        _submitCanvas->moveToThread(_submitThread.get());
-    }
-
     return Parent::internalActivate();
 }
 
@@ -505,34 +197,24 @@ void OpenVrDisplayPlugin::internalDeactivate() {
     }
 }
 
+const gpu::FramebufferPointer& OpenVrDisplayPlugin::getCompositeFramebuffer() {
+    auto renderSize = glm::uvec2(getRecommendedRenderSize());	
+    if (!_compositeFramebuffer || _compositeFramebuffer->getSize() != renderSize) {	
+        _compositeFramebuffer = gpu::FramebufferPointer(gpu::Framebuffer::create(__FUNCTION__, gpu::Element::COLOR_RGBA_32, renderSize.x, renderSize.y));	
+    }
+    return _compositeFramebuffer;
+}
+
+
 void OpenVrDisplayPlugin::customizeContext() {
     // Display plugins in DLLs must initialize GL locally
     gl::initModuleGl();
     Parent::customizeContext();
-
-    if (_threadedSubmit) {
-//        _compositeInfos[0].texture = _compositeFramebuffer->getRenderBuffer(0);
-        for (size_t i = 0; i < COMPOSITING_BUFFER_SIZE; ++i) {
-//            if (0 != i) {
-                _compositeInfos[i].texture = gpu::Texture::createRenderBuffer(gpu::Element::COLOR_RGBA_32, _renderTargetSize.x,
-                                                                              _renderTargetSize.y, gpu::Texture::SINGLE_MIP,
-                                                                              gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_POINT));
-//            }
-            _compositeInfos[i].textureID = getGLBackend()->getTextureID(_compositeInfos[i].texture);
-        }
-        _submitThread->_canvas = _submitCanvas;
-        _submitThread->start(QThread::HighPriority);
-    }
+    updatePoses();
 }
 
 void OpenVrDisplayPlugin::uncustomizeContext() {
     Parent::uncustomizeContext();
-
-    if (_threadedSubmit) {
-        _submitThread->_quit = true;
-        _submitThread->wait();
-        _submitThread.reset();
-    }
 }
 
 void OpenVrDisplayPlugin::resetSensors() {
@@ -613,51 +295,21 @@ bool OpenVrDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
     return Parent::beginFrameRender(frameIndex);
 }
 
-void OpenVrDisplayPlugin::compositeLayers(const gpu::FramebufferPointer& compositeFramebuffer) {
-    if (_threadedSubmit) {
-        ++_renderingIndex;
-        _renderingIndex %= COMPOSITING_BUFFER_SIZE;
-
-        auto& newComposite = _compositeInfos[_renderingIndex];
-        newComposite.pose = _currentPresentFrameInfo.presentPose;
-        compositeFramebuffer->setRenderBuffer(0, newComposite.texture);
-    }
-
-    Parent::compositeLayers(compositeFramebuffer);
-
-    if (_threadedSubmit) {
-        auto& newComposite = _compositeInfos[_renderingIndex];
-        newComposite.fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-        // https://www.opengl.org/registry/specs/ARB/sync.txt:
-        // > The simple flushing behavior defined by
-        // > SYNC_FLUSH_COMMANDS_BIT will not help when waiting for a fence
-        // > command issued in another context's command stream to complete.
-        // > Applications which block on a fence sync object must take
-        // > additional steps to assure that the context from which the
-        // > corresponding fence command was issued has flushed that command
-        // > to the graphics pipeline.
-        glFlush();
-
-        if (!newComposite.textureID) {
-            newComposite.textureID = getGLBackend()->getTextureID(newComposite.texture);
-        }
-        withPresentThreadLock([&] { _submitThread->update(newComposite); });
-    }
-}
-
-void OpenVrDisplayPlugin::hmdPresent(const gpu::FramebufferPointer& compositeFramebuffer) {
+void OpenVrDisplayPlugin::hmdPresent() {
     PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
+    const auto& compositeFramebuffer = getCompositeFramebuffer();
 
-    if (_threadedSubmit) {
-        _submitThread->waitForPresent();
-    } else {
-        GLuint glTexId = getGLBackend()->getTextureID(compositeFramebuffer->getRenderBuffer(0));
-        vr::Texture_t vrTexture{ (void*)(uintptr_t)glTexId, vr::TextureType_OpenGL, vr::ColorSpace_Auto };
-        vr::VRCompositor()->Submit(vr::Eye_Left, &vrTexture, &OPENVR_TEXTURE_BOUNDS_LEFT);
-        vr::VRCompositor()->Submit(vr::Eye_Right, &vrTexture, &OPENVR_TEXTURE_BOUNDS_RIGHT);
-        vr::VRCompositor()->PostPresentHandoff();
-        _presentRate.increment();
-    }
+    GLuint glTexId = getGLBackend()->getTextureID(compositeFramebuffer->getRenderBuffer(0));
+    vr::VRTextureWithPose_t vrTexture{};
+    vrTexture.handle = (void*)(uintptr_t)glTexId;
+    vrTexture.eType = vr::TextureType_OpenGL;
+    vrTexture.eColorSpace = vr::ColorSpace_Auto;
+    vrTexture.mDeviceToAbsoluteTracking = toOpenVr(_currentPresentFrameInfo.presentPose);
+
+    vr::VRCompositor()->Submit(vr::Eye_Left, &vrTexture, &OPENVR_TEXTURE_BOUNDS_LEFT, vr::Submit_TextureWithPose);
+    vr::VRCompositor()->Submit(vr::Eye_Right, &vrTexture, &OPENVR_TEXTURE_BOUNDS_RIGHT, vr::Submit_TextureWithPose);
+    vr::VRCompositor()->PostPresentHandoff();
+    _presentRate.increment();
 
     vr::Compositor_FrameTiming frameTiming;
     memset(&frameTiming, 0, sizeof(vr::Compositor_FrameTiming));
@@ -666,23 +318,23 @@ void OpenVrDisplayPlugin::hmdPresent(const gpu::FramebufferPointer& compositeFra
     _stutterRate.increment(frameTiming.m_nNumDroppedFrames);
 }
 
-void OpenVrDisplayPlugin::postPreview() {
-    PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
+void OpenVrDisplayPlugin::updatePoses() {
+    PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)(_currentFrame ? _currentFrame->frameIndex : 0))
     PoseData nextRender, nextSim;
     nextRender.frameIndex = presentCount();
 
-    if (!_threadedSubmit) {
-        vr::VRCompositor()->WaitGetPoses(nextRender.vrPoses, vr::k_unMaxTrackedDeviceCount, nextSim.vrPoses,
-                                         vr::k_unMaxTrackedDeviceCount);
+    vr::VRCompositor()->WaitGetPoses(nextRender.vrPoses, vr::k_unMaxTrackedDeviceCount, nextSim.vrPoses,
+                                        vr::k_unMaxTrackedDeviceCount);
 
-        glm::mat4 resetMat;
-        withPresentThreadLock([&] { resetMat = _sensorResetMat; });
-        nextRender.update(resetMat);
-        nextSim.update(resetMat);
-        withPresentThreadLock([&] { _nextSimPoseData = nextSim; });
-        _nextRenderPoseData = nextRender;
-    }
+    glm::mat4 resetMat;
+    withPresentThreadLock([&] { resetMat = _sensorResetMat; });
+    nextRender.update(resetMat);
+    nextSim.update(resetMat);
+    withPresentThreadLock([&] { _nextSimPoseData = nextSim; });
+    _nextRenderPoseData = nextRender;
+}
 
+void OpenVrDisplayPlugin::postPreview() {
     if (isHmdMounted() != _hmdMounted) {
         _hmdMounted = !_hmdMounted;
         emit hmdMountedChanged();
@@ -694,6 +346,7 @@ bool OpenVrDisplayPlugin::isHmdMounted() const {
 }
 
 void OpenVrDisplayPlugin::updatePresentPose() {
+    updatePoses();
     _currentPresentFrameInfo.presentPose = _nextRenderPoseData.poses[vr::k_unTrackedDeviceIndex_Hmd];
 }
 
@@ -719,10 +372,6 @@ void OpenVrDisplayPlugin::unsuppressKeyboard() {
 
 bool OpenVrDisplayPlugin::isKeyboardVisible() {
     return isOpenVrKeyboardShown();
-}
-
-int OpenVrDisplayPlugin::getRequiredThreadCount() const {
-    return Parent::getRequiredThreadCount() + (_threadedSubmit ? 1 : 0);
 }
 
 QString OpenVrDisplayPlugin::getPreferredAudioInDevice() const {


### PR DESCRIPTION
[21911](https://highfidelity.manuscript.com/f/cases/21911/Hazard-Warning-Vive-HMD-Eyepiece-Strobing-Images)

The removal of the composite framebuffer has had a negative impact on the OpenVR display plugin, leading to stuttering.  I believe this is some kind of race condition between the rendering thread and the present thread, but I haven't been able to identify it.  As a result I'm restoring the composting framebuffer specifically to this plugin.

Additionally, I've discovered that the OpenVR API has been updated to allow submission of an image with the pose it was rendered for, ensuring better reprojection, and as such have removed our own threaded custom reprojection in favor of using this updated API.  