### PR TITLE
Reduce echo when push-to-talk is used

### DIFF
--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -366,8 +366,10 @@ void Audio::onContextChanged() {
 void Audio::handlePushedToTalk(bool enabled) {
     if (getPTT()) {
         if (enabled) {
+            DependencyManager::get<AudioClient>()->setOutputGain(0.1f); // duck the output by 20dB
             setMuted(false);
         } else {
+            DependencyManager::get<AudioClient>()->setOutputGain(1.0f);
             setMuted(true);
         }
     }

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -395,6 +395,8 @@ private:
     int _outputPeriod { 0 };
     float* _outputMixBuffer { NULL };
     int16_t* _outputScratchBuffer { NULL };
+    std::atomic<float> _outputGain { 1.0f };
+    float _lastOutputGain { 1.0f };
 
     // for local audio (used by audio injectors thread)
     std::atomic<float> _localInjectorGain { 1.0f };

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -241,8 +241,10 @@ public slots:
     void setInputVolume(float volume, bool emitSignal = true);
     void setReverb(bool reverb);
     void setReverbOptions(const AudioEffectOptions* options);
+
     void setLocalInjectorGain(float gain) { _localInjectorGain = gain; };
     void setSystemInjectorGain(float gain) { _systemInjectorGain = gain; };
+    void setOutputGain(float gain) { _outputGain = gain; };
 
     void outputNotify();
 


### PR DESCRIPTION
This PR ducks the audio output by 20dB when PTT is active. It reduces the feedback from the push-to-talker's speakers into the mic, while avoiding the loss of immersion (very noticeable on headphones) of completely muting the output. Gain changes are interpolated to prevent clicking artifacts.