### PR TITLE
Case 22494, BUGZ-127: Render lightmaps in the forward renderer

### DIFF
--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -228,9 +228,11 @@ void initForwardPipelines(ShapePlumber& plumber) {
 
     // Opaques
     addPipeline(Key::Builder().withMaterial(), program::forward_model);
+    addPipeline(Key::Builder().withMaterial().withLightmap(), program::forward_model_lightmap);
     addPipeline(Key::Builder().withMaterial().withUnlit(), program::forward_model_unlit);
     addPipeline(Key::Builder().withMaterial().withTangents(), program::forward_model_normal_map);
- 
+    addPipeline(Key::Builder().withMaterial().withTangents().withLightmap(), program::forward_model_normal_map_lightmap);
+
     // Deformed Opaques
     addPipeline(Key::Builder().withMaterial().withDeformed(), program::forward_deformed_model);
     addPipeline(Key::Builder().withMaterial().withDeformed().withTangents(), program::forward_deformed_model_normal_map);

--- a/libraries/render-utils/src/forward_model_lightmap.slf
+++ b/libraries/render-utils/src/forward_model_lightmap.slf
@@ -1,0 +1,71 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+// <$_SCRIBE_FILENAME$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  Created by Sam Gateau on 2/15/2016.
+//  Copyright 2014 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include DefaultMaterials.slh@>
+<@include graphics/Material.slh@>
+<@include graphics/MaterialTextures.slh@>
+<@include render-utils/ShaderConstants.h@>
+
+<@include ForwardGlobalLight.slh@>
+
+<$declareEvalLightmappedColor()$>
+
+<@include gpu/Transform.slh@>
+<$declareStandardCameraTransform()$>
+
+<$declareMaterialTextures(ALBEDO, ROUGHNESS, _SCRIBE_NULL, METALLIC)$>
+<$declareMaterialLightmap()$>
+
+layout(location=RENDER_UTILS_ATTR_POSITION_ES) in vec4 _positionES;
+layout(location=RENDER_UTILS_ATTR_TEXCOORD01) in vec4 _texCoord01;
+#define _texCoord0 _texCoord01.xy
+#define _texCoord1 _texCoord01.zw
+layout(location=RENDER_UTILS_ATTR_NORMAL_WS) in vec3 _normalWS;
+layout(location=RENDER_UTILS_ATTR_COLOR) in vec4 _color;
+
+layout(location=0) out vec4 _fragColor0;
+
+void main(void) {
+    Material mat = getMaterial();
+    BITFIELD matKey = getMaterialKey(mat);
+    <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex)$>
+    <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmap)$>
+
+    float opacity = 1.0;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
+
+    vec3 albedo = getMaterialAlbedo(mat);
+    <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
+    albedo *= _color.rgb;
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+
+    float metallic = getMaterialMetallic(mat);
+    <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;
+
+    vec3 fragNormal = normalize(_normalWS);
+
+    TransformCamera cam = getTransformCamera();
+
+	vec4 color = vec4(evalLightmappedColor(
+		cam._viewInverse,
+		1.0, 
+		1.0,
+		fragNormal,
+		albedo,
+		lightmap),
+		opacity);
+
+    _fragColor0 = color;
+}

--- a/libraries/render-utils/src/forward_model_normal_map_lightmap.slf
+++ b/libraries/render-utils/src/forward_model_normal_map_lightmap.slf
@@ -1,0 +1,74 @@
+<@include gpu/Config.slh@>
+<$VERSION_HEADER$>
+// <$_SCRIBE_FILENAME$>
+//  Generated on <$_SCRIBE_DATE$>
+//
+//  Created by Sam Gateau on 2/15/2016.
+//  Copyright 2014 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+<@include DefaultMaterials.slh@>
+<@include graphics/Material.slh@>
+<@include graphics/MaterialTextures.slh@>
+<@include render-utils/ShaderConstants.h@>
+
+<@include ForwardGlobalLight.slh@>
+
+<$declareEvalLightmappedColor()$>
+
+<@include gpu/Transform.slh@>
+<$declareStandardCameraTransform()$>
+
+<$declareMaterialTextures(ALBEDO, ROUGHNESS, NORMAL, METALLIC)$>
+<$declareMaterialLightmap()$>
+
+layout(location=RENDER_UTILS_ATTR_POSITION_ES) in vec4 _positionES;
+layout(location=RENDER_UTILS_ATTR_TEXCOORD01) in vec4 _texCoord01;
+#define _texCoord0 _texCoord01.xy
+#define _texCoord1 _texCoord01.zw
+layout(location=RENDER_UTILS_ATTR_NORMAL_WS) in vec3 _normalWS;
+layout(location=RENDER_UTILS_ATTR_TANGENT_WS) in vec3 _tangentWS;
+layout(location=RENDER_UTILS_ATTR_COLOR) in vec4 _color;
+
+layout(location=0) out vec4 _fragColor0;
+
+void main(void) {
+    Material mat = getMaterial();
+    BITFIELD matKey = getMaterialKey(mat);
+    <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex)$>
+    <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmap)$>
+
+    float opacity = 1.0;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$discardTransparent(opacity)$>;
+
+    vec3 albedo = getMaterialAlbedo(mat);
+    <$evalMaterialAlbedo(albedoTex, albedo, matKey, albedo)$>;
+    albedo *= _color.rgb;
+
+    float roughness = getMaterialRoughness(mat);
+    <$evalMaterialRoughness(roughnessTex, roughness, matKey, roughness)$>;
+
+    float metallic = getMaterialMetallic(mat);
+    <$evalMaterialMetallic(metallicTex, metallic, matKey, metallic)$>;
+
+    vec3 fragPosition = _positionES.xyz;
+    vec3 fragNormal;
+    <$evalMaterialNormalLOD(fragPosition, normalTex, _normalWS, _tangentWS, fragNormal)$>
+
+    TransformCamera cam = getTransformCamera();
+
+	vec4 color = vec4(evalLightmappedColor(
+		cam._viewInverse,
+		1.0, 
+		1.0,
+		fragNormal,
+		albedo,
+		lightmap),
+		opacity);
+
+    _fragColor0 = color;
+}

--- a/libraries/render-utils/src/render-utils/forward_model_lightmap.slp
+++ b/libraries/render-utils/src/render-utils/forward_model_lightmap.slp
@@ -1,0 +1,1 @@
+VERTEX model

--- a/libraries/render-utils/src/render-utils/forward_model_normal_map_lightmap.slp
+++ b/libraries/render-utils/src/render-utils/forward_model_normal_map_lightmap.slp
@@ -1,0 +1,1 @@
+VERTEX model_normal_map


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-127
https://highfidelity.manuscript.com/f/cases/22494/Forward-renderer-is-missing-lightmap-pipelines

Work for experimental lightmap support being added to the forward renderer. To test, run the engine with the environment variable HIFI_RENDER_FORWARD set to 1, and simply place a lightmapped object in the world. In my case, I run the interface, log in, acquire the Desert Oasis from the marketplace and then load it via the inventory.

While this implementation works functionally correctly, the lightmapped objects currently do NOT interact with directional light, which is how the deferred renderer works; lightmaps are primarily treated as a replacement for indirect lighting only since the deferred renderer is able to handle vast numbers of direct lights without a problem. This implementation is currently concerned with simply allowing people to make aesthetically-pleasing content for something like the upcoming Quest, but hopefully more features can be added.