### PR TITLE
22421: Set default avatar-mixer connection rate to effectively unlimited

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1307,8 +1307,8 @@
           "name": "connection_rate",
           "label": "Connection Rate",
           "help": "Number of new agents that can connect to the mixer every second",
-          "placeholder": "50",
-          "default": "50",
+          "placeholder": "10000000",
+          "default": "10000000",
           "advanced": true
         },
         {


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/22421/82-1-Very-long-delay-before-connecting-to-avatar-mixer-in-hifi-HQ

RC82.1 version of  https://github.com/highfidelity/hifi/pull/15483
