### PR TITLE
(master) Disable baking of embedded material textures in material entities

### DIFF
--- a/tools/oven/src/DomainBaker.cpp
+++ b/tools/oven/src/DomainBaker.cpp
@@ -412,9 +412,13 @@ void DomainBaker::enumerateEntities() {
             if (entity.contains(MATERIAL_URL_KEY)) {
                 addMaterialBaker(MATERIAL_URL_KEY, entity[MATERIAL_URL_KEY].toString(), true, *it);
             }
+            // FIXME: Disabled for now because relative texture URLs are not supported for embedded materials in material entities
+            //        We need to make texture URLs absolute in this particular case only, keeping in mind that FSTBaker also uses embedded materials
+            /*
             if (entity.contains(MATERIAL_DATA_KEY)) {
                 addMaterialBaker(MATERIAL_DATA_KEY, entity[MATERIAL_DATA_KEY].toString(), false, *it);
             }
+            */
         }
     }
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/edit/22213/v83-Embedded-Materials-in-material-entities-break-when-baking-domain-in-Oven

This is the master version of https://github.com/highfidelity/hifi/pull/15390

A limitation of how we currently parse texture URLs was breaking material baking for material entities in the specific case of embedded materials. This PR disables baking in that specific case until a proper fix can be made.