### PR TITLE
Case 21730:  Restore composite framebuffer to display plugins

### DIFF
--- a/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.cpp
@@ -109,7 +109,7 @@ bool Basic2DWindowOpenGLDisplayPlugin::internalActivate() {
     return Parent::internalActivate();
 }
 
-void Basic2DWindowOpenGLDisplayPlugin::compositeExtra(const gpu::FramebufferPointer& compositeFramebuffer) {
+void Basic2DWindowOpenGLDisplayPlugin::compositeExtra() {
 #if defined(Q_OS_ANDROID)
     auto& virtualPadManager = VirtualPad::Manager::instance();
     if(virtualPadManager.getLeftVirtualPad()->isShown()) {
@@ -121,7 +121,7 @@ void Basic2DWindowOpenGLDisplayPlugin::compositeExtra(const gpu::FramebufferPoin
 
         render([&](gpu::Batch& batch) {
             batch.enableStereo(false);
-            batch.setFramebuffer(compositeFramebuffer);
+            batch.setFramebuffer(_compositeFramebuffer);
             batch.resetViewTransform();
             batch.setProjectionTransform(mat4());
             batch.setPipeline(_cursorPipeline);
@@ -140,7 +140,7 @@ void Basic2DWindowOpenGLDisplayPlugin::compositeExtra(const gpu::FramebufferPoin
         });
     }
 #endif
-    Parent::compositeExtra(compositeFramebuffer);
+    Parent::compositeExtra();
 }
 
 static const uint32_t MIN_THROTTLE_CHECK_FRAMES = 60;

--- a/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/Basic2DWindowOpenGLDisplayPlugin.h
@@ -33,7 +33,7 @@ public:
 
     virtual bool isThrottled() const override;
 
-    virtual void compositeExtra(const gpu::FramebufferPointer&) override;
+    virtual void compositeExtra() override;
 
     virtual void pluginUpdate() override {};
 

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.h
@@ -94,10 +94,14 @@ protected:
     // is not populated
     virtual bool alwaysPresent() const { return false; }
 
+    void updateCompositeFramebuffer();
+
     virtual QThread::Priority getPresentPriority() { return QThread::HighPriority; }
-    virtual void compositeLayers(const gpu::FramebufferPointer&);
-    virtual void compositePointer(const gpu::FramebufferPointer&);
-    virtual void compositeExtra(const gpu::FramebufferPointer&) {};
+    virtual void compositeLayers();
+    virtual void compositeScene();
+    virtual std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> getHUDOperator();
+    virtual void compositePointer();
+    virtual void compositeExtra() {};
 
     // These functions must only be called on the presentation thread
     virtual void customizeContext();
@@ -112,10 +116,10 @@ protected:
     virtual void deactivateSession() {}
 
     // Plugin specific functionality to send the composed scene to the output window or device
-    virtual void internalPresent(const gpu::FramebufferPointer&);
+    virtual void internalPresent();
 
-    
-    void renderFromTexture(gpu::Batch& batch, const gpu::TexturePointer& texture, const glm::ivec4& viewport, const glm::ivec4& scissor, const gpu::FramebufferPointer& destFbo = nullptr, const gpu::FramebufferPointer& copyFbo = nullptr);
+    void renderFromTexture(gpu::Batch& batch, const gpu::TexturePointer& texture, const glm::ivec4& viewport, const glm::ivec4& scissor, const gpu::FramebufferPointer& fbo);
+    void renderFromTexture(gpu::Batch& batch, const gpu::TexturePointer& texture, const glm::ivec4& viewport, const glm::ivec4& scissor);
     virtual void updateFrameData();
     virtual glm::mat4 getViewCorrection() { return glm::mat4(); }
 
@@ -138,8 +142,14 @@ protected:
     gpu::FramePointer _currentFrame;
     gpu::Frame* _lastFrame { nullptr };
     mat4 _prevRenderView;
+    gpu::FramebufferPointer _compositeFramebuffer;
+    gpu::PipelinePointer _hudPipeline;
+    gpu::PipelinePointer _mirrorHUDPipeline;
+    gpu::ShaderPointer _mirrorHUDPS;
+    gpu::PipelinePointer _simplePipeline;
+    gpu::PipelinePointer _presentPipeline;
     gpu::PipelinePointer _cursorPipeline;
-    gpu::TexturePointer _displayTexture;
+    gpu::TexturePointer _displayTexture{};
     float _compositeHUDAlpha { 1.0f };
 
     struct CursorData {
@@ -175,9 +185,5 @@ protected:
     // be serialized through this mutex
     mutable Mutex _presentMutex;
     float _hudAlpha{ 1.0f };
-
-private:
-    gpu::PipelinePointer _presentPipeline;
-
 };
 

--- a/libraries/display-plugins/src/display-plugins/hmd/DebugHmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/DebugHmdDisplayPlugin.h
@@ -24,7 +24,7 @@ public:
 
 protected:
     void updatePresentPose() override;
-    void hmdPresent(const gpu::FramebufferPointer&) override {}
+    void hmdPresent() override {}
     bool isHmdMounted() const override { return true; }
     bool internalActivate() override;
 private:

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -114,23 +114,20 @@ void HmdDisplayPlugin::internalDeactivate() {
 
 void HmdDisplayPlugin::customizeContext() {
     Parent::customizeContext();
-    _hudOperator = _hudRenderer.build();
+    _hudRenderer.build();
 }
 
 void HmdDisplayPlugin::uncustomizeContext() {
     // This stops the weirdness where if the preview was disabled, on switching back to 2D,
     // the vsync was stuck in the disabled state.  No idea why that happens though.
     _disablePreview = false;
-    if (_currentFrame && _currentFrame->framebuffer) {
-        render([&](gpu::Batch& batch) {
-            batch.enableStereo(false);
-            batch.resetViewTransform();
-            batch.setFramebuffer(_currentFrame->framebuffer);
-            batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, vec4(0));
-        });
-
-    }
-    _hudRenderer = {};
+    render([&](gpu::Batch& batch) {
+        batch.enableStereo(false);
+        batch.resetViewTransform();
+        batch.setFramebuffer(_compositeFramebuffer);
+        batch.clearColorFramebuffer(gpu::Framebuffer::BUFFER_COLOR0, vec4(0));
+    });
+    _hudRenderer = HUDRenderer();
     _previewTexture.reset();
     Parent::uncustomizeContext();
 }
@@ -177,11 +174,11 @@ float HmdDisplayPlugin::getLeftCenterPixel() const {
     return leftCenterPixel;
 }
 
-void HmdDisplayPlugin::internalPresent(const gpu::FramebufferPointer& compositeFramebuffer) {
+void HmdDisplayPlugin::internalPresent() {
     PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)presentCount())
 
     // Composite together the scene, hud and mouse cursor
-    hmdPresent(compositeFramebuffer);
+    hmdPresent();
 
     if (_displayTexture) {
         // Note: _displayTexture must currently be the same size as the display.
@@ -263,7 +260,7 @@ void HmdDisplayPlugin::internalPresent(const gpu::FramebufferPointer& compositeF
 
                 viewport.z *= 2;
             }
-            renderFromTexture(batch, compositeFramebuffer->getRenderBuffer(0), viewport, scissor, nullptr, fbo);
+            renderFromTexture(batch, _compositeFramebuffer->getRenderBuffer(0), viewport, scissor, fbo);
         });
         swapBuffers();
 
@@ -348,7 +345,7 @@ glm::mat4 HmdDisplayPlugin::getViewCorrection() {
     }
 }
 
-DisplayPlugin::HUDOperator HmdDisplayPlugin::HUDRenderer::build() {
+void HmdDisplayPlugin::HUDRenderer::build() {
     vertices = std::make_shared<gpu::Buffer>();
     indices = std::make_shared<gpu::Buffer>();
 
@@ -383,7 +380,7 @@ DisplayPlugin::HUDOperator HmdDisplayPlugin::HUDRenderer::build() {
     indexCount = numberOfRectangles * TRIANGLE_PER_RECTANGLE * VERTEX_PER_TRANGLE;
 
     // Compute indices order
-    std::vector<GLushort> indexData;
+    std::vector<GLushort> indices;
     for (int i = 0; i < stacks - 1; i++) {
         for (int j = 0; j < slices - 1; j++) {
             GLushort bottomLeftIndex = i * slices + j;
@@ -391,21 +388,24 @@ DisplayPlugin::HUDOperator HmdDisplayPlugin::HUDRenderer::build() {
             GLushort topLeftIndex = bottomLeftIndex + slices;
             GLushort topRightIndex = topLeftIndex + 1;
             // FIXME make a z-order curve for better vertex cache locality
-            indexData.push_back(topLeftIndex);
-            indexData.push_back(bottomLeftIndex);
-            indexData.push_back(topRightIndex);
+            indices.push_back(topLeftIndex);
+            indices.push_back(bottomLeftIndex);
+            indices.push_back(topRightIndex);
 
-            indexData.push_back(topRightIndex);
-            indexData.push_back(bottomLeftIndex);
-            indexData.push_back(bottomRightIndex);
+            indices.push_back(topRightIndex);
+            indices.push_back(bottomLeftIndex);
+            indices.push_back(bottomRightIndex);
         }
     }
-    indices->append(indexData);
+    this->indices->append(indices);
     format = std::make_shared<gpu::Stream::Format>(); // 1 for everyone
     format->setAttribute(gpu::Stream::POSITION, gpu::Stream::POSITION, gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ), 0);
     format->setAttribute(gpu::Stream::TEXCOORD, gpu::Stream::TEXCOORD, gpu::Element(gpu::VEC2, gpu::FLOAT, gpu::UV));
     uniformsBuffer = std::make_shared<gpu::Buffer>(sizeof(Uniforms), nullptr);
+    updatePipeline();
+}
 
+void HmdDisplayPlugin::HUDRenderer::updatePipeline() {
     if (!pipeline) {
         auto program = gpu::Shader::createProgram(shader::render_utils::program::hmd_ui);
         gpu::StatePointer state = gpu::StatePointer(new gpu::State());
@@ -416,6 +416,10 @@ DisplayPlugin::HUDOperator HmdDisplayPlugin::HUDRenderer::build() {
 
         pipeline = gpu::Pipeline::create(program, state);
     }
+}
+
+std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> HmdDisplayPlugin::HUDRenderer::render(HmdDisplayPlugin& plugin) {
+    updatePipeline();
 
     auto hudPipeline = pipeline;
     auto hudFormat = format;
@@ -424,9 +428,9 @@ DisplayPlugin::HUDOperator HmdDisplayPlugin::HUDRenderer::build() {
     auto hudUniformBuffer = uniformsBuffer;
     auto hudUniforms = uniforms;
     auto hudIndexCount = indexCount;
-    return [=](gpu::Batch& batch, const gpu::TexturePointer& hudTexture, const gpu::FramebufferPointer&, const bool mirror) {
-        if (pipeline && hudTexture) {
-            batch.setPipeline(pipeline);
+    return [=](gpu::Batch& batch, const gpu::TexturePointer& hudTexture, bool mirror) {
+        if (hudPipeline && hudTexture) {
+            batch.setPipeline(hudPipeline);
 
             batch.setInputFormat(hudFormat);
             gpu::BufferView posView(hudVertices, VERTEX_OFFSET, hudVertices->getSize(), VERTEX_STRIDE, hudFormat->getAttributes().at(gpu::Stream::POSITION)._element);
@@ -450,7 +454,7 @@ DisplayPlugin::HUDOperator HmdDisplayPlugin::HUDRenderer::build() {
     };
 }
 
-void HmdDisplayPlugin::compositePointer(const gpu::FramebufferPointer& compositeFramebuffer) {
+void HmdDisplayPlugin::compositePointer() {
     auto& cursorManager = Cursor::Manager::instance();
     const auto& cursorData = _cursorsData[cursorManager.getCursor()->getIcon()];
     auto compositorHelper = DependencyManager::get<CompositorHelper>();
@@ -459,7 +463,7 @@ void HmdDisplayPlugin::compositePointer(const gpu::FramebufferPointer& composite
     render([&](gpu::Batch& batch) {
         // FIXME use standard gpu stereo rendering for this.
         batch.enableStereo(false);
-        batch.setFramebuffer(compositeFramebuffer);
+        batch.setFramebuffer(_compositeFramebuffer);
         batch.setPipeline(_cursorPipeline);
         batch.setResourceTexture(0, cursorData.texture);
         batch.resetViewTransform();
@@ -472,6 +476,10 @@ void HmdDisplayPlugin::compositePointer(const gpu::FramebufferPointer& composite
             batch.draw(gpu::TRIANGLE_STRIP, 4);
         });
     });
+}
+
+std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> HmdDisplayPlugin::getHUDOperator() {
+    return _hudRenderer.render(*this);
 }
 
 HmdDisplayPlugin::~HmdDisplayPlugin() {

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -53,15 +53,16 @@ signals:
     void hmdVisibleChanged(bool visible);
 
 protected:
-    virtual void hmdPresent(const gpu::FramebufferPointer&) = 0;
+    virtual void hmdPresent() = 0;
     virtual bool isHmdMounted() const = 0;
     virtual void postPreview() {};
     virtual void updatePresentPose();
 
     bool internalActivate() override;
     void internalDeactivate() override;
-    void compositePointer(const gpu::FramebufferPointer&) override;
-    void internalPresent(const gpu::FramebufferPointer&) override;
+    std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> getHUDOperator() override;
+    void compositePointer() override;
+    void internalPresent() override;
     void customizeContext() override;
     void uncustomizeContext() override;
     void updateFrameData() override;
@@ -119,6 +120,8 @@ private:
         static const size_t TEXTURE_OFFSET { offsetof(Vertex, uv) };
         static const int VERTEX_STRIDE { sizeof(Vertex) };
 
-        HUDOperator build();
+        void build();
+        void updatePipeline();
+        std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> render(HmdDisplayPlugin& plugin);
     } _hudRenderer;
 };

--- a/libraries/display-plugins/src/display-plugins/stereo/InterleavedStereoDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/stereo/InterleavedStereoDisplayPlugin.cpp
@@ -37,13 +37,13 @@ glm::uvec2 InterleavedStereoDisplayPlugin::getRecommendedRenderSize() const {
     return result;
 }
 
-void InterleavedStereoDisplayPlugin::internalPresent(const gpu::FramebufferPointer& compositeFramebuffer) {
+void InterleavedStereoDisplayPlugin::internalPresent() {
     render([&](gpu::Batch& batch) {
         batch.enableStereo(false);
         batch.resetViewTransform();
         batch.setFramebuffer(gpu::FramebufferPointer());
         batch.setViewportTransform(ivec4(uvec2(0), getSurfacePixels()));
-        batch.setResourceTexture(0, compositeFramebuffer->getRenderBuffer(0));
+        batch.setResourceTexture(0, _currentFrame->framebuffer->getRenderBuffer(0));
         batch.setPipeline(_interleavedPresentPipeline);
         batch.draw(gpu::TRIANGLE_STRIP, 4);
     });

--- a/libraries/display-plugins/src/display-plugins/stereo/InterleavedStereoDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/stereo/InterleavedStereoDisplayPlugin.h
@@ -21,7 +21,7 @@ protected:
     // initialize OpenGL context settings needed by the plugin
     void customizeContext() override;
     void uncustomizeContext() override;
-    void internalPresent(const gpu::FramebufferPointer&) override;
+    void internalPresent() override;
 
 private:
     static const QString NAME;

--- a/libraries/oculusMobilePlugin/src/OculusMobileDisplayPlugin.cpp
+++ b/libraries/oculusMobilePlugin/src/OculusMobileDisplayPlugin.cpp
@@ -245,7 +245,7 @@ void OculusMobileDisplayPlugin::updatePresentPose() {
     });
 }
 
-void OculusMobileDisplayPlugin::internalPresent(const gpu::FramebufferPointer& compsiteFramebuffer) {
+void OculusMobileDisplayPlugin::internalPresent() {
     VrHandler::pollTask();
 
     if (!vrActive()) {
@@ -253,12 +253,8 @@ void OculusMobileDisplayPlugin::internalPresent(const gpu::FramebufferPointer& c
         return;
     }
 
-    GLuint sourceTexture = 0;
-    glm::uvec2 sourceSize;
-    if (compsiteFramebuffer) {
-        sourceTexture = getGLBackend()->getTextureID(compsiteFramebuffer->getRenderBuffer(0));
-        sourceSize = { compsiteFramebuffer->getWidth(), compsiteFramebuffer->getHeight() };
-    }
+    auto sourceTexture = getGLBackend()->getTextureID(_compositeFramebuffer->getRenderBuffer(0));
+    glm::uvec2 sourceSize{ _compositeFramebuffer->getWidth(), _compositeFramebuffer->getHeight() };
     VrHandler::presentFrame(sourceTexture, sourceSize, presentTracking);
     _presentRate.increment();
 }

--- a/libraries/oculusMobilePlugin/src/OculusMobileDisplayPlugin.h
+++ b/libraries/oculusMobilePlugin/src/OculusMobileDisplayPlugin.h
@@ -54,8 +54,8 @@ protected:
     void uncustomizeContext() override;
 
     void updatePresentPose() override;
-    void internalPresent(const gpu::FramebufferPointer&) override;
-    void hmdPresent(const gpu::FramebufferPointer&) override { throw std::runtime_error("Unused"); }
+    void internalPresent() override;
+    void hmdPresent() override { throw std::runtime_error("Unused"); }
     bool isHmdMounted() const override;
     bool alwaysPresent() const override { return true; }
 

--- a/libraries/plugins/src/plugins/DisplayPlugin.cpp
+++ b/libraries/plugins/src/plugins/DisplayPlugin.cpp
@@ -2,12 +2,6 @@
 
 #include <NumericalConstants.h>
 
-
-const DisplayPlugin::HUDOperator DisplayPlugin::DEFAULT_HUD_OPERATOR{ std::function<void(gpu::Batch&, const gpu::TexturePointer&, const gpu::FramebufferPointer&, bool mirror)>() };
-
-DisplayPlugin::DisplayPlugin() : _hudOperator{ DEFAULT_HUD_OPERATOR } {
-}
-
 int64_t DisplayPlugin::getPaintDelayUsecs() const {
     std::lock_guard<std::mutex> lock(_paintDelayMutex);
     return _paintDelayTimer.isValid() ? _paintDelayTimer.nsecsElapsed() / NSECS_PER_USEC : 0;
@@ -41,8 +35,8 @@ void DisplayPlugin::waitForPresent() {
     }
 }
 
-std::function<void(gpu::Batch&, const gpu::TexturePointer&, const gpu::FramebufferPointer& compositeFramebuffer, bool mirror)> DisplayPlugin::getHUDOperator() {
-    HUDOperator hudOperator;
+std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> DisplayPlugin::getHUDOperator() {
+    std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> hudOperator;
     {
         QMutexLocker locker(&_presentMutex);
         hudOperator = _hudOperator;
@@ -54,5 +48,3 @@ glm::mat4 HmdDisplay::getEyeToHeadTransform(Eye eye) const {
     static const glm::mat4 xform;
     return xform;
 }
-
-

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -121,8 +121,6 @@ class DisplayPlugin : public Plugin, public HmdDisplay {
     Q_OBJECT
     using Parent = Plugin;
 public:
-    DisplayPlugin();
-
     virtual int getRequiredThreadCount() const { return 0; }
     virtual bool isHmd() const { return false; }
     virtual int getHmdScreen() const { return -1; }
@@ -216,8 +214,7 @@ public:
     void waitForPresent();
     float getAveragePresentTime() { return _movingAveragePresent.average / (float)USECS_PER_MSEC; } // in msec
 
-    using HUDOperator = std::function<void(gpu::Batch&, const gpu::TexturePointer&, const gpu::FramebufferPointer&, bool mirror)>;
-    virtual HUDOperator getHUDOperator() final;
+    std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> getHUDOperator();
 
     static const QString& MENU_PATH();
 
@@ -234,8 +231,7 @@ protected:
 
     gpu::ContextPointer _gpuContext;
 
-    static const HUDOperator DEFAULT_HUD_OPERATOR;
-    HUDOperator _hudOperator;
+    std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> _hudOperator { std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)>() };
 
     MovingAverage<float, 10> _movingAveragePresent;
 

--- a/libraries/render-utils/src/RenderCommonTask.cpp
+++ b/libraries/render-utils/src/RenderCommonTask.cpp
@@ -126,8 +126,8 @@ void CompositeHUD::run(const RenderContextPointer& renderContext, const gpu::Fra
         if (inputs) {
             batch.setFramebuffer(inputs);
         }
-        if (renderContext->args->_hudOperator && renderContext->args->_blitFramebuffer) {
-            renderContext->args->_hudOperator(batch, renderContext->args->_hudTexture, renderContext->args->_blitFramebuffer, renderContext->args->_renderMode == RenderArgs::RenderMode::MIRROR_RENDER_MODE);
+        if (renderContext->args->_hudOperator) {
+            renderContext->args->_hudOperator(batch, renderContext->args->_hudTexture, renderContext->args->_renderMode == RenderArgs::RenderMode::MIRROR_RENDER_MODE);
         }
     });
 #endif

--- a/libraries/render/src/render/Args.h
+++ b/libraries/render/src/render/Args.h
@@ -131,7 +131,7 @@ namespace render {
         render::ScenePointer _scene;
         int8_t _cameraMode { -1 };
 
-        std::function<void(gpu::Batch&, const gpu::TexturePointer&, const gpu::FramebufferPointer&, bool mirror)> _hudOperator;
+        std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> _hudOperator;
         gpu::TexturePointer _hudTexture;
     };
 

--- a/plugins/oculus/src/OculusDebugDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDebugDisplayPlugin.h
@@ -16,7 +16,7 @@ public:
     bool isSupported() const override;
 
 protected:
-    void hmdPresent(const gpu::FramebufferPointer&) override {}
+    void hmdPresent() override {}
     bool isHmdMounted() const override { return true; }
 
 private:

--- a/plugins/oculus/src/OculusDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDisplayPlugin.h
@@ -28,7 +28,7 @@ protected:
     QThread::Priority getPresentPriority() override { return QThread::TimeCriticalPriority; }
 
     bool internalActivate() override;
-    void hmdPresent(const gpu::FramebufferPointer&) override;
+    void hmdPresent() override;
     bool isHmdMounted() const override;
     void customizeContext() override;
     void uncustomizeContext() override;

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.cpp
@@ -237,7 +237,7 @@ void OculusLegacyDisplayPlugin::uncustomizeContext() {
     Parent::uncustomizeContext();
 }
 
-void OculusLegacyDisplayPlugin::hmdPresent(const gpu::FramebufferPointer& compositeFramebuffer) {
+void OculusLegacyDisplayPlugin::hmdPresent() {
     if (!_hswDismissed) {
         ovrHSWDisplayState hswState;
         ovrHmd_GetHSWDisplayState(_hmd, &hswState);
@@ -252,7 +252,7 @@ void OculusLegacyDisplayPlugin::hmdPresent(const gpu::FramebufferPointer& compos
     memset(eyePoses, 0, sizeof(ovrPosef) * 2);
     eyePoses[0].Orientation = eyePoses[1].Orientation = ovrRotation;
     
-    GLint texture = getGLBackend()->getTextureID(compositeFramebuffer->getRenderBuffer(0));
+    GLint texture = getGLBackend()->getTextureID(_compositeFramebuffer->getRenderBuffer(0));
     auto sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
     glFlush();
     if (_hmdWindow->makeCurrent()) {

--- a/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
+++ b/plugins/oculusLegacy/src/OculusLegacyDisplayPlugin.h
@@ -39,7 +39,7 @@ protected:
 
     void customizeContext() override;
     void uncustomizeContext() override;
-    void hmdPresent(const gpu::FramebufferPointer&) override;
+    void hmdPresent() override;
     bool isHmdMounted() const override { return true; }
 
 private:

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -511,13 +511,13 @@ void OpenVrDisplayPlugin::customizeContext() {
     Parent::customizeContext();
 
     if (_threadedSubmit) {
-//        _compositeInfos[0].texture = _compositeFramebuffer->getRenderBuffer(0);
+        _compositeInfos[0].texture = _compositeFramebuffer->getRenderBuffer(0);
         for (size_t i = 0; i < COMPOSITING_BUFFER_SIZE; ++i) {
-//            if (0 != i) {
+            if (0 != i) {
                 _compositeInfos[i].texture = gpu::Texture::createRenderBuffer(gpu::Element::COLOR_RGBA_32, _renderTargetSize.x,
                                                                               _renderTargetSize.y, gpu::Texture::SINGLE_MIP,
                                                                               gpu::Sampler(gpu::Sampler::FILTER_MIN_MAG_POINT));
-//            }
+            }
             _compositeInfos[i].textureID = getGLBackend()->getTextureID(_compositeInfos[i].texture);
         }
         _submitThread->_canvas = _submitCanvas;
@@ -613,17 +613,17 @@ bool OpenVrDisplayPlugin::beginFrameRender(uint32_t frameIndex) {
     return Parent::beginFrameRender(frameIndex);
 }
 
-void OpenVrDisplayPlugin::compositeLayers(const gpu::FramebufferPointer& compositeFramebuffer) {
+void OpenVrDisplayPlugin::compositeLayers() {
     if (_threadedSubmit) {
         ++_renderingIndex;
         _renderingIndex %= COMPOSITING_BUFFER_SIZE;
 
         auto& newComposite = _compositeInfos[_renderingIndex];
         newComposite.pose = _currentPresentFrameInfo.presentPose;
-        compositeFramebuffer->setRenderBuffer(0, newComposite.texture);
+        _compositeFramebuffer->setRenderBuffer(0, newComposite.texture);
     }
 
-    Parent::compositeLayers(compositeFramebuffer);
+    Parent::compositeLayers();
 
     if (_threadedSubmit) {
         auto& newComposite = _compositeInfos[_renderingIndex];
@@ -645,13 +645,13 @@ void OpenVrDisplayPlugin::compositeLayers(const gpu::FramebufferPointer& composi
     }
 }
 
-void OpenVrDisplayPlugin::hmdPresent(const gpu::FramebufferPointer& compositeFramebuffer) {
+void OpenVrDisplayPlugin::hmdPresent() {
     PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)_currentFrame->frameIndex)
 
     if (_threadedSubmit) {
         _submitThread->waitForPresent();
     } else {
-        GLuint glTexId = getGLBackend()->getTextureID(compositeFramebuffer->getRenderBuffer(0));
+        GLuint glTexId = getGLBackend()->getTextureID(_compositeFramebuffer->getRenderBuffer(0));
         vr::Texture_t vrTexture{ (void*)(uintptr_t)glTexId, vr::TextureType_OpenGL, vr::ColorSpace_Auto };
         vr::VRCompositor()->Submit(vr::Eye_Left, &vrTexture, &OPENVR_TEXTURE_BOUNDS_LEFT);
         vr::VRCompositor()->Submit(vr::Eye_Right, &vrTexture, &OPENVR_TEXTURE_BOUNDS_RIGHT);

--- a/plugins/openvr/src/OpenVrDisplayPlugin.h
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.h
@@ -72,8 +72,8 @@ protected:
     void internalDeactivate() override;
     void updatePresentPose() override;
 
-    void compositeLayers(const gpu::FramebufferPointer&) override;
-    void hmdPresent(const gpu::FramebufferPointer&) override;
+    void compositeLayers() override;
+    void hmdPresent() override;
     bool isHmdMounted() const override;
     void postPreview() override;
 


### PR DESCRIPTION
[21730](https://highfidelity.manuscript.com/f/cases/21730/Remove-extra-compositing-buffer-from-display-plugins

The removal of the composite framebuffer in #15157 has led to unexpected issues:

* [21911](https://highfidelity.manuscript.com/f/cases/21911/Hazard-Warning-Vive-HMD-Eyepiece-Strobing-Images) Strobing effect in Vive HMD
* [22041](https://highfidelity.manuscript.com/f/cases/22041) Gamma issues in snapshots and screenshots

This PR reverts removal of the composite framebuffer (but retains the other two commits from the earlier PR) with the intent that we will revisit the issue later with an eye to a new design where the display plugin will _provide_ an output framebuffer to the rendering system, rather than the rendering system pushing an output framebuffer to the display plugin.  This will allow us to make the most efficient usage of said framebuffer with the minimum number of needless blits / draws.  

## Testing

Testing should be done to verify that this resolves the two mentioned issues with a standard desktop build.  