### PR TITLE
silence misleading watchdog messages

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -442,6 +442,7 @@ public slots:
     void reloadResourceCaches();
 
     void updateHeartbeat() const;
+    void resetHeartbeat(int targetRate);
 
     static void deadlockApplication();
     static void unresponsiveApplication(); // cause main thread to be unresponsive for 35 seconds

--- a/interface/src/RefreshRateManager.cpp
+++ b/interface/src/RefreshRateManager.cpp
@@ -132,6 +132,7 @@ void RefreshRateManager::setRefreshRateRegime(RefreshRateManager::RefreshRateReg
     if (_refreshRateRegime != refreshRateRegime) {
         _refreshRateRegime = refreshRateRegime;
         updateRefreshRateController();
+        qApp->resetHeartbeat(_activeRefreshRate);
     }
 
 }


### PR DESCRIPTION
We get a lot of logspam about DEADLOCK WATCHDOG WARNINGs. 
It is natural for developers to think that this is telling us that the main thread is blocked, but it turns out that is really just saying that the average is very slowly coming up to the expected value:

1) The elapsedMovingAverage is a weighted average over samples collected over a very long period. (The code said 5 seconds, but it was actually an hour or more.) So every second when we check, the elapsedMovingAverage is ever so slightly higher on its way from zero to the expected average, and that is what is being reported.

2) We now have three different target game rates and switch between them quite a bit. We have not previously been resetting the collected stats as we do this.

https://highfidelity.atlassian.net/browse/BUGZ-131