### PR TITLE
Fix for simultaneous DS check-ins by client

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1167,7 +1167,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     connect(domainCheckInTimer, &QTimer::timeout, [this, nodeListWeak] {
         auto nodeList = nodeListWeak.lock();
         if (!isServerlessMode() && nodeList) {
-            nodeList->sendDomainServerCheckIn();
+            QMetaObject::invokeMethod(nodeList.data(), &NodeList::sendDomainServerCheckIn);
         }
     });
     domainCheckInTimer->start(DOMAIN_SERVER_CHECK_IN_MSECS);
@@ -5431,11 +5431,6 @@ void Application::init() {
 
 
     qCDebug(interfaceapp) << "Loaded settings";
-
-    // fire off an immediate domain-server check in now that settings are loaded
-    if (!isServerlessMode()) {
-        DependencyManager::get<NodeList>()->sendDomainServerCheckIn();
-    }
 
     // This allows collision to be set up properly for shape entities supported by GeometryCache.
     // This is before entity setup to ensure that it's ready for whenever instance collision is initialized.


### PR DESCRIPTION
Ensures sendDomainServerCheckIn() runs on its owning thread (NodeList thread).
Looks to be a factor in https://highfidelity.atlassian.net/browse/BUGZ-107