### PR TITLE
(case 22011) Fix model processing occurring on main thread

### DIFF
--- a/libraries/material-networking/src/material-networking/MaterialCache.h
+++ b/libraries/material-networking/src/material-networking/MaterialCache.h
@@ -108,6 +108,7 @@ private:
 
 using NetworkMaterialResourcePointer = QSharedPointer<NetworkMaterialResource>;
 using MaterialMapping = std::vector<std::pair<std::string, NetworkMaterialResourcePointer>>;
+Q_DECLARE_METATYPE(MaterialMapping)
 
 class MaterialCache : public ResourceCache {
 public:

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -282,8 +282,16 @@ void GeometryReader::run() {
                 hfmModel->scripts.push_back(script.toString());
             }
         }
+
+        // Do processing on the model
+        baker::Baker modelBaker(hfmModel, _mapping.second, _mapping.first);
+        modelBaker.run();
+
+        auto processedHFMModel = modelBaker.getHFMModel();
+        auto materialMapping = modelBaker.getMaterialMapping();
+
         QMetaObject::invokeMethod(resource.data(), "setGeometryDefinition",
-                Q_ARG(HFMModel::Pointer, hfmModel), Q_ARG(GeometryMappingPair, _mapping));
+                Q_ARG(HFMModel::Pointer, processedHFMModel), Q_ARG(MaterialMapping, materialMapping));
     } catch (const std::exception&) {
         auto resource = _resource.toStrongRef();
         if (resource) {
@@ -317,7 +325,7 @@ public:
     void setExtra(void* extra) override;
 
 protected:
-    Q_INVOKABLE void setGeometryDefinition(HFMModel::Pointer hfmModel, const GeometryMappingPair& mapping);
+    Q_INVOKABLE void setGeometryDefinition(HFMModel::Pointer hfmModel, const MaterialMapping& materialMapping);
 
 private:
     ModelLoader _modelLoader;
@@ -340,14 +348,10 @@ void GeometryDefinitionResource::downloadFinished(const QByteArray& data) {
     QThreadPool::globalInstance()->start(new GeometryReader(_modelLoader, _self, _effectiveBaseURL, _mapping, data, _combineParts, _request->getWebMediaType()));
 }
 
-void GeometryDefinitionResource::setGeometryDefinition(HFMModel::Pointer hfmModel, const GeometryMappingPair& mapping) {
-    // Do processing on the model
-    baker::Baker modelBaker(hfmModel, mapping.second, mapping.first);
-    modelBaker.run();
-
+void GeometryDefinitionResource::setGeometryDefinition(HFMModel::Pointer hfmModel, const MaterialMapping& materialMapping) {
     // Assume ownership of the processed HFMModel
-    _hfmModel = modelBaker.getHFMModel();
-    _materialMapping = modelBaker.getMaterialMapping();
+    _hfmModel = hfmModel;
+    _materialMapping = materialMapping;
 
     // Copy materials
     QHash<QString, size_t> materialIDAtlas;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22011/THe-model-loading-resource-request-execute-too-much-of-the-hfm-work-in-main-thread-this-is-a-bottleneck

This PR fixes the model-baker Baker being called on the main thread, which caused performance bottlenecks when loading a domain.