### PR TITLE
Case 21925: Warn mixer about stopped injectors

### DIFF
--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -98,7 +98,8 @@ AudioMixer::AudioMixer(ReceivedMessage& message) :
             PacketType::RequestsDomainListData,
             PacketType::PerAvatarGainSet,
             PacketType::InjectorGainSet,
-            PacketType::AudioSoloRequest },
+            PacketType::AudioSoloRequest,
+            PacketType::StopInjector },
             this, "queueAudioPacket");
 
     // packets whose consequences are global should be processed on the main thread
@@ -246,7 +247,8 @@ void AudioMixer::removeHRTFsForFinishedInjector(const QUuid& streamID) {
 
     if (injectorClientData) {
         // stage the removal of this stream, workers handle when preparing mixes for listeners
-        _workerSharedData.removedStreams.emplace_back(injectorClientData->getNodeID(), injectorClientData->getNodeLocalID(),
+        _workerSharedData.removedStreams.emplace_back(injectorClientData->getNodeID(),
+                                                      injectorClientData->getNodeLocalID(),
                                                       streamID);
     }
 }

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -67,11 +67,10 @@ public:
     void parseNodeIgnoreRequest(QSharedPointer<ReceivedMessage> message, const SharedNodePointer& node);
     void parseRadiusIgnoreRequest(QSharedPointer<ReceivedMessage> message, const SharedNodePointer& node);
     void parseSoloRequest(QSharedPointer<ReceivedMessage> message, const SharedNodePointer& node);
+    void parseStopInjectorPacket(QSharedPointer<ReceivedMessage> packet);
 
     // attempt to pop a frame from each audio stream, and return the number of streams from this client
     int checkBuffersBeforeFrameSend();
-
-    void removeDeadInjectedStreams();
 
     QJsonObject getAudioStreamStats();
 
@@ -163,7 +162,7 @@ public:
     // end of methods called non-concurrently from single AudioMixerSlave
 
 signals:
-    void injectorStreamFinished(const QUuid& streamIdentifier);
+    void injectorStreamFinished(const QUuid& streamID);
 
 public slots:
     void handleMismatchAudioFormat(SharedNodePointer node, const QString& currentCodec, const QString& recievedCodec);

--- a/libraries/audio/src/AudioInjector.h
+++ b/libraries/audio/src/AudioInjector.h
@@ -100,6 +100,7 @@ private:
     int64_t injectNextFrame();
     bool inject(bool(AudioInjectorManager::*injection)(const AudioInjectorPointer&));
     bool injectLocally();
+    void sendStopInjectorPacket();
 
     static AbstractAudioInterface* _localAudioInterface;
 
@@ -120,6 +121,9 @@ private:
     // when the injector is local, we need this
     AudioHRTF _localHRTF;
     AudioFOA _localFOA;
+
+    QUuid _streamID { QUuid::createUuid() };
+
     friend class AudioInjectorManager;
 };
 

--- a/libraries/audio/src/AudioInjectorManager.cpp
+++ b/libraries/audio/src/AudioInjectorManager.cpp
@@ -105,6 +105,8 @@ void AudioInjectorManager::run() {
                         if (nextCallDelta >= 0 && !injector->isFinished()) {
                             // enqueue the injector with the correct timing in our holding queue
                             heldInjectors.emplace(heldInjectors.end(), usecTimestampNow() + nextCallDelta, injector);
+                        } else {
+                            injector->sendStopInjectorPacket();
                         }
                     }
 

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -86,7 +86,8 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::MicrophoneAudioNoEcho:
         case PacketType::MicrophoneAudioWithEcho:
         case PacketType::AudioStreamStats:
-            return static_cast<PacketVersion>(AudioVersion::HighDynamicRangeVolume);
+        case PacketType::StopInjector:
+            return static_cast<PacketVersion>(AudioVersion::StopInjectors);
         case PacketType::DomainSettings:
             return 18;  // replace min_avatar_scale and max_avatar_scale with min_avatar_height and max_avatar_height
         case PacketType::Ping:

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -134,6 +134,7 @@ public:
         BulkAvatarTraits,
         AudioSoloRequest,
         BulkAvatarTraitsAck,
+        StopInjector,
         NUM_PACKET_TYPE
     };
 
@@ -369,6 +370,7 @@ enum class AudioVersion : PacketVersion {
     SpaceBubbleChanges,
     HasPersonalMute,
     HighDynamicRangeVolume,
+    StopInjectors
 };
 
 enum class MessageDataVersion : PacketVersion {


### PR DESCRIPTION
[Manuscript Ticket](https://highfidelity.manuscript.com/f/cases/21925/client-message-to-tell-audio-mixer-that-it-is-done-with-a-source)

Let the Audio Mixer know when an injector finishes so it can get cleaned up right away.