### PR TITLE
(case 22026) Fix crash due to invalid indices in baker::calculateNormals

### DIFF
--- a/libraries/model-baker/src/model-baker/CalculateBlendshapeNormalsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateBlendshapeNormalsTask.cpp
@@ -61,7 +61,7 @@ void CalculateBlendshapeNormalsTask::run(const baker::BakeContextPointer& contex
                             outVertex = blendshape.vertices[lookupIndex];
                         } else {
                             // Index isn't in the blendshape, so return vertex from mesh
-                            outVertex = mesh.vertices[lookupIndex];
+                            outVertex = baker::safeGet(mesh.vertices, lookupIndex);
                         }
                     });
             }

--- a/libraries/model-baker/src/model-baker/CalculateMeshNormalsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateMeshNormalsTask.cpp
@@ -32,7 +32,7 @@ void CalculateMeshNormalsTask::run(const baker::BakeContextPointer& context, con
                     return &normalsOut[normalIndex];
                 },
                 [&mesh](int vertexIndex, glm::vec3& outVertex) /* VertexSetter */ {
-                    outVertex = mesh.vertices[vertexIndex];
+                    outVertex = baker::safeGet(mesh.vertices, vertexIndex);
                 }
             );
         }

--- a/libraries/model-baker/src/model-baker/ModelMath.h
+++ b/libraries/model-baker/src/model-baker/ModelMath.h
@@ -25,6 +25,17 @@ namespace baker {
         }
     }
 
+    template<typename T>
+    const T& safeGet(const QVector<T>& data, int i) {
+        static T t;
+
+        if (i >= 0 && data.size() > i) {
+            return data[i];
+        } else {
+            return t;
+        }
+    }
+
     // Returns a reference to the normal at the specified index, or nullptr if it cannot be accessed
     using NormalAccessor = std::function<glm::vec3*(int index)>;
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/22026/Crash-in-calculateNormals
https://highfidelity.atlassian.net/browse/BUGZ-30

This PR adds missing bounds checks to mesh normal calculations.