### PR TITLE
Fixed out of range error in AnimTwoBoneIK

### DIFF
--- a/libraries/animation/src/AnimTwoBoneIK.cpp
+++ b/libraries/animation/src/AnimTwoBoneIK.cpp
@@ -128,7 +128,7 @@ const AnimPoseVec& AnimTwoBoneIK::evaluate(const AnimVariantMap& animVars, const
 
     if (triggersOut.hasKey(endEffectorPositionVar)) {
         targetPose.trans() = triggersOut.lookupRigToGeometry(endEffectorPositionVar, tipPose.trans());
-    } else if (animVars.hasKey(endEffectorRotationVar)) {
+    } else if (animVars.hasKey(endEffectorPositionVar)) {
         targetPose.trans() = animVars.lookupRigToGeometry(endEffectorPositionVar, tipPose.trans());
     }
 
@@ -147,9 +147,11 @@ const AnimPoseVec& AnimTwoBoneIK::evaluate(const AnimVariantMap& animVars, const
 
     // http://mathworld.wolfram.com/Circle-CircleIntersection.html
     float midAngle = 0.0f;
-    if (d < r0 + r1) {
+    if ((d < r0 + r1) && (d > 0.0f) && (r0 > 0.0f) && (r1 > 0.0f)) {
         float y = sqrtf((-d + r1 - r0) * (-d - r1 + r0) * (-d + r1 + r0) * (d + r1 + r0)) / (2.0f * d);
-        midAngle = PI - (acosf(y / r0) + acosf(y / r1));
+        float yR0Quotient = glm::clamp(y / r0, -1.0f, 1.0f);
+        float yR1Quotient = glm::clamp(y / r1, -1.0f, 1.0f);
+        midAngle = PI - (acosf(yR0Quotient) + acosf(yR1Quotient));
     }
 
     // compute midJoint rotation


### PR DESCRIPTION
There was an error in the two bone IK code that could lead to a NAN error and a corruption of the avatar joint data.

### TEST PLAN
1. The only way to test this is to go into HMD mode and put your right hand on your right shoulder or your left hand on your left shoulder.  It can take awhile but without this fix your body will disappear into the floor. 

I will add a test case to cover this

https://highfidelity.manuscript.com/f/cases/22248/Out-of-range-error-in-AnimTwoBoneIK