### PR TITLE
Bug fixed for MyAvatar.getJointRotation(name, quat) and MyAvatar.setJointRotation(name, quat)

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1721,7 +1721,6 @@ glm::vec3 AvatarData::getJointTranslation(const QString& name) const {
     // on another thread in between the call to getJointIndex and getJointTranslation
     // return getJointTranslation(getJointIndex(name));
     return readLockWithNamedJointIndex<glm::vec3>(name, [this](int index) {
-        return _jointData.at(index).translation;
         return getJointTranslation(index);
     });
 }
@@ -1809,8 +1808,8 @@ glm::quat AvatarData::getJointRotation(const QString& name) const {
     // Can't do this, not thread safe
     // return getJointRotation(getJointIndex(name));
 
-    return readLockWithNamedJointIndex<glm::quat>(name, [&](int index) {
-        return _jointData.at(index).rotation;
+    return readLockWithNamedJointIndex<glm::quat>(name, [this](int index) {
+        return getJointRotation(index);
     });
 }
 

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1753,9 +1753,6 @@ protected:
         QReadLocker readLock(&_jointDataLock);
         int index = getJointIndex(name);
         if (index == -1) {
-            index = getFauxJointIndex(name);
-        }
-        if (index == -1) {
             return defaultValue;
         }
         return f(index);
@@ -1770,9 +1767,6 @@ protected:
     void writeLockWithNamedJointIndex(const QString& name, F f) {
         QWriteLocker writeLock(&_jointDataLock);
         int index = getJointIndex(name);
-        if (index == -1) {
-            index = getFauxJointIndex(name);
-        }
         if (index == -1) {
             return;
         }

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1750,14 +1750,14 @@ protected:
 
     template <typename T, typename F>
     T readLockWithNamedJointIndex(const QString& name, const T& defaultValue, F f) const {
-        int index = getFauxJointIndex(name);
-        QReadLocker readLock(&_jointDataLock);
-
-        // The first conditional is superfluous, but illustrative
-        if (index == -1 || index < _jointData.size()) {
+        int index = getJointIndex(name);
+        if (index == -1) {
+            index = getFauxJointIndex(name);
+        }
+        if (index == -1) {
             return defaultValue;
         }
-
+        QReadLocker readLock(&_jointDataLock);
         return f(index);
     }
 
@@ -1768,11 +1768,14 @@ protected:
 
     template <typename F>
     void writeLockWithNamedJointIndex(const QString& name, F f) {
-        int index = getFauxJointIndex(name);
-        QWriteLocker writeLock(&_jointDataLock);
+        int index = getJointIndex(name);
+        if (index == -1) {
+            index = getFauxJointIndex(name);
+        }
         if (index == -1) {
             return;
         }
+        QWriteLocker writeLock(&_jointDataLock);
         if (_jointData.size() <= index) {
             _jointData.resize(index + 1);
         }

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1750,6 +1750,7 @@ protected:
 
     template <typename T, typename F>
     T readLockWithNamedJointIndex(const QString& name, const T& defaultValue, F f) const {
+        QReadLocker readLock(&_jointDataLock);
         int index = getJointIndex(name);
         if (index == -1) {
             index = getFauxJointIndex(name);
@@ -1757,7 +1758,6 @@ protected:
         if (index == -1) {
             return defaultValue;
         }
-        QReadLocker readLock(&_jointDataLock);
         return f(index);
     }
 
@@ -1768,6 +1768,7 @@ protected:
 
     template <typename F>
     void writeLockWithNamedJointIndex(const QString& name, F f) {
+        QWriteLocker writeLock(&_jointDataLock);
         int index = getJointIndex(name);
         if (index == -1) {
             index = getFauxJointIndex(name);
@@ -1775,7 +1776,6 @@ protected:
         if (index == -1) {
             return;
         }
-        QWriteLocker writeLock(&_jointDataLock);
         if (_jointData.size() <= index) {
             _jointData.resize(index + 1);
         }


### PR DESCRIPTION
This pr addresses the bug where the getJointRotation and setJointRotation are not the same when you use different overloads of the function.  Specifically, the MyAvatar.getJointRotation(index,quat) is working but  MyAvatar.getJointRotation("jointname", quat) is not. 

 https://highfidelity.manuscript.com/f/cases/21542/MyAvatar-getJointTranslation-index-and-getJointTranslation-name-return-different-values

### Test Plan
1)  open Interface and run the following script.
https://hifi-content.s3.amazonaws.com/angus/getJointTranslationRotation.js
2) expected result: the second and third outputs for the translations and rotations should match
