### PR TITLE
Enable `--ci-build` setting via an environment variable

### DIFF
--- a/prebuild.py
+++ b/prebuild.py
@@ -94,7 +94,7 @@ def parse_args():
     parser.add_argument('--vcpkg-root', type=str, help='The location of the vcpkg distribution')
     parser.add_argument('--build-root', required=True, type=str, help='The location of the cmake build')
     parser.add_argument('--ports-path', type=str, default=defaultPortsPath)
-    parser.add_argument('--ci-build', action='store_true')
+    parser.add_argument('--ci-build', action='store_true', default=os.getenv('CI_BUILD') is not None)
     if True:
         args = parser.parse_args()
     else:


### PR DESCRIPTION
Prior to this comment the only way to enable the ci mode for the `prebuild.py` script was to pass it the `--ci-build` argument. The ci system doesn't call call prebuild directly, cmake does, so adding this argument via the CI system is impossible. This change adds the `CI_BUILD` environment variable so enabling the ci mode is possible through the CI system.

Prints timing with CI_BUILD environment variable set

    % CI_BUILD=foo cmake -G "Unix Makefiles" ../hifi
    ['/Users/mhard/src/hifi/prebuild.py', '--build-root', '/Users/mhard/src/hifi_build_make']
    1556815031 bcab3689-9ec6-49d4-bbdf-05de5840001f sha=3bb61335be
    1556815031 bcab3689-9ec6-49d4-bbdf-05de5840001f start
    Warning: Environment variable HIFI_VCPKG_BASE not set, using /Users/mhard/hifi/vcpkg
    Using vcpkg path /Users/mhard/hifi/vcpkg/c1966b8c
    [... snip ...]

Doesn't print timing when CI_BUILD environment variable is unset:

    % cmake -G "Unix Makefiles" ../hifi
    ['/Users/mhard/src/hifi/prebuild.py', '--build-root', '/Users/mhard/src/hifi_build_make']
    Warning: Environment variable HIFI_VCPKG_BASE not set, using /Users/mhard/hifi/vcpkg
    Using vcpkg path /Users/mhard/hifi/vcpkg/c1966b8c
    [... snip ...]