### PR TITLE
Fix memory corruption in _modelJointIndicesCache QHash

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1439,22 +1439,18 @@ QStringList Avatar::getJointNames() const {
     withValidJointIndicesCache([&]() {
         // find out how large the vector needs to be
         int maxJointIndex = -1;
-        QHash<QString, int>::const_iterator k = _modelJointIndicesCache.constBegin();
-        while (k != _modelJointIndicesCache.constEnd()) {
+        for (auto k = _modelJointIndicesCache.constBegin(); k != _modelJointIndicesCache.constEnd(); k++) {
             int index = k.value();
             if (index > maxJointIndex) {
                 maxJointIndex = index;
             }
-            ++k;
         }
         // iterate through the hash and put joint names
         // into the vector at their indices
         QVector<QString> resultVector(maxJointIndex+1);
-        QHash<QString, int>::const_iterator i = _modelJointIndicesCache.constBegin();
-        while (i != _modelJointIndicesCache.constEnd()) {
+        for (auto i = _modelJointIndicesCache.constBegin(); i != _modelJointIndicesCache.constEnd(); i++) {
             int index = i.value();
             resultVector[index] = i.key();
-            ++i;
         }
         // convert to QList and drop out blanks
         result = resultVector.toList();

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1428,7 +1428,7 @@ int Avatar::getJointIndex(const QString& name) const {
 
     withValidJointIndicesCache([&]() {
         if (_modelJointIndicesCache.contains(name)) {
-            result = _modelJointIndicesCache[name] - 1;
+            result = _modelJointIndicesCache.value(name) - 1;
         }
     });
     return result;
@@ -1439,22 +1439,22 @@ QStringList Avatar::getJointNames() const {
     withValidJointIndicesCache([&]() {
         // find out how large the vector needs to be
         int maxJointIndex = -1;
-        QHashIterator<QString, int> k(_modelJointIndicesCache);
-        while (k.hasNext()) {
-            k.next();
+        QHash<QString, int>::const_iterator k = _modelJointIndicesCache.constBegin();
+        while (k != _modelJointIndicesCache.constEnd()) {
             int index = k.value();
             if (index > maxJointIndex) {
                 maxJointIndex = index;
             }
+            ++k;
         }
         // iterate through the hash and put joint names
         // into the vector at their indices
         QVector<QString> resultVector(maxJointIndex+1);
-        QHashIterator<QString, int> i(_modelJointIndicesCache);
-        while (i.hasNext()) {
-            i.next();
+        QHash<QString, int>::const_iterator i = _modelJointIndicesCache.constBegin();
+        while (i != _modelJointIndicesCache.constEnd()) {
             int index = i.value();
             resultVector[index] = i.key();
+            ++i;
         }
         // convert to QList and drop out blanks
         result = resultVector.toList();


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/20787/Memory-corruption-in-_modelJointIndicesCache-QHash

https://highfidelity.atlassian.net/browse/BUGZ-54

Access to _modelJointIndicesCache inside the lambda function is now done with const iterators