### PR TITLE
Case 22093: Disable JSBaker for now

### DIFF
--- a/tools/oven/src/BakerCLI.cpp
+++ b/tools/oven/src/BakerCLI.cpp
@@ -55,8 +55,9 @@ void BakerCLI::bakeFile(QUrl inputUrl, const QString& outputPath, const QString&
             }
         }
     } else if (type == SCRIPT_EXTENSION) {
-        _baker = std::unique_ptr<Baker> { new JSBaker(inputUrl, outputPath) };
-        _baker->moveToThread(Oven::instance().getNextWorkerThread());
+        // FIXME: disabled for now because it breaks some scripts
+        //_baker = std::unique_ptr<Baker> { new JSBaker(inputUrl, outputPath) };
+        //_baker->moveToThread(Oven::instance().getNextWorkerThread());
     } else if (type == MATERIAL_EXTENSION) {
         _baker = std::unique_ptr<Baker> { new MaterialBaker(inputUrl.toDisplayString(), true, outputPath) };
         _baker->moveToThread(Oven::instance().getNextWorkerThread());

--- a/tools/oven/src/DomainBaker.cpp
+++ b/tools/oven/src/DomainBaker.cpp
@@ -397,6 +397,8 @@ void DomainBaker::enumerateEntities() {
                 }
             }
 
+            // FIXME: disabled for now because it breaks some scripts
+            /*
             // Scripts
             if (entity.contains(SCRIPT_KEY)) {
                 addScriptBaker(SCRIPT_KEY, entity[SCRIPT_KEY].toString(), *it);
@@ -404,6 +406,7 @@ void DomainBaker::enumerateEntities() {
             if (entity.contains(SERVER_SCRIPTS_KEY)) {
                 // TODO: serverScripts can be multiple scripts, need to handle that
             }
+            */
 
             // Materials
             if (entity.contains(MATERIAL_URL_KEY)) {

--- a/tools/oven/src/OvenCLIApplication.cpp
+++ b/tools/oven/src/OvenCLIApplication.cpp
@@ -33,7 +33,7 @@ OvenCLIApplication::OvenCLIApplication(int argc, char* argv[]) :
     parser.addOptions({
         { CLI_INPUT_PARAMETER, "Path to file that you would like to bake.", "input" },
         { CLI_OUTPUT_PARAMETER, "Path to folder that will be used as output.", "output" },
-        { CLI_TYPE_PARAMETER, "Type of asset. [model|material|js]", "type" },
+        { CLI_TYPE_PARAMETER, "Type of asset. [model|material]"/*|js]"*/, "type" },
         { CLI_DISABLE_TEXTURE_COMPRESSION_PARAMETER, "Disable texture compression." }
     });
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22093/Re-disable-JSBaker-for-now

Test plan:
- If you navigate to the folder with oven.exe and run this: `./oven -i "https://gist.githubusercontent.com/SamGondelman/34da6d658b9ccaf939abd7261b6c54aa/raw/fcc384b556e050d47803477e156263969c04b25b/EntityScriptEventTest.js" -o [folder of your choice] -t js`, no file should be generated.