### PR TITLE
(case 22216) Fix Interface not loading some baked models correctly

### DIFF
--- a/libraries/fbx/src/FBXSerializer_Mesh.cpp
+++ b/libraries/fbx/src/FBXSerializer_Mesh.cpp
@@ -358,7 +358,7 @@ ExtractedMesh FBXSerializer::extractMesh(const FBXNode& object, unsigned int& me
             std::vector<QString> dracoMaterialList;
             for (const auto& dracoChild : child.children) {
                 if (dracoChild.name == "FBXDracoMeshVersion") {
-                    if (!dracoChild.children.isEmpty()) {
+                    if (!dracoChild.properties.isEmpty()) {
                         dracoMeshNodeVersion = dracoChild.properties[0].toUInt();
                     }
                 } else if (dracoChild.name == "MaterialList") {

--- a/libraries/fbx/src/FBXSerializer_Mesh.cpp
+++ b/libraries/fbx/src/FBXSerializer_Mesh.cpp
@@ -492,7 +492,7 @@ ExtractedMesh FBXSerializer::extractMesh(const FBXNode& object, unsigned int& me
                     // Figure out what material this part is
                     if (dracoMeshNodeVersion >= 2) {
                         // Define the materialID now
-                        if (materialID <= dracoMaterialList.size() - 1) {
+                        if (materialID < dracoMaterialList.size()) {
                             part.materialID = dracoMaterialList[materialID];
                         }
                     } else {

--- a/libraries/fbx/src/FBXSerializer_Mesh.cpp
+++ b/libraries/fbx/src/FBXSerializer_Mesh.cpp
@@ -492,7 +492,7 @@ ExtractedMesh FBXSerializer::extractMesh(const FBXNode& object, unsigned int& me
                     // Figure out what material this part is
                     if (dracoMeshNodeVersion >= 2) {
                         // Define the materialID now
-                        if (dracoMaterialList.size() - 1 <= materialID) {
+                        if (materialID <= dracoMaterialList.size() - 1) {
                             part.materialID = dracoMaterialList[materialID];
                         }
                     } else {

--- a/libraries/graphics/src/graphics/Material.h
+++ b/libraries/graphics/src/graphics/Material.h
@@ -318,6 +318,7 @@ public:
     void setTextureTransforms(const Transform& transform, MaterialMappingMode mode, bool repeat);
 
     const std::string& getName() const { return _name; }
+    void setName(const std::string& name) { _name = name; }
 
     const std::string& getModel() const { return _model; }
     void setModel(const std::string& model) { _model = model; }

--- a/libraries/material-networking/src/material-networking/MaterialCache.cpp
+++ b/libraries/material-networking/src/material-networking/MaterialCache.cpp
@@ -184,6 +184,7 @@ std::pair<std::string, std::shared_ptr<NetworkMaterial>> NetworkMaterialResource
                 auto nameJSON = materialJSON.value(key);
                 if (nameJSON.isString()) {
                     name = nameJSON.toString().toStdString();
+                    material->setName(name);
                 }
             } else if (key == "model") {
                 auto modelJSON = materialJSON.value(key);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/edit/22216/v83-Baking-some-models-in-Oven-causes-their-materials-to-get-mixed-up

This PR is the master version of https://github.com/highfidelity/hifi/pull/15399

It fixes issues where a model baked and loaded into Interface will display incorrect materials on different parts under certain circumstances.