### PR TITLE
BUGZ-135: Edit entity icons ignorePickIntersection when not visible

### DIFF
--- a/scripts/system/libraries/entityIconOverlayManager.js
+++ b/scripts/system/libraries/entityIconOverlayManager.js
@@ -64,7 +64,8 @@ EntityIconOverlayManager = function(entityTypes, getOverlayPropertiesFunc) {
             visible = isVisible;
             for (var id in entityOverlays) {
                 Overlays.editOverlay(entityOverlays[id], {
-                    visible: visible
+                    visible: visible,
+                    ignorePickIntersection: !visible
                 });
             }
         }
@@ -85,7 +86,8 @@ EntityIconOverlayManager = function(entityTypes, getOverlayPropertiesFunc) {
     function releaseOverlay(overlay) {
         unusedOverlays.push(overlay);
         Overlays.editOverlay(overlay, {
-            visible: false
+            visible: false,
+            ignorePickIntersection: true
         });
     }
 
@@ -99,6 +101,7 @@ EntityIconOverlayManager = function(entityTypes, getOverlayPropertiesFunc) {
                 position: properties.position,
                 rotation: Quat.fromPitchYawRollDegrees(0, 0, 270),
                 visible: visible,
+                ignorePickIntersection: !visible,
                 alpha: 0.9,
                 scale: 0.5,
                 drawInFront: true,


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-135

Test plan:
- Go to an empty area
- Make a zone
- Run this snippet from the console:
```
Entities.mousePressOnEntity.connect(function(id, event) {
   print(JSON.stringify(Entities.getEntityProperties(id)));
});
```
- With the console open, open Create and click the zone icon that appears.  You should see a block of JSON describing the zone print in the console.
- Close create and click in the same place, where the zone icon used to be.  Nothing should print.