### PR TITLE
Case 22378: System cursor in desktop mode instead of rendering texture from Displayplugin

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3591,7 +3591,7 @@ void Application::setPreferAvatarFingerOverStylus(bool value) {
 
 void Application::setPreferredCursor(const QString& cursorName) {
     qCDebug(interfaceapp) << "setPreferredCursor" << cursorName;
-    _preferredCursor.set(cursorName.isEmpty() ? DEFAULT_CURSOR_NAME : cursorName);
+    _preferredCursor.set(cursorName.isEmpty() ? Cursor::Manager::getIconName(Cursor::Icon::SYSTEM) : cursorName);
     showCursor(Cursor::Manager::lookupIcon(_preferredCursor.get()));
 }
 
@@ -5041,11 +5041,8 @@ void Application::idle() {
         }
     }
 #endif
-
     
-    if((displayPlugin && displayPlugin->isHmd()) ||  _preferredCursor.get() ==  Cursor::Manager::ICON_NAMES[Cursor::Icon::RETICLE]){
-        checkChangeCursor();
-    }
+    checkChangeCursor();
 
 #if !defined(DISABLE_QML)
     auto stats = Stats::getInstance();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3591,7 +3591,14 @@ void Application::setPreferAvatarFingerOverStylus(bool value) {
 
 void Application::setPreferredCursor(const QString& cursorName) {
     qCDebug(interfaceapp) << "setPreferredCursor" << cursorName;
-    _preferredCursor.set(cursorName.isEmpty() ? Cursor::Manager::getIconName(Cursor::Icon::SYSTEM) : cursorName);
+
+    if (_displayPlugin && _displayPlugin->isHmd()) {
+        _preferredCursor.set(cursorName.isEmpty() ? DEFAULT_CURSOR_NAME : cursorName);
+    }
+    else { 
+        _preferredCursor.set(cursorName.isEmpty() ? Cursor::Manager::getIconName(Cursor::Icon::SYSTEM) : cursorName); 
+    }
+
     showCursor(Cursor::Manager::lookupIcon(_preferredCursor.get()));
 }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5042,7 +5042,10 @@ void Application::idle() {
     }
 #endif
 
-    checkChangeCursor();
+    
+    if((displayPlugin && displayPlugin->isHmd()) ||  _preferredCursor.get() ==  Cursor::Manager::ICON_NAMES[Cursor::Icon::RETICLE]){
+        checkChangeCursor();
+    }
 
 #if !defined(DISABLE_QML)
     auto stats = Stats::getInstance();

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -683,7 +683,7 @@ void OpenGLDisplayPlugin::compositeLayers() {
     }
 
      auto& cursorManager = Cursor::Manager::instance();
-    if (isHmd() || cursorManager.getCursor()->getIcon() == Cursor::RETICLE ) {
+    if (isHmd() || cursorManager.getCursor()->getIcon() == Cursor::RETICLE) {
         auto compositorHelper = DependencyManager::get<CompositorHelper>();
         // Draw the pointer last so it's on top of everything
         if (compositorHelper->getReticleVisible()) {

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -38,6 +38,7 @@
 #include <gpu/gl/GLBackend.h>
 #include <GeometryCache.h>
 
+#include <CursorManager.h>
 #include <FramebufferCache.h>
 #include <shared/NsightHelpers.h>
 #include <ui-plugins/PluginContainer.h>
@@ -681,11 +682,14 @@ void OpenGLDisplayPlugin::compositeLayers() {
         compositeExtra();
     }
 
-    // Draw the pointer last so it's on top of everything
-    auto compositorHelper = DependencyManager::get<CompositorHelper>();
-    if (compositorHelper->getReticleVisible()) {
-        PROFILE_RANGE_EX(render_detail, "compositePointer", 0xff0077ff, (uint64_t)presentCount())
+     auto& cursorManager = Cursor::Manager::instance();
+    if (isHmd() || cursorManager.getCursor()->getIcon() == Cursor::RETICLE ) {
+        auto compositorHelper = DependencyManager::get<CompositorHelper>();
+        // Draw the pointer last so it's on top of everything
+        if (compositorHelper->getReticleVisible()) {
+            PROFILE_RANGE_EX(render_detail, "compositePointer", 0xff0077ff, (uint64_t)presentCount())
             compositePointer();
+        }
     }
 }
 

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -682,7 +682,7 @@ void OpenGLDisplayPlugin::compositeLayers() {
         compositeExtra();
     }
 
-     auto& cursorManager = Cursor::Manager::instance();
+    auto& cursorManager = Cursor::Manager::instance();
     if (isHmd() || cursorManager.getCursor()->getIcon() == Cursor::RETICLE) {
         auto compositorHelper = DependencyManager::get<CompositorHelper>();
         // Draw the pointer last so it's on top of everything


### PR DESCRIPTION
 https://highfidelity.manuscript.com/f/cases/22378/Need-to-use-the-SYSTEM-Cursor-in-Desktop-instead-of-the-displayed-texture-from-DisplayPLugin

Removing system mouse override and cursor rendering for non hmd devices. When running on low end devices or eco mode the mouse cursor updates cause jitter and on some macs a mouse trail.

Test case:

Mouse cursor should be smooth on all "desktop" mode devices.
The cursor should be rendered by the OS
None of the mouse interactions should be affected
HMD mode should use the rendered texture cursor