### PR TITLE
Case 22203: Shield/bubble animation and sound plays when other users are ignored by PAL or their own shields of RC83

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -498,8 +498,10 @@ void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar
     // on the creation of entities for that avatar instance and the deletion of entities for this instance
     avatar->removeAvatarEntitiesFromTree();
     if (removalReason != KillAvatarReason::AvatarDisconnected) {
-        emit AvatarInputs::getInstance()->avatarEnteredIgnoreRadius(avatar->getSessionUUID());
-        emit DependencyManager::get<UsersScriptingInterface>()->enteredIgnoreRadius();
+        if (removalReason == KillAvatarReason::TheirAvatarEnteredYourBubble) {
+            emit AvatarInputs::getInstance()->avatarEnteredIgnoreRadius(avatar->getSessionUUID());
+            emit DependencyManager::get<UsersScriptingInterface>()->enteredIgnoreRadius();
+        }
 
         workload::Transaction workloadTransaction;
         workloadTransaction.remove(avatar->getSpaceIndex());


### PR DESCRIPTION
Ticket - https://highfidelity.manuscript.com/f/cases/22203/Shield-bubble-animation-and-sound-plays-when-other-users-are-ignored-by-PAL-or-their-own-shields-of-RC83