### PR TITLE
BUGZ-92: Refresh rate Throttling refinements

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4109,12 +4109,7 @@ bool Application::eventFilter(QObject* object, QEvent* event) {
     auto eventType = event->type();
     if (eventType == QEvent::KeyPress || eventType == QEvent::KeyRelease || eventType == QEvent::MouseMove) {
         RefreshRateManager& refreshRateManager = getRefreshRateManager();
-        auto refreshRateRegime = refreshRateManager.getRefreshRateRegime();
-
-        if (refreshRateRegime == RefreshRateManager::RefreshRateRegime::RUNNING ||
-            refreshRateRegime == RefreshRateManager::RefreshRateRegime::INACTIVE) {
-            getRefreshRateManager().resetInactiveTimer();
-        }
+        getRefreshRateManager().resetInactiveTimer();
     }
 
     if (event->type() == QEvent::Leave) {
@@ -5603,7 +5598,7 @@ void Application::resumeAfterLoginDialogActionTaken() {
     _myCamera.setMode(_previousCameraMode);
     cameraModeChanged();
     _startUpFinished = true;
-    getRefreshRateManager().setRefreshRateRegime(RefreshRateManager::RefreshRateRegime::RUNNING);
+    getRefreshRateManager().setRefreshRateRegime(RefreshRateManager::RefreshRateRegime::FOCUS_ACTIVE);
 }
 
 void Application::loadAvatarScripts(const QVector<QString>& urls) {
@@ -8547,7 +8542,7 @@ void Application::activeChanged(Qt::ApplicationState state) {
         case Qt::ApplicationActive:
             _isForeground = true;
             if (!_aboutToQuit && _startUpFinished) {
-                getRefreshRateManager().setRefreshRateRegime(RefreshRateManager::RefreshRateRegime::RUNNING);
+                getRefreshRateManager().setRefreshRateRegime(RefreshRateManager::RefreshRateRegime::FOCUS_ACTIVE);
             }
             break;
 
@@ -8890,7 +8885,7 @@ void Application::setDisplayPlugin(DisplayPluginPointer newDisplayPlugin) {
         RefreshRateManager& refreshRateManager = getRefreshRateManager();
         refreshRateManager.setRefreshRateOperator(OpenGLDisplayPlugin::getRefreshRateOperator());
         bool isHmd = newDisplayPlugin->isHmd();
-        RefreshRateManager::UXMode uxMode = isHmd ? RefreshRateManager::UXMode::HMD :
+        RefreshRateManager::UXMode uxMode = isHmd ? RefreshRateManager::UXMode::VR :
             RefreshRateManager::UXMode::DESKTOP;
 
         refreshRateManager.setUXMode(uxMode);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4111,7 +4111,6 @@ bool Application::eventFilter(QObject* object, QEvent* event) {
 
     auto eventType = event->type();
     if (eventType == QEvent::KeyPress || eventType == QEvent::KeyRelease || eventType == QEvent::MouseMove) {
-        RefreshRateManager& refreshRateManager = getRefreshRateManager();
         getRefreshRateManager().resetInactiveTimer();
     }
 

--- a/interface/src/RefreshRateManager.cpp
+++ b/interface/src/RefreshRateManager.cpp
@@ -83,8 +83,11 @@ RefreshRateManager::RefreshRateManager() {
 
 void RefreshRateManager::resetInactiveTimer() {
     if (_uxMode == RefreshRateManager::UXMode::DESKTOP) {
-        _inactiveTimer->start();
-        setRefreshRateRegime(RefreshRateManager::RefreshRateRegime::FOCUS_ACTIVE);
+        auto regime = getRefreshRateRegime();
+        if (regime == RefreshRateRegime::FOCUS_ACTIVE || regime == RefreshRateRegime::FOCUS_INACTIVE) {
+            _inactiveTimer->start();
+            setRefreshRateRegime(RefreshRateManager::RefreshRateRegime::FOCUS_ACTIVE);
+        }
     }
 }
 

--- a/interface/src/RefreshRateManager.h
+++ b/interface/src/RefreshRateManager.h
@@ -15,6 +15,8 @@
 #include <map>
 #include <string>
 
+#include <QTimer>
+
 #include <SettingHandle.h>
 #include <shared/ReadWriteLockable.h>
 
@@ -33,6 +35,7 @@ public:
         MINIMIZED,
         STARTUP,
         SHUTDOWN,
+        INACTIVE,
         REGIME_NUM
     };
 
@@ -60,6 +63,8 @@ public:
     void setInteractiveRefreshRate(int refreshRate);
     int getInteractiveRefreshRate() const;
 
+    void resetInactiveTimer();
+
     static std::string refreshRateProfileToString(RefreshRateProfile refreshRateProfile);
     static RefreshRateProfile refreshRateProfileFromString(std::string refreshRateProfile);
     static std::string uxModeToString(UXMode uxMode);
@@ -78,6 +83,9 @@ private:
     Setting::Handle<int> _refreshRateMode { "refreshRateProfile", INTERACTIVE };
 
     std::function<void(int)> _refreshRateOperator { nullptr };
+
+
+    std::shared_ptr<QTimer> _inactiveTimer { std::make_shared<QTimer>() };
 };
 
 #endif

--- a/interface/src/RefreshRateManager.h
+++ b/interface/src/RefreshRateManager.h
@@ -60,10 +60,9 @@ public:
     void setRefreshRateOperator(std::function<void(int)> refreshRateOperator) { _refreshRateOperator = refreshRateOperator; }
     int getActiveRefreshRate() const { return _activeRefreshRate; }
     void updateRefreshRateController() const;
-    void setInteractiveRefreshRate(int refreshRate);
-    int getInteractiveRefreshRate() const;
 
     void resetInactiveTimer();
+    void toggleInactive();
 
     static std::string refreshRateProfileToString(RefreshRateProfile refreshRateProfile);
     static RefreshRateProfile refreshRateProfileFromString(std::string refreshRateProfile);
@@ -71,19 +70,15 @@ public:
     static std::string refreshRateRegimeToString(RefreshRateRegime refreshRateRegime);
 
 private:
-    mutable ReadWriteLockable _refreshRateLock;
-    mutable ReadWriteLockable _refreshRateModeLock;
-
     mutable int _activeRefreshRate { 20 };
     RefreshRateProfile _refreshRateProfile { RefreshRateProfile::INTERACTIVE};
     RefreshRateRegime _refreshRateRegime { RefreshRateRegime::STARTUP };
     UXMode _uxMode;
 
-    Setting::Handle<int> _interactiveRefreshRate { "interactiveRefreshRate", 20};
-    Setting::Handle<int> _refreshRateMode { "refreshRateProfile", INTERACTIVE };
+    mutable ReadWriteLockable _refreshRateProfileSettingLock;
+    Setting::Handle<int> _refreshRateProfileSetting { "refreshRateProfile", RefreshRateProfile::INTERACTIVE };
 
     std::function<void(int)> _refreshRateOperator { nullptr };
-
 
     std::shared_ptr<QTimer> _inactiveTimer { std::make_shared<QTimer>() };
 };

--- a/interface/src/RefreshRateManager.h
+++ b/interface/src/RefreshRateManager.h
@@ -30,18 +30,18 @@ public:
     };
 
     enum RefreshRateRegime {
-        RUNNING = 0,
+        FOCUS_ACTIVE = 0,
+        FOCUS_INACTIVE,
         UNFOCUS,
         MINIMIZED,
         STARTUP,
         SHUTDOWN,
-        INACTIVE,
         REGIME_NUM
     };
 
     enum UXMode {
         DESKTOP = 0,
-        HMD,
+        VR,
         UX_NUM
     };
 


### PR DESCRIPTION
@danteruiz Did all the work, i just took over his branch to do minor tweaks.

We are introducing a detection of the user input events to switch the regime of the refresh rate manager between "FocusActive" or FocusInactive"
On Any user input, the regime is reset to  "FocusActive" with the higher refresh rate target (Interactive: 30Hz/ Eco: 20Hz)
After the last user input event, after a wait of 3sec, the regimes goes to "FocusInactive" with the lower refresh rate target (INteractive: 20Hz / Eco: 10Hz)
If the Profile is "Realtime" then both "FocusActive" and "FocusInactive" are set at 60Hz

If in VR UX mode then the PRofile is always Realtime with a target refreshrate of 90Hz

## TEST PLAN
First that the settings/graphics indicate the "Interactive" value for refresh profile

In stats, the REfresh line (left column, 3rd line) should show a the behavior
the regime should indicate "FocusActive - 30" while interacting with key pressed or mouse moves
then after doing nothing for 3 sec it should say "FocusInactive - 20"
on the first user input it should return to "FocusActive - 30"
Clicking out of the main window  should set the indication to "Unfocus - 10"

Now  go change the settings in "graphics/Refresh" to the Eco mode
The same sequence above should give the same regime changes but different values:
"FocusActive - 20"
"FocusInactive - 10"
"Unfocus- 5"

Next change the settings in "graphics/Refresh" to the Realtime mode
The same sequence above should give the same regime changes but different values:
"FocusActive - 60"
"FocusInactive - 60"   <<<<< YES Inactive and Active are the same in Realtime profile!
"Unfocus- 10"

Lastly try the same scenarii with HMD on and then it Should show the same values regadless :
"FocusActive - 90"
"FocusInactive - 90"
"Unfocus- 10"




