### PR TITLE
BUGZ-125: Error message instead of crash if the GL version is too low

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -53,6 +53,15 @@ int main(int argc, const char* argv[]) {
 	// https://i.kym-cdn.com/entries/icons/original/000/008/342/ihave.jpg
     QSurfaceFormat::setDefaultFormat(format);
 #endif
+
+#if defined(Q_OS_WIN) 
+    // Check the minimum version of 
+    if (gl::getAvailableVersion() < gl::getRequiredVersion()) {
+        MessageBoxA(nullptr, "Interface requires OpenGL 4.1 or higher", "Unsupported", MB_OK);
+        return -1;
+    }
+#endif
+
     setupHifiApplication(BuildInfo::INTERFACE_NAME);
 
     QStringList arguments;

--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -71,19 +71,159 @@ void gl::globalRelease(bool finish) {}
 #endif
 
 
-void gl::getTargetVersion(int& major, int& minor) {
+uint16_t gl::getTargetVersion() {
+    uint8_t major = 0, minor = 0;
+
 #if defined(USE_GLES)
     major = 3;
     minor = 2;
-#else
-#if defined(Q_OS_MAC)
+#elif defined(Q_OS_MAC)
     major = 4;
     minor = 1;
 #else
     major = 4;
     minor = disableGl45() ? 1 : 5;
 #endif
+    return GL_MAKE_VERSION(major, minor);
+}
+
+uint16_t gl::getRequiredVersion() {
+    uint8_t major = 0, minor = 0;
+#if defined(USE_GLES)
+    major = 3;
+    minor = 2;
+#else 
+    major = 4;
+    minor = 1;
 #endif
+    return GL_MAKE_VERSION(major, minor);
+}
+
+#if defined(Q_OS_WIN)
+
+typedef BOOL(APIENTRYP PFNWGLCHOOSEPIXELFORMATARBPROC)(HDC hdc, const int *piAttribIList, const FLOAT *pfAttribFList, UINT nMaxFormats, int *piFormats, UINT *nNumFormats);
+typedef HGLRC(APIENTRYP PFNWGLCREATECONTEXTATTRIBSARBPROC)(HDC hDC, HGLRC hShareContext, const int *attribList);
+GLAPI PFNWGLCHOOSEPIXELFORMATARBPROC wglChoosePixelFormatARB;
+GLAPI PFNWGLCREATECONTEXTATTRIBSARBPROC wglCreateContextAttribsARB;
+
+static bool setupPixelFormatSimple(HDC hdc) {
+    // FIXME build the PFD based on the 
+    static const PIXELFORMATDESCRIPTOR pfd =    // pfd Tells Windows How We Want Things To Be
+    {
+        sizeof(PIXELFORMATDESCRIPTOR),         // Size Of This Pixel Format Descriptor
+        1,                                      // Version Number
+        PFD_DRAW_TO_WINDOW |                    // Format Must Support Window
+        PFD_SUPPORT_OPENGL |                    // Format Must Support OpenGL
+        PFD_DOUBLEBUFFER,                       // Must Support Double Buffering
+        PFD_TYPE_RGBA,                          // Request An RGBA Format
+        24,                                     // Select Our Color Depth
+        0, 0, 0, 0, 0, 0,                       // Color Bits Ignored
+        1,                                      // Alpha Buffer
+        0,                                      // Shift Bit Ignored
+        0,                                      // No Accumulation Buffer
+        0, 0, 0, 0,                             // Accumulation Bits Ignored
+        24,                                     // 24 Bit Z-Buffer (Depth Buffer)  
+        8,                                      // 8 Bit Stencil Buffer
+        0,                                      // No Auxiliary Buffer
+        PFD_MAIN_PLANE,                         // Main Drawing Layer
+        0,                                      // Reserved
+        0, 0, 0                                 // Layer Masks Ignored
+    };
+    auto pixelFormat = ChoosePixelFormat(hdc, &pfd);
+    if (pixelFormat == 0) {
+        return false;
+    }
+
+    if (SetPixelFormat(hdc, pixelFormat, &pfd) == FALSE) {
+        return false;
+    }
+    return true;
+}
+
+#endif
+
+uint16_t gl::getAvailableVersion() {
+    static uint8_t major = 0, minor = 0;
+    static std::once_flag once;
+    std::call_once(once, [&] {
+#if defined(USE_GLES)
+        // FIXME do runtime detection of the available GL version
+        major = 3;
+        minor = 2;
+#elif defined(Q_OS_MAC)
+        // Damn it Apple.
+        major = 4;
+        minor = 1;
+#elif defined(Q_OS_WIN)
+        // 
+        HINSTANCE hInstance = GetModuleHandle(nullptr);
+        const auto windowClassName = "OpenGLVersionCheck";
+        WNDCLASS wc = { };
+        wc.lpfnWndProc   = DefWindowProc;
+        wc.hInstance     = hInstance;
+        wc.lpszClassName = windowClassName;
+        RegisterClass(&wc);
+
+        using Handle = std::shared_ptr<void>;
+        HWND rawHwnd = CreateWindowEx(
+            WS_EX_APPWINDOW, // extended style 
+            windowClassName, // class name
+            windowClassName, // title
+            WS_CLIPSIBLINGS | WS_CLIPCHILDREN | CS_OWNDC | WS_POPUP, // style
+            0, 0, 10, 10,   // position and size
+            NULL, NULL, hInstance, NULL);
+        auto WindowDestroyer = [](void* handle) {
+            DestroyWindow((HWND)handle);
+        };
+        Handle hWnd = Handle(rawHwnd, WindowDestroyer);
+        if (!hWnd) {
+            return;
+        }
+        HDC rawDC = GetDC(rawHwnd);
+        auto DCDestroyer = [=](void* handle) {
+            ReleaseDC(rawHwnd, (HDC)handle);
+        };
+        if (!rawDC) {
+            return;
+        }
+        Handle hDC = Handle(rawDC, DCDestroyer);
+        if (!setupPixelFormatSimple(rawDC)) {
+            return;
+        }
+        auto GLRCDestroyer = [](void* handle) {
+            wglDeleteContext((HGLRC)handle);
+        };
+        auto rawglrc = wglCreateContext(rawDC);
+        if (!rawglrc) {
+            return;
+        }
+        Handle hGLRC = Handle(rawglrc, GLRCDestroyer);
+        if (!wglMakeCurrent(rawDC, rawglrc)) {
+            return;
+        }
+        gl::initModuleGl();
+        wglMakeCurrent(0, 0);
+        hGLRC.reset();
+        if (!wglChoosePixelFormatARB || !wglCreateContextAttribsARB) {
+            return;
+        }
+
+        // The only two versions we care about on Windows 
+        // are 4.5 and 4.1
+        if (GLAD_GL_VERSION_4_5) {
+            major = 4;
+            minor = disableGl45() ? 1 : 5;
+        } else if (GLAD_GL_VERSION_4_1) {
+            major = 4;
+            minor = 1;
+        }
+#else
+        // FIXME do runtime detection of GL version on non-Mac/Windows/Mobile platforms
+        major = 4;
+        minor = disableGl45() ? 1 : 5;
+#endif
+    });
+    return GL_MAKE_VERSION(major, minor);
 }
 
 const QSurfaceFormat& getDefaultOpenGLSurfaceFormat() {
@@ -105,10 +245,9 @@ const QSurfaceFormat& getDefaultOpenGLSurfaceFormat() {
         // Qt Quick may need a depth and stencil buffer. Always make sure these are available.
         format.setDepthBufferSize(DEFAULT_GL_DEPTH_BUFFER_BITS);
         format.setStencilBufferSize(DEFAULT_GL_STENCIL_BUFFER_BITS);
-        int major, minor;
-        ::gl::getTargetVersion(major, minor);
-        format.setMajorVersion(major);
-        format.setMinorVersion(minor);
+        auto glversion = ::gl::getTargetVersion();
+        format.setMajorVersion(GL_GET_MAJOR_VERSION(glversion));
+        format.setMinorVersion(GL_GET_MINOR_VERSION(glversion));
     });
     return format;
 }

--- a/libraries/gl/src/gl/GLHelpers.h
+++ b/libraries/gl/src/gl/GLHelpers.h
@@ -34,6 +34,10 @@ int glVersionToInteger(QString glVersion);
 
 bool isRenderThread();
 
+#define GL_MAKE_VERSION(major, minor) ((major << 8) | minor)
+#define GL_GET_MINOR_VERSION(glversion) (glversion & 0x00FF)
+#define GL_GET_MAJOR_VERSION(glversion) ((glversion & 0xFF00) >> 8)
+
 namespace gl {
     void globalLock();
     void globalRelease(bool finish = true);
@@ -52,7 +56,11 @@ namespace gl {
 
     bool disableGl45();
 
-    void getTargetVersion(int& major, int& minor);
+    uint16_t getTargetVersion();
+
+    uint16_t getAvailableVersion();
+
+    uint16_t getRequiredVersion();
 } // namespace gl
 
 #define CHECK_GL_ERROR() ::gl::checkGLErrorDebug(__FUNCTION__)

--- a/tests-manual/gl/src/main.cpp
+++ b/tests-manual/gl/src/main.cpp
@@ -10,17 +10,33 @@
 #include <QtCore/QTimer>
 #include <gl/Config.h>
 #include <gl/GLWindow.h>
+#include <gl/GLHelpers.h>
 
 
 int main(int argc, char** argv) {
+    auto glversion = gl::getAvailableVersion();
+    auto major = GL_GET_MAJOR_VERSION(glversion);
+    auto minor = GL_GET_MINOR_VERSION(glversion);
+
+    if (glversion < GL_MAKE_VERSION(4, 1)) {
+        MessageBoxA(nullptr, "Interface requires OpenGL 4.1 or higher", "Unsupported", MB_OK);
+        return 0;
+    }
     QGuiApplication app(argc, argv);
-    
+
+    bool quitting = false;
+    // FIXME need to handle window closing message so that we can stop the timer
     GLWindow* window = new GLWindow();
     window->create();
     window->show();
+    window->setSurfaceType(QSurface::OpenGLSurface);
+    window->setFormat(getDefaultOpenGLSurfaceFormat());
     bool contextCreated = false;
     QTimer* timer = new QTimer();
     QObject::connect(timer, &QTimer::timeout, [&] {
+        if (quitting) {
+            return;
+        }
         if (!contextCreated) {
             window->createContext();
             contextCreated = true;
@@ -33,9 +49,17 @@ int main(int argc, char** argv) {
         window->swapBuffers();
         window->doneCurrent();
     });
+    // FIXME need to handle window closing message so that we can stop the timer
+    QObject::connect(&app, &QCoreApplication::aboutToQuit, [&] {
+        quitting = true;
+        QObject::disconnect(timer, &QTimer::timeout, nullptr, nullptr);
+        timer->stop();
+        timer->deleteLater();
+    });
 
     timer->setInterval(15);
     timer->setSingleShot(false);
     timer->start();
     app.exec();
+    return 0;
 }


### PR DESCRIPTION
[BUGZ-125](https://highfidelity.atlassian.net/browse/BUGZ-125):  We've seen a number of crashes recently during startup that appear to stem from a failure to create an OpenGL context of the required version.  Previously we had code that created a Qt GL context to validate the GL version and warn / exit if it was too low.  However, we removed this code because creating and destroying a GL context on Qt had some undesirable side-effects on Mac.

Since Mac GL versions are pretty much fixed at 4.1, this PR restores the checking of the GL version on Windows only, and requires that a 4.1 version or higher is available before continuing, otherwise exiting with an error message.  