### PR TITLE
There is no anon restriction - only open, hifi, acl

### DIFF
--- a/domain-server/src/DomainMetadata.cpp
+++ b/domain-server/src/DomainMetadata.cpp
@@ -115,7 +115,6 @@ void DomainMetadata::securityChanged(bool send) {
     auto& state = *static_cast<QVariantMap*>(_metadata[DESCRIPTORS].data());
 
     const QString RESTRICTION_OPEN = "open";
-    const QString RESTRICTION_ANON = "anon";
     const QString RESTRICTION_HIFI = "hifi";
     const QString RESTRICTION_ACL = "acl";
 
@@ -127,7 +126,7 @@ void DomainMetadata::securityChanged(bool send) {
     bool hasHifiAccess = settingsManager.getStandardPermissionsForName(NodePermissions::standardNameLoggedIn).can(
         NodePermissions::Permission::canConnectToDomain);
     if (hasAnonymousAccess) {
-        restriction = hasHifiAccess ? RESTRICTION_OPEN : RESTRICTION_ANON;
+        restriction = RESTRICTION_OPEN;
     } else if (hasHifiAccess) {
         restriction = RESTRICTION_HIFI;
     } else {


### PR DESCRIPTION
Aligned the restrictions with what is in the metaverse.  When giving 'anon', we 500 - see https://highfidelity.fogbugz.com/f/cases/22047/Investigate-these-bugsnag-errors-in-domains-update