### PR TITLE
BUGZ-163: Empty Weights FBX fix

### DIFF
--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -1521,9 +1521,28 @@ HFMModel* FBXSerializer::extractHFMModel(const hifi::VariantHash& mapping, const
         // whether we're skinned depends on how many clusters are attached
         if (clusterIDs.size() > 1) {
             // this is a multi-mesh joint
+
+            // Record the joint index to be used for unweighted vertices
+            int rootSkeletonJoint = extracted.mesh.clusters.size() - 1;
+            for (int i = 0; i < clusterIDs.size(); i++) {
+                QString clusterID = clusterIDs.at(i);
+                const Cluster& cluster = clusters[clusterID];
+                const HFMCluster& hfmCluster = extracted.mesh.clusters.at(i);
+                int jointIndex = hfmCluster.jointIndex;
+                HFMJoint& joint = hfmModel.joints[jointIndex];
+
+                if (joint.parentIndex == -1) {
+                    rootSkeletonJoint = i;
+                } else {
+                    if (hfmModel.joints[joint.parentIndex].isSkeletonJoint == false) {
+                        rootSkeletonJoint = i;
+                    }
+                }
+            }
+
             const int WEIGHTS_PER_VERTEX = 4;
             int numClusterIndices = extracted.mesh.vertices.size() * WEIGHTS_PER_VERTEX;
-            extracted.mesh.clusterIndices.fill(clusterIDs.size() - 1, numClusterIndices);
+            extracted.mesh.clusterIndices.fill(rootSkeletonJoint, numClusterIndices);
             QVector<float> weightAccumulators;
             weightAccumulators.fill(0.0f, numClusterIndices);
 

--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -1523,10 +1523,9 @@ HFMModel* FBXSerializer::extractHFMModel(const hifi::VariantHash& mapping, const
             // this is a multi-mesh joint
             const int WEIGHTS_PER_VERTEX = 4;
             int numClusterIndices = extracted.mesh.vertices.size() * WEIGHTS_PER_VERTEX;
-            extracted.mesh.clusterIndices.fill(extracted.mesh.clusters.size() - 1, numClusterIndices);
+            extracted.mesh.clusterIndices.fill(clusterIDs.size() - 1, numClusterIndices);
             QVector<float> weightAccumulators;
             weightAccumulators.fill(0.0f, numClusterIndices);
-            int rootSkeletonJoint = 0;
 
             for (int i = 0; i < clusterIDs.size(); i++) {
                 QString clusterID = clusterIDs.at(i);
@@ -1534,15 +1533,6 @@ HFMModel* FBXSerializer::extractHFMModel(const hifi::VariantHash& mapping, const
                 const HFMCluster& hfmCluster = extracted.mesh.clusters.at(i);
                 int jointIndex = hfmCluster.jointIndex;
                 HFMJoint& joint = hfmModel.joints[jointIndex];
-
-                // Record the joint index to be used for unweighted vertices
-                if (joint.parentIndex == -1) {
-                    rootSkeletonJoint = i;
-                } else {
-                    if (hfmModel.joints[joint.parentIndex].isSkeletonJoint == false) {
-                        rootSkeletonJoint = i;
-                    }
-                }
 
                 glm::mat4 meshToJoint = glm::inverse(joint.bindTransform) * modelTransform;
                 ShapeVertices& points = hfmModel.shapeVertices.at(jointIndex);
@@ -1609,7 +1599,6 @@ HFMModel* FBXSerializer::extractHFMModel(const hifi::VariantHash& mapping, const
                     }
                 } else {
                     extracted.mesh.clusterWeights[j] = (uint16_t)((float)(UINT16_MAX) + ALMOST_HALF);
-                    extracted.mesh.clusterIndices[j] = rootSkeletonJoint;
                 }
             }
         } else {


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-163

Forces unweighted vertices to be weighted to the root bone in FBX loader rather than the root of the model itself. This mimics the behavior found in Unity's FBX loader and can account for certain scuffed models which may have errors resulting in bones below the hip bone being deleted. Will provide an example model later which will demonstrate the differences in Unity's handling of the FBX model (which I believe uses the official Autodesk SDK) vs. HiFi's