### PR TITLE
(BUGZ-40) Check for possible avatar fade race condition

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -539,7 +539,7 @@ void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar
             if (avatar->getLastFadeRequested() != render::Transition::Type::USER_LEAVE_DOMAIN) {
                 // The avatar is using another transition besides the fade-out transition, which means it is still in use.
                 // Deleting the avatar now could cause state issues, so abort deletion and show message.
-                qCWarning(interfaceapp) << "An ending fade-out animation wants to delete an avatar, but the avatar is still in use. Avatar deletion has aborted. (avatar ID: " << avatar->getSessionUUID() << ")";
+                qCWarning(interfaceapp) << "An ending fade-out transition wants to delete an avatar, but the avatar is still in use. Avatar deletion has aborted. (avatar ID: " << avatar->getSessionUUID() << ")";
             } else {
                 const render::ScenePointer& scene = qApp->getMain3DScene();
                 render::Transaction transaction;

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -536,14 +536,20 @@ void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar
 
         workload::SpacePointer space = _space;
         transaction.transitionFinishedOperator(avatar->getRenderItemID(), [space, avatar]() {
-            const render::ScenePointer& scene = qApp->getMain3DScene();
-            render::Transaction transaction;
-            avatar->removeFromScene(avatar, scene, transaction);
-            scene->enqueueTransaction(transaction);
+            if (avatar->getLastFadeRequested() != render::Transition::Type::USER_LEAVE_DOMAIN) {
+                // The avatar is using another transition besides the fade-out transition, which means it is still in use.
+                // Deleting the avatar now could cause state issues, so abort deletion and show message.
+                qCWarning(interfaceapp) << "An ending fade-out animation wants to delete an avatar, but the avatar is still in use. Avatar deletion has aborted. (avatar ID: " << avatar->getSessionUUID() << ")";
+            } else {
+                const render::ScenePointer& scene = qApp->getMain3DScene();
+                render::Transaction transaction;
+                avatar->removeFromScene(avatar, scene, transaction);
+                scene->enqueueTransaction(transaction);
 
-            workload::Transaction workloadTransaction;
-            workloadTransaction.remove(avatar->getSpaceIndex());
-            space->enqueueTransaction(workloadTransaction);
+                workload::Transaction workloadTransaction;
+                workloadTransaction.remove(avatar->getSpaceIndex());
+                space->enqueueTransaction(workloadTransaction);
+            }
         });
         scene->enqueueTransaction(transaction);
     }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -690,6 +690,11 @@ void Avatar::fade(render::Transaction& transaction, render::Transition::Type typ
             transaction.addTransitionToItem(itemId, type, _renderItemID);
         }
     }
+    _lastFadeRequested = type;
+}
+
+render::Transition::Type Avatar::getLastFadeRequested() const {
+    return _lastFadeRequested;
 }
 
 void Avatar::removeFromScene(AvatarSharedPointer self, const render::ScenePointer& scene, render::Transaction& transaction) {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -523,6 +523,7 @@ public:
 
     void fadeIn(render::ScenePointer scene);
     void fadeOut(render::Transaction& transaction, KillAvatarReason reason);
+    render::Transition::Type getLastFadeRequested() const;
 
     // JSDoc is in AvatarData.h.
     Q_INVOKABLE virtual float getEyeHeight() const override;
@@ -701,6 +702,7 @@ protected:
     virtual void updatePalms();
 
     render::ItemID _renderItemID{ render::Item::INVALID_ITEM_ID };
+    render::Transition::Type _lastFadeRequested { render::Transition::Type::NONE }; // Used for sanity checking
 
     ThreadSafeValueCache<glm::vec3> _leftPalmPositionCache { glm::vec3() };
     ThreadSafeValueCache<glm::quat> _leftPalmRotationCache { glm::quat() };


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-40

This PR adds a sanity check to the lambda called when an avatar fade-out transition is removed. It attempts to address the issue where the avatar fade transition freezes while an avatar is connected.