### PR TITLE
Case22025 - Show 'create temporary place' button when no places are present

### DIFF
--- a/domain-server/resources/web/js/shared.js
+++ b/domain-server/resources/web/js/shared.js
@@ -488,7 +488,7 @@ function getMetaverseUrl(callback) {
         callback(data.metaverse_url);
       },
       error: function() {
-        callback("https://metaverse.highfidelity.com");
+        callback(URLs.METAVERSE_URL);
       }
     });
 }

--- a/domain-server/resources/web/js/shared.js
+++ b/domain-server/resources/web/js/shared.js
@@ -481,3 +481,15 @@ function prepareAccessTokenPrompt(callback) {
     swal.close();
   });
 }
+
+function getMetaverseUrl(callback) {
+    $.ajax('/api/metaverse_info', {
+      success: function(data) {
+        callback(data.metaverse_url);
+      },
+      error: function() {
+        callback("https://metaverse.highfidelity.com");
+      }
+    });
+}
+

--- a/domain-server/resources/web/settings/js/settings.js
+++ b/domain-server/resources/web/settings/js/settings.js
@@ -16,7 +16,7 @@ $(document).ready(function(){
 
   Settings.extraGroupsAtEnd = Settings.extraDomainGroupsAtEnd;
   Settings.extraGroupsAtIndex = Settings.extraDomainGroupsAtIndex;
-  var METAVERSE_URL = "https://metaverse.highfidelity.com";
+  var METAVERSE_URL = URLs.METAVERSE_URL;
 
   Settings.afterReloadActions = function() {
 

--- a/domain-server/resources/web/settings/js/settings.js
+++ b/domain-server/resources/web/settings/js/settings.js
@@ -16,47 +16,55 @@ $(document).ready(function(){
 
   Settings.extraGroupsAtEnd = Settings.extraDomainGroupsAtEnd;
   Settings.extraGroupsAtIndex = Settings.extraDomainGroupsAtIndex;
+  var METAVERSE_URL = "https://metaverse.highfidelity.com";
 
   Settings.afterReloadActions = function() {
-    // call our method to setup the HF account button
-    setupHFAccountButton();
 
-    // call our method to setup the place names table
-    setupPlacesTable();
+    getMetaverseUrl(function(metaverse_url) {
+      METAVERSE_URL = metaverse_url;
 
-    setupDomainNetworkingSettings();
-    // setupDomainLabelSetting();
+      // call our method to setup the HF account button
+      setupHFAccountButton();
 
-    setupSettingsBackup();
+      // call our method to setup the place names table
+      setupPlacesTable();
 
-    if (domainIDIsSet()) {
-      // now, ask the API for what places, if any, point to this domain
-      reloadDomainInfo();
+      setupDomainNetworkingSettings();
+      // setupDomainLabelSetting();
 
-      // we need to ask the API what a shareable name for this domain is
-      getShareName(function(success, shareName) {
-        if (success) {
-          var shareLink = "https://hifi.place/" + shareName;
-          $('#visit-domain-link').attr("href", shareLink).show();
-        }
-      });
-    }
+      setupSettingsBackup();
 
-    if (Settings.data.values.wizard.cloud_domain) {
-      $('#manage-cloud-domains-link').show();
+      if (domainIDIsSet()) {
+        // now, ask the API for what places, if any, point to this domain
+        reloadDomainInfo();
 
-      var cloudWizardExit = qs["cloud-wizard-exit"];
-      if (cloudWizardExit != undefined) {
-        $('#cloud-domains-alert').show();
+        // we need to ask the API what a shareable name for this domain is
+        getShareName(function(success, shareName) {
+          if (success) {
+            var shareLink = "https://hifi.place/" + shareName;
+            $('#visit-domain-link').attr("href", shareLink).show();
+          }
+        });
+      } else if (accessTokenIsSet()) {
+        $('#' + Settings.GET_TEMPORARY_NAME_BTN_ID).show();
       }
 
-      $(Settings.DOMAIN_ID_SELECTOR).siblings('span').append("</br><strong>Changing the domain ID for a Cloud Domain may result in an incorrect status for the domain on your Cloud Domains page.</strong>");
-    } else {
-      // append the domain selection modal
-      appendDomainIDButtons();
-    }
+      if (Settings.data.values.wizard.cloud_domain) {
+        $('#manage-cloud-domains-link').show();
 
-    handleAction();
+        var cloudWizardExit = qs["cloud-wizard-exit"];
+        if (cloudWizardExit != undefined) {
+          $('#cloud-domains-alert').show();
+        }
+
+        $(Settings.DOMAIN_ID_SELECTOR).siblings('span').append("</br><strong>Changing the domain ID for a Cloud Domain may result in an incorrect status for the domain on your Cloud Domains page.</strong>");
+      } else {
+        // append the domain selection modal
+        appendDomainIDButtons();
+      }
+
+      handleAction();
+    });
   }
 
   Settings.handlePostSettings = function(formJSON) {
@@ -258,7 +266,7 @@ $(document).ready(function(){
       buttonSetting.button_label = "Connect High Fidelity Account";
       buttonSetting.html_id = Settings.CONNECT_ACCOUNT_BTN_ID;
 
-      buttonSetting.href = URLs.METAVERSE_URL + "/user/tokens/new?for_domain_server=true";
+      buttonSetting.href = METAVERSE_URL + "/user/tokens/new?for_domain_server=true";
 
       // since we do not have an access token we change hide domain ID and auto networking settings
       // without an access token niether of them can do anything
@@ -645,7 +653,7 @@ $(document).ready(function(){
       label: 'Places',
       html_id: Settings.PLACES_TABLE_ID,
       help: "The following places currently point to this domain.</br>To point places to this domain, "
-        + " go to the <a href='" + URLs.METAVERSE_URL + "/user/places'>My Places</a> "
+        + " go to the <a href='" + METAVERSE_URL + "/user/places'>My Places</a> "
         + "page in your High Fidelity Metaverse account.",
       read_only: true,
       can_add_new_rows: false,
@@ -952,7 +960,7 @@ $(document).ready(function(){
             modal_buttons["success"] = {
               label: 'Create new domain',
               callback: function() {
-                window.open(URLs.METAVERSE_URL + "/user/domains", '_blank');
+                window.open(METAVERSE_URL + "/user/domains", '_blank');
               }
             }
             modal_body = "<p>You do not have any domains in your High Fidelity account." +
@@ -1000,7 +1008,7 @@ $(document).ready(function(){
         showSpinnerAlert('Creating temporary place name');
 
         // make a get request to get a temporary domain
-        $.post(URLs.METAVERSE_URL + '/api/v1/domains/temporary', function(data){
+        $.post(METAVERSE_URL + '/api/v1/domains/temporary', function(data){
           if (data.status == "success") {
             var domain = data.data.domain;
 

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -2167,9 +2167,6 @@ bool DomainServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
             restart();
             return true;
         } else if (url.path() == URI_API_METAVERSE_INFO) {
-            auto id = url.path().mid(QString(URI_API_BACKUPS_ID).length());
-            auto info = _contentManager->consolidateBackup(id);
-
             QJsonObject rootJSON {
                 { "metaverse_url", NetworkingConstants::METAVERSE_SERVER_URL().toString() }
             };

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1916,6 +1916,7 @@ bool DomainServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
     const QString URI_SETTINGS = "/settings";
     const QString URI_CONTENT_UPLOAD = "/content/upload";
     const QString URI_RESTART = "/restart";
+    const QString URI_API_METAVERSE_INFO = "/api/metaverse_info";
     const QString URI_API_PLACES = "/api/places";
     const QString URI_API_DOMAINS = "/api/domains";
     const QString URI_API_DOMAINS_ID = "/api/domains/";
@@ -2164,6 +2165,18 @@ bool DomainServer::handleHTTPRequest(HTTPConnection* connection, const QUrl& url
         } else if (url.path() == URI_RESTART) {
             connection->respond(HTTPConnection::StatusCode200);
             restart();
+            return true;
+        } else if (url.path() == URI_API_METAVERSE_INFO) {
+            auto id = url.path().mid(QString(URI_API_BACKUPS_ID).length());
+            auto info = _contentManager->consolidateBackup(id);
+
+            QJsonObject rootJSON {
+                { "metaverse_url", NetworkingConstants::METAVERSE_SERVER_URL().toString() }
+            };
+
+            QJsonDocument docJSON{ rootJSON };
+            connectionPtr->respond(HTTPConnection::StatusCode200, docJSON.toJson(), JSON_MIME_TYPE.toUtf8());
+
             return true;
         } else if (url.path() == URI_API_DOMAINS) {
             return forwardMetaverseAPIRequest(connection, "/api/v1/domains", "");


### PR DESCRIPTION
The metaverse urls were hard-coded to be production.  Fix is to pull them
from the domain server, which will pull them from the environment variable.

https://highfidelity.manuscript.com/f/cases/22025/After-changing-domain-ID-the-create-temporary-placename-button-doesn-t-appear-and-old-places-are-lost