### PR TITLE
Case 22213: Fix materialJSON paths in domain baker

### DIFF
--- a/libraries/baking/src/MaterialBaker.cpp
+++ b/libraries/baking/src/MaterialBaker.cpp
@@ -27,9 +27,10 @@ std::function<QThread*()> MaterialBaker::_getNextOvenWorkerThreadOperator;
 
 static int materialNum = 0;
 
-MaterialBaker::MaterialBaker(const QString& materialData, bool isURL, const QString& bakedOutputDir) :
+MaterialBaker::MaterialBaker(const QString& materialData, bool isURL, const QString& bakedOutputDir, QUrl destinationPath) :
     _materialData(materialData),
     _isURL(isURL),
+    _destinationPath(destinationPath),
     _bakedOutputDir(bakedOutputDir),
     _textureOutputDir(bakedOutputDir + "/materialTextures/" + QString::number(materialNum++))
 {
@@ -176,6 +177,10 @@ void MaterialBaker::handleFinishedTextureBaker() {
 
             auto newURL = QUrl(_textureOutputDir).resolved(baker->getMetaTextureFileName());
             auto relativeURL = QDir(_bakedOutputDir).relativeFilePath(newURL.toString());
+
+            if (!_destinationPath.isEmpty()) {
+                relativeURL = _destinationPath.resolved(relativeURL).toDisplayString();
+            }
 
             // Replace the old texture URLs
             for (auto networkMaterial : _materialsNeedingRewrite.values(textureKey)) {

--- a/libraries/baking/src/MaterialBaker.h
+++ b/libraries/baking/src/MaterialBaker.h
@@ -24,7 +24,7 @@ static const QString BAKED_MATERIAL_EXTENSION = ".baked.json";
 class MaterialBaker : public Baker {
     Q_OBJECT
 public:
-    MaterialBaker(const QString& materialData, bool isURL, const QString& bakedOutputDir);
+    MaterialBaker(const QString& materialData, bool isURL, const QString& bakedOutputDir, QUrl destinationPath = QUrl());
 
     QString getMaterialData() const { return _materialData; }
     bool isURL() const { return _isURL; }
@@ -51,6 +51,7 @@ private:
 
     QString _materialData;
     bool _isURL;
+    QUrl _destinationPath;
 
     NetworkMaterialResourcePointer _materialResource;
 

--- a/tools/oven/src/DomainBaker.cpp
+++ b/tools/oven/src/DomainBaker.cpp
@@ -258,7 +258,7 @@ void DomainBaker::addScriptBaker(const QString& property, const QString& url, co
     _entitiesNeedingRewrite.insert(scriptURL, { property, jsonRef });
 }
 
-void DomainBaker::addMaterialBaker(const QString& property, const QString& data, bool isURL, const QJsonValueRef& jsonRef) {
+void DomainBaker::addMaterialBaker(const QString& property, const QString& data, bool isURL, const QJsonValueRef& jsonRef, QUrl destinationPath) {
     // grab a clean version of the URL without a query or fragment
     QString materialData;
     if (isURL) {
@@ -272,7 +272,7 @@ void DomainBaker::addMaterialBaker(const QString& property, const QString& data,
 
         // setup a baker for this material
         QSharedPointer<MaterialBaker> materialBaker {
-            new MaterialBaker(data, isURL, _contentOutputPath),
+            new MaterialBaker(data, isURL, _contentOutputPath, destinationPath),
             &MaterialBaker::deleteLater
         };
 
@@ -412,13 +412,9 @@ void DomainBaker::enumerateEntities() {
             if (entity.contains(MATERIAL_URL_KEY)) {
                 addMaterialBaker(MATERIAL_URL_KEY, entity[MATERIAL_URL_KEY].toString(), true, *it);
             }
-            // FIXME: Disabled for now because relative texture URLs are not supported for embedded materials in material entities
-            //        We need to make texture URLs absolute in this particular case only, keeping in mind that FSTBaker also uses embedded materials
-            /*
             if (entity.contains(MATERIAL_DATA_KEY)) {
-                addMaterialBaker(MATERIAL_DATA_KEY, entity[MATERIAL_DATA_KEY].toString(), false, *it);
+                addMaterialBaker(MATERIAL_DATA_KEY, entity[MATERIAL_DATA_KEY].toString(), false, *it, _destinationPath);
             }
-            */
         }
     }
 

--- a/tools/oven/src/DomainBaker.h
+++ b/tools/oven/src/DomainBaker.h
@@ -76,7 +76,7 @@ private:
     void addModelBaker(const QString& property, const QString& url, const QJsonValueRef& jsonRef);
     void addTextureBaker(const QString& property, const QString& url, image::TextureUsage::Type type, const QJsonValueRef& jsonRef);
     void addScriptBaker(const QString& property, const QString& url, const QJsonValueRef& jsonRef);
-    void addMaterialBaker(const QString& property, const QString& data, bool isURL, const QJsonValueRef& jsonRef);
+    void addMaterialBaker(const QString& property, const QString& data, bool isURL, const QJsonValueRef& jsonRef, QUrl destinationPath = QUrl());
 };
 
 #endif // hifi_DomainBaker_h


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22213/v83-Embedded-Materials-in-material-entities-break-when-baking-domain-in-Oven

Test plan:
- Bake [this JSON](https://gist.githubusercontent.com/SamGondelman/abaace16eeb210c9cb7da372f95947f5/raw/b046cfe278109f5b4c035200840de3f7b40d7eaa/bakeMaterials.json) using the domain baker in the oven.  Provide a "Destination URL Path" (doesn't really matter what it is).  The resulting JSON should contain a material entity with a materialJSON with a bunch of paths that include that destination path you provided.