### PR TITLE
Fix out of bounds computing KDOPs when the model url is incorrect

### DIFF
--- a/libraries/hfm/src/hfm/HFM.cpp
+++ b/libraries/hfm/src/hfm/HFM.cpp
@@ -166,7 +166,7 @@ void HFMModel::computeKdops() {
         glm::vec3(INV_SQRT_3,  INV_SQRT_3, -INV_SQRT_3),
         glm::vec3(INV_SQRT_3, -INV_SQRT_3, -INV_SQRT_3)
     };
-    if (joints.size() != shapeVertices.size()) {
+    if (joints.size() != (int)shapeVertices.size()) {
         return;
     }
     // now that all joints have been scanned compute a k-Dop bounding volume of mesh

--- a/libraries/hfm/src/hfm/HFM.cpp
+++ b/libraries/hfm/src/hfm/HFM.cpp
@@ -166,7 +166,9 @@ void HFMModel::computeKdops() {
         glm::vec3(INV_SQRT_3,  INV_SQRT_3, -INV_SQRT_3),
         glm::vec3(INV_SQRT_3, -INV_SQRT_3, -INV_SQRT_3)
     };
-
+    if (joints.size() != shapeVertices.size()) {
+        return;
+    }
     // now that all joints have been scanned compute a k-Dop bounding volume of mesh
     for (int i = 0; i < joints.size(); ++i) {
         HFMJoint& joint = joints[i];


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22087/Out-of-bounds-crash-in-HFMModel-computeKdops-MASTER

This PR fixes the crash that occurs when visiting dev-content.