### PR TITLE
Case 22483: Disable the use of tbb::parallel_for in Blender

### DIFF
--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1741,15 +1741,23 @@ Blender::Blender(ModelPointer model, int blendNumber, const Geometry::WeakPointe
     _blendshapeCoefficients(blendshapeCoefficients) {
 }
 
+#define BLENDER_USE_NONE 0
+#define BLENDER_USE_TBB 1
+#define BLENDER_TBB_CHUNK_SIZE 512
+#define BLENDER_USE_OPENMP 2
+
+
+#define BLENDER_PARALLELISM BLENDER_USE_NONE
+
 void Blender::run() {
     QVector<BlendshapeOffset> blendshapeOffsets;
     QVector<int> blendedMeshSizes;
     if (_model && _model->isLoaded()) {
         DETAILED_PROFILE_RANGE_EX(simulation_animation, __FUNCTION__, 0xFFFF0000, 0, { { "url", _model->getURL().toString() } });
         int offset = 0;
-        auto meshes = _model->getHFMModel().meshes;
+        const auto& meshes = _model->getHFMModel().meshes;
         int meshIndex = 0;
-        foreach(const HFMMesh& mesh, meshes) {
+        for(const HFMMesh& mesh : meshes) {
             auto modelMeshBlendshapeOffsets = _model->_blendshapeOffsets.find(meshIndex++);
             if (mesh.blendshapes.isEmpty() || modelMeshBlendshapeOffsets == _model->_blendshapeOffsets.end()) {
                 // Not blendshaped or not initialized
@@ -1780,9 +1788,18 @@ void Blender::run() {
 
                 float normalCoefficient = vertexCoefficient * NORMAL_COEFFICIENT_SCALE;
                 const HFMBlendshape& blendshape = mesh.blendshapes.at(i);
-
-                tbb::parallel_for(tbb::blocked_range<int>(0, blendshape.indices.size()), [&](const tbb::blocked_range<int>& range) {
+#if (BLENDER_PARALLELISM == BLENDER_USE_TBB)
+                tbb::parallel_for(tbb::blocked_range<int>(0, blendshape.indices.size(), BLENDER_TBB_CHUNK_SIZE), [&](const tbb::blocked_range<int>& range) {
                     for (auto j = range.begin(); j < range.end(); j++) {
+#elif (BLENDER_PARALLELISM == BLENDER_USE_OPENMP)
+                {
+                    #pragma omp parallel for 
+                    for (int j = 0; j < (int)blendshape.indices.size(); ++j) {
+#else
+                {
+                    for (int j = 0; j < blendshape.indices.size(); ++j) {
+#endif
+
                         int index = blendshape.indices.at(j);
 
                         auto& currentBlendshapeOffset = unpackedBlendshapeOffsets[index];
@@ -1793,20 +1810,41 @@ void Blender::run() {
                             currentBlendshapeOffset.tangentOffset += blendshape.tangents.at(j) * normalCoefficient;
                         }
                     }
+#if (BLENDER_PARALLELISM == BLENDER_USE_TBB)
                 });
+#else
+                }
+#endif
             }
 
             // Blendshape offsets are generrated, now let's pack it on its way to gpu
-            tbb::parallel_for(tbb::blocked_range<int>(0, (int) unpackedBlendshapeOffsets.size()), [&](const tbb::blocked_range<int>& range) {
+#if (BLENDER_PARALLELISM == BLENDER_USE_TBB)
+            tbb::parallel_for(tbb::blocked_range<int>(0, (int) unpackedBlendshapeOffsets.size(), BLENDER_TBB_CHUNK_SIZE), [&](const tbb::blocked_range<int>& range) {
                 auto unpacked = unpackedBlendshapeOffsets.data() + range.begin();
                 auto packed = meshBlendshapeOffsets + range.begin();
                 for (auto j = range.begin(); j < range.end(); j++) {
+#elif (BLENDER_PARALLELISM == BLENDER_USE_OPENMP)
+            {
+                auto unpacked = unpackedBlendshapeOffsets.data();
+                auto packed = meshBlendshapeOffsets;
+                #pragma omp parallel for 
+                for (int j = 0; j < (int)unpackedBlendshapeOffsets.size(); ++j) {
+#else
+            {
+                auto unpacked = unpackedBlendshapeOffsets.data();
+                auto packed = meshBlendshapeOffsets;
+                for (int j = 0; j < (int)unpackedBlendshapeOffsets.size(); ++j) {
+#endif
+                    //for (auto j = range.begin(); j < range.end(); j++) {
                     packBlendshapeOffsetTo_Pos_F32_3xSN10_Nor_3xSN10_Tan_3xSN10((*packed).packedPosNorTan, (*unpacked));
-
-                    unpacked++;
-                    packed++;
+                    ++unpacked;
+                    ++packed;
                 }
+#if (BLENDER_PARALLELISM == BLENDER_USE_TBB)
             });
+#else
+            }
+#endif
         }
     }
     // post the result to the ModelBlender, which will dispatch to the model if still alive

--- a/libraries/shaders/src/shaders/Shaders.h
+++ b/libraries/shaders/src/shaders/Shaders.h
@@ -13,6 +13,7 @@
 #include <unordered_set>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 #include <QtCore/QtGlobal>
 


### PR DESCRIPTION
[22483](https://highfidelity.manuscript.com/f/cases/22483/tbb-causing-significant-cpu-overhead):  The current public build in HQ has an unreasonable amount of CPU usage, apparently regardless of the number of CPU cores available on a machine.  

Testing determined that the bulk of this appears to be coming from the tbb (threading building blocks) library, specifically the use of `tbb::parallel_for` in the `Blender::run` method.  Removing the use of tbb here drastically reduced the CPU usage of interface in local tests while connected to hq.

The basic problem is twofold.  First, the syntax of the existing code doesn't do any _chunking_, i.e. if you have 100 work items it creates 100 individual tasks that each do 1 item, rather than say, 5 tasks that each do 20 items.  Second the `Blender` task has already been dispatched to another thread, and it's possible that multiple `Blender` tasks may run concurrently.  Asking each of them to then use _all the cores_ on the system seems to negate the point of pushing Blender to it's own thread.  Also, the normal packing task is excessively simple and the 

The two issues mean that each run of the Blender task may cause hundreds of tasks to be generated, maximizing the cost of the tbb overhead far beyond any potential savings.  

In attempting to address this I both tried increasing the number of items per _chunk_ for the tbb approach, as well as trying an approach using OpenMP to see if it had better performance.  The chunk size seemed to have no effect, and the OpenMP approach made things much worse.  
