### PR TITLE
Case 20513: Extra check to make sure we remove materials from MyAvatar

### DIFF
--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -229,8 +229,9 @@ AvatarSharedPointer AvatarHashMap::newOrExistingAvatar(const QUuid& sessionUUID,
 
 AvatarSharedPointer AvatarHashMap::findAvatar(const QUuid& sessionUUID) const {
     QReadLocker locker(&_hashLock);
-    if (_avatarHash.contains(sessionUUID)) {
-        return _avatarHash.value(sessionUUID);
+    auto avatarIter = _avatarHash.find(sessionUUID);
+    if (avatarIter != _avatarHash.end()) {
+        return avatarIter.value();
     }
     return nullptr;
 }

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -358,7 +358,13 @@ void MaterialEntityRenderer::deleteMaterial(const QUuid& oldParentID, const QStr
         return;
     }
 
-    // if a remove fails, our parent is gone, so we don't need to retry
+    // if a remove fails, our parent is gone, so we don't need to retry, EXCEPT:
+    // MyAvatar can change UUIDs when you switch domains, which leads to a timing issue.  Let's just make
+    // sure we weren't attached to MyAvatar by trying this (if we weren't, this will have no effect)
+    if (EntityTreeRenderer::removeMaterialFromAvatar(AVATAR_SELF_ID, material, oldParentMaterialNameStd)) {
+        _appliedMaterial = nullptr;
+        return;
+    }
 }
 
 void MaterialEntityRenderer::applyTextureTransform(std::shared_ptr<NetworkMaterial>& material) {


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20513/Editing-Material-Entities-parented-to-an-avatar-submesh-do-not-update

Test plan:
- Make a domain material entity (this works if you're wearing the woody avatar):
```
Entities.addEntity({
    type: "Material",
    materialURL: "https://hifi-content.s3.amazonaws.com/samuel/TestMaterial.json",
    parentMaterialName: "1",
    parentID: MyAvatar.SELF_ID,
    priority: 1
});
```
- You'll have a material applied to you.  Other people will see it.
- When you switch domains, the material will stop being applied to you.  Other people won't see it either.
- Make an avatar entity material entity:
```
Entities.addEntity({
    type: "Material",
    materialURL: "https://hifi-content.s3.amazonaws.com/samuel/TestMaterial.json",
    parentMaterialName: "1",
    parentID: MyAvatar.SELF_ID,
    priority: 1
}, true);
```
- When you switch domains, the material will follow you.  When you delete the material, it will disappear for you and others.