### PR TITLE
BUGZ-87 - loading/physics stuck when entering domain

### DIFF
--- a/libraries/physics/src/ShapeManager.cpp
+++ b/libraries/physics/src/ShapeManager.cpp
@@ -49,11 +49,15 @@ const btCollisionShape* ShapeManager::getShape(const ShapeInfo& info) {
     const btCollisionShape* shape = nullptr;
     if (info.getType() == SHAPE_TYPE_STATIC_MESH) {
         uint64_t hash = info.getHash();
+
+        // bump the request count to the caller knows we're 
+        // starting or waiting on a thread.
+        ++_workRequestCount;
+
         const auto itr = std::find(_pendingMeshShapes.begin(), _pendingMeshShapes.end(), hash);
         if (itr == _pendingMeshShapes.end()) {
             // start a worker
             _pendingMeshShapes.push_back(hash);
-            ++_workRequestCount;
             // try to recycle old deadWorker
             ShapeFactory::Worker* worker = _deadWorker;
             if (!worker) {


### PR DESCRIPTION
A race condition was occurring when multiple entities using
the same models were handed over to physics around the same time.
The first model is passed to a worker thread to turn it into a shape
and subsequent models note they are the same and don't create a shape
or worker thread.

The physics system was ignoring these, never marking them as ready
for physics.

https://highfidelity.atlassian.net/browse/BUGZ-87