### PR TITLE
Case 22340 : turning on blit present for quest

### DIFF
--- a/libraries/oculusMobile/src/ovr/VrHandler.cpp
+++ b/libraries/oculusMobile/src/ovr/VrHandler.cpp
@@ -28,7 +28,7 @@
 
 static AAssetManager* ASSET_MANAGER = nullptr;
 
-#define USE_BLIT_PRESENT 0
+#define USE_BLIT_PRESENT 1
 
 #if !USE_BLIT_PRESENT
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22340/Quest-app-crashes-on-startup

Fixes issue with quest not able to render due to backbuffer setup issues. 

Test case:
Open app on quest. Should render correctly.
Knwon issue  is that the colors are displayed in the wrong RGB space (washed out) but it s ok for now