### PR TITLE
SharedObject::onRender deadlock fix

### DIFF
--- a/libraries/qml/src/qml/impl/RenderEventHandler.cpp
+++ b/libraries/qml/src/qml/impl/RenderEventHandler.cpp
@@ -31,6 +31,10 @@ bool RenderEventHandler::event(QEvent* e) {
             onRender();
             return true;
 
+        case OffscreenEvent::RenderSync:
+            onRenderSync();
+            return true;
+
         case OffscreenEvent::Initialize:
             onInitalize();
             return true;
@@ -106,6 +110,14 @@ void RenderEventHandler::resize() {
 }
 
 void RenderEventHandler::onRender() {
+    qmlRender(false);
+}
+
+void RenderEventHandler::onRenderSync() {
+    qmlRender(true);
+}
+
+void RenderEventHandler::qmlRender(bool sceneGraphSync) {
     if (_shared->isQuit()) {
         return;
     }
@@ -117,7 +129,8 @@ void RenderEventHandler::onRender() {
     PROFILE_RANGE(render_qml_gl, __FUNCTION__);
 
     gl::globalLock();
-    if (!_shared->preRender()) {
+    if (!_shared->preRender(sceneGraphSync)) {
+        gl::globalRelease();
         return;
     }
 

--- a/libraries/qml/src/qml/impl/RenderEventHandler.h
+++ b/libraries/qml/src/qml/impl/RenderEventHandler.h
@@ -25,6 +25,7 @@ public:
     enum Type {
         Initialize = QEvent::User + 1,
         Render,
+        RenderSync,
         Quit
     };
 
@@ -45,6 +46,8 @@ private:
     void onInitalize();
     void resize();
     void onRender();
+    void onRenderSync();
+    void qmlRender(bool sceneGraphSync);
     void onQuit();
 
     SharedObject* const _shared;

--- a/libraries/qml/src/qml/impl/SharedObject.h
+++ b/libraries/qml/src/qml/impl/SharedObject.h
@@ -71,7 +71,7 @@ public:
 private:
     bool event(QEvent* e) override;
 
-    bool preRender();
+    bool preRender(bool sceneGraphSync);
     void shutdownRendering(OffscreenGLCanvas& canvas, const QSize& size);
     // Called by the render event handler, from the render thread
     void initializeRenderControl(QOpenGLContext* context);


### PR DESCRIPTION
Call gl::globalRelease() for paused surfaces, this fixes a very common deadlock on mac.

But for PC, by inspection, a race condition could occur over the _syncRequested boolean, between the main and qml rendering thread.  To fix this, we split render and renderSync into separate messages.

https://highfidelity.atlassian.net/browse/BUGZ-78