### PR TITLE
Case 22246: Picks, PickType, RayPick JSDoc update

### DIFF
--- a/interface/src/raypick/CollisionPick.cpp
+++ b/interface/src/raypick/CollisionPick.cpp
@@ -61,7 +61,7 @@ void buildObjectIntersectionsMap(IntersectionType intersectionType, const std::v
  * An intersection result for a collision pick.
  *
  * @typedef {object} CollisionPickResult
- * @property {boolean} intersects - <code>truen</code> if there is at least one intersection, <code>false</code> if there isn't.
+ * @property {boolean} intersects - <code>true</code> if there is at least one intersection, <code>false</code> if there isn't.
  * @property {IntersectingObject[]} intersectingObjects - All objects which intersect with the <code>collisionRegion</code>.
  * @property {CollisionRegion} collisionRegion - The collision region that was used. Valid even if there was no intersection.
  */

--- a/interface/src/raypick/CollisionPick.cpp
+++ b/interface/src/raypick/CollisionPick.cpp
@@ -57,6 +57,37 @@ void buildObjectIntersectionsMap(IntersectionType intersectionType, const std::v
     }
 }
 
+/**jsdoc
+ * An intersection result for a collision pick.
+ *
+ * @typedef {object} CollisionPickResult
+ * @property {boolean} intersects - <code>truen</code> if there is at least one intersection, <code>false</code> if there isn't.
+ * @property {IntersectingObject[]} intersectingObjects - All objects which intersect with the <code>collisionRegion</code>.
+ * @property {CollisionRegion} collisionRegion - The collision region that was used. Valid even if there was no intersection.
+ */
+
+/**jsdoc
+ * Information about a {@link CollisionPick}'s intersection with an object.
+ *
+ * @typedef {object} IntersectingObject
+ * @property {Uuid} id - The ID of the object.
+ * @property {IntersectionType} type - The type of the object, either <code>1</code> for INTERSECTED_ENTITY or <code>3</code> 
+ *     for INTERSECTED_AVATAR.
+ * @property {CollisionContact[]} collisionContacts - Information on the penetration between the pick and the object.
+ */
+
+/**jsdoc
+ * A pair of points that represents part of an overlap between a {@link CollisionPick} and an object in the physics engine. 
+ * Points which are further apart represent deeper overlap.
+ *
+ * @typedef {object} CollisionContact
+ * @property {Vec3} pointOnPick - A point representing a penetration of the object's surface into the volume of the pick, in 
+ *     world coordinates.
+ * @property {Vec3} pointOnObject - A point representing a penetration of the pick's surface into the volume of the object, in 
+ *     world coordinates.
+ * @property {Vec3} normalOnPick - The normal vector pointing away from the pick, representing the direction of collision.
+ */
+
 QVariantMap CollisionPickResult::toVariantMap() const {
     QVariantMap variantMap;
 

--- a/interface/src/raypick/ParabolaPick.h
+++ b/interface/src/raypick/ParabolaPick.h
@@ -42,6 +42,23 @@ public:
     float parabolicDistance { FLT_MAX };
     bool intersects { false };
 
+    /**jsdoc
+     * An intersection result for a parabola pick.
+     *
+     * @typedef {object} ParabolaPickResult
+     * @property {number} type - The intersection type.
+     * @property {boolean} intersects - <code>true</code> if there's a valid intersection, <code>false</code> if there isn't.
+     * @property {Uuid} objectID - The ID of the intersected object. <code>null</code> for HUD or invalid intersections.
+     * @property {number} distance - The distance from the parabola origin to the intersection point in a straight line.
+     * @property {number} parabolicDistance - The distance from  the parabola origin to the intersection point along the arc of
+     *     the parabola.
+     * @property {Vec3} intersection - The intersection point in world coordinates.
+     * @property {Vec3} surfaceNormal - The surface normal at the intersected point. All <code>NaN</code>s if <code>type ==
+     *     Picks.INTERSECTED_HUD</code>.
+     * @property {SubmeshIntersection} extraInfo - Additional intersection details for model objects, otherwise
+     *     <code>{ }</code>.
+     * @property {PickParabola} parabola - The pick parabola that was used. Valid even if there is no intersection.
+     */
     virtual QVariantMap toVariantMap() const override {
         QVariantMap toReturn;
         toReturn["type"] = type;

--- a/interface/src/raypick/ParabolaPick.h
+++ b/interface/src/raypick/ParabolaPick.h
@@ -50,7 +50,7 @@ public:
      * @property {boolean} intersects - <code>true</code> if there's a valid intersection, <code>false</code> if there isn't.
      * @property {Uuid} objectID - The ID of the intersected object. <code>null</code> for HUD or invalid intersections.
      * @property {number} distance - The distance from the parabola origin to the intersection point in a straight line.
-     * @property {number} parabolicDistance - The distance from  the parabola origin to the intersection point along the arc of
+     * @property {number} parabolicDistance - The distance from the parabola origin to the intersection point along the arc of
      *     the parabola.
      * @property {Vec3} intersection - The intersection point in world coordinates.
      * @property {Vec3} surfaceNormal - The surface normal at the intersected point. All <code>NaN</code>s if <code>type ==

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -325,7 +325,7 @@ unsigned int PickScriptingInterface::createParabolaPick(const QVariant& properti
  * @property {number} threshold - The approximate minimum penetration depth for a test object to be considered in contact with
  *     the collision region. The depth is in world coordinates but scales with the parent if defined.
  * @property {CollisionMask} [collisionGroup=8] - The type of objects the collision region collides as. Objects whose collision
- *     masks overlap with the regions's collision group are considered to be colliding with the region.
+ *     masks overlap with the region's collision group are considered to be colliding with the region.
  */
 unsigned int PickScriptingInterface::createCollisionPick(const QVariant& properties) {
     QVariantMap propMap = properties.toMap();

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -64,12 +64,12 @@ PickFilter getPickFilter(unsigned int filter) {
  *     values (e.g., <code>Picks.PICK_DOMAIN_ENTTITIES</code>) combined with <code>|</code> (bitwise OR) operators.
  * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code> 
  *     means no maximum.
- * @property {Uuid} [parentID] - The ID of the parent: either an avatar, an entity, or another pick.
+ * @property {Uuid} [parentID] - The ID of the parent: an avatar, an entity, or another pick.
  * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint. 
  *     A value of <code>0</code> means no joint.<br />
  *     <em>Used only if <code>parentID</code> is specified.</em>
  * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to 
- *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise the pick is "static", not 
+ *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not 
  *     parented to anything.<br />
  *     <em>Used only if <code>parentID</code> is not specified.</em>
  * @property {Vec3} [position=Vec3.ZERO] - The offset of the ray origin from its parent if parented, otherwise the ray origin 
@@ -198,12 +198,12 @@ unsigned int PickScriptingInterface::createStylusPick(const QVariant& properties
  *     values (e.g., <code>Picks.PICK_DOMAIN_ENTTITIES</code>) combined with <code>|</code> (bitwise OR) operators.
  * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code> 
  *     means no maximum.
- * @property {Uuid} [parentID] - The ID of the parent: either an avatar, an entity, or another pick.
+ * @property {Uuid} [parentID] - The ID of the parent: an avatar, an entity, or another pick.
  * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint.
  *     A value of <code>0</code> means no joint.<br />
  *     <em>Used only if <code>parentID</code> is specified.</em>
  * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to 
- *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise the pick is "static", not 
+ *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not 
  *     parented to anything.
  *     <em>Used only if <code>parentID</code> is not specified.</em>
  * @property {Vec3} [position=Vec3.ZERO] - The offset of the parabola origin from its parent if parented, otherwise the 
@@ -307,12 +307,12 @@ unsigned int PickScriptingInterface::createParabolaPick(const QVariant& properti
  *     <p><strong>Note:</strong> Collision picks do not intersect the HUD.</p>
  * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code>
  *     means no maximum.
- * @property {Uuid} [parentID] - The ID of the parent: either an avatar, an entity, or another pick.
+ * @property {Uuid} [parentID] - The ID of the parent: an avatar, an entity, or another pick.
  * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint.
  *     A value of <code>0</code> means no joint.<br />
  *     <em>Used only if <code>parentID</code> is specified.</em>
  * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to
- *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise the pick is "static", not
+ *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise, the pick is "static", not
  *     parented to anything.<br />
  *     <em>Used only if <code>parentID</code> is not specified.</em>
  * @property {boolean} [scaleWithParent=true] - <code>true</code> to scale the pick's dimensions and threshold according to the 

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -55,22 +55,36 @@ PickFilter getPickFilter(unsigned int filter) {
 }
 
 /**jsdoc
- * A set of properties that can be passed to {@link Picks.createPick} to create a new Ray Pick.
+ * A set of properties that can be passed to {@link Picks.createPick} when creating a new ray pick.
+ *
  * @typedef {object} Picks.RayPickProperties
- * @property {boolean} [enabled=false] If this Pick should start enabled or not.  Disabled Picks do not updated their pick results.
- * @property {number} [filter=0] The filter for this Pick to use, constructed using filter flags combined using bitwise OR.
- * @property {number} [maxDistance=0.0] The max distance at which this Pick will intersect.  0.0 = no max.  < 0.0 is invalid.
- * @property {Uuid} parentID - The ID of the parent, either an avatar, an entity, or a pick.
- * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, the joints on the model of an avatar. (default = 0, no joint)
- * @property {string} joint - If "Mouse," parents the pick to the mouse. If "Avatar," parents the pick to MyAvatar's head. Otherwise, parents to the joint of the given name on MyAvatar.
- * @property {Vec3} [posOffset=Vec3.ZERO] Only for Joint Ray Picks.  A local joint position offset, in meters.  x = upward, y = forward, z = lateral
- * @property {Vec3} [dirOffset=Vec3.UP] Only for Joint Ray Picks.  A local joint direction offset.  x = upward, y = forward, z = lateral
- * @property {Vec3} [position] Only for Static Ray Picks.  The world-space origin of the ray.
- * @property {Vec3} [direction=-Vec3.UP] Only for Static Ray Picks.  The world-space direction of the ray.
+ * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should 
+ *     start disabled. Disabled picks do not update their pick results.
+ * @property {FilterFlags} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property 
+ *     values (e.g., <code>Picks.PICK_DOMAIN_ENTTITIES</code>) combined with <code>|</code> (bitwise OR) operators.
+ * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code> 
+ *     means no maximum.
+ * @property {Uuid} [parentID] - The ID of the parent: either an avatar, an entity, or another pick.
+ * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint. 
+ *     A value of <code>0</code> means no joint.<br />
+ *     <em>Used only if <code>parentID</code> is specified.</em>
+ * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to 
+ *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise the pick is "static", not 
+ *     parented to anything.<br />
+ *     <em>Used only if <code>parentID</code> is not specified.</em>
+ * @property {Vec3} [position=Vec3.ZERO] - The offset of the ray origin from its parent if parented, otherwise the ray origin 
+ *     in world coordinates.
+ * @property {Vec3} [posOffset] - Synonym for <code>position</code>.
+ * @property {Vec3} [direction] - The offset of the ray direction from its parent's y-axis if parented, otherwise the ray
+ *     direction in world coordinates.
+ *     <p><strong>Default Value:</strong> <code>Vec3.UP</code> direction if <code>joint</code> is specified, otherwise
+ *     <code>-Vec3.UP</code>.</p>
+ * @property {Vec3} [dirOffset] - Synonym for <code>direction</code>.
+ * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the 
+ *     default <code>direction</code> value.
  */
 unsigned int PickScriptingInterface::createRayPick(const QVariant& properties) {
     QVariantMap propMap = properties.toMap();
-
 
 #if defined (Q_OS_ANDROID)
     QString jointName { "" };
@@ -124,12 +138,20 @@ unsigned int PickScriptingInterface::createRayPick(const QVariant& properties) {
 }
 
 /**jsdoc
- * A set of properties that can be passed to {@link Picks.createPick} to create a new Stylus Pick.
+ * A set of properties that can be passed to {@link Picks.createPick} when creating a new stylus pick.
+ *
  * @typedef {object} Picks.StylusPickProperties
- * @property {number} [hand=-1] An integer.  0 == left, 1 == right.  Invalid otherwise.
- * @property {boolean} [enabled=false] If this Pick should start enabled or not.  Disabled Picks do not updated their pick results.
- * @property {number} [filter=0] The filter for this Pick to use, constructed using filter flags combined using bitwise OR.
- * @property {number} [maxDistance=0.0] The max distance at which this Pick will intersect.  0.0 = no max.  < 0.0 is invalid.
+ * @property {number} [hand=-1] <code>0</code> for the left hand, <code>1</code> for the right hand, invalid (<code>-1</code>) 
+ *     otherwise.
+ * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should
+ *     start disabled. Disabled picks do not update their pick results.
+ * @property {number} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property
+ *     values (e.g., <code>Picks.PICK_DOMAIN_ENTTITIES</code>) combined with <code>|</code> (bitwise OR) operators.
+ *     <p><strong>Note:</strong> Stylus picks do not intersect avatars or the HUD.</p>
+ * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code>
+ *     means no maximum.
+ * @property {Vec3} [tipOffset=0,0.095,0] - The position of the stylus tip relative to the hand position at default avatar 
+ *     scale.
  */
 unsigned int PickScriptingInterface::createStylusPick(const QVariant& properties) {
     QVariantMap propMap = properties.toMap();
@@ -167,23 +189,45 @@ unsigned int PickScriptingInterface::createStylusPick(const QVariant& properties
 
 // NOTE: Laser pointer still uses scaleWithAvatar. Until scaleWithAvatar is also deprecated for pointers, scaleWithAvatar should not be removed from the pick API.
 /**jsdoc
- * A set of properties that can be passed to {@link Picks.createPick} to create a new Parabola Pick.
+ * A set of properties that can be passed to {@link Picks.createPick} when creating a new parabola pick.
+ *
  * @typedef {object} Picks.ParabolaPickProperties
- * @property {boolean} [enabled=false] If this Pick should start enabled or not.  Disabled Picks do not updated their pick results.
- * @property {number} [filter=0] The filter for this Pick to use, constructed using filter flags combined using bitwise OR.
- * @property {number} [maxDistance=0.0] The max distance at which this Pick will intersect.  0.0 = no max.  < 0.0 is invalid.
- * @property {Uuid} parentID - The ID of the parent, either an avatar, an entity, or a pick.
- * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, the joints on the model of an avatar. (default = 0, no joint)
- * @property {string} joint - If "Mouse," parents the pick to the mouse. If "Avatar," parents the pick to MyAvatar's head. Otherwise, parents to the joint of the given name on MyAvatar.
- * @property {Vec3} [posOffset=Vec3.ZERO] Only for Joint Parabola Picks.  A local joint position offset, in meters.  x = upward, y = forward, z = lateral
- * @property {Vec3} [dirOffset=Vec3.UP] Only for Joint Parabola Picks.  A local joint direction offset.  x = upward, y = forward, z = lateral
- * @property {Vec3} [position] Only for Static Parabola Picks.  The world-space origin of the parabola segment.
- * @property {Vec3} [direction=-Vec3.FRONT] Only for Static Parabola Picks.  The world-space direction of the parabola segment.
- * @property {number} [speed=1] The initial speed of the parabola, i.e. the initial speed of the projectile whose trajectory defines the parabola.
- * @property {Vec3} [accelerationAxis=-Vec3.UP] The acceleration of the parabola, i.e. the acceleration of the projectile whose trajectory defines the parabola, both magnitude and direction.
- * @property {boolean} [rotateAccelerationWithAvatar=true] Whether or not the acceleration axis should rotate with the avatar's local Y axis.
- * @property {boolean} [rotateAccelerationWithParent=false] Whether or not the acceleration axis should rotate with the parent's local Y axis, if available.
- * @property {boolean} [scaleWithParent=true] If true, the velocity and acceleration of the Pick will scale linearly with the parent, if available. scaleWithAvatar is an alias but is deprecated.
+ * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should 
+ *     start disabled. Disabled picks do not update their pick results.
+ * @property {number} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property 
+ *     values (e.g., <code>Picks.PICK_DOMAIN_ENTTITIES</code>) combined with <code>|</code> (bitwise OR) operators.
+ * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code> 
+ *     means no maximum.
+ * @property {Uuid} [parentID] - The ID of the parent: either an avatar, an entity, or another pick.
+ * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint.
+ *     A value of <code>0</code> means no joint.<br />
+ *     <em>Used only if <code>parentID</code> is specified.</em>
+ * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to 
+ *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise the pick is "static", not 
+ *     parented to anything.
+ *     <em>Used only if <code>parentID</code> is not specified.</em>
+ * @property {Vec3} [position=Vec3.ZERO] - The offset of the parabola origin from its parent if parented, otherwise the 
+ *     parabola origin in world coordinates.
+ * @property {Vec3} [posOffset] - Synonym for <code>position</code>.
+ * @property {Vec3} [direction] - The offset of the parabola direction from its parent's y-axis if parented, otherwise the 
+ *     parabola direction in world coordinates.
+ *     <p><strong>Default Value:</strong> <code>Vec3.UP</code> direction if <code>joint</code> is specified, otherwise
+ *     <code>Vec3.FRONT</code>.</p>
+ * @property {Vec3} [dirOffset] - Synonym for <code>direction</code>.
+ * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the 
+ *     default <code>direction</code> value.
+ * @property {number} [speed=1] - The initial speed of the parabola in m/s, i.e., the initial speed of a virtual projectile 
+ *     whose trajectory defines the parabola.
+ * @property {Vec3} [accelerationAxis=-Vec3.UP] - The acceleration of the parabola in m/s<sup>2</sup>, i.e., the acceleration
+ *     of a virtual projectile whose trajectory defines the parabola, both magnitude and direction.
+ * @property {boolean} [rotateAccelerationWithAvatar=true] - <code>true</code> if the acceleration axis should rotate with the
+ *     avatar about the avatar's y-axis, <code>false</code> if it shouldn't.
+ * @property {boolean} [rotateAccelerationWithParent=false] - <code>true</code> if the acceleration axis should rotate with the
+ *     parent about the parent's y-axis, if available.
+ * @property {boolean} [scaleWithParent=true] - <code>true</code> if the velocity and acceleration of the pick should scale
+ *     with the avatar or other parent.
+ * @property {boolean} [scaleWithAvatar=true] - Synonym for <code>scalewithParent</code>.
+ *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
  */
 unsigned int PickScriptingInterface::createParabolaPick(const QVariant& properties) {
     QVariantMap propMap = properties.toMap();
@@ -251,35 +295,38 @@ unsigned int PickScriptingInterface::createParabolaPick(const QVariant& properti
     return DependencyManager::get<PickManager>()->addPick(PickQuery::Parabola, parabolaPick);
 }
 
-/**jsdoc
-* A Shape defines a physical volume.
-*
-* @typedef {object} Shape
-* @property {string} shapeType The type of shape to use. Can be one of the following: "box", "sphere", "capsule-x", "capsule-y", "capsule-z", "cylinder-x", "cylinder-y", "cylinder-z"
-* @property {Vec3} dimensions - The size to scale the shape to.
-*/
-
-// TODO: Add this property to the Shape jsdoc above once model picks work properly
-// * @property {string} modelURL - If shapeType is one of: "compound", "simple-hull", "simple-compound", or "static-mesh", this defines the model to load to generate the collision volume.
 
 /**jsdoc
-* A set of properties that can be passed to {@link Picks.createPick} to create a new Collision Pick.
-
-* @typedef {object} Picks.CollisionPickProperties
-* @property {boolean} [enabled=false] If this Pick should start enabled or not.  Disabled Picks do not updated their pick results.
-* @property {number} [filter=0] The filter for this Pick to use, constructed using filter flags combined using bitwise OR.
-* @property {Shape} shape - The information about the collision region's size and shape. Dimensions are in world space, but will scale with the parent if defined.
-* @property {Vec3} position - The position of the collision region, relative to a parent if defined.
-* @property {Quat} orientation - The orientation of the collision region, relative to a parent if defined.
-* @property {float} threshold - The approximate minimum penetration depth for a test object to be considered in contact with the collision region.
-* The depth is measured in world space, but will scale with the parent if defined.
-* @property {CollisionMask} [collisionGroup=8] - The type of object this collision pick collides as. Objects whose collision masks overlap with the pick's collision group
-* will be considered colliding with the pick.
-* @property {Uuid} parentID - The ID of the parent, either an avatar, an entity, or a pick.
-* @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, the joints on the model of an avatar. (default = 0, no joint)
-* @property {string} joint - If "Mouse," parents the pick to the mouse. If "Avatar," parents the pick to MyAvatar's head. Otherwise, parents to the joint of the given name on MyAvatar.
-* @property {boolean} [scaleWithParent=true] If true, the collision pick's dimensions and threshold will adjust according to the scale of the parent.
-*/
+ * A set of properties that can be passed to {@link Picks.createPick} when creating a new collision pick.
+ *
+ * @typedef {object} Picks.CollisionPickProperties
+ * @property {boolean} [enabled=false] - <code>true</code> if this pick should start enabled, <code>false</code> if it should
+ *     start disabled. Disabled picks do not update their pick results.
+ * @property {FilterFlags} [filter=0] - The filter for this pick to use. Construct using {@link Picks} FilterFlags property
+ *     values (e.g., <code>Picks.PICK_DOMAIN_ENTTITIES</code>) combined with <code>|</code> (bitwise OR) operators.
+ *     <p><strong>Note:</strong> Collision picks do not intersect the HUD.</p>
+ * @property {number} [maxDistance=0.0] - The maximum distance at which this pick will intersect. A value of <code>0.0</code>
+ *     means no maximum.
+ * @property {Uuid} [parentID] - The ID of the parent: either an avatar, an entity, or another pick.
+ * @property {number} [parentJointIndex=0] - The joint of the parent to parent to, for example, an avatar joint.
+ *     A value of <code>0</code> means no joint.<br />
+ *     <em>Used only if <code>parentID</code> is specified.</em>
+ * @property {string} [joint] - <code>"Mouse"</code> parents the pick to the mouse; <code>"Avatar"</code> parents the pick to
+ *     the user's avatar head; a joint name parents to the joint in the user's avatar; otherwise the pick is "static", not
+ *     parented to anything.<br />
+ *     <em>Used only if <code>parentID</code> is not specified.</em>
+ * @property {boolean} [scaleWithParent=true] - <code>true</code> to scale the pick's dimensions and threshold according to the 
+ *     scale of the parent.
+ *
+ * @property {Shape} shape - The collision region's shape and size. Dimensions are in world coordinates but scale with the 
+ *     parent if defined.
+ * @property {Vec3} position - The position of the collision region, relative to the parent if defined.
+ * @property {Quat} orientation - The orientation of the collision region, relative to the parent if defined.
+ * @property {number} threshold - The approximate minimum penetration depth for a test object to be considered in contact with
+ *     the collision region. The depth is in world coordinates but scales with the parent if defined.
+ * @property {CollisionMask} [collisionGroup=8] - The type of objects the collision region collides as. Objects whose collision
+ *     masks overlap with the regions's collision group are considered to be colliding with the region.
+ */
 unsigned int PickScriptingInterface::createCollisionPick(const QVariant& properties) {
     QVariantMap propMap = properties.toMap();
 

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -109,7 +109,7 @@ public:
      * Creates a new pick. Different {@link PickType}s use different properties, and within one PickType the properties you 
      * choose can lead to a wide range of behaviors. For example, with <code>PickType.Ray</code>, the properties could 
      * configure a mouse ray pick, an avatar head ray pick, or a joint ray pick.
-     * <p><strong>Warning:</strong> Picks created with this method currently always intersect at least visible and collidable 
+     * <p><strong>Warning:</strong> Picks created using this method currently always intersect at least visible and collidable 
      * things but this may not always be the case.</p>
      * @function Picks.createPick
      * @param {PickType} type - The type of picking to use.
@@ -121,7 +121,7 @@ public:
     Q_INVOKABLE unsigned int createPick(const PickQuery::PickType type, const QVariant& properties);
 
     /**jsdoc
-     * Enables a pick. enabled picks update their pick results.
+     * Enables a pick. Enabled picks update their pick results.
      * @function Picks.enablePick
      * @param {number} id - The ID of the pick.
      */

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -32,10 +32,11 @@
  * @property {FilterFlags} PICK_HUD - Include the HUD sphere when intersecting in HMD mode. <em>Read-only.</em>
  *
  * @property {FilterFlags} PICK_ENTITIES - Include domain and avatar entities when intersecting. <em>Read-only.</em>
- *     <p class="important"><strong>Deprecated:</strong> Use <code>PICK_DOMAIN_ENTITIES | PICK_AVATAR_ENTITIES</code> 
- *     instead.</p>
+ *     <p class="important">Deprecated: This property is deprecated and will be removed. Use <code>PICK_DOMAIN_ENTITIES | 
+ *     PICK_AVATAR_ENTITIES</code> instead.</p>
  * @property {FilterFlags} PICK_OVERLAYS - Include local entities when intersecting. <em>Read-only.</em>
- *     <p class="important"><strong>Deprecated:</strong> Use <code>PICK_LOCAL_ENTITIES</code> instead.</p>
+ *     <p class="important">Deprecated: This property is deprecated and will be removed. Use <code>PICK_LOCAL_ENTITIES</code> 
+ *     instead.</p>
  *
  * @property {FilterFlags} PICK_INCLUDE_VISIBLE - Include visible objects when intersecting. <em>Read-only.</em>
  *     <p><strong>Warning:</strong> Is currently always enabled by default but may not be in the future.</p>
@@ -57,7 +58,8 @@
  * @property {IntersectionType} INTERSECTED_LOCAL_ENTITY - Intersected a local entity. <em>Read-only.</em>
  * @property {IntersectionType} INTERSECTED_OVERLAY - Intersected a local entity. (3D overlays no longer exist.) 
  *     <em>Read-only.</em>
- *     <p class="important"><strong>Deprecated:</strong> Use <code>INTERSECTED_LOCAL_ENTITY</code> instead.</p>
+ *     <p class="important">Deprecated: This property is deprecated and will be removed. Use 
+ *     <code>INTERSECTED_LOCAL_ENTITY</code> instead.</p>
  * @property {IntersectionType} INTERSECTED_AVATAR - Intersected an avatar. <em>Read-only.</em>
  * @property {IntersectionType} INTERSECTED_HUD - Intersected the HUD sphere. <em>Read-only.</em>
  *
@@ -253,14 +255,16 @@ public slots:
 
     /**jsdoc
      * @function Picks.PICK_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_DOMAIN_ENTITIES | 
+     *     Picks.PICK_AVATAR_ENTITIES</cpode> properties expression instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_ENTITIES() { return PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES); }
 
     /**jsdoc
      * @function Picks.PICK_OVERLAYS
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_LOCAL_ENTITIES</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_OVERLAYS() { return PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES); }
@@ -268,35 +272,39 @@ public slots:
 
     /**jsdoc
      * @function Picks.PICK_DOMAIN_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_DOMAIN_ENTITIES</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_DOMAIN_ENTITIES() { return PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES); }
 
     /**jsdoc
      * @function Picks.PICK_AVATAR_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_AVATAR_ENTITIES</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_AVATAR_ENTITIES() { return PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES); }
 
     /**jsdoc
      * @function Picks.PICK_LOCAL_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_LOCAL_ENTITIES</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_LOCAL_ENTITIES() { return PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES); }
 
     /**jsdoc
      * @function Picks.PICK_AVATARS
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_AVATARS</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_AVATARS() { return PickFilter::getBitMask(PickFilter::FlagBit::AVATARS); }
 
     /**jsdoc
      * @function Picks.PICK_HUD
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_HUD</code> property instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_HUD() { return PickFilter::getBitMask(PickFilter::FlagBit::HUD); }
@@ -304,14 +312,16 @@ public slots:
 
     /**jsdoc
      * @function Picks.PICK_INCLUDE_VISIBLE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_VISIBLE</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_INCLUDE_VISIBLE() { return PickFilter::getBitMask(PickFilter::FlagBit::VISIBLE); }
 
     /**jsdoc
      * @function Picks.PICK_INCLUDE_INVISIBLE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_INVISIBLE</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_INCLUDE_INVISIBLE() { return PickFilter::getBitMask(PickFilter::FlagBit::INVISIBLE); }
@@ -319,14 +329,16 @@ public slots:
 
     /**jsdoc
      * @function Picks.PICK_INCLUDE_COLLIDABLE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_COLLIDABLE</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_INCLUDE_COLLIDABLE() { return PickFilter::getBitMask(PickFilter::FlagBit::COLLIDABLE); }
 
     /**jsdoc
      * @function Picks.PICK_INCLUDE_NONCOLLIDABLE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_INCLUDE_NONCOLLIDABLE</code> 
+     *     property instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_INCLUDE_NONCOLLIDABLE() { return PickFilter::getBitMask(PickFilter::FlagBit::NONCOLLIDABLE); }
@@ -334,14 +346,14 @@ public slots:
 
     /**jsdoc
      * @function Picks.PICK_PRECISE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_PRECISE</code> property instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_PRECISE() { return PickFilter::getBitMask(PickFilter::FlagBit::PRECISE); }
 
     /**jsdoc
      * @function Picks.PICK_COARSE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_COARSE</code> property instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_COARSE() { return PickFilter::getBitMask(PickFilter::FlagBit::COARSE); }
@@ -349,49 +361,56 @@ public slots:
 
     /**jsdoc
      * @function Picks.PICK_ALL_INTERSECTIONS
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.PICK_ALL_INTERSECTIONS</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_ALL_INTERSECTIONS() { return PickFilter::getBitMask(PickFilter::FlagBit::PICK_ALL_INTERSECTIONS); }
 
     /**jsdoc
      * @function Picks.INTERSECTED_NONE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_NONE</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_NONE() { return IntersectionType::NONE; }
 
     /**jsdoc
      * @function Picks.INTERSECTED_ENTITY
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_ENTITY</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_ENTITY() { return IntersectionType::ENTITY; }
 
     /**jsdoc
      * @function Picks.INTERSECTED_LOCAL_ENTITY
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_LOCAL_ENTITY</code> 
+     *     property instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_LOCAL_ENTITY() { return IntersectionType::LOCAL_ENTITY; }
 
     /**jsdoc
      * @function Picks.INTERSECTED_OVERLAY
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_LOCAL_ENTITY</code> 
+     *     property instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_OVERLAY() { return INTERSECTED_LOCAL_ENTITY(); }
 
     /**jsdoc
      * @function Picks.INTERSECTED_AVATAR
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_AVATAR</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_AVATAR() { return IntersectionType::AVATAR; }
 
     /**jsdoc
      * @function Picks.INTERSECTED_HUD
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Picks.INTERSECTED_HUD</code> property 
+     *     instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_HUD() { return IntersectionType::HUD; }

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -17,7 +17,7 @@
 #include <PickFilter.h>
 
 /**jsdoc
- * The Picks API lets you create and manage objects for repeatedly calculating intersections in different ways.
+ * The <code>Picks</code> API lets you create and manage objects for repeatedly calculating intersections.
  *
  * @namespace Picks
  *
@@ -25,33 +25,43 @@
  * @hifi-client-entity
  * @hifi-avatar
  *
- * @property {number} PICK_ENTITIES A filter flag. Include domain and avatar entities when intersecting. <em>Read-only.</em>.  Deprecated.
- * @property {number} PICK_OVERLAYS A filter flag. Include local entities when intersecting. <em>Read-only.</em>. Deprecated.
+ * @property {FilterFlags} PICK_DOMAIN_ENTITIES - Include domain entities when intersecting. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_AVATAR_ENTITIES - Include avatar entities when intersecting. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_LOCAL_ENTITIES - Include local entities when intersecting. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_AVATARS - Include avatars when intersecting. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_HUD - Include the HUD sphere when intersecting in HMD mode. <em>Read-only.</em>
  *
- * @property {number} PICK_DOMAIN_ENTITIES A filter flag. Include domain entities when intersecting. <em>Read-only.</em>.
- * @property {number} PICK_AVATAR_ENTITIES A filter flag. Include avatar entities when intersecting. <em>Read-only.</em>.
- * @property {number} PICK_LOCAL_ENTITIES A filter flag. Include local entities when intersecting. <em>Read-only.</em>.
- * @property {number} PICK_AVATARS A filter flag. Include avatars when intersecting. <em>Read-only.</em>.
- * @property {number} PICK_HUD A filter flag. Include the HUD sphere when intersecting in HMD mode. <em>Read-only.</em>.
+ * @property {FilterFlags} PICK_ENTITIES - Include domain and avatar entities when intersecting. <em>Read-only.</em>
+ *     <p class="important"><strong>Deprecated:</strong> Use <code>PICK_DOMAIN_ENTITIES | PICK_AVATAR_ENTITIES</code> 
+ *     instead.</p>
+ * @property {FilterFlags} PICK_OVERLAYS - Include local entities when intersecting. <em>Read-only.</em>
+ *     <p class="important"><strong>Deprecated:</strong> Use <code>PICK_LOCAL_ENTITIES</code> instead.</p>
  *
- * @property {number} PICK_INCLUDE_VISIBLE A filter flag. Include visible objects when intersecting. <em>Read-only.</em>.
- * @property {number} PICK_INCLUDE_INVISIBLE A filter flag. Include invisible objects when intersecting. <em>Read-only.</em>.
+ * @property {FilterFlags} PICK_INCLUDE_VISIBLE - Include visible objects when intersecting. <em>Read-only.</em>
+ *     <p><strong>Warning:</strong> Is currently always enabled by default but may not be in the future.</p>
+ * @property {FilterFlags} PICK_INCLUDE_INVISIBLE - Include invisible objects when intersecting. <em>Read-only.</em>
  *
- * @property {number} PICK_INCLUDE_COLLIDABLE A filter flag. Include collidable objects when intersecting. <em>Read-only.</em>.
- * @property {number} PICK_INCLUDE_NONCOLLIDABLE A filter flag. Include non-collidable objects when intersecting. <em>Read-only.</em>.
+ * @property {FilterFlags} PICK_INCLUDE_COLLIDABLE - Include collidable objects when intersecting. <em>Read-only.</em>
+ *     <p><strong>Warning:</strong> Is currently always enabled by default but may not be in the future.</p>
+ * @property {FilterFlags} PICK_INCLUDE_NONCOLLIDABLE - Include non-collidable objects when intersecting. <em>Read-only.</em>
  *
- * @property {number} PICK_PRECISE A filter flag. Pick against exact meshes. <em>Read-only.</em>.
- * @property {number} PICK_COARSE A filter flag. Pick against coarse meshes. <em>Read-only.</em>.
+ * @property {FilterFlags} PICK_PRECISE - Pick against exact meshes. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_COARSE - Pick against coarse meshes. <em>Read-only.</em>
  *
- * @property {number} PICK_ALL_INTERSECTIONS <em>Read-only.</em>.
+ * @property {FilterFlags} PICK_ALL_INTERSECTIONS - If set, returns all intersections instead of just the closest. 
+ *     <em>Read-only.</em>
+ *     <p><strong>Warning:</strong> Not yet implemented.</p>
  *
- * @property {number} INTERSECTED_NONE An intersection type. Intersected nothing with the given filter flags. <em>Read-only.</em>
- * @property {number} INTERSECTED_ENTITY An intersection type. Intersected an entity. <em>Read-only.</em>
- * @property {number} INTERSECTED_LOCAL_ENTITY An intersection type. Intersected a local entity.</em>
- * @property {number} INTERSECTED_OVERLAY An intersection type. Intersected an entity (3D Overlays no longer exist). <em>Read-only.</em>
- * @property {number} INTERSECTED_AVATAR An intersection type. Intersected an avatar. <em>Read-only.</em>
- * @property {number} INTERSECTED_HUD An intersection type. Intersected the HUD sphere. <em>Read-only.</em>
- * @property {number} perFrameTimeBudget - The max number of usec to spend per frame updating Pick results.
+ * @property {IntersectionType} INTERSECTED_NONE - Intersected nothing. <em>Read-only.</em>
+ * @property {IntersectionType} INTERSECTED_ENTITY - Intersected an entity. <em>Read-only.</em>
+ * @property {IntersectionType} INTERSECTED_LOCAL_ENTITY - Intersected a local entity. <em>Read-only.</em>
+ * @property {IntersectionType} INTERSECTED_OVERLAY - Intersected a local entity. (3D overlays no longer exist.) 
+ *     <em>Read-only.</em>
+ *     <p class="important"><strong>Deprecated:</strong> Use <code>INTERSECTED_LOCAL_ENTITY</code> instead.</p>
+ * @property {IntersectionType} INTERSECTED_AVATAR - Intersected an avatar. <em>Read-only.</em>
+ * @property {IntersectionType} INTERSECTED_HUD - Intersected the HUD sphere. <em>Read-only.</em>
+ *
+ * @property {number} perFrameTimeBudget - The maximum time, in microseconds, to spend per frame updating pick results.
  */
 
 class PickScriptingInterface : public QObject, public Dependency {
@@ -94,163 +104,145 @@ public:
     void registerMetaTypes(QScriptEngine* engine);
 
     /**jsdoc
-     * Adds a new Pick.
-     * Different {@link PickType}s use different properties, and within one PickType, the properties you choose can lead to a wide range of behaviors.  For example,
-     *   with PickType.Ray, depending on which optional parameters you pass, you could create a Static Ray Pick, a Mouse Ray Pick, or a Joint Ray Pick.
-     * Picks created with this method always intersect at least visible and collidable things
+     * Creates a new pick. Different {@link PickType}s use different properties, and within one PickType the properties you 
+     * choose can lead to a wide range of behaviors. For example, with <code>PickType.Ray</code>, the properties could 
+     * configure a mouse ray pick, an avatar head ray pick, or a joint ray pick.
+     * <p><strong>Warning:</strong> Picks created with this method currently always intersect at least visible and collidable 
+     * things but this may not always be the case.</p>
      * @function Picks.createPick
-     * @param {PickType} type A PickType that specifies the method of picking to use
-     * @param {Picks.RayPickProperties|Picks.StylusPickProperties|Picks.ParabolaPickProperties|Picks.CollisionPickProperties} properties A PickProperties object, containing all the properties for initializing this Pick
-     * @returns {number} The ID of the created Pick.  Used for managing the Pick.  0 if invalid.
+     * @param {PickType} type - The type of picking to use.
+     * @param {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties} 
+     *     properties - Properties of the pick, per the pick <code>type</code>.
+     * @returns {number} The ID of the pick created. <code>0</code> if invalid.
      */
     // TODO: expand Pointers to be able to be fully configurable with PickFilters
     Q_INVOKABLE unsigned int createPick(const PickQuery::PickType type, const QVariant& properties);
 
     /**jsdoc
-     * Enables a Pick.
+     * Enables a pick. enabled picks update their pick results.
      * @function Picks.enablePick
-     * @param {number} uid The ID of the Pick, as returned by {@link Picks.createPick}.
+     * @param {number} id - The ID of the pick.
      */
     Q_INVOKABLE void enablePick(unsigned int uid);
 
     /**jsdoc
-     * Disables a Pick.
+     * Disables a pick. Disabled picks do not update their pick results.
      * @function Picks.disablePick
-     * @param {number} uid The ID of the Pick, as returned by {@link Picks.createPick}.
+     * @param {number} id - The ID of the pick.
      */
     Q_INVOKABLE void disablePick(unsigned int uid);
 
     /**jsdoc
-     * Removes a Pick.
+     * Removes (deletes) a pick.
      * @function Picks.removePick
-     * @param {number} uid The ID of the Pick, as returned by {@link Picks.createPick}.
+     * @param {number} id - The ID of the pick.
      */
     Q_INVOKABLE void removePick(unsigned int uid);
 
     /**jsdoc
-     * An intersection result for a Ray Pick.
-     *
-     * @typedef {object} RayPickResult
-     * @property {number} type The intersection type.
-     * @property {boolean} intersects If there was a valid intersection (type != INTERSECTED_NONE)
-     * @property {Uuid} objectID The ID of the intersected object.  Uuid.NULL for the HUD or invalid intersections.
-     * @property {number} distance The distance to the intersection point from the origin of the ray.
-     * @property {Vec3} intersection The intersection point in world-space.
-     * @property {Vec3} surfaceNormal The surface normal at the intersected point.  All NANs if type == INTERSECTED_HUD.
-     * @property {Variant} extraInfo Additional intersection details when available for Model objects.
-     * @property {PickRay} searchRay The PickRay that was used.  Valid even if there was no intersection.
-     */
-
-    /**jsdoc
-     * An intersection result for a Stylus Pick.
-     *
-     * @typedef {object} StylusPickResult
-     * @property {number} type The intersection type.
-     * @property {boolean} intersects If there was a valid intersection (type != INTERSECTED_NONE)
-     * @property {Uuid} objectID The ID of the intersected object.  Uuid.NULL for the HUD or invalid intersections.
-     * @property {number} distance The distance to the intersection point from the origin of the ray.
-     * @property {Vec3} intersection The intersection point in world-space.
-     * @property {Vec3} surfaceNormal The surface normal at the intersected point.  All NANs if type == INTERSECTED_HUD.
-     * @property {Variant} extraInfo Additional intersection details when available for Model objects.
-     * @property {StylusTip} stylusTip The StylusTip that was used.  Valid even if there was no intersection.
-     */
-
-     /**jsdoc
-     * An intersection result for a Parabola Pick.
-     *
-     * @typedef {object} ParabolaPickResult
-     * @property {number} type The intersection type.
-     * @property {boolean} intersects If there was a valid intersection (type != INTERSECTED_NONE)
-     * @property {Uuid} objectID The ID of the intersected object.  Uuid.NULL for the HUD or invalid intersections.
-     * @property {number} distance The distance to the intersection point from the origin of the parabola, not along the parabola.
-     * @property {number} parabolicDistance The distance to the intersection point from the origin of the parabola, along the parabola.
-     * @property {Vec3} intersection The intersection point in world-space.
-     * @property {Vec3} surfaceNormal The surface normal at the intersected point.  All NANs if type == INTERSECTED_HUD.
-     * @property {Variant} extraInfo Additional intersection details when available for Model objects.
-     * @property {PickParabola} parabola The PickParabola that was used.  Valid even if there was no intersection.
-     */
-
-     /**jsdoc
-     * An intersection result for a Collision Pick.
-     *
-     * @typedef {object} CollisionPickResult
-     * @property {boolean} intersects If there was at least one valid intersection (intersectingObjects.length > 0)
-     * @property {IntersectingObject[]} intersectingObjects The collision information of each object which intersect with the CollisionRegion.
-     * @property {CollisionRegion} collisionRegion The CollisionRegion that was used. Valid even if there was no intersection.
-     */
-
-    /**jsdoc
-    * Information about the Collision Pick's intersection with an object
-    *
-    * @typedef {object} IntersectingObject
-    * @property {QUuid} id The ID of the object.
-    * @property {number} type The type of the object, either Picks.INTERSECTED_ENTITY() or Picks.INTERSECTED_AVATAR()
-    * @property {CollisionContact[]} collisionContacts Pairs of points representing penetration information between the pick and the object
-    */
-
-     /**jsdoc
-     * A pair of points that represents part of an overlap between a Collision Pick and an object in the physics engine. Points which are further apart represent deeper overlap
-     *
-     * @typedef {object} CollisionContact
-     * @property {Vec3} pointOnPick A point representing a penetration of the object's surface into the volume of the pick, in world space.
-     * @property {Vec3} pointOnObject A point representing a penetration of the pick's surface into the volume of the found object, in world space.
-     * @property {Vec3} normalOnPick The normalized vector pointing away from the pick, representing the direction of collision.
-     */
-
-    /**jsdoc
-     * Get the most recent pick result from this Pick.  This will be updated as long as the Pick is enabled.
+     * Gets the most recent result from a pick. A pick continues to be updated ready to return a result, as long as it is 
+     * enabled.
+     * <p><strong>Note:</strong> Stylus picks only intersect with objects in their include list, set using 
+     * {@link Picks.setIncludeItems|setIncludeItems}.</p>
      * @function Picks.getPrevPickResult
-     * @param {number} uid The ID of the Pick, as returned by {@link Picks.createPick}.
-     * @returns {RayPickResult|StylusPickResult|ParabolaPickResult|CollisionPickResult} The most recent intersection result.  This will be different for different PickTypes.
+     * @param {number} id - The ID of the pick.
+     * @returns {RayPickResult|ParabolaPickResult|StylusPickResult|CollisionPickResult} The most recent intersection result.
+     * @example <caption>Highlight entities under your mouse in desktop mode or that you're looking at in HMD mode.</caption>
+     * // Highlight.
+     * var HIGHLIGHT_LIST_NAME = "highlightEntitiesExampleList";
+     * var HIGHLIGHT_LIST_TYPE = "entity";
+     * Selection.enableListHighlight(HIGHLIGHT_LIST_NAME, {});
+     * 
+     * // Ray pick.
+     * var PICK_FILTER = Picks.PICK_DOMAIN_ENTITIES | Picks.PICK_AVATAR_ENTITIES
+     *         | Picks.PICK_INCLUDE_COLLIDABLE | Picks.PICK_INCLUDE_NONCOLLIDABLE;
+     * var rayPick = Picks.createPick(PickType.Ray, {
+     *     enabled: true,
+     *     filter: PICK_FILTER,
+     *     joint: HMD.active ? "Avatar" : "Mouse"
+     * });
+     * 
+     * // Highlight intersected entity.
+     * var highlightedEntityID = null;
+     * Script.update.connect(function () {
+     *     var rayPickResult = Picks.getPrevPickResult(rayPick);
+     *     if (rayPickResult.intersects) {
+     *         if (rayPickResult.objectID !== highlightedEntityID) {
+     *             if (highlightedEntityID) {
+     *                 Selection.removeFromSelectedItemsList(HIGHLIGHT_LIST_NAME, HIGHLIGHT_LIST_TYPE, highlightedEntityID);
+     *             }
+     *             highlightedEntityID = rayPickResult.objectID;
+     *             Selection.addToSelectedItemsList(HIGHLIGHT_LIST_NAME, HIGHLIGHT_LIST_TYPE, highlightedEntityID);
+     *         }
+     *     } else {
+     *         if (highlightedEntityID) {
+     *             Selection.removeFromSelectedItemsList(HIGHLIGHT_LIST_NAME, HIGHLIGHT_LIST_TYPE, highlightedEntityID);
+     *             highlightedEntityID = null;
+     *         }
+     *     }
+     * });
+     * 
+     * // Clean up.
+     * Script.scriptEnding.connect(function () {
+     *     if (highlightedEntityID) {
+     *         Selection.removeFromSelectedItemsList(HIGHLIGHT_LIST_NAME, HIGHLIGHT_LIST_TYPE, highlightedEntityID);
+     *     }
+     * });
      */
     Q_INVOKABLE QVariantMap getPrevPickResult(unsigned int uid);
 
     /**jsdoc
-     * Sets whether or not to use precision picking.
+     * Sets whether or not to use precision picking, i.e., whether to pick against precise meshes or coarse meshes.
+     * This has the same effect as using the <code>PICK_PRECISE</code> or <code>PICK_COARSE</code> filter flags.
      * @function Picks.setPrecisionPicking
-     * @param {number} uid The ID of the Pick, as returned by {@link Picks.createPick}.
-     * @param {boolean} precisionPicking Whether or not to use precision picking
+     * @param {number} id - The ID of the pick.
+     * @param {boolean} precisionPicking - <code>true</code> to use precision picking, <code>false</code> to use coarse picking.
      */
     Q_INVOKABLE void setPrecisionPicking(unsigned int uid, bool precisionPicking);
 
     /**jsdoc
-     * Sets a list of Entity IDs and/or Avatar IDs to ignore during intersection.  Not used by Stylus Picks.
+     * Sets a list of entity and avatar IDs to ignore during intersection.
+     * <p><strong>Note:</strong> Not used by stylus picks.</p>
      * @function Picks.setIgnoreItems
-     * @param {number} uid The ID of the Pick, as returned by {@link Picks.createPick}.
-     * @param {Uuid[]} ignoreItems A list of IDs to ignore.
+     * @param {number} id - The ID of the pick.
+     * @param {Uuid[]} ignoreItems - The list of IDs to ignore.
      */
     Q_INVOKABLE void setIgnoreItems(unsigned int uid, const QScriptValue& ignoreItems);
 
     /**jsdoc
-     * Sets a list of Entity IDs and/or Avatar IDs to include during intersection, instead of intersecting with everything.  Stylus
-     *   Picks <b>only</b> intersect with objects in their include list.
+     * Sets a list of entity IDs and/or avatar IDs to include during intersection, instead of intersecting with everything.
+     * <p><strong>Note:</strong> Stylus picks only intersect with objects in their include list.</p>
      * @function Picks.setIncludeItems
-     * @param {number} uid The ID of the Pick, as returned by {@link Picks.createPick}.
-     * @param {Uuid[]} includeItems A list of IDs to include.
+     * @param {number} id - The ID of the pick.
+     * @param {Uuid[]} includeItems - The list of IDs to include.
      */
     Q_INVOKABLE void setIncludeItems(unsigned int uid, const QScriptValue& includeItems);
 
     /**jsdoc
-     * Check if a Pick is associated with the left hand.
+     * Checks if a pick is associated with the left hand: a ray or parabola pick with joint set to 
+     * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with hand 
+     * set to <code>0</code>.
      * @function Picks.isLeftHand
-     * @param {number} uid The ID of the Pick, as returned by {@link Picks.createPick}.
-     * @returns {boolean} True if the Pick is a Joint Ray or Parabola Pick with joint == "_CONTROLLER_LEFTHAND" or "_CAMERA_RELATIVE_CONTROLLER_LEFTHAND", or a Stylus Pick with hand == 0.
+     * @param {number} id - The ID of the pick.
+     * @returns {boolean} <code>true</code> if the pick is associated with the left hand, <code>false</code> if it isn't.
      */
     Q_INVOKABLE bool isLeftHand(unsigned int uid);
 
     /**jsdoc
-     * Check if a Pick is associated with the right hand.
+     * Checks if a pick is associated with the right hand: a ray or parabola pick with joint set to
+     * <code>"_CONTROLLER_RIGHTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND"</code>, or a stylus pick with hand
+     * set to <code>1</code>.
      * @function Picks.isRightHand
-     * @param {number} uid The ID of the Pick, as returned by {@link Picks.createPick}.
-     * @returns {boolean} True if the Pick is a Joint Ray or Parabola Pick with joint == "_CONTROLLER_RIGHTHAND" or "_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND", or a Stylus Pick with hand == 1.
+     * @param {number} id - The ID of the pick.
+     * @returns {boolean} <code>true</code> if the pick is associated with the right hand, <code>false</code> if it isn't.
      */
     Q_INVOKABLE bool isRightHand(unsigned int uid);
 
     /**jsdoc
-     * Check if a Pick is associated with the system mouse.
+     * Checks if a pick is associated with the system mouse: a ray or parabola pick with joint set to <code>"Mouse"</code>.
      * @function Picks.isMouse
-     * @param {number} uid The ID of the Pick, as returned by {@link Picks.createPick}.
-     * @returns {boolean} True if the Pick is a Mouse Ray or Parabola Pick, false otherwise.
+     * @param {number} id - The ID of the pick.
+     * @returns {boolean} <code>true</code> if the pick is associated with the system mouse, <code>false</code> if it isn't.
      */
     Q_INVOKABLE bool isMouse(unsigned int uid);
 
@@ -261,112 +253,145 @@ public slots:
 
     /**jsdoc
      * @function Picks.PICK_ENTITIES
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_ENTITIES() { return PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES) | PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES); }
+
     /**jsdoc
      * @function Picks.PICK_OVERLAYS
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_OVERLAYS() { return PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES); }
 
+
     /**jsdoc
      * @function Picks.PICK_DOMAIN_ENTITIES
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_DOMAIN_ENTITIES() { return PickFilter::getBitMask(PickFilter::FlagBit::DOMAIN_ENTITIES); }
+
     /**jsdoc
      * @function Picks.PICK_AVATAR_ENTITIES
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_AVATAR_ENTITIES() { return PickFilter::getBitMask(PickFilter::FlagBit::AVATAR_ENTITIES); }
+
     /**jsdoc
      * @function Picks.PICK_LOCAL_ENTITIES
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_LOCAL_ENTITIES() { return PickFilter::getBitMask(PickFilter::FlagBit::LOCAL_ENTITIES); }
+
     /**jsdoc
      * @function Picks.PICK_AVATARS
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_AVATARS() { return PickFilter::getBitMask(PickFilter::FlagBit::AVATARS); }
+
     /**jsdoc
      * @function Picks.PICK_HUD
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_HUD() { return PickFilter::getBitMask(PickFilter::FlagBit::HUD); }
 
+
     /**jsdoc
      * @function Picks.PICK_INCLUDE_VISIBLE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_INCLUDE_VISIBLE() { return PickFilter::getBitMask(PickFilter::FlagBit::VISIBLE); }
+
     /**jsdoc
      * @function Picks.PICK_INCLUDE_INVISIBLE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_INCLUDE_INVISIBLE() { return PickFilter::getBitMask(PickFilter::FlagBit::INVISIBLE); }
 
+
     /**jsdoc
      * @function Picks.PICK_INCLUDE_COLLIDABLE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_INCLUDE_COLLIDABLE() { return PickFilter::getBitMask(PickFilter::FlagBit::COLLIDABLE); }
+
     /**jsdoc
      * @function Picks.PICK_INCLUDE_NONCOLLIDABLE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_INCLUDE_NONCOLLIDABLE() { return PickFilter::getBitMask(PickFilter::FlagBit::NONCOLLIDABLE); }
 
+
     /**jsdoc
      * @function Picks.PICK_PRECISE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_PRECISE() { return PickFilter::getBitMask(PickFilter::FlagBit::PRECISE); }
+
     /**jsdoc
      * @function Picks.PICK_COARSE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_COARSE() { return PickFilter::getBitMask(PickFilter::FlagBit::COARSE); }
 
+
     /**jsdoc
      * @function Picks.PICK_ALL_INTERSECTIONS
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int PICK_ALL_INTERSECTIONS() { return PickFilter::getBitMask(PickFilter::FlagBit::PICK_ALL_INTERSECTIONS); }
 
     /**jsdoc
      * @function Picks.INTERSECTED_NONE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_NONE() { return IntersectionType::NONE; }
 
     /**jsdoc
      * @function Picks.INTERSECTED_ENTITY
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_ENTITY() { return IntersectionType::ENTITY; }
 
     /**jsdoc
-     * @function Picks.INTERSECTED_OVERLAY
+     * @function Picks.INTERSECTED_LOCAL_ENTITY
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_LOCAL_ENTITY() { return IntersectionType::LOCAL_ENTITY; }
 
     /**jsdoc
      * @function Picks.INTERSECTED_OVERLAY
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_OVERLAY() { return INTERSECTED_LOCAL_ENTITY(); }
 
     /**jsdoc
      * @function Picks.INTERSECTED_AVATAR
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_AVATAR() { return IntersectionType::AVATAR; }
 
     /**jsdoc
      * @function Picks.INTERSECTED_HUD
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static constexpr unsigned int INTERSECTED_HUD() { return IntersectionType::HUD; }

--- a/interface/src/raypick/PointerScriptingInterface.h
+++ b/interface/src/raypick/PointerScriptingInterface.h
@@ -49,7 +49,7 @@ public:
      *   with PickType.Ray, depending on which optional parameters you pass, you could create a Static Ray Pointer, a Mouse Ray Pointer, or a Joint Ray Pointer.
      * Pointers created with this method always intersect at least visible and collidable things
      * @function Pointers.createPointer
-     * @param {PickType} type A PickType that specifies the method of picking to use
+     * @param {PickType} type A PickType that specifies the method of picking to use. Cannot be {@link PickType|PickType.Collision}.
      * @param {Pointers.LaserPointerProperties|Pointers.StylusPointerProperties|Pointers.ParabolaPointerProperties} properties A PointerProperties object, containing all the properties for initializing this Pointer <b>and</b> the {@link Picks.PickProperties} for the Pick that
      *   this Pointer will use to do its picking.
      * @returns {number} The ID of the created Pointer.  Used for managing the Pointer.  0 if invalid.

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -39,6 +39,21 @@ public:
     float distance { FLT_MAX };
     bool intersects { false };
 
+    /**jsdoc
+     * An intersection result for a ray pick.
+     *
+     * @typedef {object} RayPickResult
+     * @property {IntersectionType} type - The intersection type.
+     * @property {boolean} intersects - <code>true</code> if there's a valid intersection, <code>false</code> if there isn't.
+     * @property {Uuid} objectID - The ID of the intersected object. <code>null</code> for HUD or invalid intersections.
+     * @property {number} distance - The distance from the ray origin to the intersection point.
+     * @property {Vec3} intersection - The intersection point in world coordinates.
+     * @property {Vec3} surfaceNormal - The surface normal at the intersected point. All <code>NaN</code>s if <code>type == 
+     *     Picks.INTERSECTED_HUD</code>.
+     * @property {SubmeshIntersection} extraInfo - Additional intersection details for model objects, otherwise
+     *     <code>{ }</code>.
+     * @property {PickRay} searchRay - The pick ray that was used. Valid even if there is no intersection.
+     */
     virtual QVariantMap toVariantMap() const override {
         QVariantMap toReturn;
         toReturn["type"] = type;

--- a/interface/src/raypick/RayPickScriptingInterface.h
+++ b/interface/src/raypick/RayPickScriptingInterface.h
@@ -163,98 +163,107 @@ public slots:
 
     /**jsdoc
      * @function RayPick.PICK_ENTITIES
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>Raypick.PICK_ENTITIES</code> property instead.
      * @returns {number}
      */
     static unsigned int PICK_ENTITIES() { return PickScriptingInterface::PICK_ENTITIES(); }
 
     /**jsdoc
      * @function RayPick.PICK_OVERLAYS
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_OVERLAYS</code> property instead.
      * @returns {number}
      */
     static unsigned int PICK_OVERLAYS() { return PickScriptingInterface::PICK_OVERLAYS(); }
 
     /**jsdoc
      * @function RayPick.PICK_AVATARS
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_AVATARS</code> property instead.
      * @returns {number}
      */
     static unsigned int PICK_AVATARS() { return PickScriptingInterface::PICK_AVATARS(); }
 
     /**jsdoc
      * @function RayPick.PICK_HUD
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_HUD</code> property instead.
      * @returns {number}
      */
     static unsigned int PICK_HUD() { return PickScriptingInterface::PICK_HUD(); }
 
     /**jsdoc
      * @function RayPick.PICK_COARSE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_COARSE</code> property instead.
      * @returns {number}
      */
     static unsigned int PICK_COARSE() { return PickScriptingInterface::PICK_COARSE(); }
 
     /**jsdoc
      * @function RayPick.PICK_INCLUDE_INVISIBLE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_INCLUDE_INVISIBLE</code> 
+     *     property instead.
      * @returns {number}
      */
     static unsigned int PICK_INCLUDE_INVISIBLE() { return PickScriptingInterface::PICK_INCLUDE_INVISIBLE(); }
 
     /**jsdoc
      * @function RayPick.PICK_INCLUDE_NONCOLLIDABLE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_INCLUDE_NONCOLLIDABLE</code> 
+     *     property instead.
      * @returns {number}
      */
     static unsigned int PICK_INCLUDE_NONCOLLIDABLE() { return PickScriptingInterface::PICK_INCLUDE_NONCOLLIDABLE(); }
 
     /**jsdoc
      * @function RayPick.PICK_ALL_INTERSECTIONS
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.PICK_ALL_INTERSECTIONS</code> 
+     *     property instead.
      * @returns {number}
      */
     static unsigned int PICK_ALL_INTERSECTIONS() { return PickScriptingInterface::PICK_ALL_INTERSECTIONS(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_NONE
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_NONE</code> property 
+     *     instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_NONE() { return PickScriptingInterface::INTERSECTED_NONE(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_ENTITY
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_ENTITY</code> property 
+     *     instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_ENTITY() { return PickScriptingInterface::INTERSECTED_ENTITY(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_OVERLAY
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_LOCAL_ENTITY</code> 
+     *     property instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_LOCAL_ENTITY() { return PickScriptingInterface::INTERSECTED_LOCAL_ENTITY(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_OVERLAY
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_OVERLAY</code> property 
+     *     instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_OVERLAY() { return PickScriptingInterface::INTERSECTED_LOCAL_ENTITY(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_AVATAR
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_AVATAR</code> property 
+     *     instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_AVATAR() { return PickScriptingInterface::INTERSECTED_AVATAR(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_HUD
-     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
+     * @deprecated This function is deprecated and will be removed. Use the <code>RayPick.INTERSECTED_HUD</code> property 
+     *     instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_HUD() { return PickScriptingInterface::INTERSECTED_HUD(); }

--- a/interface/src/raypick/RayPickScriptingInterface.h
+++ b/interface/src/raypick/RayPickScriptingInterface.h
@@ -67,7 +67,7 @@ public:
 
     /**jsdoc
      * Creates a new ray pick.
-     * <p><strong>Warning:</strong> Picks created with this method currently always intersect at least visible and collidable
+     * <p><strong>Warning:</strong> Picks created using this method currently always intersect at least visible and collidable
      * things but this may not always be the case.</p>
      * @function RayPick.createRayPick
      * @param {Picks.RayPickProperties} properties - Properties of the pick.

--- a/interface/src/raypick/RayPickScriptingInterface.h
+++ b/interface/src/raypick/RayPickScriptingInterface.h
@@ -19,29 +19,32 @@
 #include "PickScriptingInterface.h"
 
 /**jsdoc
- * Synonym for {@link Picks} as used for ray picks.  Deprecated.
+ * The <code>RayPick</code> API is a subset of the {@link Picks} API, as used for ray picks.
  *
  * @namespace RayPick
+ *
+ * @deprecated This API is deprecated and will be removed. Use the {@link Picks} API instead.
  *
  * @hifi-interface
  * @hifi-client-entity
  * @hifi-avatar
  *
- * @property {number} PICK_ENTITIES <em>Read-only.</em>
- * @property {number} PICK_OVERLAYS <em>Read-only.</em>
- * @property {number} PICK_AVATARS <em>Read-only.</em>
- * @property {number} PICK_HUD <em>Read-only.</em>
- * @property {number} PICK_COARSE <em>Read-only.</em>
- * @property {number} PICK_INCLUDE_INVISIBLE <em>Read-only.</em>
- * @property {number} PICK_INCLUDE_NONCOLLIDABLE <em>Read-only.</em>
- * @property {number} PICK_ALL_INTERSECTIONS <em>Read-only.</em>
- * @property {number} INTERSECTED_NONE <em>Read-only.</em>
- * @property {number} INTERSECTED_ENTITY <em>Read-only.</em>
- * @property {number} INTERSECTED_OVERLAY <em>Read-only.</em>
- * @property {number} INTERSECTED_AVATAR <em>Read-only.</em>
- * @property {number} INTERSECTED_HUD <em>Read-only.</em>
+ * @property {FilterFlags} PICK_ENTITIES - Include domain and avatar entities when intersecting. 
+ *     <em>Read-only.</em>
+ * @property {FilterFlags} PICK_OVERLAYS - Include local entities when intersecting. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_AVATARS - Include avatars when intersecting. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_HUD - Include the HUD sphere when intersecting in HMD mode. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_PRECISE - Pick against exact meshes. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_INCLUDE_INVISIBLE - Include invisible objects when intersecting. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_INCLUDE_NONCOLLIDABLE - Include non-collidable objects when intersecting. <em>Read-only.</em>
+ * @property {FilterFlags} PICK_ALL_INTERSECTIONS - Return all intersections instead of just the closest. <em>Read-only.</em>
+ * @property {IntersectionType} INTERSECTED_NONE - Intersected nothing with the given filter flags. <em>Read-only.</em>
+ * @property {IntersectionType} INTERSECTED_ENTITY - Intersected an entity. <em>Read-only.</em>
+ * @property {IntersectionType} INTERSECTED_LOCAL_ENTITY - Intersected a local entity. <em>Read-only.</em>
+ * @property {IntersectionType} INTERSECTED_OVERLAY - Intersected an entity (3D Overlays no longer exist). <em>Read-only.</em>
+ * @property {IntersectionType} INTERSECTED_AVATAR - Intersected an avatar. <em>Read-only.</em>
+ * @property {IntersectionType} INTERSECTED_HUD - Intersected the HUD sphere. <em>Read-only.</em>
  */
-
 class RayPickScriptingInterface : public QObject, public Dependency {
     Q_OBJECT
     Q_PROPERTY(unsigned int PICK_ENTITIES READ PICK_ENTITIES CONSTANT)
@@ -63,78 +66,96 @@ class RayPickScriptingInterface : public QObject, public Dependency {
 public:
 
     /**jsdoc
+     * Creates a new ray pick.
+     * <p><strong>Warning:</strong> Picks created with this method currently always intersect at least visible and collidable
+     * things but this may not always be the case.</p>
      * @function RayPick.createRayPick
-     * @param {Picks.RayPickProperties}
-     * @returns {number}
+     * @param {Picks.RayPickProperties} properties - Properties of the pick.
+     * @returns {number} The ID of the pick created. <code>0</code> if invalid.
      */
     Q_INVOKABLE unsigned int createRayPick(const QVariant& properties);
 
     /**jsdoc
+     * Enables a ray pick.
      * @function RayPick.enableRayPick
-     * @param {number} id
+     * @param {number} id - The ID of the ray pick.
      */
     Q_INVOKABLE void enableRayPick(unsigned int uid);
 
     /**jsdoc
+     * Disables a ray pick.
      * @function RayPick.disableRayPick
-     * @param {number} id
+     * @param {number} id - The ID of the ray pick.
      */
     Q_INVOKABLE void disableRayPick(unsigned int uid);
 
     /**jsdoc
+     * Removes (deletes) a ray pick.
      * @function RayPick.removeRayPick
-     * @param {number} id
+     * @param {number} id - The ID of the ray pick.
      */
     Q_INVOKABLE void removeRayPick(unsigned int uid);
 
     /**jsdoc
+     * Gets the most recent pick result from a ray pick. A ray pick continues to be updated ready to return a result, as long 
+     * as it is enabled.
      * @function RayPick.getPrevRayPickResult
-     * @param {number} id
+     * @param {number} id - The ID of the ray pick.
      * @returns {RayPickResult}
      */
     Q_INVOKABLE QVariantMap getPrevRayPickResult(unsigned int uid);
 
 
     /**jsdoc
+     * Sets whether or not to use precision picking, i.e., whether to pick against precise meshes or coarse meshes.
      * @function RayPick.setPrecisionPicking
-     * @param {number} id
-     * @param {boolean} precisionPicking
+     * @param {number} id - The ID of the ray pick.
+     * @param {boolean} precisionPicking - <code>true</code> to use precision picking, <code>false</code> to use coarse picking.
      */
     Q_INVOKABLE void setPrecisionPicking(unsigned int uid, bool precisionPicking);
 
     /**jsdoc
+     * Sets a list of entity and avatar IDs to ignore during intersection.
      * @function RayPick.setIgnoreItems
-     * @param {number} id
-     * @param {Uuid[]) ignoreEntities
+     * @param {number} id - The ID of the ray pick.
+     * @param {Uuid[]} ignoreItems - The list of IDs to ignore.
      */
     Q_INVOKABLE void setIgnoreItems(unsigned int uid, const QScriptValue& ignoreEntities);
 
     /**jsdoc
+     * Sets a list of entity IDs and/or avatar IDs to include during intersection, instead of intersecting with everything.
      * @function RayPick.setIncludeItems
-     * @param {number} id
-     * @param {Uuid[]) includeEntities
+     * @param {number} id - The ID of the ray pick.
+     * @param {Uuid[]} includeItems - The list of IDs to include.
      */
     Q_INVOKABLE void setIncludeItems(unsigned int uid, const QScriptValue& includeEntities);
 
 
     /**jsdoc
+     * Checks if a pick is associated with the left hand: a ray or parabola pick with joint set to
+     * <code>"_CONTROLLER_LEFTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_LEFTHAND"</code>, or a stylus pick with hand
+     * set to <code>0</code>.
      * @function RayPick.isLeftHand
-     * @param {number} id
-     * @returns {boolean}
+     * @param {number} id - The ID of the ray pick.
+     * @returns {boolean} <code>true</code> if the pick is associated with the left hand, <code>false</code> if it isn't.
      */
     Q_INVOKABLE bool isLeftHand(unsigned int uid);
 
     /**jsdoc
+     * Checks if a pick is associated with the right hand: a ray or parabola pick with joint set to
+     * <code>"_CONTROLLER_RIGHTHAND"</code> or <code>"_CAMERA_RELATIVE_CONTROLLER_RIGHTHAND"</code>, or a stylus pick with hand
+     * set to <code>1</code>.
      * @function RayPick.isRightHand
-     * @param {number} id
-     * @returns {boolean}
+     * @param {number} id - The ID of the ray pick.
+     * @returns {boolean} <code>true</code> if the pick is associated with the right hand, <code>false</code> if it isn't.
      */
     Q_INVOKABLE bool isRightHand(unsigned int uid);
 
     /**jsdoc
+     * Checks if a pick is associated with the system mouse: a ray or parabola pick with joint set to <code>"Mouse"</code>.
      * @function RayPick.isMouse
-     * @param {number} id
-     * @returns {boolean}
+     * @param {number} id - The ID of the ray pick.
+     * @returns {boolean} <code>true</code> if the pick is associated with the system mouse, <code>false</code> if it isn't.
      */
     Q_INVOKABLE bool isMouse(unsigned int uid);
 
@@ -142,84 +163,98 @@ public slots:
 
     /**jsdoc
      * @function RayPick.PICK_ENTITIES
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int PICK_ENTITIES() { return PickScriptingInterface::PICK_ENTITIES(); }
 
     /**jsdoc
      * @function RayPick.PICK_OVERLAYS
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int PICK_OVERLAYS() { return PickScriptingInterface::PICK_OVERLAYS(); }
 
     /**jsdoc
      * @function RayPick.PICK_AVATARS
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int PICK_AVATARS() { return PickScriptingInterface::PICK_AVATARS(); }
 
     /**jsdoc
      * @function RayPick.PICK_HUD
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int PICK_HUD() { return PickScriptingInterface::PICK_HUD(); }
 
     /**jsdoc
      * @function RayPick.PICK_COARSE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int PICK_COARSE() { return PickScriptingInterface::PICK_COARSE(); }
 
     /**jsdoc
      * @function RayPick.PICK_INCLUDE_INVISIBLE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int PICK_INCLUDE_INVISIBLE() { return PickScriptingInterface::PICK_INCLUDE_INVISIBLE(); }
 
     /**jsdoc
      * @function RayPick.PICK_INCLUDE_NONCOLLIDABLE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int PICK_INCLUDE_NONCOLLIDABLE() { return PickScriptingInterface::PICK_INCLUDE_NONCOLLIDABLE(); }
 
     /**jsdoc
      * @function RayPick.PICK_ALL_INTERSECTIONS
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int PICK_ALL_INTERSECTIONS() { return PickScriptingInterface::PICK_ALL_INTERSECTIONS(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_NONE
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_NONE() { return PickScriptingInterface::INTERSECTED_NONE(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_ENTITY
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_ENTITY() { return PickScriptingInterface::INTERSECTED_ENTITY(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_OVERLAY
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_LOCAL_ENTITY() { return PickScriptingInterface::INTERSECTED_LOCAL_ENTITY(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_OVERLAY
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_OVERLAY() { return PickScriptingInterface::INTERSECTED_LOCAL_ENTITY(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_AVATAR
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_AVATAR() { return PickScriptingInterface::INTERSECTED_AVATAR(); }
 
     /**jsdoc
      * @function RayPick.INTERSECTED_HUD
+     * @deprecated This function is deprecated and will be removed. Use the property of the same name instead.
      * @returns {number}
      */
     static unsigned int INTERSECTED_HUD() { return PickScriptingInterface::INTERSECTED_HUD(); }

--- a/interface/src/raypick/StylusPick.h
+++ b/interface/src/raypick/StylusPick.h
@@ -38,6 +38,18 @@ public:
     glm::vec3 intersection { NAN };
     glm::vec3 surfaceNormal { NAN };
 
+    /**jsdoc
+     * An intersection result for a stylus pick.
+     *
+     * @typedef {object} StylusPickResult
+     * @property {number} type - The intersection type.
+     * @property {boolean} intersects - <code>true</code> if there's a valid intersection, <code>false</code> if there isn't.
+     * @property {Uuid} objectID - The ID of the intersected object. <code>null</code> for invalid intersections.
+     * @property {number} distance - The distance to the intersection point from the stylus tip.
+     * @property {Vec3} intersection - The intersection point in world coordinates.
+     * @property {Vec3} surfaceNormal - The surface normal at the intersected point.
+     * @property {StylusTip} stylusTip - The stylus tip at the time of the result. Valid even if there is no intersection.
+     */
     virtual QVariantMap toVariantMap() const override {
         QVariantMap toReturn;
         toReturn["type"] = type;

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -801,7 +801,7 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  *
  * @property {boolean} collisionless=false - Whether or not the entity should collide with items per its 
  *     <code>collisionMask<code> property. If <code>true</code> then the entity does not collide. A synonym is <code>ignoreForCollisions</code>.
- * @property {Entities.CollisionMask} collisionMask=31 - What types of items the entity should collide with.
+ * @property {CollisionMask} collisionMask=31 - What types of items the entity should collide with.
  * @property {string} collidesWith="static,dynamic,kinematic,myAvatar,otherAvatar," - Synonym for <code>collisionMask</code>,
  *     in text format.
  * @property {string} collisionSoundURL="" - The sound to play when the entity experiences a collision. Valid file formats are

--- a/libraries/pointers/src/Pick.h
+++ b/libraries/pointers/src/Pick.h
@@ -20,6 +20,22 @@
 #include <TransformNode.h>
 #include <PickFilter.h>
 
+/**jsdoc
+ * <p>The type of an intersection.</p>
+ * <table>
+ *   <thead>
+ *     <tr><th>Name</th><th>Value</th><th>Description</th></tr>
+ *   </thead>
+ *   <tbody>
+ *     <tr><td>INTERSECTED_NONE</td><td><code>0</code></td><td>Intersected nothing.</td></tr>
+ *     <tr><td>INTERSECTED_ENTITY</td><td><code>1</code></td><td>Intersected an entity.</td></tr>
+ *     <tr><td>INTERSECTED_LOCAL_ENTITY</td><td><code>2</code></td><td>Intersected a local entity.</td></tr>
+ *     <tr><td>INTERSECTED_AVATAR</td><td><code>3</code></td><td>Intersected an avatar.</td></tr>
+ *     <tr><td>INTERSECTED_HUD</td><td><code>4</code></td><td>Intersected the HUD sphere.</td></tr>
+ *   </tbody>
+ * </table>
+ * @typedef {number} IntersectionType
+ */
 enum IntersectionType {
     NONE = 0,
     ENTITY,
@@ -61,7 +77,7 @@ public:
     virtual ~PickQuery() = default;
 
     /**jsdoc
-     * Enum for different types of Picks and Pointers.
+     * The <code>PickType</code> API provides constant numeric values that represent different types of picks.
      *
      * @namespace PickType
      * @variation 0
@@ -70,22 +86,28 @@ public:
      * @hifi-client-entity
      * @hifi-avatar
      *
-     * @property {number} Ray Ray picks intersect a ray with the nearest object in front of them, along a given direction.
-     * @property {number} Stylus Stylus picks provide "tapping" functionality on/into flat surfaces.
-     * @property {number} Parabola Parabola picks intersect a parabola with the nearest object in front of them, with a given 
-     *     initial velocity and acceleration.
-     * @property {number} Collision Collision picks intersect a collision volume with avatars and entities that have collisions.
+     * @property {number} Ray - Ray picks intersect a ray with objects in front of them, along their direction.
+     * @property {number} Parabola - Parabola picks intersect a parabola with objects in front of them, along their arc.
+     * @property {number} Stylus - Stylus picks provide "tapping" functionality on or into flat surfaces.
+     * @property {number} Collision - Collision picks intersect a collision volume with avatars and entities that have 
+     *     collisions.
      */
-    /**jsdoc
+
+     /**jsdoc
+     * <p>A type of pick.</p>
      * <table>
      *   <thead>
      *     <tr><th>Value</th><th>Description</th></tr>
      *   </thead>
      *   <tbody>
-     *     <tr><td><code>{@link PickType(0)|PickType.Ray}</code></td><td></td></tr>
-     *     <tr><td><code>{@link PickType(0)|PickType.Stylus}</code></td><td></td></tr>
-     *     <tr><td><code>{@link PickType(0)|PickType.Parabola}</code></td><td></td></tr>
-     *     <tr><td><code>{@link PickType(0)|PickType.Collision}</code></td><td></td></tr>
+     *     <tr><td><code>{@link PickType(0)|PickType.Ray}</code></td><td>Ray picks intersect a ray with objects in front of 
+     *       them, along their direction.</td></tr>
+     *     <tr><td><code>{@link PickType(0)|PickType.Parabola}</code></td><td>Parabola picks intersect a parabola with objects
+     *       in front of them, along their arc.</td></tr>
+     *     <tr><td><code>{@link PickType(0)|PickType.Stylus}</code></td><td>Stylus picks provide "tapping" functionality on or
+     *       into flat surfaces.</td></tr>
+     *     <tr><td><code>{@link PickType(0)|PickType.Collision}</code></td><td>Collision picks intersect a collision volume 
+     *       with avatars and entities that have collisions.</td></tr>
      *   </tbody>
      * </table>
      * @typedef {number} PickType

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -445,7 +445,7 @@ bool Model::findRayIntersectionAgainstSubMeshes(const glm::vec3& origin, const g
         }
 
         /**jsdoc
-         * Information about a submesh intersection point.
+         * A submesh intersection point.
          * @typedef {object} SubmeshIntersection
          * @property {Vec3} worldIntersectionPoint - The intersection point in world coordinates.
          * @property {Vec3} meshIntersectionPoint - The intersection point in model coordinates.

--- a/libraries/shared/src/PhysicsCollisionGroups.h
+++ b/libraries/shared/src/PhysicsCollisionGroups.h
@@ -72,7 +72,7 @@ const int32_t BULLET_COLLISION_MASK_DETAILED_RAY = BULLET_COLLISION_GROUP_DETAIL
 const int32_t BULLET_COLLISION_MASK_COLLISIONLESS = 0;
 
 /**jsdoc
- * <p>An entity may collide with the following types of items:</p>
+ * <p>A collision may be with the following types of items:</p>
  * <table>
  *   <thead>
  *     <tr><th>Value</th><th>Description</th>
@@ -88,7 +88,7 @@ const int32_t BULLET_COLLISION_MASK_COLLISIONLESS = 0;
  * </table>
  * <p>The values for the collision types that are enabled are added together to give the CollisionMask value. For example, a
  * value of <code>31</code> means that an entity will collide with all item types.</p>
- * @typedef {number} Entities.CollisionMask
+ * @typedef {number} CollisionMask
  */
 
 // The USER collision groups are exposed to script and can be used to generate per-object collision masks.

--- a/libraries/shared/src/PhysicsCollisionGroups.h
+++ b/libraries/shared/src/PhysicsCollisionGroups.h
@@ -72,7 +72,7 @@ const int32_t BULLET_COLLISION_MASK_DETAILED_RAY = BULLET_COLLISION_GROUP_DETAIL
 const int32_t BULLET_COLLISION_MASK_COLLISIONLESS = 0;
 
 /**jsdoc
- * <p>A collision may be with the following types of items:</p>
+ * <p>A collision may occur with the following types of items:</p>
  * <table>
  *   <thead>
  *     <tr><th>Value</th><th>Description</th>

--- a/libraries/shared/src/PickFilter.h
+++ b/libraries/shared/src/PickFilter.h
@@ -13,6 +13,34 @@
 
 class PickFilter {
 public:
+
+    /**jsdoc
+     * <p>A set of flags for a pick filter. The value is constructed by using the <code>|</code> (bitwise OR) operator on the 
+     * individual flag values.</p>
+     * <table>
+     *   <thead>
+     *     <tr><th>Flag name</th><th>Value</th><th>Description</th></tr>
+     *   </thead>
+     *   <tbody>
+     *     <tr><td>PICK_DOMAIN_ENTITIES</td><td><code>1</code></td><td>Include domain entities when intersecting.</td></tr>
+     *     <tr><td>PICK_AVATAR_ENTITIES</td><td><code>2</code></td><td>Include avatar entities when intersecting.</td></tr>
+     *     <tr><td>PICK_LOCAL_ENTITIES</td><td><code>4</code></td><td>Include local entities when intersecting.</td></tr>
+     *     <tr><td>PICK_AVATATRS</td><td><code>8</code></td><td>Include avatars when intersecting.</td></tr>
+     *     <tr><td>PICK_HUD</td><td><code>16</code></td><td>Include the HUD sphere when intersecting in HMD mode.</td></tr>
+     *     <tr><td>PICK_INCLUDE_VISIBLE</td><td><code>32</code></td><td>Include visible objects when intersecting.</td></tr>
+     *     <tr><td>PICK_INCLUDE_INVISIBLE</td><td><code>64</code></td><td>Include invisible objects when intersecting.</td></tr>
+     *     <tr><td>PICK_INCLUDE_COLLIDABLE</td><td><code>128</code></td><td>Include collidable objects when 
+     *       intersecting.</td></tr>
+     *     <tr><td>PICK_INCLUDE_NONCOLLIDABLE</td><td><code>256</code></td><td>Include non-collidable objects when 
+     *       intersecting.</td></tr>
+     *     <tr><td>PICK_PRECISE</td><td><code>512</code></td><td>Pick against exact meshes.</td></tr>
+     *     <tr><td>PICK_COARSE</td><td><code>1024</code></td><td>Pick against coarse meshes.</td></tr>
+     *     <tr><td>PICK_ALL_INTERSECTIONS</td><td><code>2048</code></td><td>Return all intersections instead of just the 
+     *       closest.</td></tr>
+     *   </tbody>
+     * </table>
+     * @typedef {number} FilterFlags
+     */
     enum FlagBit {
         DOMAIN_ENTITIES = 0,
         AVATAR_ENTITIES,

--- a/libraries/shared/src/PickFilter.h
+++ b/libraries/shared/src/PickFilter.h
@@ -19,7 +19,7 @@ public:
      * individual flag values.</p>
      * <table>
      *   <thead>
-     *     <tr><th>Flag name</th><th>Value</th><th>Description</th></tr>
+     *     <tr><th>Flag Name</th><th>Value</th><th>Description</th></tr>
      *   </thead>
      *   <tbody>
      *     <tr><td>PICK_DOMAIN_ENTITIES</td><td><code>1</code></td><td>Include domain entities when intersecting.</td></tr>

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -426,15 +426,16 @@ public:
     /**jsdoc
      * A volume for checking collisions in the physics simulation.
      * @typedef {object} CollisionRegion
-     * @property {Shape} shape - The collision region's shape and size. Dimensions are in world space, but scale with the parent
-     *     if defined.
-     * @property {boolean} loaded - <code>true</code> if the <code>shape</code> has no model, or has a model and it is loaded.
+     * @property {Shape} shape - The collision region's shape and size. Dimensions are in world coordinates, but scale with the 
+     *     parent if defined.
+     * @property {boolean} loaded - <code>true</code> if the <code>shape</code> has no model, or has a model and it is loaded, 
+     *     <code>false</code> if otherwise.
      * @property {Vec3} position - The position of the collision region, relative to the parent if defined.
      * @property {Quat} orientation - The orientation of the collision region, relative to the parent if defined.
      * @property {number} threshold - The approximate minimum penetration depth for a test object to be considered in contact with
      *     the collision region. The depth is in world coordinates but scales with the parent if defined.
      * @property {CollisionMask} [collisionGroup=8] - The type of objects the collision region collides as. Objects whose collision
-     *     masks overlap with the regions's collision group are considered to be colliding with the region.
+     *     masks overlap with the region's collision group are considered to be colliding with the region.
      */
 
     /**jsdoc

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -296,7 +296,7 @@ void pickRayFromScriptValue(const QScriptValue& object, PickRay& pickRay);
  * @typedef {object} StylusTip
  * @property {number} side - The hand that the stylus is attached to: <code>0</code> for left hand, <code>1</code> for the 
  *     right hand, <code>-1</code> for invalid.
- * @property {Vec3} tipOffset  - The position of the stylus tip relative to the body of the stylus.
+ * @property {Vec3} tipOffset - The position of the stylus tip relative to the body of the stylus.
  * @property {Vec3} position - The position of the stylus tip.
  * @property {Quat} orientation - The orientation of the stylus.
  * @property {Vec3} velocity - The velocity of the stylus tip.

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -258,12 +258,12 @@ public:
 };
 
 /**jsdoc
- * A PickRay defines a vector with a starting point. It is used, for example, when finding entities or avatars that lie under a
- * mouse click or intersect a laser beam.
+ * A vector with a starting point. It is used, for example, when finding entities or avatars that lie under a mouse click or 
+ * intersect a laser beam.
  *
  * @typedef {object} PickRay
- * @property {Vec3} origin - The starting position of the PickRay.
- * @property {Vec3} direction - The direction that the PickRay travels.
+ * @property {Vec3} origin - The starting position of the ray.
+ * @property {Vec3} direction - The direction that the ray travels.
  */
 class PickRay : public MathPick {
 public:
@@ -291,13 +291,14 @@ QScriptValue pickRayToScriptValue(QScriptEngine* engine, const PickRay& pickRay)
 void pickRayFromScriptValue(const QScriptValue& object, PickRay& pickRay);
 
 /**jsdoc
- * A StylusTip defines the tip of a stylus.
+ * The tip of a stylus.
  *
  * @typedef {object} StylusTip
- * @property {number} side - The hand the tip is attached to: <code>0</code> for left, <code>1</code> for right.
- * @property {Vec3} tipOffset  - the position offset of the stylus tip.
+ * @property {number} side - The hand that the stylus is attached to: <code>0</code> for left hand, <code>1</code> for the 
+ *     right hand, <code>-1</code> for invalid.
+ * @property {Vec3} tipOffset  - The position of the stylus tip relative to the body of the stylus.
  * @property {Vec3} position - The position of the stylus tip.
- * @property {Quat} orientation - The orientation of the stylus tip.
+ * @property {Quat} orientation - The orientation of the stylus.
  * @property {Vec3} velocity - The velocity of the stylus tip.
  */
 class StylusTip : public MathPick {
@@ -333,12 +334,16 @@ public:
 };
 
 /**jsdoc
-* A PickParabola defines a parabola with a starting point, intitial velocity, and acceleration.
+* A parabola defined by a starting point, initial velocity, and acceleration. It is used, for example, when finding entities or
+* avatars that intersect a parabolic beam.
 *
 * @typedef {object} PickParabola
-* @property {Vec3} origin - The starting position of the PickParabola.
-* @property {Vec3} velocity - The starting velocity of the parabola.
-* @property {Vec3} acceleration - The acceleration that the parabola experiences.
+* @property {Vec3} origin - The starting position of the parabola, i.e., the initial position of a virtual projectile whose 
+*     trajectory defines the parabola.
+* @property {Vec3} velocity - The starting velocity of the parabola in m/s, i.e., the initial speed of a virtual projectile 
+*     whose trajectory defines the parabola.
+* @property {Vec3} acceleration - The acceleration that the parabola experiences in m/s<sup>2</sup>, i.e., the acceleration of 
+*     a virtual projectile whose trajectory defines the parabola, both magnitude and direction.
 */
 class PickParabola : public MathPick {
 public:
@@ -364,23 +369,6 @@ public:
     }
 };
 
-// TODO: Add "loaded" to CollisionRegion jsdoc once model collision picks are supported.
-
-/**jsdoc
-* A CollisionRegion defines a volume for checking collisions in the physics simulation.
-
-* @typedef {object} CollisionRegion
-* @property {Shape} shape - The information about the collision region's size and shape. Dimensions are in world space, but will scale with the parent if defined.
-* @property {Vec3} position - The position of the collision region, relative to a parent if defined.
-* @property {Quat} orientation - The orientation of the collision region, relative to a parent if defined.
-* @property {float} threshold - The approximate minimum penetration depth for a test object to be considered in contact with the collision region.
-* The depth is measured in world space, but will scale with the parent if defined.
-* @property {CollisionMask} [collisionGroup=8] - The type of object this collision pick collides as. Objects whose collision masks overlap with the pick's collision group
-* will be considered colliding with the pick.
-* @property {Uuid} parentID - The ID of the parent, either an avatar or an entity.
-* @property {number} parentJointIndex - The joint of the parent to parent to, for example, the joints on the model of an avatar. (default = 0, no joint)
-* @property {string} joint - If "Mouse," parents the pick to the mouse. If "Avatar," parents the pick to MyAvatar's head. Otherwise, parents to the joint of the given name on MyAvatar.
-*/
 class CollisionRegion : public MathPick {
 public:
     CollisionRegion() { }
@@ -434,6 +422,29 @@ public:
             collisionGroup = pickVariant["collisionGroup"].toUInt();
         }
     }
+
+    /**jsdoc
+     * A volume for checking collisions in the physics simulation.
+     * @typedef {object} CollisionRegion
+     * @property {Shape} shape - The collision region's shape and size. Dimensions are in world space, but scale with the parent
+     *     if defined.
+     * @property {boolean} loaded - <code>true</code> if the <code>shape</code> has no model, or has a model and it is loaded.
+     * @property {Vec3} position - The position of the collision region, relative to the parent if defined.
+     * @property {Quat} orientation - The orientation of the collision region, relative to the parent if defined.
+     * @property {number} threshold - The approximate minimum penetration depth for a test object to be considered in contact with
+     *     the collision region. The depth is in world coordinates but scales with the parent if defined.
+     * @property {CollisionMask} [collisionGroup=8] - The type of objects the collision region collides as. Objects whose collision
+     *     masks overlap with the regions's collision group are considered to be colliding with the region.
+     */
+
+    /**jsdoc
+     * A physical volume.
+     * @typedef {object} Shape
+     * @property {ShapeType} shapeType="none" - The type of shape.
+     * @property {string} [modelUrl=""] - The model to load to for the shape if <code>shapeType</code> is one of
+     *     <code>"compound"</code>, <code>"simple-hull"</code>, <code>"simple-compound"</code>, or <code>"static-mesh"</code>.
+     * @property {Vec3} dimensions - The dimensions of the shape.
+     */
 
     QVariantMap toVariantMap() const override {
         QVariantMap collisionRegion;
@@ -589,7 +600,7 @@ namespace std {
 }
 
 /**jsdoc
- * <p>The type of a collision contact event.
+ * <p>The type of a collision contact event.</p>
  * <table>
  *   <thead>
  *     <tr><th>Value</th><th>Description</th></tr>

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -39,6 +39,8 @@
  *         sub-meshes.</td></tr>
  *     <tr><td><code>"static-mesh"</code></td><td>The exact shape of the model.</td></tr>
  *     <tr><td><code>"plane"</code></td><td>A plane.</td></tr>
+ *     <tr><td><code>"ellipsoid"</code></td><td>An ellipsoid.</td></tr>
+ *     <tr><td><code>"circle"</code></td><td>A circle.</td></tr>
  *     <tr><td><code>"multisphere"</code></td><td>A convex hull generated from a set of spheres.</td></tr>
  *   </tbody>
  * </table>


### PR DESCRIPTION
Namepaces:
- Picks
- PickType
- RayPick

Globals:
- CollisionContact
- CollisionMask
- CollisionPickResult
- CollisionRegion
- IntersectingObject
- IntersectionType
- FilterFlags
- PickParabola
- PickRay
- PickType
- RayPickResult
- Shape
- ShapeType
- StylusPickResult
- StulusTip
- SubmeshIntersection

Primary Manuscript case: https://highfidelity.manuscript.com/f/cases/22246/JSdoc-Picks-PickType-RayPick

Other Manuscript cases addressed: https://highfidelity.manuscript.com/f/cases/19972/JSDoc-RayPickResult-s-type-value-is-not-defined

Note: No executable code changes.