### PR TITLE
Case 22283: Fix transparent textures on baked assets

### DIFF
--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -498,6 +498,20 @@ bool Geometry::areTexturesLoaded() const {
             material->checkResetOpacityMap();
         }
 
+        for (auto& materialMapping : _materialMapping) {
+            if (materialMapping.second) {
+                for (auto& materialPair : materialMapping.second->parsedMaterials.networkMaterials) {
+                    if (materialPair.second) {
+                        if (materialPair.second->isMissingTexture()) {
+                            return false;
+                        }
+
+                        materialPair.second->checkResetOpacityMap();
+                    }
+                }
+            }
+        }
+
         _areTexturesLoaded = true;
     }
     return true;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22283/v83-Oven-Textures-with-transparency-disappear-after-bake

Test plan:
- Bake the models in the [original ticket](https://highfidelity.manuscript.com/f/cases/22276/Oven-Textures-with-transparency-disappear-after-bake).  When they load, the transparent parts will render properly.