### PR TITLE
Case 22309: Fix domain baker not finishing (merge to master)

### DIFF
--- a/tools/oven/src/DomainBaker.cpp
+++ b/tools/oven/src/DomainBaker.cpp
@@ -171,7 +171,7 @@ void DomainBaker::addModelBaker(const QString& property, const QString& url, con
                 // move the baker to the baker thread
                 // and kickoff the bake
                 baker->moveToThread(Oven::instance().getNextWorkerThread());
-                QMetaObject::invokeMethod(baker.data(), "bake");
+                QMetaObject::invokeMethod(baker.data(), "bake", Qt::QueuedConnection);
 
                 // keep track of the total number of baking entities
                 ++_totalNumberOfSubBakes;
@@ -212,7 +212,7 @@ void DomainBaker::addTextureBaker(const QString& property, const QString& url, i
 
             // move the baker to a worker thread and kickoff the bake
             textureBaker->moveToThread(Oven::instance().getNextWorkerThread());
-            QMetaObject::invokeMethod(textureBaker.data(), "bake");
+            QMetaObject::invokeMethod(textureBaker.data(), "bake", Qt::QueuedConnection);
 
             // keep track of the total number of baking entities
             ++_totalNumberOfSubBakes;
@@ -247,7 +247,7 @@ void DomainBaker::addScriptBaker(const QString& property, const QString& url, co
 
         // move the baker to a worker thread and kickoff the bake
         scriptBaker->moveToThread(Oven::instance().getNextWorkerThread());
-        QMetaObject::invokeMethod(scriptBaker.data(), "bake");
+        QMetaObject::invokeMethod(scriptBaker.data(), "bake", Qt::QueuedConnection);
 
         // keep track of the total number of baking entities
         ++_totalNumberOfSubBakes;
@@ -272,7 +272,7 @@ void DomainBaker::addMaterialBaker(const QString& property, const QString& data,
 
         // setup a baker for this material
         QSharedPointer<MaterialBaker> materialBaker {
-            new MaterialBaker(data, isURL, _contentOutputPath, destinationPath),
+            new MaterialBaker(materialData, isURL, _contentOutputPath, destinationPath),
             &MaterialBaker::deleteLater
         };
 
@@ -284,7 +284,7 @@ void DomainBaker::addMaterialBaker(const QString& property, const QString& data,
 
         // move the baker to a worker thread and kickoff the bake
         materialBaker->moveToThread(Oven::instance().getNextWorkerThread());
-        QMetaObject::invokeMethod(materialBaker.data(), "bake");
+        QMetaObject::invokeMethod(materialBaker.data(), "bake", Qt::QueuedConnection);
 
         // keep track of the total number of baking entities
         ++_totalNumberOfSubBakes;


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/22309/merge-to-master-Oven-Domain-baking-can-fail-to-finish

This addresses 2 cases where the domain baker would not finish

1. For material baking, we were storing a value in
_entitiesNeedingRewrite with a different key than what
we use when we later remove it from _entitiesNeedingRewrite

2. The domain baker runs on a worker thread. When starting a
baker for an item in the domain, we do an invokeMethod,
which will happen synchronously if the baker ends up on the
same thread as the thread that the domain baker is on.
This can cause issues if the baker finishes immediately.
The case I saw was a local model url that immediately failed,
and finished before return from the invokeMethod in the domain baker .