### PR TITLE
Case 19510: Unify cube and sphere edit menu entries into one.

### DIFF
--- a/interface/resources/qml/hifi/tablet/EditTabView.qml
+++ b/interface/resources/qml/hifi/tablet/EditTabView.qml
@@ -85,23 +85,11 @@ TabBar {
 
                         NewEntityButton {
                             icon: "icons/create-icons/21-cube-01.svg"
-                            text: "CUBE"
+                            text: "SHAPE"
                             onClicked: {
                                 editRoot.sendToScript({
                                     method: "newEntityButtonClicked",
-                                    params: { buttonName: "newCubeButton" }
-                                });
-                                editTabView.currentIndex = 2
-                            }
-                        }
-
-                        NewEntityButton {
-                            icon: "icons/create-icons/22-sphere-01.svg"
-                            text: "SPHERE"
-                            onClicked: {
-                                editRoot.sendToScript({
-                                    method: "newEntityButtonClicked",
-                                    params: { buttonName: "newSphereButton" }
+                                    params: { buttonName: "newShapeButton" }
                                 });
                                 editTabView.currentIndex = 2
                             }

--- a/interface/resources/qml/hifi/tablet/EditToolsTabView.qml
+++ b/interface/resources/qml/hifi/tablet/EditToolsTabView.qml
@@ -91,23 +91,11 @@ TabBar {
 
                         NewEntityButton {
                             icon: "icons/create-icons/21-cube-01.svg"
-                            text: "CUBE"
+                            text: "SHAPE"
                             onClicked: {
                                 editRoot.sendToScript({
                                     method: "newEntityButtonClicked",
-                                    params: { buttonName: "newCubeButton" }
-                                });
-                                editTabView.currentIndex = tabIndex.properties
-                            }
-                        }
-
-                        NewEntityButton {
-                            icon: "icons/create-icons/22-sphere-01.svg"
-                            text: "SPHERE"
-                            onClicked: {
-                                editRoot.sendToScript({
-                                    method: "newEntityButtonClicked",
-                                    params: { buttonName: "newSphereButton" }
+                                    params: { buttonName: "newShapeButton" }
                                 });
                                 editTabView.currentIndex = tabIndex.properties
                             }

--- a/scripts/developer/tests/toolbarTest.js
+++ b/scripts/developer/tests/toolbarTest.js
@@ -5,8 +5,7 @@ var toolBar = (function() {
         toolBar,
         activeButton,
         newModelButton,
-        newCubeButton,
-        newSphereButton,
+        newShapeButton,
         newLightButton,
         newTextButton,
         newWebButton,
@@ -41,16 +40,9 @@ var toolBar = (function() {
             visible: false
         });
 
-        newCubeButton = toolBar.addButton({
-            objectName: "newCubeButton",
+        newShapeButton = toolBar.addButton({
+            objectName: "newShapeButton",
             imageURL: toolIconUrl + "cube-01.svg",
-            alpha: 0.9,
-            visible: false
-        });
-
-        newSphereButton = toolBar.addButton({
-            objectName: "newSphereButton",
-            imageURL: toolIconUrl + "sphere-01.svg",
             alpha: 0.9,
             visible: false
         });
@@ -111,8 +103,7 @@ var toolBar = (function() {
     // Sets visibility of tool buttons, excluding the power button
     that.showTools = function(doShow) {
         newModelButton.writeProperty('visible', doShow);
-        newCubeButton.writeProperty('visible', doShow);
-        newSphereButton.writeProperty('visible', doShow);
+        newShapeButton.writeProperty('visible', doShow);
         newLightButton.writeProperty('visible', doShow);
         newTextButton.writeProperty('visible', doShow);
         newWebButton.writeProperty('visible', doShow);

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -860,15 +860,10 @@ var toolBar = (function () {
 
         addButton("newModelButton", createNewEntityDialogButtonCallback("Model"));
 
-        addButton("newCubeButton", function () {
+        addButton("newShapeButton", function () {
             createNewEntity({
-                type: "Box",
-            });
-        });
-
-        addButton("newSphereButton", function () {
-            createNewEntity({
-                type: "Sphere",
+                type: "Shape",
+				shape: "Cube",
             });
         });
 

--- a/scripts/system/edit.js
+++ b/scripts/system/edit.js
@@ -863,7 +863,7 @@ var toolBar = (function () {
         addButton("newShapeButton", function () {
             createNewEntity({
                 type: "Shape",
-				shape: "Cube",
+                shape: "Cube",
             });
         });
 


### PR DESCRIPTION
https://highfidelity.manuscript.com/f/cases/19510/Create-app-combine-Cube-and-Sphere-into-Shape

Based on the suggestion posted here (http://roadmap.highfidelity.com/feature-requests/p/create-menu-combine-cube-sphere-into-one-category-primitives). I kind of always felt this would be cleaner. To test, simply launch the create app and press the new 'shape' button.