### PR TITLE
Fix crash sending other avatars hands to flow

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -5811,12 +5811,19 @@ void MyAvatar::releaseGrab(const QUuid& grabID) {
 }
 
 void MyAvatar::addAvatarHandsToFlow(const std::shared_ptr<Avatar>& otherAvatar) {
+    if (QThread::currentThread() != thread()) {
+        QMetaObject::invokeMethod(this, "addAvatarHandsToFlow",
+            Q_ARG(const std::shared_ptr<Avatar>&, otherAvatar));
+        return;
+    }
     auto &flow = _skeletonModel->getRig().getFlow();
-    for (auto &handJointName : HAND_COLLISION_JOINTS) {
-        int jointIndex = otherAvatar->getJointIndex(handJointName);
-        if (jointIndex != -1) {
-            glm::vec3 position = otherAvatar->getJointPosition(jointIndex);
-            flow.setOthersCollision(otherAvatar->getID(), jointIndex, position);
+    if (otherAvatar != nullptr && flow.getActive()) {
+        for (auto &handJointName : HAND_COLLISION_JOINTS) {
+            int jointIndex = otherAvatar->getJointIndex(handJointName);
+            if (jointIndex != -1) {
+                glm::vec3 position = otherAvatar->getJointPosition(jointIndex);
+                flow.setOthersCollision(otherAvatar->getID(), jointIndex, position);
+            }
         }
     }
 }


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22362/Interface-crash-sending-other-avatars-hands-to-flow
This PR fixes a crash that occurs when calling `MyAvatar::addAvatarHandsToFlow`
