### PR TITLE
Clear any reliable connection state upon Node ID change

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -3755,6 +3755,7 @@ void MyAvatar::restrictScaleFromDomainSettings(const QJsonObject& domainSettings
 void MyAvatar::leaveDomain() {
     clearScaleRestriction();
     saveAvatarScale();
+    prepareResetTraitInstances();
 }
 
 void MyAvatar::saveAvatarScale() {

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -665,6 +665,8 @@ void NodeList::processDomainServerList(QSharedPointer<ReceivedMessage> message) 
             // tell the domain handler that we're no longer connected so that below
             // it can re-perform actions as if we just connected
             _domainHandler.setIsConnected(false);
+            // Clear any reliable connections using old ID.
+            _nodeSocket.clearConnections();
     }
 
     setSessionLocalID(newLocalID);


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-107


The PR has two changes: when a Node changes its domain-assigned IDs clear its reliable-connection state, and when the domain changes (including the ID change) reset the avatar-traits outstanding trait changes, in case one has been sent with the old ID.