### PR TITLE
Case 22121: Allow players to disable automatic falling to flight threshold.

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -168,6 +168,7 @@ MyAvatar::MyAvatar(QThread* thread) :
     _displayNameSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "displayName", ""),
     _collisionSoundURLSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "collisionSoundURL", QUrl(_collisionSoundURL)),
     _useSnapTurnSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "useSnapTurn", _useSnapTurn),
+    _useFallHeightThresholdSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "useFallHeightThreshold", _useFallHeightThreshold),
     _userHeightSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "userHeight", DEFAULT_AVATAR_HEIGHT),
     _flyingHMDSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "flyingHMD", _flyingPrefHMD),
     _movementReferenceSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "movementReference", _movementReference),
@@ -956,6 +957,7 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
         bool collisionlessAllowed = zoneInteractionProperties.second;
         _characterController.setZoneFlyingAllowed(zoneAllowsFlying || !isPhysicsEnabled);
         _characterController.setComfortFlyingAllowed(_enableFlying);
+        _characterController.setUseFallHeightThreshold(_useFallHeightThreshold);
         _characterController.setCollisionlessAllowed(collisionlessAllowed);
     }
 
@@ -1296,6 +1298,7 @@ void MyAvatar::saveData() {
     _displayNameSetting.set(_displayName);
     _collisionSoundURLSetting.set(_collisionSoundURL);
     _useSnapTurnSetting.set(_useSnapTurn);
+    _useFallHeightThresholdSetting.set(_useFallHeightThreshold);
     _userHeightSetting.set(getUserHeight());
     _flyingHMDSetting.set(getFlyingHMDPref());
     _movementReferenceSetting.set(getMovementReference());
@@ -1898,6 +1901,7 @@ void MyAvatar::loadData() {
     setDisplayName(_displayNameSetting.get());
     setCollisionSoundURL(_collisionSoundURLSetting.get(QUrl(DEFAULT_AVATAR_COLLISION_SOUND_URL)).toString());
     setSnapTurn(_useSnapTurnSetting.get());
+    setUseFallHeightThreshold(_useFallHeightThresholdSetting.get());
     setDominantHand(_dominantHandSetting.get(DOMINANT_RIGHT_HAND).toLower());
     setStrafeEnabled(_strafeEnabledSetting.get(DEFAULT_STRAFE_ENABLED));
     setHmdAvatarAlignmentType(_hmdAvatarAlignmentTypeSetting.get(DEFAULT_HMD_AVATAR_ALIGNMENT_TYPE).toLower());

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -168,7 +168,7 @@ MyAvatar::MyAvatar(QThread* thread) :
     _displayNameSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "displayName", ""),
     _collisionSoundURLSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "collisionSoundURL", QUrl(_collisionSoundURL)),
     _useSnapTurnSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "useSnapTurn", _useSnapTurn),
-    _useFallHeightThresholdSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "useFallHeightThreshold", _useFallHeightThreshold),
+    _hoverWhenUnsupportedSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "hoverWhenUnsupported", _hoverWhenUnsupported),
     _userHeightSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "userHeight", DEFAULT_AVATAR_HEIGHT),
     _flyingHMDSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "flyingHMD", _flyingPrefHMD),
     _movementReferenceSetting(QStringList() << AVATAR_SETTINGS_GROUP_NAME << "movementReference", _movementReference),
@@ -957,7 +957,7 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
         bool collisionlessAllowed = zoneInteractionProperties.second;
         _characterController.setZoneFlyingAllowed(zoneAllowsFlying || !isPhysicsEnabled);
         _characterController.setComfortFlyingAllowed(_enableFlying);
-        _characterController.setUseFallHeightThreshold(_useFallHeightThreshold);
+        _characterController.setHoverWhenUnsupported(_hoverWhenUnsupported);
         _characterController.setCollisionlessAllowed(collisionlessAllowed);
     }
 
@@ -1298,7 +1298,7 @@ void MyAvatar::saveData() {
     _displayNameSetting.set(_displayName);
     _collisionSoundURLSetting.set(_collisionSoundURL);
     _useSnapTurnSetting.set(_useSnapTurn);
-    _useFallHeightThresholdSetting.set(_useFallHeightThreshold);
+    _hoverWhenUnsupportedSetting.set(_hoverWhenUnsupported);
     _userHeightSetting.set(getUserHeight());
     _flyingHMDSetting.set(getFlyingHMDPref());
     _movementReferenceSetting.set(getMovementReference());
@@ -1901,7 +1901,7 @@ void MyAvatar::loadData() {
     setDisplayName(_displayNameSetting.get());
     setCollisionSoundURL(_collisionSoundURLSetting.get(QUrl(DEFAULT_AVATAR_COLLISION_SOUND_URL)).toString());
     setSnapTurn(_useSnapTurnSetting.get());
-    setUseFallHeightThreshold(_useFallHeightThresholdSetting.get());
+    setHoverWhenUnsupported(_hoverWhenUnsupportedSetting.get());
     setDominantHand(_dominantHandSetting.get(DOMINANT_RIGHT_HAND).toLower());
     setStrafeEnabled(_strafeEnabledSetting.get(DEFAULT_STRAFE_ENABLED));
     setHmdAvatarAlignmentType(_hmdAvatarAlignmentTypeSetting.get(DEFAULT_HMD_AVATAR_ALIGNMENT_TYPE).toLower());

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -759,6 +759,18 @@ public:
      * @param {number} index
     */
     Q_INVOKABLE void setControlScheme(int index) { _controlSchemeIndex = (index >= 0 && index <= 2) ? index : 0; }
+    
+    /**jsdoc
+     * @function MyAvatar.useFallHeightThreshold
+     * @returns {boolean} 
+     */
+    Q_INVOKABLE bool useFallHeightThreshold() const { return _useFallHeightThreshold; }
+    /**jsdoc
+     * @function MyAvatar.setUseFallHeightThreshold
+     * @param {boolean} on
+     */
+    Q_INVOKABLE void setUseFallHeightThreshold(bool on) { _useFallHeightThreshold = on; }
+
     /**jsdoc
      * Sets the avatar's dominant hand.
      * @function MyAvatar.setDominantHand
@@ -2442,6 +2454,7 @@ private:
     ThreadSafeValueCache<QUrl> _prefOverrideAnimGraphUrl;
     QUrl _fstAnimGraphOverrideUrl;
     bool _useSnapTurn { true };
+    bool _useFallHeightThreshold{ true };
     ThreadSafeValueCache<QString> _dominantHand { DOMINANT_RIGHT_HAND };
     ThreadSafeValueCache<QString> _hmdAvatarAlignmentType { DEFAULT_HMD_AVATAR_ALIGNMENT_TYPE };
     ThreadSafeValueCache<bool> _strafeEnabled{ DEFAULT_STRAFE_ENABLED };
@@ -2637,6 +2650,7 @@ private:
     Setting::Handle<QString> _displayNameSetting;
     Setting::Handle<QUrl> _collisionSoundURLSetting;
     Setting::Handle<bool> _useSnapTurnSetting;
+    Setting::Handle<bool> _useFallHeightThresholdSetting;
     Setting::Handle<float> _userHeightSetting;
     Setting::Handle<bool> _flyingHMDSetting;
     Setting::Handle<int> _movementReferenceSetting;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -761,15 +761,15 @@ public:
     Q_INVOKABLE void setControlScheme(int index) { _controlSchemeIndex = (index >= 0 && index <= 2) ? index : 0; }
     
     /**jsdoc
-     * @function MyAvatar.useFallHeightThreshold
+     * @function MyAvatar.hoverWhenUnsupported
      * @returns {boolean} 
      */
-    Q_INVOKABLE bool useFallHeightThreshold() const { return _useFallHeightThreshold; }
+    Q_INVOKABLE bool hoverWhenUnsupported() const { return _hoverWhenUnsupported; }
     /**jsdoc
-     * @function MyAvatar.setUseFallHeightThreshold
+     * @function MyAvatar.setHoverWhenUnsupported
      * @param {boolean} on
      */
-    Q_INVOKABLE void setUseFallHeightThreshold(bool on) { _useFallHeightThreshold = on; }
+    Q_INVOKABLE void setHoverWhenUnsupported(bool on) { _hoverWhenUnsupported = on; }
 
     /**jsdoc
      * Sets the avatar's dominant hand.
@@ -2454,7 +2454,7 @@ private:
     ThreadSafeValueCache<QUrl> _prefOverrideAnimGraphUrl;
     QUrl _fstAnimGraphOverrideUrl;
     bool _useSnapTurn { true };
-    bool _useFallHeightThreshold{ true };
+    bool _hoverWhenUnsupported{ true };
     ThreadSafeValueCache<QString> _dominantHand { DOMINANT_RIGHT_HAND };
     ThreadSafeValueCache<QString> _hmdAvatarAlignmentType { DEFAULT_HMD_AVATAR_ALIGNMENT_TYPE };
     ThreadSafeValueCache<bool> _strafeEnabled{ DEFAULT_STRAFE_ENABLED };
@@ -2650,7 +2650,7 @@ private:
     Setting::Handle<QString> _displayNameSetting;
     Setting::Handle<QUrl> _collisionSoundURLSetting;
     Setting::Handle<bool> _useSnapTurnSetting;
-    Setting::Handle<bool> _useFallHeightThresholdSetting;
+    Setting::Handle<bool> _hoverWhenUnsupportedSetting;
     Setting::Handle<float> _userHeightSetting;
     Setting::Handle<bool> _flyingHMDSetting;
     Setting::Handle<int> _movementReferenceSetting;

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -279,6 +279,12 @@ void setupPreferences() {
         preferences->addPreference(preference);
     }
     {
+        auto getter = [myAvatar]() -> bool { return myAvatar->hoverWhenUnsupported(); };
+        auto setter = [myAvatar](bool value) { myAvatar->setHoverWhenUnsupported(value); };
+        auto preference = new CheckPreference(VR_MOVEMENT, "Hover When Unsupported", getter, setter);
+        preferences->addPreference(preference);
+    }
+    {
         auto getter = [myAvatar]()->int { return myAvatar->getMovementReference(); };
         auto setter = [myAvatar](int value) { myAvatar->setMovementReference(value);  };
         //auto preference = new CheckPreference(VR_MOVEMENT, "Hand-Relative Movement", getter, setter);
@@ -302,12 +308,6 @@ void setupPreferences() {
         items << "Snap turn" << "Smooth turn";
         preference->setHeading("Rotation mode");
         preference->setItems(items);
-        preferences->addPreference(preference);
-    }
-    {
-        auto getter = [myAvatar]() -> bool { return myAvatar->useFallHeightThreshold(); };
-        auto setter = [myAvatar](bool value) { myAvatar->setUseFallHeightThreshold(value); };
-        auto preference = new CheckPreference(VR_MOVEMENT, "Use Fall Height Threshold", getter, setter);
         preferences->addPreference(preference);
     }
     {

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -305,6 +305,12 @@ void setupPreferences() {
         preferences->addPreference(preference);
     }
     {
+        auto getter = [myAvatar]() -> bool { return myAvatar->useFallHeightThreshold(); };
+        auto setter = [myAvatar](bool value) { myAvatar->setUseFallHeightThreshold(value); };
+        auto preference = new CheckPreference(VR_MOVEMENT, "Use Fall Height Threshold", getter, setter);
+        preferences->addPreference(preference);
+    }
+    {
         auto getter = [myAvatar]()->int { return myAvatar->getControlScheme(); };
         auto setter = [myAvatar](int index) { myAvatar->setControlScheme(index); };
         auto preference = new RadioButtonsPreference(VR_MOVEMENT, "Control Scheme", getter, setter);

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -754,7 +754,11 @@ void CharacterController::updateState() {
         switch (_state) {
             case State::Ground:
                 if (!rayHasHit && !_hasSupport) {
-                    SET_STATE(State::Hover, "no ground detected");
+                    if (_useFallHeightThreshold) {
+                       SET_STATE(State::Hover, "no ground detected");
+                    } else {
+                       SET_STATE(State::InAir, "falling");
+                    }
                 } else if (_pendingFlags & PENDING_FLAG_JUMP && _jumpButtonDownCount != _takeoffJumpButtonID) {
                     _takeoffJumpButtonID = _jumpButtonDownCount;
                     _takeoffToInAirStartTime = now;
@@ -764,7 +768,7 @@ void CharacterController::updateState() {
                 }
                 break;
             case State::Takeoff:
-                if (!rayHasHit && !_hasSupport) {
+                if (_useFallHeightThreshold && (!rayHasHit && !_hasSupport)) {
                     SET_STATE(State::Hover, "no ground");
                 } else if ((now - _takeoffToInAirStartTime) > TAKE_OFF_TO_IN_AIR_PERIOD) {
                     SET_STATE(State::InAir, "takeoff done");

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -791,7 +791,7 @@ void CharacterController::updateState() {
                         SET_STATE(State::Hover, "double jump button");
                     } else if (_comfortFlyingAllowed && (jumpButtonHeld || vertTargetSpeedIsNonZero) && (now - _jumpButtonDownStartTime) > JUMP_TO_HOVER_PERIOD) {
                         SET_STATE(State::Hover, "jump button held");
-                    } else if ((!rayHasHit && !_hasSupport) || _floorDistance > _scaleFactor * DEFAULT_AVATAR_FALL_HEIGHT) {
+                    } else if (_useFallHeightThreshold && ((!rayHasHit && !_hasSupport) || _floorDistance > _scaleFactor * DEFAULT_AVATAR_FALL_HEIGHT)) {
                         // Transition to hover if there's no ground beneath us or we are above the fall threshold, regardless of _comfortFlyingAllowed
                         SET_STATE(State::Hover, "above fall threshold");
                     }

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -754,7 +754,7 @@ void CharacterController::updateState() {
         switch (_state) {
             case State::Ground:
                 if (!rayHasHit && !_hasSupport) {
-                    if (_useFallHeightThreshold) {
+                    if (_hoverWhenUnsupported) {
                        SET_STATE(State::Hover, "no ground detected");
                     } else {
                        SET_STATE(State::InAir, "falling");
@@ -768,7 +768,7 @@ void CharacterController::updateState() {
                 }
                 break;
             case State::Takeoff:
-                if (_useFallHeightThreshold && (!rayHasHit && !_hasSupport)) {
+                if (_hoverWhenUnsupported && (!rayHasHit && !_hasSupport)) {
                     SET_STATE(State::Hover, "no ground");
                 } else if ((now - _takeoffToInAirStartTime) > TAKE_OFF_TO_IN_AIR_PERIOD) {
                     SET_STATE(State::InAir, "takeoff done");
@@ -795,7 +795,7 @@ void CharacterController::updateState() {
                         SET_STATE(State::Hover, "double jump button");
                     } else if (_comfortFlyingAllowed && (jumpButtonHeld || vertTargetSpeedIsNonZero) && (now - _jumpButtonDownStartTime) > JUMP_TO_HOVER_PERIOD) {
                         SET_STATE(State::Hover, "jump button held");
-                    } else if (_useFallHeightThreshold && ((!rayHasHit && !_hasSupport) || _floorDistance > _scaleFactor * DEFAULT_AVATAR_FALL_HEIGHT)) {
+                    } else if (_hoverWhenUnsupported && ((!rayHasHit && !_hasSupport) || _floorDistance > _scaleFactor * DEFAULT_AVATAR_FALL_HEIGHT)) {
                         // Transition to hover if there's no ground beneath us or we are above the fall threshold, regardless of _comfortFlyingAllowed
                         SET_STATE(State::Hover, "above fall threshold");
                     }

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -131,6 +131,7 @@ public:
 
     void setZoneFlyingAllowed(bool value) { _zoneFlyingAllowed = value; }
     void setComfortFlyingAllowed(bool value) { _comfortFlyingAllowed = value; }
+    void setUseFallHeightThreshold(bool value) { _useFallHeightThreshold = value; }
     void setCollisionlessAllowed(bool value);
 
     void setPendingFlagsUpdateCollisionMask(){ _pendingFlags |= PENDING_FLAG_UPDATE_COLLISION_MASK; }
@@ -215,6 +216,7 @@ protected:
 
     bool _zoneFlyingAllowed { true };
     bool _comfortFlyingAllowed { true };
+    bool _useFallHeightThreshold{ true };
     bool _collisionlessAllowed { true };
     bool _collisionless { false };
 

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -131,7 +131,7 @@ public:
 
     void setZoneFlyingAllowed(bool value) { _zoneFlyingAllowed = value; }
     void setComfortFlyingAllowed(bool value) { _comfortFlyingAllowed = value; }
-    void setUseFallHeightThreshold(bool value) { _useFallHeightThreshold = value; }
+    void setHoverWhenUnsupported(bool value) { _hoverWhenUnsupported = value; }
     void setCollisionlessAllowed(bool value);
 
     void setPendingFlagsUpdateCollisionMask(){ _pendingFlags |= PENDING_FLAG_UPDATE_COLLISION_MASK; }
@@ -216,7 +216,7 @@ protected:
 
     bool _zoneFlyingAllowed { true };
     bool _comfortFlyingAllowed { true };
-    bool _useFallHeightThreshold{ true };
+    bool _hoverWhenUnsupported{ true };
     bool _collisionlessAllowed { true };
     bool _collisionless { false };
 


### PR DESCRIPTION
This PR adds an option to completely turn off the check in the character controller which forces the player into a flight mode if they are above a certain distance from the ground. To test, the option is added as a flag in the 'settings/controls' menu under the option 'Hover When Unsupported'. By default it is toggled as on and behaves the same as existing behavior and turning it off will allow free falling from any height. The setting itself will persist across sessions.

https://highfidelity.manuscript.com/f/cases/22121/The-ability-to-fall-not-float