### PR TITLE
Fixed: turning on your microphone will now take you out of Away mode

### DIFF
--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -223,7 +223,7 @@ function setAwayProperties() {
 
 function setActiveProperties() {
     isAway = false;
-    if ((Audio.muted === true) && (wasMuted === false)) {
+    if (Audio.muted && !wasMuted) {
         Audio.muted = false;
     }
     MyAvatar.setEnableMeshVisible(true); // IWBNI we respected Developer->Avatar->Draw Mesh setting.

--- a/scripts/system/away.js
+++ b/scripts/system/away.js
@@ -203,7 +203,7 @@ function setAwayProperties() {
     if (!wasMuted) {
         Audio.muted = !Audio.muted;
     }
-    MyAvatar.setEnableMeshVisible(false);  // just for our own display, without changing point of view
+    MyAvatar.setEnableMeshVisible(false); // just for our own display, without changing point of view
     playAwayAnimation(); // animation is still seen by others
     showOverlay();
 
@@ -223,8 +223,8 @@ function setAwayProperties() {
 
 function setActiveProperties() {
     isAway = false;
-    if (!wasMuted) {
-        Audio.muted = !Audio.muted;
+    if ((Audio.muted === true) && (wasMuted === false)) {
+        Audio.muted = false;
     }
     MyAvatar.setEnableMeshVisible(true); // IWBNI we respected Developer->Avatar->Draw Mesh setting.
     stopAwayAnimation();
@@ -254,7 +254,7 @@ function setActiveProperties() {
 }
 
 function maybeGoActive(event) {
-    if (event.isAutoRepeat) {  // isAutoRepeat is true when held down (or when Windows feels like it)
+    if (event.isAutoRepeat) { // isAutoRepeat is true when held down (or when Windows feels like it)
         return;
     }
     if (!isAway && (event.text === 'ESC')) {
@@ -314,6 +314,13 @@ function setEnabled(value) {
     isEnabled = value;
 }
 
+function checkAudioToggled() {
+    if (isAway && !Audio.muted) {
+        goActive();
+    }
+}
+
+
 var CHANNEL_AWAY_ENABLE = "Hifi-Away-Enable";
 var handleMessage = function(channel, message, sender) {
     if (channel === CHANNEL_AWAY_ENABLE && sender === MyAvatar.sessionUUID) {
@@ -324,9 +331,10 @@ var handleMessage = function(channel, message, sender) {
 Messages.subscribe(CHANNEL_AWAY_ENABLE);
 Messages.messageReceived.connect(handleMessage);
 
-var maybeIntervalTimer = Script.setInterval(function(){
+var maybeIntervalTimer = Script.setInterval(function() {
     maybeMoveOverlay();
     maybeGoAway();
+    checkAudioToggled();
 }, BASIC_TIMER_INTERVAL);
 
 


### PR DESCRIPTION
Previously you could turn on your mic in Away mode.  When you left Away mode, it would be muted again.

https://highfidelity.fogbugz.com/f/cases/21511/If-you-unmute-yourself-while-away-exiting-away-mode-will-mute-you
https://highfidelity.atlassian.net/browse/BUGZ-45

The fix here is to make it so that you become active again if you turn on your mic.

Also, if you are muted and in Away mode, you will now be restored to your previous mute state when you exit Away mode.

### Test Plan
1. open interface
2. with your mic unmuted, press 'esc' to enter away mode,
3. your mic should now be muted.  if you unmute you will exit away mode, your mic will remain unmuted
4. repeat the first three steps, but start with you mic muted. your mic will be unmuted when you exit away mode.
5. with you mic unmuted hit 'esc' to go to away mode with mic muted.  then press a key to return to active.  your mic should be unmuted again.
6. repeat 5 but start with your mic muted.  when you return to active, you mic will be muted once  more