### PR TITLE
Case 20521: Unplugging headphones with hifi open causes freeze

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -557,7 +557,10 @@ public:
                     return true;
                 }
             }
-
+            // Attempting to close MIDI interfaces of a hot-unplugged device can result in audio-driver deadlock.
+            // Detecting MIDI devices that have been added/removed after starting Inteface has been disabled.
+            // https://support.microsoft.com/en-us/help/4460006/midi-device-app-hangs-when-former-midi-api-is-used
+#if 0
             if (message->message == WM_DEVICECHANGE) {
                 const float MIN_DELTA_SECONDS = 2.0f; // de-bounce signal
                 static float lastTriggerTime = 0.0f;
@@ -567,6 +570,7 @@ public:
                     Midi::USBchanged();                // re-scan the MIDI bus
                 }
             }
+#endif
         }
         return false;
     }

--- a/libraries/midi/src/Midi.cpp
+++ b/libraries/midi/src/Midi.cpp
@@ -206,7 +206,7 @@ void Midi::MidiSetup() {
 
     MIDIOUTCAPS outcaps;
     for (unsigned int i = 0; i < midiOutGetNumDevs(); i++) {
-        midiOutGetDevCaps(i, &outcaps, sizeof(MIDIINCAPS));
+        midiOutGetDevCaps(i, &outcaps, sizeof(MIDIOUTCAPS));
 
         bool found = false;
         for (int j = 0; j < midiOutExclude.size(); j++) {

--- a/libraries/midi/src/Midi.cpp
+++ b/libraries/midi/src/Midi.cpp
@@ -187,38 +187,43 @@ void Midi::MidiSetup() {
 
     MIDIINCAPS incaps;
     for (unsigned int i = 0; i < midiInGetNumDevs(); i++) {
-        midiInGetDevCaps(i, &incaps, sizeof(MIDIINCAPS));
+        if (MMSYSERR_NOERROR == midiInGetDevCaps(i, &incaps, sizeof(MIDIINCAPS))) {
 
-        bool found = false;
-        for (int j = 0; j < midiInExclude.size(); j++) {
-            if (midiInExclude[j].toStdString().compare(incaps.szPname) == 0) {
-                found = true;
-                break;
+            bool found = false;
+            for (int j = 0; j < midiInExclude.size(); j++) {
+                if (midiInExclude[j].toStdString().compare(incaps.szPname) == 0) {
+                    found = true;
+                    break;
+                }
             }
-        }
-        if (!found) {        // EXCLUDE AN INPUT BY NAME
-            HMIDIIN tmphin;
-            midiInOpen(&tmphin, i, (DWORD_PTR)MidiInProc, NULL, CALLBACK_FUNCTION);
-            midiInStart(tmphin);
-            midihin.push_back(tmphin);
+            if (!found) {        // EXCLUDE AN INPUT BY NAME
+                HMIDIIN tmphin;
+                if (MMSYSERR_NOERROR == midiInOpen(&tmphin, i, (DWORD_PTR)MidiInProc, NULL, CALLBACK_FUNCTION)) {
+                    if (MMSYSERR_NOERROR == midiInStart(tmphin)) {
+                        midihin.push_back(tmphin);
+                    }
+                }
+            }
         }
     }
 
     MIDIOUTCAPS outcaps;
     for (unsigned int i = 0; i < midiOutGetNumDevs(); i++) {
-        midiOutGetDevCaps(i, &outcaps, sizeof(MIDIOUTCAPS));
+        if (MMSYSERR_NOERROR == midiOutGetDevCaps(i, &outcaps, sizeof(MIDIOUTCAPS))) {
 
-        bool found = false;
-        for (int j = 0; j < midiOutExclude.size(); j++) {
-            if (midiOutExclude[j].toStdString().compare(outcaps.szPname) == 0) {
-                found = true;
-                break;
+            bool found = false;
+            for (int j = 0; j < midiOutExclude.size(); j++) {
+                if (midiOutExclude[j].toStdString().compare(outcaps.szPname) == 0) {
+                    found = true;
+                    break;
+                }
             }
-        }
-        if (!found) {        // EXCLUDE AN OUTPUT BY NAME
-            HMIDIOUT tmphout;
-            midiOutOpen(&tmphout, i, (DWORD_PTR)MidiOutProc, NULL, CALLBACK_FUNCTION);
-            midihout.push_back(tmphout);
+            if (!found) {        // EXCLUDE AN OUTPUT BY NAME
+                HMIDIOUT tmphout;
+                if (MMSYSERR_NOERROR == midiOutOpen(&tmphout, i, (DWORD_PTR)MidiOutProc, NULL, CALLBACK_FUNCTION)) {
+                    midihout.push_back(tmphout);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
https://highfidelity.fogbugz.com/f/cases/20521/Unplugging-headphones-with-hifi-open-causes-freeze
https://highfidelity.fogbugz.com/f/cases/22193/Unplugging-headphones-with-other-avatars-around-causes-deadlock
https://highfidelity.manuscript.com/f/cases/22396/unplugging-dongle-of-Wireless-USB-headset-crashes-interface

Hot-plugging/unplugging a USB audio device can occasionally hang the audio driver and deadlock Interface. The call stack (below) shows this was occurring when our MIDI support attempts to rescan the MIDI bus after a USB device change. Due to a flaw in the legacy (Win32) MIDI API, attempting to close a MIDI device after it's been hot-unplugged has a significant chance of deadlock.

https://support.microsoft.com/en-us/help/4460006/midi-device-app-hangs-when-former-midi-api-is-used
```
This issue may occur after a Plug and Play (PnP) removal event, 
because the former Microsoft Windows MIDI API implementation 
does not correctly handle that removal in Windows 10.
```

Fixed by disabling detection of MIDI devices added/removed after starting Interface.
To restore this functionality, MIDI support should be reimplemented using WINRT/UWP.

![callstack](https://user-images.githubusercontent.com/13965157/57246392-fcc3c280-6ff1-11e9-8227-1818b407fd50.png)
