### PR TITLE
Skeleton Trait Implementation

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -179,7 +179,13 @@ void AvatarMixerClientData::processSetTraitsMessage(ReceivedMessage& message,
             if (packetTraitVersion > _lastReceivedTraitVersions[traitType]) {
                 _avatar->processTrait(traitType, message.read(traitSize));
                 _lastReceivedTraitVersions[traitType] = packetTraitVersion;
-
+                if (traitType == AvatarTraits::SkeletonData) {
+                    qDebug() << "Sending skeleton avatar trait";
+                    auto packet = NLPacket::create(PacketType::SetAvatarTraits, -1, true);
+                    AvatarTraits::packVersionedTrait(AvatarTraits::SkeletonData, *packet, packetTraitVersion, *_avatar);
+                    auto nodeList = DependencyManager::get<NodeList>();
+                    nodeList->sendPacket(std::move(packet), sendingNode);
+                }
                 if (traitType == AvatarTraits::SkeletonModelURL) {
                     // special handling for skeleton model URL, since we need to make sure it is in the whitelist
                     checkSkeletonURLAgainstWhitelist(slaveSharedData, sendingNode, packetTraitVersion);

--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -179,13 +179,6 @@ void AvatarMixerClientData::processSetTraitsMessage(ReceivedMessage& message,
             if (packetTraitVersion > _lastReceivedTraitVersions[traitType]) {
                 _avatar->processTrait(traitType, message.read(traitSize));
                 _lastReceivedTraitVersions[traitType] = packetTraitVersion;
-                if (traitType == AvatarTraits::SkeletonData) {
-                    qDebug() << "Sending skeleton avatar trait";
-                    auto packet = NLPacket::create(PacketType::SetAvatarTraits, -1, true);
-                    AvatarTraits::packVersionedTrait(AvatarTraits::SkeletonData, *packet, packetTraitVersion, *_avatar);
-                    auto nodeList = DependencyManager::get<NodeList>();
-                    nodeList->sendPacket(std::move(packet), sendingNode);
-                }
                 if (traitType == AvatarTraits::SkeletonModelURL) {
                     // special handling for skeleton model URL, since we need to make sure it is in the whitelist
                     checkSkeletonURLAgainstWhitelist(slaveSharedData, sendingNode, packetTraitVersion);

--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -627,6 +627,8 @@ Menu::Menu() {
         avatar.get(), SLOT(setEnableDebugDrawAnimPose(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::AnimDebugDrawPosition, 0, false,
         avatar.get(), SLOT(setEnableDebugDrawPosition(bool)));
+    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::AnimDebugDrawOtherSkeletons, 0, false,
+        avatarManager.data(), SLOT(setEnableDebugDrawOtherSkeletons(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::MeshVisible, 0, true,
         avatar.get(), SLOT(setEnableMeshVisible(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::DisableEyelidAdjustment, 0, false);

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -33,6 +33,7 @@ namespace MenuOption {
     const QString AnimDebugDrawBaseOfSupport = "Debug Draw Base of Support";
     const QString AnimDebugDrawDefaultPose = "Debug Draw Default Pose";
     const QString AnimDebugDrawPosition= "Debug Draw Position";
+    const QString AnimDebugDrawOtherSkeletons = "Debug Draw Other Skeletons";
     const QString AskToResetSettings = "Ask To Reset Settings on Start";
     const QString AssetMigration = "ATP Asset Migration";
     const QString AssetServer = "Asset Browser";

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -120,6 +120,8 @@ void AvatarManager::init() {
         _myAvatar->addToScene(_myAvatar, scene, transaction);
         scene->enqueueTransaction(transaction);
     }
+
+    setEnableDebugDrawOtherSkeletons(Menu::getInstance()->isOptionChecked(MenuOption::AnimDebugDrawOtherSkeletons));
 }
 
 void AvatarManager::setSpace(workload::SpacePointer& space ) {
@@ -334,9 +336,14 @@ void AvatarManager::updateOtherAvatars(float deltaTime) {
                 if (avatar->getSkeletonModel()->isLoaded() && avatar->getWorkloadRegion() == workload::Region::R1) {
                     _myAvatar->addAvatarHandsToFlow(avatar);
                 }
+                if (_drawOtherAvatarSkeletons) {
+                    avatar->debugJointData();
+                }
+                avatar->setEnableMeshVisible(!_drawOtherAvatarSkeletons);
                 avatar->updateRenderItem(renderTransaction);
                 avatar->updateSpaceProxy(workloadTransaction);
                 avatar->setLastRenderUpdateTime(startTime);
+
             } else {
                 // we've spent our time budget for this priority bucket
                 // let's deal with the reminding avatars if this pass and BREAK from the for loop

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -213,6 +213,15 @@ public slots:
      */
     void updateAvatarRenderStatus(bool shouldRenderAvatars);
 
+    /**jsdoc
+    * Displays other avatars skeletons debug graphics.
+    * @function AvatarManager.setEnableDebugDrawOtherSkeletons
+    * @param {boolean} enabled - <code>true</code> to show the debug graphics, <code>false</code> to hide.
+    */
+    void setEnableDebugDrawOtherSkeletons(bool isEnabled) {
+        _drawOtherAvatarSkeletons = isEnabled;
+    }
+
 protected:
     AvatarSharedPointer addAvatar(const QUuid& sessionUUID, const QWeakPointer<Node>& mixerWeakPointer) override;
 
@@ -250,6 +259,7 @@ private:
     workload::SpacePointer _space;
 
     AvatarTransit::TransitConfig  _transitConfig;
+    bool _drawOtherAvatarSkeletons { false };
 };
 
 #endif // hifi_AvatarManager_h

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -375,7 +375,6 @@ void OtherAvatar::debugJointData() const {
         const float AXIS_LENGTH = 0.1f;
     
         AnimPoseVec jointPoses;
-        glm::quat rotationOffset = Quaternions::IDENTITY;
         std::vector<QString> jointNames;
         AnimPose rigToAvatar = AnimPose(Quaternions::Y_180 * getWorldOrientation(), getWorldPosition());
         for (int i = 0; i < jointData.size(); i++) {

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -374,7 +374,7 @@ void OtherAvatar::debugJointData() const {
         const vec4 WHITE(1.0f, 1.0f, 1.0f, 1.0f);
         const float AXIS_LENGTH = 0.1f;
     
-        std::vector<AnimPose> jointPoses;
+        AnimPoseVec jointPoses;
         glm::quat rotationOffset = Quaternions::IDENTITY;
         std::vector<QString> jointNames;
         AnimPose rigToAvatar = AnimPose(Quaternions::Y_180 * getWorldOrientation(), getWorldPosition());
@@ -389,7 +389,7 @@ void OtherAvatar::debugJointData() const {
             jointNames.push_back(skeletonData[i].jointName);
         }
         QVector<AnimPose> worldFramePoses;
-        for (size_t i = 0; i < jointPoses.size(); i++) {
+        for (int i = 0; i < (int)jointPoses.size(); i++) {
             auto &jointPose = jointPoses[i];
             int parentIndex = skeletonData[i].parentIndex;
             if (parentIndex < worldFramePoses.size()) {

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -389,7 +389,7 @@ void OtherAvatar::debugJointData() const {
         }
         QVector<AnimPose> worldFramePoses;
         for (int i = 0; i < (int)jointPoses.size(); i++) {
-            auto &jointPose = jointPoses[i];
+            auto& jointPose = jointPoses[i];
             int parentIndex = skeletonData[i].parentIndex;
             if (parentIndex < worldFramePoses.size()) {
                 glm::vec3 xAxis = jointPose.rot() * Vectors::UNIT_X;

--- a/interface/src/avatar/OtherAvatar.h
+++ b/interface/src/avatar/OtherAvatar.h
@@ -66,7 +66,7 @@ public:
     void setCollisionWithOtherAvatarsFlags() override;
 
     void simulate(float deltaTime, bool inView) override;
-    void OtherAvatar::debugJointData() const;
+    void debugJointData() const;
     friend AvatarManager;
 
 protected:

--- a/interface/src/avatar/OtherAvatar.h
+++ b/interface/src/avatar/OtherAvatar.h
@@ -66,7 +66,7 @@ public:
     void setCollisionWithOtherAvatarsFlags() override;
 
     void simulate(float deltaTime, bool inView) override;
-
+    void OtherAvatar::debugJointData() const;
     friend AvatarManager;
 
 protected:

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1452,8 +1452,8 @@ QStringList Avatar::getJointNames() const {
 std::vector<AvatarSkeletonTrait::UnpackedJointData> Avatar::getSkeletonDefaultData() {
     std::vector<AvatarSkeletonTrait::UnpackedJointData> defaultSkeletonData;
     if (_skeletonModel->isLoaded()) {
-        auto &model = _skeletonModel->getHFMModel();
-        auto &rig = _skeletonModel->getRig();
+        auto& model = _skeletonModel->getHFMModel();
+        auto& rig = _skeletonModel->getRig();
         float geometryToRigScale = glm::length(extractScale(rig.getGeometryToRigTransform()));
         QStringList jointNames = getJointNames();
         int sizeCount = 0;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1454,7 +1454,7 @@ std::vector<AvatarSkeletonTrait::UnpackedJointData> Avatar::getSkeletonDefaultDa
     if (_skeletonModel->isLoaded()) {
         auto& model = _skeletonModel->getHFMModel();
         auto& rig = _skeletonModel->getRig();
-        float geometryToRigScale = glm::length(extractScale(rig.getGeometryToRigTransform()));
+        float geometryToRigScale = extractScale(rig.getGeometryToRigTransform())[0];
         QStringList jointNames = getJointNames();
         int sizeCount = 0;
         for (int i = 0; i < jointNames.size(); i++) {
@@ -1468,7 +1468,7 @@ std::vector<AvatarSkeletonTrait::UnpackedJointData> Avatar::getSkeletonDefaultDa
             }
             jointData.defaultRotation = rig.getAbsoluteDefaultPose(i).rot();
             jointData.defaultTranslation = getDefaultJointTranslation(i);
-            float jointLocalScale = glm::length(extractScale(model.joints[i].transform));
+            float jointLocalScale = extractScale(model.joints[i].transform)[0];
             jointData.defaultScale = jointLocalScale / geometryToRigScale;
             jointData.jointName = jointNames[i];
             jointData.stringLength = jointNames[i].size();

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1449,6 +1449,28 @@ QStringList Avatar::getJointNames() const {
     return result;
 }
 
+std::vector<AvatarSkeletonTrait::UnpackedJointData> Avatar::getSkeletonDefaultData() {
+    std::vector<AvatarSkeletonTrait::UnpackedJointData> defaultSkeletonData;
+    if (_skeletonModel->isLoaded()) {
+        auto jointNames = getJointNames();
+        int sizeCount = 0;
+        for (int i = 0; i < min(43, jointNames.size()); i++) {
+            AvatarSkeletonTrait::UnpackedJointData jointData;
+            jointData.jointParent = _skeletonModel->getRig().getJointParentIndex(i);
+            jointData.jointIndex = i;
+            jointData.defaultRotation = getDefaultJointRotation(i);
+            jointData.defaultTranslation = getDefaultJointTranslation(i);
+            jointData.defaultScale = glm::length(getAbsoluteJointScaleInObjectFrame(i));
+            jointData.jointName = jointNames[i];
+            jointData.stringLength = jointNames[i].size();
+            jointData.stringStart = sizeCount;
+            sizeCount += jointNames[i].size();
+            defaultSkeletonData.push_back(jointData);
+        }
+    }
+    return defaultSkeletonData;
+}
+
 glm::vec3 Avatar::getJointPosition(int index) const {
     glm::vec3 position;
     _skeletonModel->getJointPositionInWorldFrame(index, position);
@@ -1515,6 +1537,8 @@ void Avatar::rigReady() {
     buildSpine2SplineRatioCache();
     computeMultiSphereShapes();
     buildSpine2SplineRatioCache();
+    setSkeletonData(getSkeletonDefaultData());
+    sendSkeletonData();
 }
 
 // rig has been reset.

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1457,7 +1457,6 @@ std::vector<AvatarSkeletonTrait::UnpackedJointData> Avatar::getSkeletonDefaultDa
         float geometryToRigScale = glm::length(extractScale(rig.getGeometryToRigTransform()));
         QStringList jointNames = getJointNames();
         int sizeCount = 0;
-        int jointCount = 0;
         for (int i = 0; i < jointNames.size(); i++) {
             AvatarSkeletonTrait::UnpackedJointData jointData;
             jointData.jointIndex = i;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -199,6 +199,8 @@ public:
     virtual int getJointIndex(const QString& name) const override;
     virtual QStringList getJointNames() const override;
 
+    std::vector<AvatarSkeletonTrait::UnpackedJointData> getSkeletonDefaultData();
+
     /**jsdoc
      * Gets the default rotation of a joint (in the current avatar) relative to its parent.
      * <p>For information on the joint hierarchy used, see

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2055,7 +2055,6 @@ QByteArray AvatarData::packSkeletonModelURL() const {
 void AvatarData::unpackSkeletonData(const QByteArray& data) {
 
     const unsigned char* startPosition = reinterpret_cast<const unsigned char*>(data.data());
-    const unsigned char* endPosition = startPosition + data.size();
     const unsigned char* sourceBuffer = startPosition;
     
     auto header = reinterpret_cast<const AvatarSkeletonTrait::Header*>(sourceBuffer);

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2011,7 +2011,7 @@ QByteArray AvatarData::packSkeletonData() const {
 
         for (size_t i = 0; i < _avatarSkeletonData.size(); i++) {
             header.stringTableLength += (uint16_t)_avatarSkeletonData[i].jointName.size();
-            auto &translation = _avatarSkeletonData[i].defaultTranslation;
+            auto& translation = _avatarSkeletonData[i].defaultTranslation;
             header.maxTranslationDimension = std::max(header.maxTranslationDimension, std::max(std::max(translation.x, translation.y), translation.z));
             header.maxScaleDimension = std::max(header.maxScaleDimension, _avatarSkeletonData[i].defaultScale);
         }

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -145,6 +145,39 @@ const char AVATARDATA_FLAGS_MINIMUM = 0;
 
 using SmallFloat = uint16_t; // a compressed float with less precision, user defined radix
 
+namespace AvatarSkeletonTrait {
+    PACKED_BEGIN struct Header {
+        float maxTranslationDimension;
+        float maxScaleDimension;
+        uint8_t numJoints;
+        uint8_t padding;
+        uint16_t stringTableLength;
+    } PACKED_END;
+
+    PACKED_BEGIN struct JointData {
+        uint16_t stringStart;
+        uint8_t stringLength;
+        uint8_t boneType;
+        uint8_t defaultTranslation[6];
+        uint8_t defaultRotation[6];
+        uint16_t defaultScale;
+        uint16_t jointIndex;
+        uint16_t jointParent;
+    } PACKED_END;
+
+    struct UnpackedJointData {
+        int jointParent;
+        int stringStart;
+        int stringLength;
+        int boneType;
+        glm::vec3 defaultTranslation;
+        glm::quat defaultRotation;
+        float defaultScale;
+        int jointIndex;
+        QString jointName;
+    };
+}
+
 namespace AvatarDataPacket {
 
     // NOTE: every time AvatarData is sent from mixer to client, it also includes the GUIID for the session
@@ -258,6 +291,7 @@ namespace AvatarDataPacket {
     PACKED_BEGIN struct AvatarLocalPosition {
         float localPosition[3];           // parent frame translation of the avatar
     } PACKED_END;
+
     const size_t AVATAR_LOCAL_POSITION_SIZE = 12;
     static_assert(sizeof(AvatarLocalPosition) == AVATAR_LOCAL_POSITION_SIZE, "AvatarDataPacket::AvatarLocalPosition size doesn't match.");
 
@@ -1419,6 +1453,8 @@ public:
     void setIsNewAvatar(bool isNewAvatar) { _isNewAvatar = isNewAvatar; }
     bool getIsNewAvatar() { return _isNewAvatar; }
     void setIsClientAvatar(bool isClientAvatar) { _isClientAvatar = isClientAvatar; }
+    void setSkeletonData(const std::vector<AvatarSkeletonTrait::UnpackedJointData>& skeletonData);
+    void sendSkeletonData() const;
 
 signals:
 
@@ -1597,12 +1633,13 @@ protected:
     bool hasParent() const { return !getParentID().isNull(); }
     bool hasFaceTracker() const { return _headData ? _headData->_isFaceTrackerConnected : false; }
 
+    QByteArray packSkeletonData() const;
     QByteArray packSkeletonModelURL() const;
     QByteArray packAvatarEntityTraitInstance(AvatarTraits::TraitInstanceID traitInstanceID);
     QByteArray packGrabTraitInstance(AvatarTraits::TraitInstanceID traitInstanceID);
 
     void unpackSkeletonModelURL(const QByteArray& data);
-
+    void unpackSkeletonData(const QByteArray& data);
     
     // isReplicated will be true on downstream Avatar Mixers and their clients, but false on the upstream "master"
     // Audio Mixer that the replicated avatar is connected to.
@@ -1718,6 +1755,9 @@ protected:
     mutable ReadWriteLockable _avatarGrabsLock;
     AvatarGrabDataMap _avatarGrabData;
     bool _avatarGrabDataChanged { false }; // by network
+
+    mutable ReadWriteLockable _avatarSkeletonDataLock;
+    std::vector<AvatarSkeletonTrait::UnpackedJointData> _avatarSkeletonData;
 
     // used to transform any sensor into world space, including the _hmdSensorMat, or hand controllers.
     ThreadSafeValueCache<glm::mat4> _sensorToWorldMatrixCache { glm::mat4() };

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -146,11 +146,17 @@ const char AVATARDATA_FLAGS_MINIMUM = 0;
 using SmallFloat = uint16_t; // a compressed float with less precision, user defined radix
 
 namespace AvatarSkeletonTrait {
+    enum BoneType {
+        SkeletonRoot = 0,
+        SkeletonChild,
+        NonSkeletonRoot,
+        NonSkeletonChild
+    };
+
     PACKED_BEGIN struct Header {
         float maxTranslationDimension;
         float maxScaleDimension;
         uint8_t numJoints;
-        uint8_t padding;
         uint16_t stringTableLength;
     } PACKED_END;
 
@@ -162,11 +168,10 @@ namespace AvatarSkeletonTrait {
         uint8_t defaultRotation[6];
         uint16_t defaultScale;
         uint16_t jointIndex;
-        uint16_t jointParent;
+        uint16_t parentIndex;
     } PACKED_END;
 
     struct UnpackedJointData {
-        int jointParent;
         int stringStart;
         int stringLength;
         int boneType;
@@ -174,6 +179,7 @@ namespace AvatarSkeletonTrait {
         glm::quat defaultRotation;
         float defaultScale;
         int jointIndex;
+        int parentIndex;
         QString jointName;
     };
 }
@@ -1454,7 +1460,9 @@ public:
     bool getIsNewAvatar() { return _isNewAvatar; }
     void setIsClientAvatar(bool isClientAvatar) { _isClientAvatar = isClientAvatar; }
     void setSkeletonData(const std::vector<AvatarSkeletonTrait::UnpackedJointData>& skeletonData);
+    std::vector<AvatarSkeletonTrait::UnpackedJointData> getSkeletonData() const;
     void sendSkeletonData() const;
+    QVector<JointData> getJointData() const;
 
 signals:
 

--- a/libraries/avatars/src/AvatarTraits.h
+++ b/libraries/avatars/src/AvatarTraits.h
@@ -29,7 +29,7 @@ namespace AvatarTraits {
 
         // Simple traits
         SkeletonModelURL = 0,
-
+        SkeletonData,
         // Instanced traits
         FirstInstancedTrait,
         AvatarEntity = FirstInstancedTrait,

--- a/libraries/avatars/src/ClientTraitsHandler.cpp
+++ b/libraries/avatars/src/ClientTraitsHandler.cpp
@@ -107,8 +107,7 @@ int ClientTraitsHandler::sendChangedTraitsToMixer() {
 
             if (initialSend || *simpleIt == Updated) {
                 bytesWritten += AvatarTraits::packTrait(traitType, *traitsPacketList, *_owningAvatar);
-
-
+                
                 if (traitType == AvatarTraits::SkeletonModelURL) {
                     // keep track of our skeleton version in case we get an override back
                     _currentSkeletonVersion = _currentTraitVersion;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22182/Implement-Avatar-Traits

This PR creates an Avatar Skeleton Trait that provides enough information to the client to represent the avatar skeleton before loading its fbx file.
A new menu item has been created in order to draw a stick figure based on this skeleton data.