### PR TITLE
Bugz-129 JS APIs accessible to new dockable windows QML items is not the same as JS APIs accessible to floating / overlay QML windows

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -211,6 +211,8 @@ public:
     float getNumCollisionObjects() const;
     float getTargetRenderFrameRate() const; // frames/second
 
+    static void setupQmlSurface(QQmlContext* surfaceContext, bool setAdditionalContextProperties);
+
     float getFieldOfView() { return _fieldOfView.get(); }
     void setFieldOfView(float fov);
 
@@ -604,7 +606,6 @@ private:
     void maybeToggleMenuVisible(QMouseEvent* event) const;
     void toggleTabletUI(bool shouldOpen = false) const;
 
-    static void setupQmlSurface(QQmlContext* surfaceContext, bool setAdditionalContextProperties);
     void userKickConfirmation(const QUuid& nodeID);
 
     MainWindow* _window;

--- a/interface/src/ui/InteractiveWindow.cpp
+++ b/interface/src/ui/InteractiveWindow.cpp
@@ -92,6 +92,8 @@ InteractiveWindow::InteractiveWindow(const QString& sourceUrl, const QVariantMap
 
         auto mainWindow = qApp->getWindow();
         _dockWidget = std::shared_ptr<DockWidget>(new DockWidget(title, mainWindow), dockWidgetDeleter);
+        auto quickView = _dockWidget->getQuickView();
+        Application::setupQmlSurface(quickView->rootContext(), true);
 
         if (nativeWindowInfo.contains(DOCK_AREA_PROPERTY)) {
             DockArea dockedArea = (DockArea) nativeWindowInfo[DOCK_AREA_PROPERTY].toInt();
@@ -119,7 +121,6 @@ InteractiveWindow::InteractiveWindow(const QString& sourceUrl, const QVariantMap
             }
         }
 
-        auto quickView = _dockWidget->getQuickView();
         QObject::connect(quickView.get(), &QQuickView::statusChanged, [&, this] (QQuickView::Status status) {
             if (status == QQuickView::Ready) {
                 QQuickItem* rootItem = _dockWidget->getRootItem();


### PR DESCRIPTION
ticket - https://highfidelity.atlassian.net/browse/BUGZ-129