### PR TITLE
Case 17368: Fix wearables not disappearing with avatar

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -776,7 +776,8 @@ protected:
     void updateAttachmentRenderIDs();
     render::ItemIDs _attachmentRenderIDs;
     void updateDescendantRenderIDs();
-    render::ItemIDSet _descendantRenderIDs;
+    render::ItemIDs _descendantRenderIDs;
+    std::unordered_set<EntityItemID> _renderingDescendantEntityIDs;
     uint32_t _lastAncestorChainRenderableVersion { 0 };
 };
 

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -776,7 +776,7 @@ protected:
     void updateAttachmentRenderIDs();
     render::ItemIDs _attachmentRenderIDs;
     void updateDescendantRenderIDs();
-    render::ItemIDs _descendantRenderIDs;
+    render::ItemIDSet _descendantRenderIDs;
     uint32_t _lastAncestorChainRenderableVersion { 0 };
 };
 

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -186,16 +186,20 @@ render::hifi::Layer EntityRenderer::getHifiRenderLayer() const {
 }
 
 ItemKey EntityRenderer::getKey() {
+    auto builder = ItemKey::Builder().withTypeShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
     if (isTransparent()) {
-        return ItemKey::Builder::transparentShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+        builder.withTransparent();
     }
 
-    // This allows shapes to cast shadows
     if (_canCastShadow) {
-        return ItemKey::Builder::opaqueShape().withTypeMeta().withTagBits(getTagMask()).withShadowCaster().withLayer(getHifiRenderLayer());
-    } else {
-        return ItemKey::Builder::opaqueShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+        builder.withShadowCaster();
     }
+
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
+    }
+
+    return builder.build();
 }
 
 uint32_t EntityRenderer::metaFetchMetaSubItems(ItemIDs& subItems) {
@@ -430,6 +434,7 @@ void EntityRenderer::doRenderUpdateSynchronous(const ScenePointer& scene, Transa
         setRenderLayer(entity->getRenderLayer());
         setPrimitiveMode(entity->getPrimitiveMode());
         _canCastShadow = entity->getCanCastShadow();
+        setCullWithParent(entity->getCullWithParent());
         _cauterized = entity->getCauterized();
         _needsRenderUpdate = false;
     });

--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -107,7 +107,8 @@ protected:
     virtual void setIsVisibleInSecondaryCamera(bool value) { _isVisibleInSecondaryCamera = value; }
     virtual void setRenderLayer(RenderLayer value) { _renderLayer = value; }
     virtual void setPrimitiveMode(PrimitiveMode value) { _primitiveMode = value; }
-    
+    virtual void setCullWithParent(bool value) { _cullWithParent = value; }
+
     template <typename F, typename T>
     T withReadLockResult(const std::function<T()>& f) {
         T result;
@@ -139,6 +140,7 @@ protected:
     bool _visible { false };
     bool _isVisibleInSecondaryCamera { false };
     bool _canCastShadow { false };
+    bool _cullWithParent { false };
     RenderLayer _renderLayer { RenderLayer::WORLD };
     PrimitiveMode _primitiveMode { PrimitiveMode::SOLID };
     bool _cauterized { false };

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -230,8 +230,7 @@ void MaterialEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPo
 }
 
 ItemKey MaterialEntityRenderer::getKey() {
-    ItemKey::Builder builder;
-    builder.withTypeShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+    auto builder = ItemKey::Builder().withTypeShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
 
     if (!_visible) {
         builder.withInvisible();

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -1051,8 +1051,10 @@ ModelEntityRenderer::ModelEntityRenderer(const EntityItemPointer& entity) : Pare
 void ModelEntityRenderer::setKey(bool didVisualGeometryRequestSucceed) {
     auto builder = ItemKey::Builder().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
 
-    if (_model && _model->isGroupCulled()) {
+    if (!_cullWithParent && _model && _model->isGroupCulled()) {
         builder.withMetaCullGroup();
+    } else if (_cullWithParent) {
+        builder.withoutSubMetaCulled();
     }
 
     if (didVisualGeometryRequestSucceed) {
@@ -1500,6 +1502,14 @@ void ModelEntityRenderer::setPrimitiveMode(PrimitiveMode value) {
     Parent::setPrimitiveMode(value);
     if (_model) {
         _model->setPrimitiveMode(_primitiveMode);
+    }
+}
+
+void ModelEntityRenderer::setCullWithParent(bool value) {
+    Parent::setCullWithParent(value);
+    setKey(_didLastVisualGeometryRequestSucceed);
+    if (_model) {
+        _model->setCullWithParent(_cullWithParent);
     }
 }
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.h
@@ -164,6 +164,7 @@ protected:
     void setIsVisibleInSecondaryCamera(bool value) override;
     void setRenderLayer(RenderLayer value) override;
     void setPrimitiveMode(PrimitiveMode value) override;
+    void setCullWithParent(bool value) override;
 
 private:
     void animate(const TypedEntityPointer& entity);

--- a/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableParticleEffectEntityItem.cpp
@@ -177,11 +177,17 @@ void ParticleEffectEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEn
 
 ItemKey ParticleEffectEntityRenderer::getKey() {
     // FIXME: implement isTransparent() for particles and an opaque pipeline
-    if (_visible) {
-        return ItemKey::Builder::transparentShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
-    } else {
-        return ItemKey::Builder().withInvisible().withTagBits(getTagMask()).withLayer(getHifiRenderLayer()).build();
+    auto builder = ItemKey::Builder::transparentShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+
+    if (!_visible) {
+        builder.withInvisible();
     }
+
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
+    }
+
+    return builder.build();
 }
 
 ShapeKey ParticleEffectEntityRenderer::getShapeKey() {

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -71,7 +71,14 @@ void PolyLineEntityRenderer::buildPipeline() {
 }
 
 ItemKey PolyLineEntityRenderer::getKey() {
-    return ItemKey::Builder::transparentShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+    // FIXME: implement isTransparent() for polylines and an opaque pipeline
+    auto builder = ItemKey::Builder::transparentShape().withTypeMeta().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
+    }
+
+    return builder.build();
 }
 
 ShapeKey PolyLineEntityRenderer::getShapeKey() {

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -1612,6 +1612,16 @@ PolyVoxEntityRenderer::PolyVoxEntityRenderer(const EntityItemPointer& entity) : 
     _params = std::make_shared<gpu::Buffer>(sizeof(glm::vec4), nullptr);
 }
 
+ItemKey PolyVoxEntityRenderer::getKey() {
+    auto builder = ItemKey::Builder::opaqueShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer());
+
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
+    }
+
+    return builder.build();
+}
+
 ShapeKey PolyVoxEntityRenderer::getShapeKey() {
     auto builder = ShapeKey::Builder().withCustom(CUSTOM_PIPELINE_NUMBER);
     if (_primitiveMode == PrimitiveMode::LINES) {

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.h
@@ -173,7 +173,7 @@ public:
     }
     
 protected:
-    virtual ItemKey getKey() override { return ItemKey::Builder::opaqueShape().withTagBits(getTagMask()).withLayer(getHifiRenderLayer()); }
+    virtual ItemKey getKey() override;
     virtual ShapeKey getShapeKey() override;
     virtual bool needsRenderUpdateFromTypedEntity(const TypedEntityPointer& entity) const override;
     virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -3061,6 +3061,17 @@ void EntityItem::setCanCastShadow(bool value) {
     }
 }
 
+bool EntityItem::getCullWithParent() const {
+    return _cullWithParent;
+}
+
+void EntityItem::setCullWithParent(bool value) {
+    if (_cullWithParent != value) {
+        _cullWithParent = value;
+        emit requestRenderUpdate();
+    }
+}
+
 bool EntityItem::isChildOfMyAvatar() const {
     QUuid ancestorID = findAncestorOfType(NestableType::Avatar);
     return !ancestorID.isNull() && (ancestorID == Physics::getSessionUUID() || ancestorID == AVATAR_SELF_ID);

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -303,6 +303,9 @@ public:
     bool getCanCastShadow() const;
     void setCanCastShadow(bool value);
 
+    bool getCullWithParent() const;
+    void setCullWithParent(bool value);
+
     void setCauterized(bool value);
     bool getCauterized() const;
 
@@ -751,6 +754,8 @@ protected:
     GrabPropertyGroup _grabProperties;
 
     QHash<QUuid, EntityDynamicPointer> _grabActions;
+
+    bool _cullWithParent { false };
 
 private:
     static std::function<glm::quat(const glm::vec3&, const glm::quat&, BillboardMode, const glm::vec3&)> _getBillboardRotationOperator;

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -92,6 +92,10 @@ void MeshPartPayload::updateKey(const render::ItemKey& key) {
         builder.withTransparent();
     }
 
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
+    }
+
     _itemKey = builder.build();
 }
 
@@ -335,6 +339,10 @@ void ModelMeshPartPayload::updateKey(const render::ItemKey& key) {
     auto matKey = _drawMaterials.getMaterialKey();
     if (matKey.isTranslucent()) {
         builder.withTransparent();
+    }
+
+    if (_cullWithParent) {
+        builder.withSubMetaCulled();
     }
 
     _itemKey = builder.build();

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -43,7 +43,7 @@ public:
     // Render Item interface
     virtual render::ItemKey getKey() const;
     virtual render::Item::Bound getBound() const;
-    virtual render::ShapeKey getShapeKey() const; // shape interface
+    virtual render::ShapeKey getShapeKey() const;
     virtual void render(RenderArgs* args);
 
     // ModelMeshPartPayload functions to perform render
@@ -73,8 +73,11 @@ public:
     void addMaterial(graphics::MaterialLayer material);
     void removeMaterial(graphics::MaterialPointer material);
 
+    void setCullWithParent(bool value) { _cullWithParent = value; }
+
 protected:
     render::ItemKey _itemKey{ render::ItemKey::Builder::opaqueShape().build() };
+    bool _cullWithParent { false };
 };
 
 namespace render {
@@ -103,7 +106,7 @@ public:
     void updateTransformForSkinnedMesh(const Transform& renderTransform, const Transform& boundTransform);
 
     // Render Item interface
-    render::ShapeKey getShapeKey() const override; // shape interface
+    render::ShapeKey getShapeKey() const override;
     void render(RenderArgs* args) override;
 
     void setShapeKey(bool invalidateShapeKey, PrimitiveMode primitiveMode, bool useDualQuaternionSkinning);

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -151,7 +151,7 @@ void Model::setOffset(const glm::vec3& offset) {
 }
 
 void Model::calculateTextureInfo() {
-    if (!_hasCalculatedTextureInfo && isLoaded() && getGeometry()->areTexturesLoaded() && !_modelMeshRenderItemsMap.isEmpty()) {
+    if (!_hasCalculatedTextureInfo && isLoaded() && getGeometry()->areTexturesLoaded() && !_modelMeshRenderItems.isEmpty()) {
         size_t textureSize = 0;
         int textureCount = 0;
         bool allTexturesLoaded = true;
@@ -951,6 +951,20 @@ void Model::setCauterized(bool cauterized, const render::ScenePointer& scene) {
             });
         }
         scene->enqueueTransaction(transaction);
+    }
+}
+
+void Model::setCullWithParent(bool cullWithParent) {
+    if (_cullWithParent != cullWithParent) {
+        _cullWithParent = cullWithParent;
+
+        render::Transaction transaction;
+        foreach(auto item, _modelMeshRenderItemsMap.keys()) {
+            transaction.updateItem<ModelMeshPartPayload>(item, [cullWithParent](ModelMeshPartPayload& data) {
+                data.setCullWithParent(cullWithParent);
+            });
+        }
+        AbstractViewStateInterface::instance()->getMain3DScene()->enqueueTransaction(transaction);
     }
 }
 

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -129,6 +129,8 @@ public:
     bool isCauterized() const { return _cauterized; }
     void setCauterized(bool value, const render::ScenePointer& scene);
 
+    void setCullWithParent(bool value);
+
     // Access the current RenderItemKey Global Flags used by the model and applied to the render items  representing the parts of the model.
     const render::ItemKey getRenderItemKeyGlobalFlags() const;
 
@@ -506,6 +508,7 @@ protected:
     //  
     render::ItemKey _renderItemKeyGlobalFlags;
     bool _cauterized { false };
+    bool _cullWithParent { false };
 
     bool shouldInvalidatePayloadShapeKey(int meshIndex);
 

--- a/libraries/render/src/render/Item.cpp
+++ b/libraries/render/src/render/Item.cpp
@@ -123,7 +123,11 @@ namespace render {
         if (!payload) {
             return ItemKey::Builder::opaqueShape().withTypeMeta();
         }
-        return payload->getKey();
+        if (payload->overrideSubMetaCulled()) {
+            return ItemKey::Builder(payload->getKey()).withSubMetaCulled();
+        } else {
+            return payload->getKey();
+        }
     }
 
     template <> const ShapeKey shapeGetShapeKey(const PayloadProxyInterface::Pointer& payload) {

--- a/libraries/render/src/render/Item.cpp
+++ b/libraries/render/src/render/Item.cpp
@@ -123,11 +123,7 @@ namespace render {
         if (!payload) {
             return ItemKey::Builder::opaqueShape().withTypeMeta();
         }
-        if (payload->overrideSubMetaCulled()) {
-            return ItemKey::Builder(payload->getKey()).withSubMetaCulled();
-        } else {
-            return payload->getKey();
-        }
+        return payload->getKey();
     }
 
     template <> const ShapeKey shapeGetShapeKey(const PayloadProxyInterface::Pointer& payload) {

--- a/libraries/render/src/render/Item.h
+++ b/libraries/render/src/render/Item.h
@@ -599,6 +599,12 @@ public:
     virtual Item::Bound getBound() = 0;
     virtual void render(RenderArgs* args) = 0;
     virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) = 0;
+
+    bool overrideSubMetaCulled() const { return _overrideSubMetaCulled; }
+    void setOverrideSubMetaCulled(bool overrideSubMetaCulled) { _overrideSubMetaCulled = overrideSubMetaCulled; }
+
+protected:
+    bool _overrideSubMetaCulled { false };
 };
 
 template <> const ItemKey payloadGetKey(const PayloadProxyInterface::Pointer& payload);

--- a/libraries/render/src/render/Item.h
+++ b/libraries/render/src/render/Item.h
@@ -599,12 +599,6 @@ public:
     virtual Item::Bound getBound() = 0;
     virtual void render(RenderArgs* args) = 0;
     virtual uint32_t metaFetchMetaSubItems(ItemIDs& subItems) = 0;
-
-    bool overrideSubMetaCulled() const { return _overrideSubMetaCulled; }
-    void setOverrideSubMetaCulled(bool overrideSubMetaCulled) { _overrideSubMetaCulled = overrideSubMetaCulled; }
-
-protected:
-    bool _overrideSubMetaCulled { false };
 };
 
 template <> const ItemKey payloadGetKey(const PayloadProxyInterface::Pointer& payload);
@@ -615,7 +609,7 @@ template <> const ShapeKey shapeGetShapeKey(const PayloadProxyInterface::Pointer
 
 
 typedef Item::PayloadPointer PayloadPointer;
-typedef std::vector< PayloadPointer > Payloads;
+typedef std::vector<PayloadPointer> Payloads;
 
 // A map of items by ShapeKey to optimize rendering pipeline assignments
 using ShapeBounds = std::unordered_map<ShapeKey, ItemBounds, ShapeKey::Hash, ShapeKey::KeyEqual>;


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/17368/When-going-away-pressing-escape-key-wearables-do-not-disappear

https://github.com/highfidelity/hifi/issues/9462

Test plan:
- Run [this script](https://gist.githubusercontent.com/SamGondelman/f18015d6dcf95c3cdf4eb02f5bc515fa/raw/80437e30f2e5848b86c69543a609883f676950cf/AwayToggleWearablesTest.js), you'll see a bunch of entities (1 box, two models, one text, one image, one web, one particle, one polyline, one polyvox, one grid, one ring gizmo, one material)
- Toggle your avatar's visibility by pressing Escape.  Your avatar will disappear but the entities will remain the same.
- Press "h".  The entities are now attached to your avatar.  They should appear the same, but they'll follow you when you move. (Note: the material entity will vanish because its parent has been set, this is fine, ignore it for the rest of the test)
- Toggle your avatar's visibility by pressing Escape.  Your avatar and all the entities will appear/disappear at the same time.
- While visible, press "h" again.  The entities won't follow you anymore and won't disappear when you press escape.