### PR TITLE
Material alpha-blending modes

### DIFF
--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -228,15 +228,15 @@ int GLTFSerializer::getAccessorType(const QString& type)
 int GLTFSerializer::getMaterialAlphaMode(const QString& type)
 {
     if (type == "OPAQUE") {
-        return GLTFMaterialAlphaMode::OPAQUE;
+        return GLTFMaterialAlphaMode::GLTF_OPAQUE;
     }
     if (type == "MASK") {
-        return GLTFMaterialAlphaMode::MASK;
+        return GLTFMaterialAlphaMode::GLTF_MASK;
     }
     if (type == "BLEND") {
-        return GLTFMaterialAlphaMode::BLEND;
+        return GLTFMaterialAlphaMode::GLTF_BLEND;
     }
-    return GLTFMaterialAlphaMode::OPAQUE;
+    return GLTFMaterialAlphaMode::GLTF_OPAQUE;
 }
 
 int GLTFSerializer::getCameraType(const QString& type)
@@ -1744,6 +1744,31 @@ HFMTexture GLTFSerializer::getHFMTexture(const GLTFTexture& texture) {
 void GLTFSerializer::setHFMMaterial(HFMMaterial& fbxmat, const GLTFMaterial& material) {
 
 
+    if (material.defined["alphaMode"]) {
+        switch (material.alphaMode) {
+            case GLTFMaterialAlphaMode::GLTF_OPAQUE:
+                fbxmat.alphaMode = hfm::AlphaMode::HFM_OPAQUE;
+                break;
+            case GLTFMaterialAlphaMode::GLTF_MASK:
+                fbxmat.alphaMode = hfm::AlphaMode::HFM_MASK;
+                break;
+            case GLTFMaterialAlphaMode::GLTF_BLEND:
+                fbxmat.alphaMode = hfm::AlphaMode::HFM_BLEND;
+                break;
+            default:
+                fbxmat.alphaMode = hfm::AlphaMode::HFM_OPAQUE;
+                break;
+        }
+    } else {
+        fbxmat.alphaMode = hfm::AlphaMode::HFM_OPAQUE;
+    }
+
+    if (material.defined["cullMode"]) {
+        fbxmat.cullMode = material.doubleSided ? hfm::CullMode::HFM_DISABLED : hfm::CullMode::HFM_BACK;
+    } else {
+        fbxmat.cullMode = hfm::CullMode::HFM_BACK;
+    }
+    
     if (material.defined["emissiveFactor"] && material.emissiveFactor.size() == 3) {
         glm::vec3 emissive = glm::vec3(material.emissiveFactor[0], 
                                        material.emissiveFactor[1], 
@@ -2074,6 +2099,8 @@ void GLTFSerializer::hfmDebugDump(const HFMModel& hfmModel) {
     foreach(HFMMaterial mat, hfmModel.materials) {
         qCDebug(modelformat) << "\n";
         qCDebug(modelformat) << "  mat.materialID =" << mat.materialID;
+        qCDebug(modelformat) << "  alphaMode =" << hfm::AlphaMode::ToString(mat.alphaMode);
+        qCDebug(modelformat) << "  cullMode =" << hfm::CullMode::ToString(mat.cullMode);
         qCDebug(modelformat) << "  diffuseColor =" << mat.diffuseColor;
         qCDebug(modelformat) << "  diffuseFactor =" << mat.diffuseFactor;
         qCDebug(modelformat) << "  specularColor =" << mat.specularColor;

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -1762,7 +1762,11 @@ void GLTFSerializer::setHFMMaterial(HFMMaterial& fbxmat, const GLTFMaterial& mat
     } else {
         fbxmat.alphaMode = hfm::AlphaMode::HFM_OPAQUE;
     }
-    
+
+    if (material.defined["alphaCutoff"]) {
+        fbxmat.alphaCutoff = material.alphaCutoff;
+    }
+
     if (material.defined["emissiveFactor"] && material.emissiveFactor.size() == 3) {
         glm::vec3 emissive = glm::vec3(material.emissiveFactor[0], 
                                        material.emissiveFactor[1], 

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -228,15 +228,15 @@ int GLTFSerializer::getAccessorType(const QString& type)
 int GLTFSerializer::getMaterialAlphaMode(const QString& type)
 {
     if (type == "OPAQUE") {
-        return hfm::AlphaMode::HFM_OPAQUE;
+        return graphics::Material::MAT_OPAQUE;
     }
     if (type == "MASK") {
-        return hfm::AlphaMode::HFM_MASK;
+        return graphics::Material::MAT_MASK;
     }
     if (type == "BLEND") {
-        return hfm::AlphaMode::HFM_BLEND;
+        return graphics::Material::MAT_BLEND;
     }
-    return hfm::AlphaMode::HFM_OPAQUE;
+    return graphics::Material::MAT_BLEND;
 }
 
 int GLTFSerializer::getCameraType(const QString& type)
@@ -1741,84 +1741,71 @@ HFMTexture GLTFSerializer::getHFMTexture(const GLTFTexture& texture) {
     return fbxtex;
 }
 
-void GLTFSerializer::setHFMMaterial(HFMMaterial& fbxmat, const GLTFMaterial& material) {
+void GLTFSerializer::setHFMMaterial(HFMMaterial& hfmMat, const GLTFMaterial& material) {
 
 
     if (material.defined["alphaMode"]) {
-        switch (material.alphaMode) {
-            case hfm::AlphaMode::HFM_OPAQUE:
-                fbxmat.alphaMode = hfm::AlphaMode::HFM_OPAQUE;
-                break;
-            case hfm::AlphaMode::HFM_MASK:
-                fbxmat.alphaMode = hfm::AlphaMode::HFM_MASK;
-                break;
-            case hfm::AlphaMode::HFM_BLEND:
-                fbxmat.alphaMode = hfm::AlphaMode::HFM_BLEND;
-                break;
-            default:
-                fbxmat.alphaMode = hfm::AlphaMode::HFM_OPAQUE;
-                break;
-        }
+        hfmMat.alphaMode = static_cast<graphics::Material::AlphaMode>(material.alphaMode);
     } else {
-        fbxmat.alphaMode = hfm::AlphaMode::HFM_OPAQUE;
+        hfmMat.alphaMode = graphics::Material::MAT_OPAQUE; // GLTF defaults to opaque
     }
 
     if (material.defined["alphaCutoff"]) {
-        fbxmat.alphaCutoff = material.alphaCutoff;
+        hfmMat.alphaCutoff = material.alphaCutoff;
     }
 
     if (material.defined["emissiveFactor"] && material.emissiveFactor.size() == 3) {
         glm::vec3 emissive = glm::vec3(material.emissiveFactor[0], 
                                        material.emissiveFactor[1], 
                                        material.emissiveFactor[2]);
-        fbxmat._material->setEmissive(emissive);
+        hfmMat._material->setEmissive(emissive);
     }
 
     if (material.defined["emissiveTexture"]) {
-        fbxmat.emissiveTexture = getHFMTexture(_file.textures[material.emissiveTexture]);
-        fbxmat.useEmissiveMap = true;
+        hfmMat.emissiveTexture = getHFMTexture(_file.textures[material.emissiveTexture]);
+        hfmMat.useEmissiveMap = true;
     }
     
     if (material.defined["normalTexture"]) {
-        fbxmat.normalTexture = getHFMTexture(_file.textures[material.normalTexture]);
-        fbxmat.useNormalMap = true;
+        hfmMat.normalTexture = getHFMTexture(_file.textures[material.normalTexture]);
+        hfmMat.useNormalMap = true;
     }
     
     if (material.defined["occlusionTexture"]) {
-        fbxmat.occlusionTexture = getHFMTexture(_file.textures[material.occlusionTexture]);
-        fbxmat.useOcclusionMap = true;
+        hfmMat.occlusionTexture = getHFMTexture(_file.textures[material.occlusionTexture]);
+        hfmMat.useOcclusionMap = true;
     }
 
     if (material.defined["pbrMetallicRoughness"]) {
-        fbxmat.isPBSMaterial = true;
+        hfmMat.isPBSMaterial = true;
         
         if (material.pbrMetallicRoughness.defined["metallicFactor"]) {
-            fbxmat.metallic = material.pbrMetallicRoughness.metallicFactor;
+            hfmMat.metallic = material.pbrMetallicRoughness.metallicFactor;
         }
         if (material.pbrMetallicRoughness.defined["baseColorTexture"]) {
-            fbxmat.opacityTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.baseColorTexture]);
-            fbxmat.albedoTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.baseColorTexture]);
-            fbxmat.useAlbedoMap = true;
+            hfmMat.opacityTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.baseColorTexture]);
+            hfmMat.albedoTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.baseColorTexture]);
+            hfmMat.useAlbedoMap = true;
         }
         if (material.pbrMetallicRoughness.defined["metallicRoughnessTexture"]) {
-            fbxmat.roughnessTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.metallicRoughnessTexture]);
-            fbxmat.roughnessTexture.sourceChannel = image::ColorChannel::GREEN;
-            fbxmat.useRoughnessMap = true;
-            fbxmat.metallicTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.metallicRoughnessTexture]);
-            fbxmat.metallicTexture.sourceChannel = image::ColorChannel::BLUE;
-            fbxmat.useMetallicMap = true;
+            hfmMat.roughnessTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.metallicRoughnessTexture]);
+            hfmMat.roughnessTexture.sourceChannel = image::ColorChannel::GREEN;
+            hfmMat.useRoughnessMap = true;
+            hfmMat.metallicTexture = getHFMTexture(_file.textures[material.pbrMetallicRoughness.metallicRoughnessTexture]);
+            hfmMat.metallicTexture.sourceChannel = image::ColorChannel::BLUE;
+            hfmMat.useMetallicMap = true;
         }
         if (material.pbrMetallicRoughness.defined["roughnessFactor"]) {
-            fbxmat._material->setRoughness(material.pbrMetallicRoughness.roughnessFactor);
+            hfmMat._material->setRoughness(material.pbrMetallicRoughness.roughnessFactor);
         }
         if (material.pbrMetallicRoughness.defined["baseColorFactor"] && 
             material.pbrMetallicRoughness.baseColorFactor.size() == 4) {
             glm::vec3 dcolor =  glm::vec3(material.pbrMetallicRoughness.baseColorFactor[0], 
                                           material.pbrMetallicRoughness.baseColorFactor[1], 
                                           material.pbrMetallicRoughness.baseColorFactor[2]);
-            fbxmat.diffuseColor = dcolor;
-            fbxmat._material->setAlbedo(dcolor);
-            fbxmat._material->setOpacity(material.pbrMetallicRoughness.baseColorFactor[3]);
+            hfmMat.diffuseColor = dcolor;
+            hfmMat._material->setAlbedo(dcolor);
+            hfmMat._material->setOpacity(material.pbrMetallicRoughness.baseColorFactor[3]);
         }   
     }
 
@@ -2097,7 +2084,8 @@ void GLTFSerializer::hfmDebugDump(const HFMModel& hfmModel) {
     foreach(HFMMaterial mat, hfmModel.materials) {
         qCDebug(modelformat) << "\n";
         qCDebug(modelformat) << "  mat.materialID =" << mat.materialID;
-        qCDebug(modelformat) << "  alphaMode =" << hfm::AlphaMode::toString(mat.alphaMode).c_str();
+        qCDebug(modelformat) << "  alphaMode =" << graphics::Material::alphaModeAsString(mat.alphaMode);
+        qCDebug(modelformat) << "  alphaCutoff =" << mat.alphaCutoff;
         qCDebug(modelformat) << "  diffuseColor =" << mat.diffuseColor;
         qCDebug(modelformat) << "  diffuseFactor =" << mat.diffuseFactor;
         qCDebug(modelformat) << "  specularColor =" << mat.specularColor;

--- a/libraries/fbx/src/GLTFSerializer.cpp
+++ b/libraries/fbx/src/GLTFSerializer.cpp
@@ -228,15 +228,15 @@ int GLTFSerializer::getAccessorType(const QString& type)
 int GLTFSerializer::getMaterialAlphaMode(const QString& type)
 {
     if (type == "OPAQUE") {
-        return GLTFMaterialAlphaMode::GLTF_OPAQUE;
+        return hfm::AlphaMode::HFM_OPAQUE;
     }
     if (type == "MASK") {
-        return GLTFMaterialAlphaMode::GLTF_MASK;
+        return hfm::AlphaMode::HFM_MASK;
     }
     if (type == "BLEND") {
-        return GLTFMaterialAlphaMode::GLTF_BLEND;
+        return hfm::AlphaMode::HFM_BLEND;
     }
-    return GLTFMaterialAlphaMode::GLTF_OPAQUE;
+    return hfm::AlphaMode::HFM_OPAQUE;
 }
 
 int GLTFSerializer::getCameraType(const QString& type)
@@ -1746,13 +1746,13 @@ void GLTFSerializer::setHFMMaterial(HFMMaterial& fbxmat, const GLTFMaterial& mat
 
     if (material.defined["alphaMode"]) {
         switch (material.alphaMode) {
-            case GLTFMaterialAlphaMode::GLTF_OPAQUE:
+            case hfm::AlphaMode::HFM_OPAQUE:
                 fbxmat.alphaMode = hfm::AlphaMode::HFM_OPAQUE;
                 break;
-            case GLTFMaterialAlphaMode::GLTF_MASK:
+            case hfm::AlphaMode::HFM_MASK:
                 fbxmat.alphaMode = hfm::AlphaMode::HFM_MASK;
                 break;
-            case GLTFMaterialAlphaMode::GLTF_BLEND:
+            case hfm::AlphaMode::HFM_BLEND:
                 fbxmat.alphaMode = hfm::AlphaMode::HFM_BLEND;
                 break;
             default:
@@ -1761,12 +1761,6 @@ void GLTFSerializer::setHFMMaterial(HFMMaterial& fbxmat, const GLTFMaterial& mat
         }
     } else {
         fbxmat.alphaMode = hfm::AlphaMode::HFM_OPAQUE;
-    }
-
-    if (material.defined["cullMode"]) {
-        fbxmat.cullMode = material.doubleSided ? hfm::CullMode::HFM_DISABLED : hfm::CullMode::HFM_BACK;
-    } else {
-        fbxmat.cullMode = hfm::CullMode::HFM_BACK;
     }
     
     if (material.defined["emissiveFactor"] && material.emissiveFactor.size() == 3) {
@@ -2099,8 +2093,7 @@ void GLTFSerializer::hfmDebugDump(const HFMModel& hfmModel) {
     foreach(HFMMaterial mat, hfmModel.materials) {
         qCDebug(modelformat) << "\n";
         qCDebug(modelformat) << "  mat.materialID =" << mat.materialID;
-        qCDebug(modelformat) << "  alphaMode =" << hfm::AlphaMode::ToString(mat.alphaMode);
-        qCDebug(modelformat) << "  cullMode =" << hfm::CullMode::ToString(mat.cullMode);
+        qCDebug(modelformat) << "  alphaMode =" << hfm::AlphaMode::toString(mat.alphaMode).c_str();
         qCDebug(modelformat) << "  diffuseColor =" << mat.diffuseColor;
         qCDebug(modelformat) << "  diffuseFactor =" << mat.diffuseFactor;
         qCDebug(modelformat) << "  specularColor =" << mat.specularColor;

--- a/libraries/fbx/src/GLTFSerializer.h
+++ b/libraries/fbx/src/GLTFSerializer.h
@@ -418,9 +418,9 @@ struct GLTFpbrMetallicRoughness {
 
 namespace GLTFMaterialAlphaMode {
     enum Values {
-        OPAQUE = 0,
-        MASK,
-        BLEND
+        GLTF_OPAQUE = 0,
+        GLTF_MASK,
+        GLTF_BLEND
     };
 };
 

--- a/libraries/fbx/src/GLTFSerializer.h
+++ b/libraries/fbx/src/GLTFSerializer.h
@@ -846,7 +846,7 @@ private:
     bool doesResourceExist(const QString& url);
 
 
-    void setHFMMaterial(HFMMaterial& fbxmat, const GLTFMaterial& material);
+    void setHFMMaterial(HFMMaterial& hfmMat, const GLTFMaterial& material);
     HFMTexture getHFMTexture(const GLTFTexture& texture);
     void glTFDebugDump();
     void hfmDebugDump(const HFMModel& hfmModel);

--- a/libraries/fbx/src/GLTFSerializer.h
+++ b/libraries/fbx/src/GLTFSerializer.h
@@ -416,14 +416,6 @@ struct GLTFpbrMetallicRoughness {
     }
 };
 
-namespace GLTFMaterialAlphaMode {
-    enum Values {
-        GLTF_OPAQUE = 0,
-        GLTF_MASK,
-        GLTF_BLEND
-    };
-};
-
 struct GLTFMaterial {
     QString name;
     QVector<double> emissiveFactor;

--- a/libraries/fbx/src/OBJSerializer.cpp
+++ b/libraries/fbx/src/OBJSerializer.cpp
@@ -897,8 +897,7 @@ HFMModel::Pointer OBJSerializer::read(const hifi::ByteArray& data, const hifi::V
                                                                                 objMaterial.emissiveColor,
                                                                                 objMaterial.shininess,
                                                                                 objMaterial.opacity,
-                                                                                hfm::AlphaMode::HFM_BLEND,
-                                                                                hfm::CullMode::HFM_BACK);
+                                                                                hfm::AlphaMode::HFM_BLEND);
         hfmMaterial.name = materialID;
         hfmMaterial.materialID = materialID;
         hfmMaterial._material = std::make_shared<graphics::Material>();

--- a/libraries/fbx/src/OBJSerializer.cpp
+++ b/libraries/fbx/src/OBJSerializer.cpp
@@ -897,7 +897,7 @@ HFMModel::Pointer OBJSerializer::read(const hifi::ByteArray& data, const hifi::V
                                                                                 objMaterial.emissiveColor,
                                                                                 objMaterial.shininess,
                                                                                 objMaterial.opacity,
-                                                                                hfm::AlphaMode::HFM_BLEND,
+                                                                                graphics::Material::MAT_BLEND,
                                                                                 0.5f);
         hfmMaterial.name = materialID;
         hfmMaterial.materialID = materialID;

--- a/libraries/fbx/src/OBJSerializer.cpp
+++ b/libraries/fbx/src/OBJSerializer.cpp
@@ -896,8 +896,9 @@ HFMModel::Pointer OBJSerializer::read(const hifi::ByteArray& data, const hifi::V
                                                                                 objMaterial.specularColor,
                                                                                 objMaterial.emissiveColor,
                                                                                 objMaterial.shininess,
-                                                                                objMaterial.opacity);
-
+                                                                                objMaterial.opacity,
+                                                                                hfm::AlphaMode::HFM_BLEND,
+                                                                                hfm::CullMode::HFM_BACK);
         hfmMaterial.name = materialID;
         hfmMaterial.materialID = materialID;
         hfmMaterial._material = std::make_shared<graphics::Material>();

--- a/libraries/fbx/src/OBJSerializer.cpp
+++ b/libraries/fbx/src/OBJSerializer.cpp
@@ -897,7 +897,8 @@ HFMModel::Pointer OBJSerializer::read(const hifi::ByteArray& data, const hifi::V
                                                                                 objMaterial.emissiveColor,
                                                                                 objMaterial.shininess,
                                                                                 objMaterial.opacity,
-                                                                                hfm::AlphaMode::HFM_BLEND);
+                                                                                hfm::AlphaMode::HFM_BLEND,
+                                                                                0.5f);
         hfmMaterial.name = materialID;
         hfmMaterial.materialID = materialID;
         hfmMaterial._material = std::make_shared<graphics::Material>();

--- a/libraries/graphics-scripting/src/graphics-scripting/Forward.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/Forward.h
@@ -41,9 +41,10 @@ namespace scriptable {
     /**jsdoc
      * @typedef {object} Graphics.Material
      * @property {string} name
-     * @property {string} alphaMode
      * @property {string} model
      * @property {number|string} opacity
+     * @property {string} alphaMode
+     * @property {number} alphaCutoff
      * @property {number|string} roughness
      * @property {number|string} metallic
      * @property {number|string} scattering
@@ -76,10 +77,10 @@ namespace scriptable {
         ScriptableMaterial& operator=(const ScriptableMaterial& material);
 
         QString name;
-        Material::MaterialAlphaMode alphaMode;
-        float alphaCutoff;
         QString model;
         float opacity;
+        Material::AlphaMode alphaMode;
+        float alphaCutoff;
         float roughness;
         float metallic;
         float scattering;

--- a/libraries/graphics-scripting/src/graphics-scripting/Forward.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/Forward.h
@@ -29,6 +29,8 @@ namespace scriptable {
     using MeshPointer = std::shared_ptr<scriptable::Mesh>;
     using WeakMeshPointer = std::weak_ptr<scriptable::Mesh>;
 
+    using Material = graphics::Material;
+
     class ScriptableModelBase;
     using ScriptableModelBasePointer = QPointer<ScriptableModelBase>;
 
@@ -39,6 +41,8 @@ namespace scriptable {
     /**jsdoc
      * @typedef {object} Graphics.Material
      * @property {string} name
+     * @property {string} alphaMode
+     * @property {string} cullMode
      * @property {string} model
      * @property {number|string} opacity
      * @property {number|string} roughness
@@ -73,6 +77,8 @@ namespace scriptable {
         ScriptableMaterial& operator=(const ScriptableMaterial& material);
 
         QString name;
+        Material::MaterialAlphaMode alphaMode;
+        Material::MaterialCullMode cullMode;
         QString model;
         float opacity;
         float roughness;

--- a/libraries/graphics-scripting/src/graphics-scripting/Forward.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/Forward.h
@@ -77,6 +77,7 @@ namespace scriptable {
 
         QString name;
         Material::MaterialAlphaMode alphaMode;
+        float alphaCutoff;
         QString model;
         float opacity;
         float roughness;

--- a/libraries/graphics-scripting/src/graphics-scripting/Forward.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/Forward.h
@@ -42,7 +42,6 @@ namespace scriptable {
      * @typedef {object} Graphics.Material
      * @property {string} name
      * @property {string} alphaMode
-     * @property {string} cullMode
      * @property {string} model
      * @property {number|string} opacity
      * @property {number|string} roughness
@@ -78,7 +77,6 @@ namespace scriptable {
 
         QString name;
         Material::MaterialAlphaMode alphaMode;
-        Material::MaterialCullMode cullMode;
         QString model;
         float opacity;
         float roughness;

--- a/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
@@ -363,8 +363,6 @@ namespace scriptable {
         obj.setProperty("name", material.name);
         obj.setProperty("model", material.model);
 
-        obj.setProperty("alphaMode", Material::alphaModeAsString(material.alphaMode));
-
         bool hasPropertyFallthroughs = !material.propertyFallthroughs.empty();
 
         const QScriptValue FALLTHROUGH("fallthrough");
@@ -485,6 +483,11 @@ namespace scriptable {
         }
         if (hasPropertyFallthroughs && material.propertyFallthroughs.at(graphics::Material::MATERIAL_PARAMS)) {
             obj.setProperty("materialParams", FALLTHROUGH);
+        }
+        if (hasPropertyFallthroughs && material.propertyFallthroughs.at(graphics::Material::ALPHA_MODE)) {
+            obj.setProperty("alphaMode", FALLTHROUGH);
+        } else {
+            obj.setProperty("alphaMode", Material::alphaModeAsString(material.alphaMode));
         }
         if (hasPropertyFallthroughs && material.propertyFallthroughs.at(graphics::Material::ALPHA_CUTOFF)) {
             obj.setProperty("alphaCutoff", FALLTHROUGH);

--- a/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
@@ -363,6 +363,8 @@ namespace scriptable {
         obj.setProperty("name", material.name);
         obj.setProperty("model", material.model);
 
+        obj.setProperty("alphaMode", Material::alphaModeAsString(material.alphaMode));
+
         bool hasPropertyFallthroughs = !material.propertyFallthroughs.empty();
 
         const QScriptValue FALLTHROUGH("fallthrough");

--- a/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
@@ -486,6 +486,11 @@ namespace scriptable {
         if (hasPropertyFallthroughs && material.propertyFallthroughs.at(graphics::Material::MATERIAL_PARAMS)) {
             obj.setProperty("materialParams", FALLTHROUGH);
         }
+        if (hasPropertyFallthroughs && material.propertyFallthroughs.at(graphics::Material::ALPHA_CUTOFF)) {
+            obj.setProperty("alphaCutoff", FALLTHROUGH);
+        } else if (material.alphaCutoff != graphics::Material::DEFAULT_ALPHA_CUTOFF) {
+            obj.setProperty("alphaCutoff", material.alphaCutoff);
+        }
 
         obj.setProperty("defaultFallthrough", material.defaultFallthrough);
 

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
@@ -21,6 +21,8 @@
 
 scriptable::ScriptableMaterial& scriptable::ScriptableMaterial::operator=(const scriptable::ScriptableMaterial& material) {
     name = material.name;
+    alphaMode = material.alphaMode;
+    cullMode = material.cullMode;
     model = material.model;
     opacity = material.opacity;
     roughness = material.roughness;
@@ -53,6 +55,8 @@ scriptable::ScriptableMaterial& scriptable::ScriptableMaterial::operator=(const 
 scriptable::ScriptableMaterial::ScriptableMaterial(const graphics::MaterialPointer& material) {
     if (material) {
         name = material->getName().c_str();
+        alphaMode = material->getAlphaMode();
+        cullMode = material->getCullMode();
         model = material->getModel().c_str();
         opacity = material->getOpacity();
         roughness = material->getRoughness();

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
@@ -22,7 +22,6 @@
 scriptable::ScriptableMaterial& scriptable::ScriptableMaterial::operator=(const scriptable::ScriptableMaterial& material) {
     name = material.name;
     alphaMode = material.alphaMode;
-    cullMode = material.cullMode;
     model = material.model;
     opacity = material.opacity;
     roughness = material.roughness;
@@ -56,7 +55,6 @@ scriptable::ScriptableMaterial::ScriptableMaterial(const graphics::MaterialPoint
     if (material) {
         name = material->getName().c_str();
         alphaMode = material->getAlphaMode();
-        cullMode = material->getCullMode();
         model = material->getModel().c_str();
         opacity = material->getOpacity();
         roughness = material->getRoughness();

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
@@ -22,6 +22,7 @@
 scriptable::ScriptableMaterial& scriptable::ScriptableMaterial::operator=(const scriptable::ScriptableMaterial& material) {
     name = material.name;
     alphaMode = material.alphaMode;
+    alphaCutoff = material.alphaCutoff;
     model = material.model;
     opacity = material.opacity;
     roughness = material.roughness;
@@ -55,6 +56,7 @@ scriptable::ScriptableMaterial::ScriptableMaterial(const graphics::MaterialPoint
     if (material) {
         name = material->getName().c_str();
         alphaMode = material->getAlphaMode();
+        alphaCutoff = material->getAlphaCutoff();
         model = material->getModel().c_str();
         opacity = material->getOpacity();
         roughness = material->getRoughness();

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableModel.cpp
@@ -21,10 +21,10 @@
 
 scriptable::ScriptableMaterial& scriptable::ScriptableMaterial::operator=(const scriptable::ScriptableMaterial& material) {
     name = material.name;
-    alphaMode = material.alphaMode;
-    alphaCutoff = material.alphaCutoff;
     model = material.model;
     opacity = material.opacity;
+    alphaMode = material.alphaMode;
+    alphaCutoff = material.alphaCutoff;
     roughness = material.roughness;
     metallic = material.metallic;
     scattering = material.scattering;
@@ -55,10 +55,10 @@ scriptable::ScriptableMaterial& scriptable::ScriptableMaterial::operator=(const 
 scriptable::ScriptableMaterial::ScriptableMaterial(const graphics::MaterialPointer& material) {
     if (material) {
         name = material->getName().c_str();
-        alphaMode = material->getAlphaMode();
-        alphaCutoff = material->getAlphaCutoff();
         model = material->getModel().c_str();
         opacity = material->getOpacity();
+        alphaMode = material->getAlphaMode();
+        alphaCutoff = material->getAlphaCutoff();
         roughness = material->getRoughness();
         metallic = material->getMetallic();
         scattering = material->getScattering();

--- a/libraries/graphics/src/graphics/Material.cpp
+++ b/libraries/graphics/src/graphics/Material.cpp
@@ -23,6 +23,7 @@ const float Material::DEFAULT_ALBEDO { 0.5f };
 const float Material::DEFAULT_METALLIC { 0.0f };
 const float Material::DEFAULT_ROUGHNESS { 1.0f };
 const float Material::DEFAULT_SCATTERING { 0.0f };
+const float Material::DEFAULT_ALPHA_CUTOFF { 0.5f };
 
 Material::Material() {
     for (int i = 0; i < NUM_TOTAL_FLAGS; i++) {
@@ -33,6 +34,7 @@ Material::Material() {
 Material::Material(const Material& material) :
     _name(material._name),
     _alphaMode(material._alphaMode),
+    _alphaCutoff(material._alphaCutoff),
     _model(material._model),
     _key(material._key),
     _emissive(material._emissive),
@@ -55,6 +57,7 @@ Material& Material::operator=(const Material& material) {
 
     _name = material._name;
     _alphaMode = material._alphaMode;
+    _alphaCutoff = material._alphaCutoff;
     _model = material._model;
     _key = material._key;
     _emissive = material._emissive;

--- a/libraries/graphics/src/graphics/Material.cpp
+++ b/libraries/graphics/src/graphics/Material.cpp
@@ -33,12 +33,12 @@ Material::Material() {
 
 Material::Material(const Material& material) :
     _name(material._name),
-    _alphaMode(material._alphaMode),
-    _alphaCutoff(material._alphaCutoff),
     _model(material._model),
     _key(material._key),
     _emissive(material._emissive),
     _opacity(material._opacity),
+    _alphaMode(material._alphaMode),
+    _alphaCutoff(material._alphaCutoff),
     _albedo(material._albedo),
     _roughness(material._roughness),
     _metallic(material._metallic),
@@ -56,12 +56,12 @@ Material& Material::operator=(const Material& material) {
     QMutexLocker locker(&_textureMapsMutex);
 
     _name = material._name;
-    _alphaMode = material._alphaMode;
-    _alphaCutoff = material._alphaCutoff;
     _model = material._model;
     _key = material._key;
     _emissive = material._emissive;
     _opacity = material._opacity;
+    _alphaMode = material._alphaMode;
+    _alphaCutoff = material._alphaCutoff;
     _albedo = material._albedo;
     _roughness = material._roughness;
     _metallic = material._metallic;
@@ -77,10 +77,10 @@ Material& Material::operator=(const Material& material) {
     return (*this);
 }
 
-void Material::setAlphaMode(const MaterialAlphaMode alphaMode) {
+void Material::setAlphaMode(const AlphaMode alphaMode) {
     if (alphaMode != _alphaMode) {
         _alphaMode = alphaMode;
-        resetOpacityMap();
+        resetOpacityMap(_alphaMode);
     }
 }
 
@@ -133,7 +133,7 @@ void Material::setTextureMap(MapChannel channel, const TextureMapPointer& textur
     }
 
     if (channel == MaterialKey::ALBEDO_MAP) {
-        resetOpacityMap();
+        resetOpacityMap(_alphaMode);
         _texcoordTransforms[0] = (textureMap ? textureMap->getTextureTransform().getMatrix() : glm::mat4());
     }
 
@@ -151,12 +151,12 @@ void Material::setTextureMap(MapChannel channel, const TextureMapPointer& textur
 
 }
 
-void Material::resetOpacityMap() const {
+void Material::resetOpacityMap(AlphaMode alphaMode) const {
     // Clear the previous flags
     _key.setOpacityMaskMap(false);
     _key.setTranslucentMap(false);
 
-    if (_alphaMode == MAT_OPAQUE) {
+    if (alphaMode == MAT_OPAQUE) {
         return;
     }
 
@@ -168,7 +168,7 @@ void Material::resetOpacityMap() const {
 
         auto usage = textureMap->getTextureView()._texture->getUsage();
         if (usage.isAlpha()) {
-            if (usage.isAlphaMask() || _alphaMode == MAT_MASK) {
+            if (usage.isAlphaMask() || alphaMode == MAT_MASK) {
                 // Texture has alpha, but it is just a mask
                 _key.setOpacityMaskMap(true);
                 _key.setTranslucentMap(false);

--- a/libraries/graphics/src/graphics/Material.cpp
+++ b/libraries/graphics/src/graphics/Material.cpp
@@ -33,7 +33,6 @@ Material::Material() {
 Material::Material(const Material& material) :
     _name(material._name),
     _alphaMode(material._alphaMode),
-    _cullMode(material._cullMode),
     _model(material._model),
     _key(material._key),
     _emissive(material._emissive),
@@ -56,7 +55,6 @@ Material& Material::operator=(const Material& material) {
 
     _name = material._name;
     _alphaMode = material._alphaMode;
-    _cullMode = material._cullMode;
     _model = material._model;
     _key = material._key;
     _emissive = material._emissive;

--- a/libraries/graphics/src/graphics/Material.h
+++ b/libraries/graphics/src/graphics/Material.h
@@ -327,42 +327,32 @@ public:
         MAT_OPAQUE,
     };
 
-    static MaterialAlphaMode AlphaModeFromString(const std::string& alphaMode) {
-        if (alphaMode == "BLEND" || alphaMode == "Blend" || alphaMode == "blend") {
+    static MaterialAlphaMode alphaModeFromString(const QString& alphaMode) {
+        if (alphaMode.toLower() == "blend") {
             return MAT_BLEND;
-        } else if (alphaMode == "MASK" || alphaMode == "Mask" || alphaMode == "mask") {
+        } else if (alphaMode.toLower() == "mask") {
             return MAT_MASK;
-        } else if (alphaMode == "OPAQUE" || alphaMode == "Opaque" || alphaMode == "opaque") {
+        } else if (alphaMode.toLower() == "opaque") {
             return MAT_OPAQUE;
         } else {
             return MAT_BLEND;
         }
     };
 
-    const MaterialAlphaMode getAlphaMode() const { return _alphaMode; }
-    void setAlphaMode(const MaterialAlphaMode alphaMode);
-
-    enum MaterialCullMode
-    {
-        MAT_BACK = 0,
-        MAT_FRONT,
-        MAT_DISABLED
-    };
-
-    static MaterialCullMode CullModeFromString(const std::string& cullMode) {
-        if (cullMode == "BACK" || cullMode == "Back" || cullMode == "back") {
-            return MAT_BACK;
-        } else if (cullMode == "FRONT" || cullMode == "Front" || cullMode == "front") {
-            return MAT_FRONT;
-        } else if (cullMode == "DISABLED" || cullMode == "Disabled" || cullMode == "disabled") {
-            return MAT_DISABLED;
+    static QString alphaModeAsString(const MaterialAlphaMode& alphaMode) {
+        if (alphaMode == MAT_BLEND) {
+            return "blend";
+        } else if (alphaMode == MAT_MASK) {
+            return "mask";
+        } else if (alphaMode == MAT_OPAQUE) {
+            return "opaque";
         } else {
-            return MAT_BACK;
+            return "blend";
         }
     };
 
-    const MaterialCullMode getCullMode() const { return _cullMode; }
-    void setCullMode(const MaterialCullMode cullMode) { _cullMode = cullMode; }
+    const MaterialAlphaMode getAlphaMode() const { return _alphaMode; }
+    void setAlphaMode(const MaterialAlphaMode alphaMode);
 
     const std::string& getModel() const { return _model; }
     void setModel(const std::string& model) { _model = model; }
@@ -390,7 +380,6 @@ public:
 protected:
     std::string _name { "" };
     MaterialAlphaMode _alphaMode { MAT_BLEND };
-    MaterialCullMode _cullMode { MAT_BACK };
 private:
     std::string _model { "hifi_pbr" };
     mutable MaterialKey _key { 0 };

--- a/libraries/graphics/src/graphics/Material.h
+++ b/libraries/graphics/src/graphics/Material.h
@@ -283,6 +283,45 @@ public:
     void setOpacity(float opacity);
     float getOpacity() const { return _opacity; }
 
+    enum AlphaMode
+    {
+        MAT_BLEND = 0,
+        MAT_MASK,
+        MAT_OPAQUE,
+    };
+
+    static AlphaMode alphaModeFromString(const std::string& alphaMode) {
+        QString alphaModeLower = QString::fromStdString(alphaMode).toLower();
+        if (alphaModeLower == "blend") {
+            return MAT_BLEND;
+        } else if (alphaModeLower == "mask") {
+            return MAT_MASK;
+        } else if (alphaModeLower == "opaque") {
+            return MAT_OPAQUE;
+        } else {
+            return MAT_BLEND;
+        }
+    };
+
+    static QString alphaModeAsString(const AlphaMode& alphaMode) {
+        if (alphaMode == MAT_BLEND) {
+            return "blend";
+        } else if (alphaMode == MAT_MASK) {
+            return "mask";
+        } else if (alphaMode == MAT_OPAQUE) {
+            return "opaque";
+        } else {
+            return "blend";
+        }
+    };
+
+    const AlphaMode getAlphaMode() const { return _alphaMode; }
+    void setAlphaMode(const AlphaMode alphaMode);
+
+    static const float DEFAULT_ALPHA_CUTOFF;
+    void setAlphaCutoff(float alphaCutoff) { _alphaCutoff = alphaCutoff; }
+    float getAlphaCutoff() const { return _alphaCutoff; }
+
     void setUnlit(bool value);
     bool isUnlit() const { return _key.isUnlit(); }
 
@@ -310,7 +349,7 @@ public:
 
     // Albedo maps cannot have opacity detected until they are loaded
     // This method allows const changing of the key/schemaBuffer without touching the map
-    void resetOpacityMap() const;
+    void resetOpacityMap(AlphaMode alphaMode) const;
 
     // conversion from legacy material properties to PBR equivalent
     static float shininessToRoughness(float shininess) { return 1.0f - shininess / 100.0f; }
@@ -319,44 +358,6 @@ public:
 
     const std::string& getName() const { return _name; }
     void setName(const std::string& name) { _name = name; }
-
-    enum MaterialAlphaMode
-    {
-        MAT_BLEND = 0,
-        MAT_MASK,
-        MAT_OPAQUE,
-    };
-
-    static MaterialAlphaMode alphaModeFromString(const QString& alphaMode) {
-        if (alphaMode.toLower() == "blend") {
-            return MAT_BLEND;
-        } else if (alphaMode.toLower() == "mask") {
-            return MAT_MASK;
-        } else if (alphaMode.toLower() == "opaque") {
-            return MAT_OPAQUE;
-        } else {
-            return MAT_BLEND;
-        }
-    };
-
-    static QString alphaModeAsString(const MaterialAlphaMode& alphaMode) {
-        if (alphaMode == MAT_BLEND) {
-            return "blend";
-        } else if (alphaMode == MAT_MASK) {
-            return "mask";
-        } else if (alphaMode == MAT_OPAQUE) {
-            return "opaque";
-        } else {
-            return "blend";
-        }
-    };
-
-    const MaterialAlphaMode getAlphaMode() const { return _alphaMode; }
-    void setAlphaMode(const MaterialAlphaMode alphaMode);
-
-    static const float DEFAULT_ALPHA_CUTOFF;
-    void setAlphaCutoff(float alphaCutoff) { _alphaCutoff = alphaCutoff; }
-    float getAlphaCutoff() const { return _alphaCutoff; }
 
     const std::string& getModel() const { return _model; }
     void setModel(const std::string& model) { _model = model; }
@@ -374,6 +375,7 @@ public:
         TEXCOORDTRANSFORM1,
         LIGHTMAP_PARAMS,
         MATERIAL_PARAMS,
+        ALPHA_MODE,
         ALPHA_CUTOFF,
 
         NUM_TOTAL_FLAGS
@@ -384,7 +386,6 @@ public:
 
 protected:
     std::string _name { "" };
-    MaterialAlphaMode _alphaMode { MAT_BLEND };
 private:
     std::string _model { "hifi_pbr" };
     mutable MaterialKey _key { 0 };
@@ -392,6 +393,8 @@ private:
     // Material properties
     glm::vec3 _emissive { DEFAULT_EMISSIVE };
     float _opacity { DEFAULT_OPACITY };
+    AlphaMode _alphaMode{ MAT_BLEND };
+    float _alphaCutoff{ DEFAULT_ALPHA_CUTOFF };
     glm::vec3 _albedo { DEFAULT_ALBEDO };
     float _roughness { DEFAULT_ROUGHNESS };
     float _metallic { DEFAULT_METALLIC };
@@ -399,7 +402,6 @@ private:
     std::array<glm::mat4, NUM_TEXCOORD_TRANSFORMS> _texcoordTransforms;
     glm::vec2 _lightmapParams { 0.0, 1.0 };
     glm::vec2 _materialParams { 0.0, 1.0 };
-    float _alphaCutoff { DEFAULT_ALPHA_CUTOFF };
     TextureMaps _textureMaps;
 
     bool _defaultFallthrough { false };

--- a/libraries/graphics/src/graphics/Material.h
+++ b/libraries/graphics/src/graphics/Material.h
@@ -354,6 +354,10 @@ public:
     const MaterialAlphaMode getAlphaMode() const { return _alphaMode; }
     void setAlphaMode(const MaterialAlphaMode alphaMode);
 
+    static const float DEFAULT_ALPHA_CUTOFF;
+    void setAlphaCutoff(float alphaCutoff) { _alphaCutoff = alphaCutoff; }
+    float getAlphaCutoff() const { return _alphaCutoff; }
+
     const std::string& getModel() const { return _model; }
     void setModel(const std::string& model) { _model = model; }
 
@@ -370,6 +374,7 @@ public:
         TEXCOORDTRANSFORM1,
         LIGHTMAP_PARAMS,
         MATERIAL_PARAMS,
+        ALPHA_CUTOFF,
 
         NUM_TOTAL_FLAGS
     };
@@ -394,6 +399,7 @@ private:
     std::array<glm::mat4, NUM_TEXCOORD_TRANSFORMS> _texcoordTransforms;
     glm::vec2 _lightmapParams { 0.0, 1.0 };
     glm::vec2 _materialParams { 0.0, 1.0 };
+    float _alphaCutoff { DEFAULT_ALPHA_CUTOFF };
     TextureMaps _textureMaps;
 
     bool _defaultFallthrough { false };
@@ -459,10 +465,12 @@ public:
 
         float _metallic { Material::DEFAULT_METALLIC }; // Not Metallic
         float _scattering { Material::DEFAULT_SCATTERING }; // Scattering info
+
+		float _alphaCutoff{ Material::DEFAULT_ALPHA_CUTOFF };
 #if defined(__clang__)
         __attribute__((unused))
 #endif
-        glm::vec2 _spare { 0.0f }; // Padding
+        float _spare { 0.0f }; // Padding
 
         uint32_t _key { 0 }; // a copy of the materialKey
 #if defined(__clang__)

--- a/libraries/graphics/src/graphics/Material.h
+++ b/libraries/graphics/src/graphics/Material.h
@@ -320,6 +320,50 @@ public:
     const std::string& getName() const { return _name; }
     void setName(const std::string& name) { _name = name; }
 
+    enum MaterialAlphaMode
+    {
+        MAT_BLEND = 0,
+        MAT_MASK,
+        MAT_OPAQUE,
+    };
+
+    static MaterialAlphaMode AlphaModeFromString(const std::string& alphaMode) {
+        if (alphaMode == "BLEND" || alphaMode == "Blend" || alphaMode == "blend") {
+            return MAT_BLEND;
+        } else if (alphaMode == "MASK" || alphaMode == "Mask" || alphaMode == "mask") {
+            return MAT_MASK;
+        } else if (alphaMode == "OPAQUE" || alphaMode == "Opaque" || alphaMode == "opaque") {
+            return MAT_OPAQUE;
+        } else {
+            return MAT_BLEND;
+        }
+    };
+
+    const MaterialAlphaMode getAlphaMode() const { return _alphaMode; }
+    void setAlphaMode(const MaterialAlphaMode alphaMode);
+
+    enum MaterialCullMode
+    {
+        MAT_BACK = 0,
+        MAT_FRONT,
+        MAT_DISABLED
+    };
+
+    static MaterialCullMode CullModeFromString(const std::string& cullMode) {
+        if (cullMode == "BACK" || cullMode == "Back" || cullMode == "back") {
+            return MAT_BACK;
+        } else if (cullMode == "FRONT" || cullMode == "Front" || cullMode == "front") {
+            return MAT_FRONT;
+        } else if (cullMode == "DISABLED" || cullMode == "Disabled" || cullMode == "disabled") {
+            return MAT_DISABLED;
+        } else {
+            return MAT_BACK;
+        }
+    };
+
+    const MaterialCullMode getCullMode() const { return _cullMode; }
+    void setCullMode(const MaterialCullMode cullMode) { _cullMode = cullMode; }
+
     const std::string& getModel() const { return _model; }
     void setModel(const std::string& model) { _model = model; }
 
@@ -345,7 +389,8 @@ public:
 
 protected:
     std::string _name { "" };
-
+    MaterialAlphaMode _alphaMode { MAT_BLEND };
+    MaterialCullMode _cullMode { MAT_BACK };
 private:
     std::string _model { "hifi_pbr" };
     mutable MaterialKey _key { 0 };

--- a/libraries/graphics/src/graphics/Material.slh
+++ b/libraries/graphics/src/graphics/Material.slh
@@ -49,7 +49,7 @@ struct TexMapArray {
 struct Material {
     vec4 _emissiveOpacity;
     vec4 _albedoRoughness;
-    vec4 _metallicScatteringSpare2;
+    vec4 _metallicScatteringAlphaCutoffSpare1;
     vec4 _keySpare3;
 };
 
@@ -72,8 +72,9 @@ vec3 getMaterialAlbedo(Material m) { return m._albedoRoughness.rgb; }
 float getMaterialRoughness(Material m) { return m._albedoRoughness.a; }
 float getMaterialShininess(Material m) { return 1.0 - getMaterialRoughness(m); }
 
-float getMaterialMetallic(Material m) { return m._metallicScatteringSpare2.x; }
-float getMaterialScattering(Material m) { return m._metallicScatteringSpare2.y; }
+float getMaterialMetallic(Material m) { return m._metallicScatteringAlphaCutoffSpare1.x; }
+float getMaterialScattering(Material m) { return m._metallicScatteringAlphaCutoffSpare1.y; }
+float getMaterialAlphaCutoff(Material m) { return m._metallicScatteringAlphaCutoffSpare1.z; }
 
 BITFIELD getMaterialKey(Material m) { return floatBitsToInt(m._keySpare3.x); }
 

--- a/libraries/graphics/src/graphics/MaterialTextures.slh
+++ b/libraries/graphics/src/graphics/MaterialTextures.slh
@@ -214,12 +214,11 @@ vec3 fetchLightmapMap(vec2 uv) {
 }
 <@endfunc@>
 
-<@func evalMaterialOpacity(fetchedOpacity, materialOpacity, matKey, opacity)@>
+<@func evalMaterialOpacity(fetchedOpacity, materialOpacity, matKey, opacity, cutoff)@>
 {
-    const float OPACITY_MASK_THRESHOLD = 0.5;
     <$opacity$> = mix(1.0,
                       mix(<$fetchedOpacity$>,
-                          step(OPACITY_MASK_THRESHOLD, <$fetchedOpacity$>),
+                          step(<$cutoff$>, <$fetchedOpacity$>),
                           float((<$matKey$> & OPACITY_MASK_MAP_BIT) != 0)),
                       float((<$matKey$> & (OPACITY_TRANSLUCENT_MAP_BIT | OPACITY_MASK_MAP_BIT)) != 0)) * <$materialOpacity$>;
 }

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -184,18 +184,20 @@ class Material {
 public:
     Material() {};
     Material(const glm::vec3& diffuseColor, const glm::vec3& specularColor, const glm::vec3& emissiveColor,
-         float shininess, float opacity, AlphaMode::Values alphaMode) :
+         float shininess, float opacity, AlphaMode::Values alphaMode, float alphaCutoff) :
         diffuseColor(diffuseColor),
         specularColor(specularColor),
         emissiveColor(emissiveColor),
         shininess(shininess),
         opacity(opacity),
-        alphaMode(alphaMode) {}
+        alphaMode(alphaMode),
+        alphaCutoff(alphaCutoff) {}
 
     void getTextureNames(QSet<QString>& textureList) const;
     void setMaxNumPixelsPerTexture(int maxNumPixels);
 
     AlphaMode::Values alphaMode{ AlphaMode::HFM_BLEND };
+    float alphaCutoff{ 0.5f };
 
     glm::vec3 diffuseColor{ 1.0f };
     float diffuseFactor{ 1.0f };

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -159,32 +159,11 @@ public:
     QString materialID;
 };
 
-namespace AlphaMode {
-    enum Values {
-        HFM_BLEND = 0,
-        HFM_MASK,
-        HFM_OPAQUE,
-    };
-
-    static std::string toString(Values alphaMode) {
-        switch (alphaMode) {
-            case HFM_BLEND:
-                return "BLEND";
-            case HFM_MASK:
-                return "MASK";
-            case HFM_OPAQUE:
-                return "OPAQUE";
-            default:
-                return "INVALID";
-        };
-    };
-};
-
 class Material {
 public:
     Material() {};
     Material(const glm::vec3& diffuseColor, const glm::vec3& specularColor, const glm::vec3& emissiveColor,
-         float shininess, float opacity, AlphaMode::Values alphaMode, float alphaCutoff) :
+         float shininess, float opacity, graphics::Material::AlphaMode alphaMode, float alphaCutoff) :
         diffuseColor(diffuseColor),
         specularColor(specularColor),
         emissiveColor(emissiveColor),
@@ -196,7 +175,7 @@ public:
     void getTextureNames(QSet<QString>& textureList) const;
     void setMaxNumPixelsPerTexture(int maxNumPixels);
 
-    AlphaMode::Values alphaMode{ AlphaMode::HFM_BLEND };
+    graphics::Material::AlphaMode alphaMode{ graphics::Material::MAT_BLEND };
     float alphaCutoff{ 0.5f };
 
     glm::vec3 diffuseColor{ 1.0f };

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -159,19 +159,66 @@ public:
     QString materialID;
 };
 
+namespace AlphaMode {
+    enum Values {
+        HFM_BLEND = 0,
+        HFM_MASK,
+        HFM_OPAQUE,
+    };
+
+    static QString ToString(Values alphaMode) {
+        switch (alphaMode) {
+            case HFM_BLEND:
+                return "BLEND";
+            case HFM_MASK:
+                return "MASK";
+            case HFM_OPAQUE:
+                return "OPAQUE";
+            default:
+                return "INVALID";
+        };
+    };
+};
+
+namespace CullMode {
+    enum Values {
+        HFM_BACK = 0,
+        HFM_FRONT,
+        HFM_DISABLED,
+    };
+
+    static QString ToString(Values cullMode) {
+        switch (cullMode) {
+            case HFM_BACK:
+                return "BACK";
+            case HFM_FRONT:
+                return "FRONT";
+            case HFM_DISABLED:
+                return "DISABLED";
+            default:
+                return "INVALID";
+        };
+    };
+};
+
 class Material {
 public:
     Material() {};
     Material(const glm::vec3& diffuseColor, const glm::vec3& specularColor, const glm::vec3& emissiveColor,
-         float shininess, float opacity) :
+         float shininess, float opacity, AlphaMode::Values alphaMode, CullMode::Values cullMode) :
         diffuseColor(diffuseColor),
         specularColor(specularColor),
         emissiveColor(emissiveColor),
         shininess(shininess),
-        opacity(opacity)  {}
+        opacity(opacity),
+        alphaMode(alphaMode),
+        cullMode(cullMode) {}
 
     void getTextureNames(QSet<QString>& textureList) const;
     void setMaxNumPixelsPerTexture(int maxNumPixels);
+
+    AlphaMode::Values alphaMode{ AlphaMode::HFM_BLEND };
+    CullMode::Values cullMode{ CullMode::HFM_BACK };
 
     glm::vec3 diffuseColor{ 1.0f };
     float diffuseFactor{ 1.0f };

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -166,7 +166,7 @@ namespace AlphaMode {
         HFM_OPAQUE,
     };
 
-    static QString ToString(Values alphaMode) {
+    static std::string toString(Values alphaMode) {
         switch (alphaMode) {
             case HFM_BLEND:
                 return "BLEND";
@@ -180,45 +180,22 @@ namespace AlphaMode {
     };
 };
 
-namespace CullMode {
-    enum Values {
-        HFM_BACK = 0,
-        HFM_FRONT,
-        HFM_DISABLED,
-    };
-
-    static QString ToString(Values cullMode) {
-        switch (cullMode) {
-            case HFM_BACK:
-                return "BACK";
-            case HFM_FRONT:
-                return "FRONT";
-            case HFM_DISABLED:
-                return "DISABLED";
-            default:
-                return "INVALID";
-        };
-    };
-};
-
 class Material {
 public:
     Material() {};
     Material(const glm::vec3& diffuseColor, const glm::vec3& specularColor, const glm::vec3& emissiveColor,
-         float shininess, float opacity, AlphaMode::Values alphaMode, CullMode::Values cullMode) :
+         float shininess, float opacity, AlphaMode::Values alphaMode) :
         diffuseColor(diffuseColor),
         specularColor(specularColor),
         emissiveColor(emissiveColor),
         shininess(shininess),
         opacity(opacity),
-        alphaMode(alphaMode),
-        cullMode(cullMode) {}
+        alphaMode(alphaMode) {}
 
     void getTextureNames(QSet<QString>& textureList) const;
     void setMaxNumPixelsPerTexture(int maxNumPixels);
 
     AlphaMode::Values alphaMode{ AlphaMode::HFM_BLEND };
-    CullMode::Values cullMode{ CullMode::HFM_BACK };
 
     glm::vec3 diffuseColor{ 1.0f };
     float diffuseFactor{ 1.0f };

--- a/libraries/material-networking/src/material-networking/MaterialCache.cpp
+++ b/libraries/material-networking/src/material-networking/MaterialCache.cpp
@@ -115,7 +115,6 @@ NetworkMaterialResource::ParsedMaterials NetworkMaterialResource::parseJSONMater
  *     Supported models are: "hifi_pbr"
  * @property {string} name="" - A name for the material. Supported by all material models.
  * @property {string} alphaMode="" - The alpha mode for the material. Can be <code>"BLEND"</code>, <code>"MASK"</code>, or <code>"OPAQUE"</code>.
- * @property {string} cullMode="" - The cull mode for the material. Can be <code>"BACK"</code>, <code>"FRONT"</code>, or <code>"DISABLED"</code>.
  * @property {Color|RGBS|string} emissive - The emissive color, i.e., the color that the material emits. A {@link Color} value
  *     is treated as sRGB. A {@link RGBS} value can be either RGB or sRGB.  Set to <code>"fallthrough"</code> to fallthrough to
  *     the material below.  "hifi_pbr" model only.
@@ -198,12 +197,7 @@ std::pair<std::string, std::shared_ptr<NetworkMaterial>> NetworkMaterialResource
             } else if (key == "alphaMode") {
                 auto alphaModeJSON = materialJSON.value(key);
                 if (alphaModeJSON.isString()) {
-                    material->setAlphaMode(NetworkMaterial::AlphaModeFromString(alphaModeJSON.toString().toStdString()));
-                }
-            } else if (key == "cullMode") {
-                auto cullModeJSON = materialJSON.value(key);
-                if (cullModeJSON.isString()) {
-                    material->setCullMode(NetworkMaterial::CullModeFromString(cullModeJSON.toString().toStdString()));
+                    material->setAlphaMode(NetworkMaterial::alphaModeFromString(alphaModeJSON.toString()));
                 }
             } else if (key == "emissive") {
                 auto value = materialJSON.value(key);
@@ -601,17 +595,6 @@ NetworkMaterial::NetworkMaterial(const HFMMaterial& material, const QUrl& textur
             break;
         case hfm::AlphaMode::HFM_OPAQUE:
             _alphaMode = NetworkMaterial::MAT_OPAQUE;
-            break;
-    }
-    switch (material.cullMode) {
-        case hfm::CullMode::HFM_BACK:
-            _cullMode = NetworkMaterial::MAT_BACK;
-            break;
-        case hfm::CullMode::HFM_FRONT:
-            _cullMode = NetworkMaterial::MAT_FRONT;
-            break;
-        case hfm::CullMode::HFM_DISABLED:
-            _cullMode = NetworkMaterial::MAT_DISABLED;
             break;
     }
 

--- a/libraries/material-networking/src/material-networking/MaterialCache.cpp
+++ b/libraries/material-networking/src/material-networking/MaterialCache.cpp
@@ -114,6 +114,8 @@ NetworkMaterialResource::ParsedMaterials NetworkMaterialResource::parseJSONMater
  * @property {string} model="hifi_pbr" - Different material models support different properties and rendering modes.
  *     Supported models are: "hifi_pbr"
  * @property {string} name="" - A name for the material. Supported by all material models.
+ * @property {string} alphaMode="" - The alpha mode for the material. Can be <code>"BLEND"</code>, <code>"MASK"</code>, or <code>"OPAQUE"</code>.
+ * @property {string} cullMode="" - The cull mode for the material. Can be <code>"BACK"</code>, <code>"FRONT"</code>, or <code>"DISABLED"</code>.
  * @property {Color|RGBS|string} emissive - The emissive color, i.e., the color that the material emits. A {@link Color} value
  *     is treated as sRGB. A {@link RGBS} value can be either RGB or sRGB.  Set to <code>"fallthrough"</code> to fallthrough to
  *     the material below.  "hifi_pbr" model only.
@@ -192,6 +194,16 @@ std::pair<std::string, std::shared_ptr<NetworkMaterial>> NetworkMaterialResource
                 auto modelJSON = materialJSON.value(key);
                 if (modelJSON.isString()) {
                     material->setModel(modelJSON.toString().toStdString());
+                }
+            } else if (key == "alphaMode") {
+                auto alphaModeJSON = materialJSON.value(key);
+                if (alphaModeJSON.isString()) {
+                    material->setAlphaMode(NetworkMaterial::AlphaModeFromString(alphaModeJSON.toString().toStdString()));
+                }
+            } else if (key == "cullMode") {
+                auto cullModeJSON = materialJSON.value(key);
+                if (cullModeJSON.isString()) {
+                    material->setCullMode(NetworkMaterial::CullModeFromString(cullModeJSON.toString().toStdString()));
                 }
             } else if (key == "emissive") {
                 auto value = materialJSON.value(key);
@@ -580,6 +592,29 @@ NetworkMaterial::NetworkMaterial(const HFMMaterial& material, const QUrl& textur
     graphics::Material(*material._material)
 {
     _name = material.name.toStdString();
+    switch (material.alphaMode) {
+        case hfm::AlphaMode::HFM_BLEND:
+            _alphaMode = NetworkMaterial::MAT_BLEND;
+            break;
+        case hfm::AlphaMode::HFM_MASK:
+            _alphaMode = NetworkMaterial::MAT_MASK;
+            break;
+        case hfm::AlphaMode::HFM_OPAQUE:
+            _alphaMode = NetworkMaterial::MAT_OPAQUE;
+            break;
+    }
+    switch (material.cullMode) {
+        case hfm::CullMode::HFM_BACK:
+            _cullMode = NetworkMaterial::MAT_BACK;
+            break;
+        case hfm::CullMode::HFM_FRONT:
+            _cullMode = NetworkMaterial::MAT_FRONT;
+            break;
+        case hfm::CullMode::HFM_DISABLED:
+            _cullMode = NetworkMaterial::MAT_DISABLED;
+            break;
+    }
+
     if (!material.albedoTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.albedoTexture, image::TextureUsage::ALBEDO_TEXTURE, MapChannel::ALBEDO_MAP);
         if (map) {

--- a/libraries/material-networking/src/material-networking/MaterialCache.cpp
+++ b/libraries/material-networking/src/material-networking/MaterialCache.cpp
@@ -115,6 +115,8 @@ NetworkMaterialResource::ParsedMaterials NetworkMaterialResource::parseJSONMater
  *     Supported models are: "hifi_pbr"
  * @property {string} name="" - A name for the material. Supported by all material models.
  * @property {string} alphaMode="" - The alpha mode for the material. Can be <code>"BLEND"</code>, <code>"MASK"</code>, or <code>"OPAQUE"</code>.
+ * @property {number|string} alphaCutoff=0.5 - The cutoff for alpha mask mode, <code>0.0</code> &ndash; <code>1.0</code>.  Set to <code>"fallthrough"</code> to fallthrough to
+ *     the material below.  "hifi_pbr" model only.
  * @property {Color|RGBS|string} emissive - The emissive color, i.e., the color that the material emits. A {@link Color} value
  *     is treated as sRGB. A {@link RGBS} value can be either RGB or sRGB.  Set to <code>"fallthrough"</code> to fallthrough to
  *     the material below.  "hifi_pbr" model only.
@@ -415,6 +417,16 @@ std::pair<std::string, std::shared_ptr<NetworkMaterial>> NetworkMaterialResource
                     }
                 }
                 // TODO: implement materialParams
+            } else if (key == "alphaCutoff") {
+                auto value = materialJSON.value(key);
+                if (value.isString()) {
+                    auto valueString = value.toString();
+                    if (valueString == FALLTHROUGH) {
+                        material->setPropertyDoesFallthrough(graphics::Material::ExtraFlagBit::ALPHA_CUTOFF);
+                    }
+                } else if (value.isDouble()) {
+                    material->setAlphaCutoff(value.toDouble());
+                }
             } else if (key == "defaultFallthrough") {
                 auto value = materialJSON.value(key);
                 if (value.isBool()) {
@@ -667,6 +679,8 @@ NetworkMaterial::NetworkMaterial(const HFMMaterial& material, const QUrl& textur
         }
         setTextureMap(MapChannel::LIGHTMAP_MAP, map);
     }
+
+    setAlphaCutoff(material.alphaCutoff);
 }
 
 void NetworkMaterial::setTextures(const QVariantMap& textureMap) {

--- a/libraries/render-utils/src/RenderPipelines.cpp
+++ b/libraries/render-utils/src/RenderPipelines.cpp
@@ -325,6 +325,7 @@ void batchSetter(const ShapePipeline& pipeline, gpu::Batch& batch, RenderArgs* a
             schema._opacity = 1.0f;
             schema._metallic = 0.1f;
             schema._roughness = 0.9f;
+            schema._alphaCutoff = graphics::Material::DEFAULT_ALPHA_CUTOFF;
 
             schemaKey.setAlbedo(true);
             schemaKey.setTranslucentFactor(false);
@@ -641,6 +642,12 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
                         wasSet = true;
                     }
                     break;
+                case graphics::Material::ALPHA_CUTOFF:
+                    if (!fallthrough) {
+                        schema._alphaCutoff = material->getAlphaCutoff();
+                        wasSet = true;
+                    }
+                    break;
                 default:
                     break;
             }
@@ -679,6 +686,7 @@ void RenderPipelines::updateMultiMaterial(graphics::MultiMaterial& multiMaterial
             case graphics::Material::TEXCOORDTRANSFORM1:
             case graphics::Material::LIGHTMAP_PARAMS:
             case graphics::Material::MATERIAL_PARAMS:
+            case graphics::Material::ALPHA_CUTOFF:
                 // these are initialized to the correct default values in Schema()
                 break;
             case graphics::MaterialKey::ALBEDO_MAP_BIT:

--- a/libraries/render-utils/src/forward_model.slf
+++ b/libraries/render-utils/src/forward_model.slf
@@ -39,8 +39,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/forward_model.slf
+++ b/libraries/render-utils/src/forward_model.slf
@@ -39,7 +39,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/forward_model_lightmap.slf
+++ b/libraries/render-utils/src/forward_model_lightmap.slf
@@ -40,8 +40,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmap)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/forward_model_lightmap.slf
+++ b/libraries/render-utils/src/forward_model_lightmap.slf
@@ -40,7 +40,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmap)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/forward_model_normal_map.slf
+++ b/libraries/render-utils/src/forward_model_normal_map.slf
@@ -40,8 +40,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)&>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/forward_model_normal_map.slf
+++ b/libraries/render-utils/src/forward_model_normal_map.slf
@@ -40,7 +40,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/forward_model_normal_map_lightmap.slf
+++ b/libraries/render-utils/src/forward_model_normal_map_lightmap.slf
@@ -41,7 +41,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmap)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/forward_model_normal_map_lightmap.slf
+++ b/libraries/render-utils/src/forward_model_normal_map_lightmap.slf
@@ -41,8 +41,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, _SCRIBE_NULL, lightmap)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/forward_model_translucent.slf
+++ b/libraries/render-utils/src/forward_model_translucent.slf
@@ -39,8 +39,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/forward_model_translucent.slf
+++ b/libraries/render-utils/src/forward_model_translucent.slf
@@ -39,7 +39,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;

--- a/libraries/render-utils/src/forward_model_unlit.slf
+++ b/libraries/render-utils/src/forward_model_unlit.slf
@@ -30,7 +30,7 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/forward_model_unlit.slf
+++ b/libraries/render-utils/src/forward_model_unlit.slf
@@ -30,8 +30,9 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -29,7 +29,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, scatteringTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/model.slf
+++ b/libraries/render-utils/src/model.slf
@@ -29,8 +29,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, scatteringTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_fade.slf
+++ b/libraries/render-utils/src/model_fade.slf
@@ -38,7 +38,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, scatteringTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/model_fade.slf
+++ b/libraries/render-utils/src/model_fade.slf
@@ -38,8 +38,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex, scatteringTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_normal_map.slf
+++ b/libraries/render-utils/src/model_normal_map.slf
@@ -31,7 +31,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, scatteringTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/model_normal_map.slf
+++ b/libraries/render-utils/src/model_normal_map.slf
@@ -31,8 +31,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, scatteringTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_normal_map_fade.slf
@@ -40,7 +40,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, scatteringTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/model_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_normal_map_fade.slf
@@ -40,8 +40,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex, scatteringTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)&>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_shadow.slf
+++ b/libraries/render-utils/src/model_shadow.slf
@@ -25,7 +25,7 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/model_shadow.slf
+++ b/libraries/render-utils/src/model_shadow.slf
@@ -25,8 +25,9 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     // pass-through to set z-buffer

--- a/libraries/render-utils/src/model_shadow_fade.slf
+++ b/libraries/render-utils/src/model_shadow_fade.slf
@@ -33,7 +33,7 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/model_shadow_fade.slf
+++ b/libraries/render-utils/src/model_shadow_fade.slf
@@ -33,8 +33,9 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL, _SCRIBE_NULL)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     // pass-through to set z-buffer

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -41,7 +41,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;

--- a/libraries/render-utils/src/model_translucent.slf
+++ b/libraries/render-utils/src/model_translucent.slf
@@ -41,8 +41,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_translucent_fade.slf
+++ b/libraries/render-utils/src/model_translucent_fade.slf
@@ -49,7 +49,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/model_translucent_fade.slf
+++ b/libraries/render-utils/src/model_translucent_fade.slf
@@ -49,8 +49,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, _SCRIBE_NULL, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_translucent_normal_map.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map.slf
@@ -42,7 +42,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;

--- a/libraries/render-utils/src/model_translucent_normal_map.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map.slf
@@ -42,8 +42,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_translucent_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map_fade.slf
@@ -50,7 +50,7 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;

--- a/libraries/render-utils/src/model_translucent_normal_map_fade.slf
+++ b/libraries/render-utils/src/model_translucent_normal_map_fade.slf
@@ -50,8 +50,9 @@ void main(void) {
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex, roughnessTex, normalTex, metallicTex, emissiveTex)$>
     <$fetchMaterialTexturesCoord1(matKey, _texCoord1, occlusionTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_translucent_unlit.slf
+++ b/libraries/render-utils/src/model_translucent_unlit.slf
@@ -30,7 +30,7 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;

--- a/libraries/render-utils/src/model_translucent_unlit.slf
+++ b/libraries/render-utils/src/model_translucent_unlit.slf
@@ -30,8 +30,9 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_translucent_unlit_fade.slf
+++ b/libraries/render-utils/src/model_translucent_unlit_fade.slf
@@ -39,8 +39,9 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_translucent_unlit_fade.slf
+++ b/libraries/render-utils/src/model_translucent_unlit_fade.slf
@@ -39,7 +39,7 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = getMaterialOpacity(mat) * _color.a;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardInvisible(opacity)$>;

--- a/libraries/render-utils/src/model_unlit.slf
+++ b/libraries/render-utils/src/model_unlit.slf
@@ -30,7 +30,7 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/model_unlit.slf
+++ b/libraries/render-utils/src/model_unlit.slf
@@ -30,8 +30,9 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);

--- a/libraries/render-utils/src/model_unlit_fade.slf
+++ b/libraries/render-utils/src/model_unlit_fade.slf
@@ -39,7 +39,7 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
-	float alphaCutoff = getMaterialAlphaCutoff(mat);
+    float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
     <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;

--- a/libraries/render-utils/src/model_unlit_fade.slf
+++ b/libraries/render-utils/src/model_unlit_fade.slf
@@ -39,8 +39,9 @@ void main(void) {
     BITFIELD matKey = getMaterialKey(mat);
     <$fetchMaterialTexturesCoord0(matKey, _texCoord0, albedoTex)$>
 
+	float alphaCutoff = getMaterialAlphaCutoff(mat);
     float opacity = 1.0;
-    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity)$>;
+    <$evalMaterialOpacity(albedoTex.a, opacity, matKey, opacity, alphaCutoff)$>;
     <$discardTransparent(opacity)$>;
 
     vec3 albedo = getMaterialAlbedo(mat);


### PR DESCRIPTION
This PR adds support for specifiable blend modes to HF materials. The current implementation only looks at the albedo alpha channel and makes a judgement on the blend mode based on whether it has A. no alpha at all for opaque, B. 1-bit of alpha for masked transparency, or C. 8-bit alpha for full translucency. This implementation approaches it kind of like a fallback: by default, it is specified as using blend mode, meaning it will behave exactly as the system currently does, reading the properties of the albedo texture's alpha and choosing the most appropriate alpha blend, however, the other two modes allow you to explicitly specify the usage of treating the alpha as cutoff regardless of whether it uses 8bits of alpha, or opaque which will ignore the alpha entirely and render it as full opaque. While it is not 100% clear whether this fallback mechanic is the right way to go about this, whether this should instead allow the user to EXPLICITLY force a particular blend mode (I don't know why this ever might be necessary, disabling shadow casting is one, but this would be better implemented as its own setting), this functionality is needed at least to retain greater compliance with the GLTF spec, as can be seen here.

In order to test this, enter your local host and enter coordinates /8000,8000,8000, run the script (https://raw.githubusercontent.com/highfidelity/hifi_tests/master/tests/content/entity/model/modelReaders/gltfReader/testRecursive.js), and observe the alphaBlendModeTest. The following should look like this:
![alpha](https://user-images.githubusercontent.com/12756047/57698835-6ecd8480-764e-11e9-90ca-1129266ccf69.jpg)

It supports all the correct blending modes, although specifiable cutoff is not currently supported. Explicit specification of cull mode will also be required to be fully compliant with the spec.