### PR TITLE
Case 22371: Fix domain baking (RC82)

### DIFF
--- a/tools/oven/src/DomainBaker.cpp
+++ b/tools/oven/src/DomainBaker.cpp
@@ -752,10 +752,11 @@ void DomainBaker::writeNewEntitiesFile() {
     // time to write out a main models.json.gz file
 
     // first setup a document with the entities array below the entities key
-    _json.object()[ENTITIES_OBJECT_KEY] = _entities;
+    QJsonObject json = _json.object();
+    json[ENTITIES_OBJECT_KEY] = _entities;
 
     // turn that QJsonDocument into a byte array ready for compression
-    QByteArray jsonByteArray = _json.toJson();
+    QByteArray jsonByteArray = QJsonDocument(json).toJson();
 
     // compress the json byte array using gzip
     QByteArray compressedJson;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22371/Domain-baking-is-broken-in-82

Test plan:
- Re-verify https://highfidelity.manuscript.com/f/cases/22314/Baking-a-domain-removes-Version-field-82-version
- Confirm that in the baked version, the links have been swapped out for the baked links.