### PR TITLE
Dependencies have correct osx deploy target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,14 @@ endif()
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/macros/TargetPython.cmake")
 target_python()
 
-if (HIFI_ANDROID )
+# set our OS X deployment target
+# (needs to be set before first project() call and before prebuild.py)
+# Will affect VCPKG dependencies
+if (APPLE)
+  set(ENV{MACOSX_DEPLOYMENT_TARGET} 10.9)
+endif()
+
+if (HIFI_ANDROID)
     execute_process(
         COMMAND ${HIFI_PYTHON_EXEC} ${CMAKE_CURRENT_SOURCE_DIR}/prebuild.py --android ${HIFI_ANDROID_APP} --build-root ${CMAKE_BINARY_DIR}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -88,11 +88,9 @@ if (APPLE)
   exec_program(sw_vers ARGS -productVersion  OUTPUT_VARIABLE OSX_VERSION)
   string(REGEX MATCH "^[0-9]+\\.[0-9]+" OSX_VERSION ${OSX_VERSION})
   message(STATUS "Detected OS X version = ${OSX_VERSION}")
+  message(STATUS "OS X deployment target = ${CMAKE_OSX_DEPLOYMENT_TARGET}")
 
   set(OSX_SDK "${OSX_VERSION}" CACHE String "OS X SDK version to look for inside Xcode bundle or at OSX_SDK_PATH")
-
-  # set our OS X deployment target
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
 
   # find the SDK path for the desired SDK
   find_path(


### PR DESCRIPTION
[Manuscript Ticket](https://highfidelity.manuscript.com/f/cases/22325/Mac-Dependencies-are-build-with-the-wrong-SDK)

Fix dependencies build with VCPKG so that they use the proper deploy target on OS X