### PR TITLE
Case 22263: Persist Mute Settings Between Sessions

### DIFF
--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -174,9 +174,11 @@ void Audio::setPTTDesktop(bool enabled) {
             _pttDesktop = enabled;
         }
     });
-    if (!enabled && _settingsLoaded) {
-        // Set to default behavior (unmuted for Desktop) on Push-To-Talk disable.
-        setMutedDesktop(true);
+    if (!enabled) {
+        if (_settingsLoaded) {
+            // Set to default behavior (unmuted for Desktop) on Push-To-Talk disable.
+            setMutedDesktop(true);
+        }
     } else {
         // Should be muted when not pushing to talk while PTT is enabled.
         setMutedDesktop(true);
@@ -202,9 +204,11 @@ void Audio::setPTTHMD(bool enabled) {
             _pttHMD = enabled;
         }
     });
-    if (!enabled && _settingsLoaded) {
-        // Set to default behavior (unmuted for HMD) on Push-To-Talk disable.
-        setMutedHMD(false);
+    if (!enabled) {
+        if (_settingsLoaded) {
+            // Set to default behavior (unmuted for HMD) on Push-To-Talk disable.
+            setMutedHMD(false);
+        }
     } else {
         // Should be muted when not pushing to talk while PTT is enabled.
         setMutedHMD(true);
@@ -358,11 +362,6 @@ void Audio::onContextChanged() {
             changed = true;
         }
     });
-    if (isHMD) {
-        setMuted(getMutedHMD());
-    } else {
-        setMuted(getMutedDesktop());
-    }
     if (changed) {
         emit contextChanged(isHMD ? Audio::HMD : Audio::DESKTOP);
     }

--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -174,7 +174,7 @@ void Audio::setPTTDesktop(bool enabled) {
             _pttDesktop = enabled;
         }
     });
-    if (!enabled) {
+    if (!enabled && _settingsLoaded) {
         // Set to default behavior (unmuted for Desktop) on Push-To-Talk disable.
         setMutedDesktop(true);
     } else {
@@ -202,7 +202,7 @@ void Audio::setPTTHMD(bool enabled) {
             _pttHMD = enabled;
         }
     });
-    if (!enabled) {
+    if (!enabled && _settingsLoaded) {
         // Set to default behavior (unmuted for HMD) on Push-To-Talk disable.
         setMutedHMD(false);
     } else {
@@ -231,6 +231,7 @@ void Audio::loadData() {
 
     auto client = DependencyManager::get<AudioClient>().data();
     QMetaObject::invokeMethod(client, "setMuted", Q_ARG(bool, isMuted()), Q_ARG(bool, false));
+    _settingsLoaded = true;
 }
 
 bool Audio::getPTTHMD() const {

--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -174,16 +174,10 @@ void Audio::setPTTDesktop(bool enabled) {
             _pttDesktop = enabled;
         }
     });
-    if (!enabled) {
-        if (_settingsLoaded) {
-            // Set to default behavior (unmuted for Desktop) on Push-To-Talk disable.
-            setMutedDesktop(true);
-        }
-    } else {
-        // Should be muted when not pushing to talk while PTT is enabled.
+    if (enabled || _settingsLoaded) {
+        // Set to default behavior (muted for Desktop) on Push-To-Talk disable or when enabled. Settings also need to be loaded.
         setMutedDesktop(true);
     }
-
     if (changed) {
         emit pushToTalkChanged(enabled);
         emit pushToTalkDesktopChanged(enabled);
@@ -204,14 +198,9 @@ void Audio::setPTTHMD(bool enabled) {
             _pttHMD = enabled;
         }
     });
-    if (!enabled) {
-        if (_settingsLoaded) {
-            // Set to default behavior (unmuted for HMD) on Push-To-Talk disable.
-            setMutedHMD(false);
-        }
-    } else {
-        // Should be muted when not pushing to talk while PTT is enabled.
-        setMutedHMD(true);
+    if (enabled || _settingsLoaded) {
+        // Set to default behavior (unmuted for HMD) on Push-To-Talk disable or muted for when PTT is enabled.
+        setMutedHMD(enabled);
     }
 
     if (changed) {

--- a/interface/src/scripting/Audio.h
+++ b/interface/src/scripting/Audio.h
@@ -409,6 +409,7 @@ protected:
 
 private:
 
+    bool _settingsLoaded { false };
     float _inputVolume { 1.0f };
     float _inputLevel { 0.0f };
     float _localInjectorGain { 0.0f };  // in dB


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22263/Interface-Mute-setting-does-not-persist-after-relaunching-interface

# TEST PLAN

1) Launch interface
2) Unmute interface
3) Close interface
4) Launch interface
5) Mute interface
6) Close interface
7) Launch interface
8) Repeat in VR mode, observe mute setting persists after relaunching interface