### PR TITLE
Case 18299: Fix ScriptEngine not being destroyed on its own thread

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -163,7 +163,7 @@ ScriptEnginePointer scriptEngineFactory(ScriptEngine::Context context,
                                                  const QString& scriptContents,
                                                  const QString& fileNameString) {
     ScriptEngine* engine = new ScriptEngine(context, scriptContents, fileNameString);
-    ScriptEnginePointer engineSP = ScriptEnginePointer(engine);
+    ScriptEnginePointer engineSP = ScriptEnginePointer(engine, &QObject::deleteLater);
     auto scriptEngines = DependencyManager::get<ScriptEngines>();
     scriptEngines->addScriptEngine(qSharedPointerCast<ScriptEngine>(engineSP));
     engine->setScriptEngines(scriptEngines);
@@ -267,7 +267,7 @@ void ScriptEngine::disconnectNonEssentialSignals() {
     QThread* workerThread;
     // Ensure the thread should be running, and does exist
     if (_isRunning && _isThreaded && (workerThread = thread())) {
-        connect(this, &ScriptEngine::doneRunning, workerThread, &QThread::quit);
+        connect(this, &QObject::destroyed, workerThread, &QThread::quit);
         connect(workerThread, &QThread::finished, workerThread, &QObject::deleteLater);
     }
 }
@@ -381,7 +381,7 @@ void ScriptEngine::runInThread() {
     // the script engine, make sure to add code to "reconnect" them to the
     // disconnectNonEssentialSignals() method
     connect(workerThread, &QThread::started, this, &ScriptEngine::run);
-    connect(this, &ScriptEngine::doneRunning, workerThread, &QThread::quit);
+    connect(this, &QObject::destroyed, workerThread, &QThread::quit);
     connect(workerThread, &QThread::finished, workerThread, &QObject::deleteLater);
 
     workerThread->start();


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/18299

**This is a sensitive change.**

This change moves `ScriptEngine` destruction to the `ScriptEngine`'s thread, instead of the main thread, and shuts the `ScriptEngine` thread down after the `ScriptEngine` has been destroyed.

What we were seeing was that the ScriptEngine and QObject's that were set to `ScriptOwnership` (like `InteractiveWindow`) were being destroyed while there might still be script slots executing on the `ScriptEngine`'s thread. In particular, a callback related to `InteractiveWindow` would execute and try to access the since-deleted `InteractiveWindow`, causing a crash.