### PR TITLE
Tiny logical error in wallet creation

### DIFF
--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -126,7 +126,7 @@ namespace {
         }
 
         QFile file(filename);
-        if (!file.open(QIODevice::WriteOnly)) {
+        if (file.open(QIODevice::WriteOnly)) {
             const char* bio_data;
             long bio_size = BIO_get_mem_data(bio, &bio_data);
 


### PR DESCRIPTION
Small error, large effect.  Probably when converting from using file pointers (where the ! would have been looking at a file pointer's existence).  