### PR TITLE
Clear delayed Node-adds upon restart

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -588,6 +588,8 @@ void LimitedNodeList::eraseAllNodes() {
     foreach(const SharedNodePointer& killedNode, killedNodes) {
         handleNodeKill(killedNode);
     }
+
+    _delayedNodeAdds.clear();
 }
 
 void LimitedNodeList::reset() {
@@ -755,7 +757,7 @@ void LimitedNodeList::delayNodeAdd(NewNodeInfo info) {
 }
 
 void LimitedNodeList::removeDelayedAdd(QUuid nodeUUID) {
-    auto it = std::find_if(_delayedNodeAdds.begin(), _delayedNodeAdds.end(), [&](auto info) {
+    auto it = std::find_if(_delayedNodeAdds.begin(), _delayedNodeAdds.end(), [&](const auto& info) {
         return info.uuid == nodeUUID;
     });
     if (it != _delayedNodeAdds.end()) {
@@ -764,7 +766,7 @@ void LimitedNodeList::removeDelayedAdd(QUuid nodeUUID) {
 }
 
 bool LimitedNodeList::isDelayedNode(QUuid nodeUUID) {
-    auto it = std::find_if(_delayedNodeAdds.begin(), _delayedNodeAdds.end(), [&](auto info) {
+    auto it = std::find_if(_delayedNodeAdds.begin(), _delayedNodeAdds.end(), [&](const auto& info) {
         return info.uuid == nodeUUID;
     });
     return it != _delayedNodeAdds.end();


### PR DESCRIPTION
The vector of throttled nodes-to-add was growing very large in practice; this should reduce that. Also avoid constructors in search lambdas.

https://highfidelity.fogbugz.com/f/cases/22184/

Related issue:
https://highfidelity.fogbugz.com/f/cases/22232/