### PR TITLE
Fix VS2019 build failure

### DIFF
--- a/libraries/shaders/src/shaders/Shaders.h
+++ b/libraries/shaders/src/shaders/Shaders.h
@@ -13,6 +13,7 @@
 #include <unordered_set>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 #include <QtCore/QtGlobal>
 


### PR DESCRIPTION
A small header change is required to ensure that `std::runtime_error` is defined in `Shaders.h`