### PR TITLE
Avatar-Mixer restart issues (RC82)

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -588,6 +588,8 @@ void LimitedNodeList::eraseAllNodes() {
     foreach(const SharedNodePointer& killedNode, killedNodes) {
         handleNodeKill(killedNode);
     }
+
+    _delayedNodeAdds.clear();
 }
 
 void LimitedNodeList::reset() {
@@ -755,7 +757,7 @@ void LimitedNodeList::delayNodeAdd(NewNodeInfo info) {
 }
 
 void LimitedNodeList::removeDelayedAdd(QUuid nodeUUID) {
-    auto it = std::find_if(_delayedNodeAdds.begin(), _delayedNodeAdds.end(), [&](auto info) {
+    auto it = std::find_if(_delayedNodeAdds.begin(), _delayedNodeAdds.end(), [&](const auto& info) {
         return info.uuid == nodeUUID;
     });
     if (it != _delayedNodeAdds.end()) {
@@ -764,7 +766,7 @@ void LimitedNodeList::removeDelayedAdd(QUuid nodeUUID) {
 }
 
 bool LimitedNodeList::isDelayedNode(QUuid nodeUUID) {
-    auto it = std::find_if(_delayedNodeAdds.begin(), _delayedNodeAdds.end(), [&](auto info) {
+    auto it = std::find_if(_delayedNodeAdds.begin(), _delayedNodeAdds.end(), [&](const auto& info) {
         return info.uuid == nodeUUID;
     });
     return it != _delayedNodeAdds.end();

--- a/libraries/networking/src/NetworkPeer.h
+++ b/libraries/networking/src/NetworkPeer.h
@@ -26,7 +26,7 @@ const quint16 ICE_SERVER_DEFAULT_PORT = 7337;
 const int ICE_HEARBEAT_INTERVAL_MSECS = 2 * 1000;
 const int MAX_ICE_CONNECTION_ATTEMPTS = 5;
 
-const int UDP_PUNCH_PING_INTERVAL_MS = 25;
+const int UDP_PUNCH_PING_INTERVAL_MS = 250;
 
 class NetworkPeer : public QObject {
     Q_OBJECT

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -752,11 +752,11 @@ void NodeList::pingPunchForInactiveNode(const SharedNodePointer& node) {
         flagTimeForConnectionStep(LimitedNodeList::ConnectionStep::SendAudioPing);
     }
 
-    // every second we're trying to ping this node and we're not getting anywhere - debug that out
-    const int NUM_DEBUG_CONNECTION_ATTEMPTS = 1000 / (UDP_PUNCH_PING_INTERVAL_MS);
+    // every two seconds we're trying to ping this node and we're not getting anywhere - debug that out
+    const int NUM_DEBUG_CONNECTION_ATTEMPTS = 2000 / (UDP_PUNCH_PING_INTERVAL_MS);
 
     if (node->getConnectionAttempts() > 0 && node->getConnectionAttempts() % NUM_DEBUG_CONNECTION_ATTEMPTS == 0) {
-        qCDebug(networking) << "No response to UDP hole punch pings for node" << node->getUUID() << "in last second.";
+        qCDebug(networking) << "No response to UDP hole punch pings for node" << node->getUUID() << "in last 2 s.";
     }
     
     auto nodeID = node->getUUID();


### PR DESCRIPTION
Ticket: https://highfidelity.manuscript.com/f/cases/22252/82-version-of-avatar-mixer-concurrency-fixes

Combines two master PRs for RC82 branch (reduce ping frequency & clear delayed-add node-list).

https://github.com/highfidelity/hifi/pull/15375
https://github.com/highfidelity/hifi/pull/15376
