### PR TITLE
Case 22263: Interface Mute setting does not persist after relaunching interface.

### DIFF
--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -351,6 +351,13 @@ void Audio::onContextChanged() {
             changed = true;
         }
     });
+    if (_settingsLoaded) {
+        if (isHMD) {
+            setMuted(getMutedHMD());
+        } else {
+            setMuted(getMutedDesktop());
+        }
+    }
     if (changed) {
         emit contextChanged(isHMD ? Audio::HMD : Audio::DESKTOP);
     }

--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -352,11 +352,11 @@ void Audio::onContextChanged() {
         }
     });
     if (_settingsLoaded) {
-        if (isHMD) {
-            setMuted(getMutedHMD());
-        } else {
-            setMuted(getMutedDesktop());
-        }
+        bool isMuted = isHMD ? getMutedHMD() : getMutedDesktop();
+        setMuted(isMuted);
+        // always set audio client muted state on context changed - sometimes setMuted does not catch it.
+        auto client = DependencyManager::get<AudioClient>().data();
+        QMetaObject::invokeMethod(client, "setMuted", Q_ARG(bool, isMuted), Q_ARG(bool, false));
     }
     if (changed) {
         emit contextChanged(isHMD ? Audio::HMD : Audio::DESKTOP);


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22263/Interface-Mute-setting-does-not-persist-after-relaunching-interface

# TEST PLAN
Launch interface
Unmute interface
Close interface
Launch interface
Mute interface
Close interface
Launch interface
Repeat in VR mode, observe mute setting persists after relaunching interface

Post-Merge Test Plan:
https://highfidelity.testrail.net/index.php?/cases/view/43176
https://highfidelity.testrail.net/index.php?/cases/view/43179