### PR TITLE
Case 21884: send update after changing AvatarEntity via AvatarBookmarks.updateAvatarEntities()

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1630,7 +1630,9 @@ void MyAvatar::handleChangedAvatarEntityData() {
         if (!skip) {
             sanitizeAvatarEntityProperties(properties);
             entityTree->withWriteLock([&] {
-                entityTree->updateEntity(id, properties);
+                if (entityTree->updateEntity(id, properties)) {
+                    packetSender->queueEditAvatarEntityMessage(entityTree, id);
+                }
             });
         }
     }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/21884

Fixes a bug where changes from `AvatarBookmarks.updateAvatarEntities()` are not seen on remote interfaces.