### PR TITLE
Disable baking of embedded material textures in material entities

### DIFF
--- a/tools/oven/src/DomainBaker.cpp
+++ b/tools/oven/src/DomainBaker.cpp
@@ -412,9 +412,13 @@ void DomainBaker::enumerateEntities() {
             if (entity.contains(MATERIAL_URL_KEY)) {
                 addMaterialBaker(MATERIAL_URL_KEY, entity[MATERIAL_URL_KEY].toString(), true, *it);
             }
+            // FIXME: Disabled for now because relative texture URLs are not supported for embedded materials in material entities
+            //        We need to make texture URLs absolute in this particular case only, keeping in mind that FSTBaker also uses embedded materials
+            /*
             if (entity.contains(MATERIAL_DATA_KEY)) {
                 addMaterialBaker(MATERIAL_DATA_KEY, entity[MATERIAL_DATA_KEY].toString(), false, *it);
             }
+            */
         }
     }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22199/Embedded-Materials-in-material-entities-break-when-baking-domain-in-Oven

A limitation of how we currently parse texture URLs was breaking material baking for material entities in the specific case of embedded materials. This PR disables baking in that specific case until a proper fix can be made.