### PR TITLE
(case 22429) Do sanity checks on FBX data array lengths

### DIFF
--- a/libraries/fbx/src/FBXSerializer_Node.cpp
+++ b/libraries/fbx/src/FBXSerializer_Node.cpp
@@ -41,8 +41,14 @@ QVariant readBinaryArray(QDataStream& in, int& position) {
     quint32 compressedLength;
 
     in >> arrayLength;
+    if (arrayLength > std::numeric_limits<int>::max() / sizeof(T)) { // Upcoming byte containers are limited to max signed int
+        throw QString("FBX file most likely corrupt: binary data exceeds data limits");
+    }
     in >> encoding;
     in >> compressedLength;
+    if (compressedLength > std::numeric_limits<int>::max() / sizeof(T)) { // Upcoming byte containers are limited to max signed int
+        throw QString("FBX file most likely corrupt: compressed binary data exceeds data limits");
+    }
     position += sizeof(quint32) * 3;
 
     QVector<T> values;


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/edit/22429/Crash-in-parseBinaryFBXProperty-in-fbxserializer_node-cpp
https://highfidelity.atlassian.net/browse/BUGZ-80

This PR sets a sane limit on the amount of data that can be read from a single binary array in an FBX node.