### PR TITLE
Case 22290: Fixing Shield Icon Behavior in Desktop Mode

### DIFF
--- a/interface/resources/qml/BubbleIcon.qml
+++ b/interface/resources/qml/BubbleIcon.qml
@@ -23,15 +23,15 @@ Rectangle {
     property bool ignoreRadiusEnabled: AvatarInputs.ignoreRadiusEnabled;
 
     function updateOpacity() {
-        if (ignoreRadiusEnabled) {
-            bubbleRect.opacity = 1.0;
-        } else {
-            bubbleRect.opacity = 0.7;
-        }
+        var rectOpacity = ignoreRadiusEnabled ? 1.0 : (mouseArea.containsMouse ? 1.0 : 0.7);
+        bubbleRect.opacity = rectOpacity;
     }
 
     Component.onCompleted: {
         updateOpacity();
+        AvatarInputs.ignoreRadiusEnabledChanged.connect(function() {
+            ignoreRadiusEnabled = AvatarInputs.ignoreRadiusEnabled;
+        });
     }
 
     onIgnoreRadiusEnabledChanged: {
@@ -74,10 +74,10 @@ Rectangle {
         }
         drag.target: dragTarget;
         onContainsMouseChanged: {
-            var rectOpacity = (ignoreRadiusEnabled && containsMouse) ? 1.0 : (containsMouse ? 1.0 : 0.7);
             if (containsMouse) {
                 Tablet.playSound(TabletEnums.ButtonHover);
             }
+            var rectOpacity = ignoreRadiusEnabled ? 1.0 : (mouseArea.containsMouse ? 1.0 : 0.7);
             bubbleRect.opacity = rectOpacity;
         }
     }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22290/Desktop-mode-shield-icon-highlighting

# TEST PLAN

- Launch interface in desktop mode
- Opacity of shield icon in top left should be low (looks grey)
- highlighting over should make it white
- clicking it should turn on the privacy shield and match the behavior in the app toolbar
- clicking to toggle this again in the desktop shield icon should make the icon turn back grey after mouse leaves the icon
- the icon in the top left should mirror the same state as the one in the desktop toolbar