### PR TITLE
Case 22259: Fix Mute Warning Switch Text

### DIFF
--- a/interface/resources/qml/hifi/audio/Audio.qml
+++ b/interface/resources/qml/hifi/audio/Audio.qml
@@ -254,7 +254,7 @@ Rectangle {
                     switchWidth: root.switchWidth;
                     anchors.top: parent.top
                     anchors.left: parent.left
-                    labelTextOn: qsTr("Warn when muted in HMD");
+                    labelTextOn: qsTr("HMD Mute Warning");
                     labelTextSize: 16;
                     backgroundOnColor: "#E3E3E3";
                     checked: AudioScriptingInterface.warnWhenMuted;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22259/Warn-when-muted-in-HMD-setting-s-label-text-only-displays-Warn-when-muted-in

# TEST PLAN
- Launch interface in HMD mode
- open `AUDIO` app in tablet
- warn when muted warning option should display "HMD Mute Warning"