### PR TITLE
case 22412: allow independent camera to be set by scripts

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5804,7 +5804,8 @@ void Application::cameraModeChanged() {
             Menu::getInstance()->setIsOptionChecked(MenuOption::FullscreenMirror, true);
             break;
         default:
-            break;
+            // we don't have menu items for the others, so just leave it alone.
+            return;
     }
     cameraMenuChanged();
 }


### PR DESCRIPTION
- allow independent camera to be set by scripts


fix bug introduced by https://github.com/highfidelity/hifi/pull/15377

https://highfidelity.fogbugz.com/f/cases/22412/Hidden-Camera-mode-s-switch-back-shortly-after-set
