### PR TITLE
Case 20989: Call leaveEntity when script on containing entity stops

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -169,7 +169,7 @@ private:
 
     void resetEntitiesScriptEngine();
 
-    bool findBestZoneAndMaybeContainingEntities(QVector<EntityItemID>* entitiesContainingAvatar = nullptr);
+    bool findBestZoneAndMaybeContainingEntities(QSet<EntityItemID>& entitiesContainingAvatar);
 
     bool applyLayeredZones();
     void stopDomainAndNonOwnedEntities();
@@ -186,7 +186,8 @@ private:
     void forceRecheckEntities();
 
     glm::vec3 _avatarPosition { 0.0f };
-    QVector<EntityItemID> _currentEntitiesInside;
+    bool _forceRecheckEntities { true };
+    QSet<EntityItemID> _currentEntitiesInside;
 
     bool _wantScripts;
     ScriptEnginePointer _entitiesScriptEngine;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20989/enter-leaveEntity-should-be-called-if-an-entity-script-starts-stops-while-the-Avatar-is-inside-the-entity

Test plan:
- First we're going to test enter events with this script: https://gist.githubusercontent.com/SamGondelman/f41a56dc19467c4084887c4a609d2fc2/raw/06fe6ba007457a0e02374b689527f639a6470120/EnterZoneTest.js
- Create a Zone and stand outside of it.  Add the script to the entity.
- When you walk into the zone, you'll be teleported to eschatology/1000,1000,1000
- Use GOTO to teleport inside of the zone you made from a different domain.  You should be instantly to eschatology/1000,1000,1000 instead.
- Go back to the domain with the zone and remove the script.  Stand inside of the zone and re-add the script.  Once it loads you should be teleported to eschatology/1000,1000,1000.
- Now we're going to test leave events with this script: https://gist.githubusercontent.com/SamGondelman/142e584a2a3426313615b2a8c7376bdf/raw/c644a0675fd8ffe66bae24ca8d9c66810fe81273/LeaveZoneTest.js
- Create a Zone and stand outside of it.  Add the script to the entity.
- You should be able to walk into the zone.  When you walk out of it, you'll be teleported to eschatology/1000,1000,1000
- Go back inside the zone.  Use GOTO to go to a different domain.  Regardless of where you enter in GOTO, you should be teleported to eschatology/1000,1000,1000
- Go back to the domain and stand inside of the zone.  Remove the script.  You should be teleported to eschatology/1000,1000,1000
- Go back to the domain, stand inside the zone, and put the script back.  Delete the zone.  You should be teleported to eschatology/1000,1000,1000