### PR TITLE
Fixed possible divide by zero error in setPacketSendPeriod()

### DIFF
--- a/libraries/networking/src/udt/CongestionControl.cpp
+++ b/libraries/networking/src/udt/CongestionControl.cpp
@@ -29,7 +29,7 @@ void CongestionControl::setMaxBandwidth(int maxBandwidth) {
 void CongestionControl::setPacketSendPeriod(double newSendPeriod) {
     Q_ASSERT_X(newSendPeriod >= 0, "CongestionControl::setPacketPeriod", "Can not set a negative packet send period");
 
-    auto packetsPerSecond = _mss > 0.0f ? (double)_maxBandwidth / (BITS_PER_BYTE * _mss) : -1.0f;
+    auto packetsPerSecond = _mss > 0 ? (double)_maxBandwidth / (BITS_PER_BYTE * _mss) : -1.0;
     if (packetsPerSecond > 0.0) {
         // anytime the packet send period is about to be increased, make sure it stays below the minimum period,
         // calculated based on the maximum desired bandwidth

--- a/libraries/networking/src/udt/CongestionControl.cpp
+++ b/libraries/networking/src/udt/CongestionControl.cpp
@@ -29,7 +29,7 @@ void CongestionControl::setMaxBandwidth(int maxBandwidth) {
 void CongestionControl::setPacketSendPeriod(double newSendPeriod) {
     Q_ASSERT_X(newSendPeriod >= 0, "CongestionControl::setPacketPeriod", "Can not set a negative packet send period");
 
-    auto packetsPerSecond = (double)_maxBandwidth / (BITS_PER_BYTE * _mss);
+    auto packetsPerSecond = _mss > 0.0f ? (double)_maxBandwidth / (BITS_PER_BYTE * _mss) : -1.0f;
     if (packetsPerSecond > 0.0) {
         // anytime the packet send period is about to be increased, make sure it stays below the minimum period,
         // calculated based on the maximum desired bandwidth


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/15508/AddressSanitizer-caught-divide-by-zero-in-CongestionControl-cpp

This pr prevents a divide by zero error occuring when you setPacketSendPeriod is called in CongestionControl.cpp.  The bug is the result of _mss (maximum packet size) being initialized to 0.0 but never being set before it is used in setPacketSendPeriod.

### Test Plan
This bug was found while running interface with Address Sanitizer so that is probably the best way to test to see that it not happening any more