### PR TITLE
BUGZ-139, Case 22502: Fix zone inheritance

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -591,7 +591,7 @@ void EntityTreeRenderer::findBestZoneAndMaybeContainingEntities(QSet<EntityItemI
             if (contains) {
                 // if this entity is a zone and visible, add it to our layered zones
                 if (isZone && entity->getVisible() && renderableIdForEntity(entity) != render::Item::INVALID_ITEM_ID) {
-                    _layeredZones.emplace(std::dynamic_pointer_cast<ZoneEntityItem>(entity));
+                    _layeredZones.emplace_back(std::dynamic_pointer_cast<ZoneEntityItem>(entity));
                 }
 
                 if ((!hasScript && isZone) || scriptHasLoaded) {
@@ -600,6 +600,7 @@ void EntityTreeRenderer::findBestZoneAndMaybeContainingEntities(QSet<EntityItemI
             }
         }
 
+        _layeredZones.sort();
         if (!_layeredZones.equals(oldLayeredZones)) {
             applyLayeredZones();
         }
@@ -1187,66 +1188,73 @@ void EntityTreeRenderer::updateEntityRenderStatus(bool shouldRenderEntities) {
 
 void EntityTreeRenderer::updateZone(const EntityItemID& id) {
     if (auto zone = std::dynamic_pointer_cast<ZoneEntityItem>(getTree()->findEntityByEntityItemID(id))) {
-        _layeredZones.update(zone, _avatarPosition, this);
-        applyLayeredZones();
+        if (_layeredZones.update(zone, _avatarPosition, this)) {
+            applyLayeredZones();
+        }
     }
 }
 
 bool EntityTreeRenderer::LayeredZones::clearDomainAndNonOwnedZones(const QUuid& sessionUUID) {
     bool zonesChanged = false;
 
-    auto it = c.begin();
-    while (it != c.end()) {
+    auto it = begin();
+    while (it != end()) {
         auto zone = it->zone.lock();
         if (!zone || !(zone->isLocalEntity() || (zone->isAvatarEntity() && zone->getOwningAvatarID() == sessionUUID))) {
             zonesChanged = true;
-            it = c.erase(it);
+            it = erase(it);
         } else {
             it++;
         }
     }
 
     if (zonesChanged) {
-        std::make_heap(c.begin(), c.end(), comp);
+        sort();
     }
     return zonesChanged;
 }
 
 std::pair<bool, bool> EntityTreeRenderer::LayeredZones::getZoneInteractionProperties() const {
-    auto it = c.cbegin();
-    while (it != c.cend()) {
+    for (auto it = cbegin(); it != cend(); it++) {
         auto zone = it->zone.lock();
         if (zone && zone->isDomainEntity()) {
             return { zone->getFlyingAllowed(), zone->getGhostingAllowed() };
         }
-        it++;
     }
     return { true, true };
 }
 
-void EntityTreeRenderer::LayeredZones::remove(const std::shared_ptr<ZoneEntityItem>& zone) {
-    auto it = c.begin();
-    while (it != c.end()) {
-        if (it->zone.lock() == zone) {
-            break;
-        }
-        it++;
-    }
-    if (it != c.end()) {
-        c.erase(it);
-        std::make_heap(c.begin(), c.end(), comp);
-    }
-}
-
-void EntityTreeRenderer::LayeredZones::update(std::shared_ptr<ZoneEntityItem> zone, const glm::vec3& position, EntityTreeRenderer* entityTreeRenderer) {
+bool EntityTreeRenderer::LayeredZones::update(std::shared_ptr<ZoneEntityItem> zone, const glm::vec3& position, EntityTreeRenderer* entityTreeRenderer) {
     // When a zone's position or visibility changes, we call this method
     // In order to resort our zones, we first remove the changed zone, and then re-insert it if necessary
-    remove(zone);
+
+    bool needsResort = false;
+
+    {
+        auto it = begin();
+        while (it != end()) {
+            if (it->zone.lock() == zone) {
+                break;
+            }
+            it++;
+        }
+        if (it != end()) {
+            erase(it);
+            needsResort = true;
+        }
+    }
 
     // Only call contains if the zone is rendering
     if (zone->isVisible() && entityTreeRenderer->renderableIdForEntity(zone) != render::Item::INVALID_ITEM_ID && zone->contains(position)) {
-        emplace(zone);
+        emplace_back(zone);
+        needsResort = true;
     }
+
+    if (needsResort) {
+        sort();
+    }
+
+    return needsResort;
 }
 
 bool EntityTreeRenderer::LayeredZones::equals(const LayeredZones& other) const {
@@ -1254,9 +1262,9 @@ bool EntityTreeRenderer::LayeredZones::equals(const LayeredZones& other) const {
         return false;
     }
 
-    auto it = c.cbegin();
-    auto otherIt = other.c.cbegin();
-    while (it != c.cend()) {
+    auto it = cbegin();
+    auto otherIt = other.cbegin();
+    while (it != cend()) {
         if (*it != *otherIt) {
             return false;
         }
@@ -1268,15 +1276,13 @@ bool EntityTreeRenderer::LayeredZones::equals(const LayeredZones& other) const {
 }
 
 void EntityTreeRenderer::LayeredZones::appendRenderIDs(render::ItemIDs& list, EntityTreeRenderer* entityTreeRenderer) const {
-    auto it = c.cbegin();
-    while (it != c.cend()) {
+    for (auto it = cbegin(); it != cend(); it++) {
         if (it->zone.lock()) {
             auto id = entityTreeRenderer->renderableIdForEntityId(it->id);
             if (id != render::Item::INVALID_ITEM_ID) {
                 list.push_back(id);
             }
         }
-        it++;
     }
 }
 


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-139
https://highfidelity.manuscript.com/f/cases/22502/Nestled-zones-set-to-inherit-alternate-between-what-zones-to-inherit

Test plan:
- Run the content / entity / zone / ambientLightInheritance test
- Run the test plan from: https://github.com/highfidelity/hifi/pull/15523
- Go to an empty area in a domain and run [this](https://gist.githubusercontent.com/SamGondelman/96e16158b47d8c5478589440d5801c0d/raw/c53de82f65ba566f9eefa796568fdf88433b959c/ZoneInheritTest.js).  You'll see this:
![image](https://user-images.githubusercontent.com/7650116/57558768-e8563180-7333-11e9-978f-b7617529a0fc.png)
- As you walk towards the edge of the cubes, the sky will remain blue.  Only in the outer section will it be red.  Outside of that, it will be the default skybox:
![hifi-snap-by-SamGondelman-on-2019-05-10_14-58-11](https://user-images.githubusercontent.com/7650116/57558799-13d91c00-7334-11e9-84dc-ea8e75b7b101.gif)