### PR TITLE
Fix JS to QML event bridge messages with Docked Windows

### DIFF
--- a/interface/src/ui/InteractiveWindow.cpp
+++ b/interface/src/ui/InteractiveWindow.cpp
@@ -69,7 +69,6 @@ void interactiveWindowPointerFromScriptValue(const QScriptValue& object, Interac
 }
 
 InteractiveWindow::InteractiveWindow(const QString& sourceUrl, const QVariantMap& properties) {
-    bool docked = false;
     InteractiveWindowPresentationMode presentationMode = InteractiveWindowPresentationMode::Native;
 
     if (properties.contains(PRESENTATION_MODE_PROPERTY)) {
@@ -124,12 +123,12 @@ InteractiveWindow::InteractiveWindow(const QString& sourceUrl, const QVariantMap
         QObject::connect(quickView.get(), &QQuickView::statusChanged, [&, this] (QQuickView::Status status) {
             if (status == QQuickView::Ready) {
                 QQuickItem* rootItem = _dockWidget->getRootItem();
+                _dockWidget->getQuickView()->rootContext()->setContextProperty(EVENT_BRIDGE_PROPERTY, this);
                 QObject::connect(rootItem, SIGNAL(sendToScript(QVariant)), this, SLOT(qmlToScript(const QVariant&)), Qt::QueuedConnection);
             }
         });
         _dockWidget->setSource(QUrl(sourceUrl));
         mainWindow->addDockWidget(dockArea, _dockWidget.get());
-        _dockedWindow = docked;
     } else {
         auto offscreenUi = DependencyManager::get<OffscreenUi>();
         // Build the event bridge and wrapper on the main thread
@@ -188,10 +187,10 @@ InteractiveWindow::~InteractiveWindow() {
 
 void InteractiveWindow::sendToQml(const QVariant& message) {
     // Forward messages received from the script on to QML
-    if (_dockedWindow) {
+    if (_dockWidget) {
         QQuickItem* rootItem = _dockWidget->getRootItem();
         if (rootItem) {
-            QMetaObject::invokeMethod(_qmlWindow, "fromScript", Qt::QueuedConnection, Q_ARG(QVariant, message));
+            QMetaObject::invokeMethod(rootItem, "fromScript", Qt::QueuedConnection, Q_ARG(QVariant, message));
         }
     } else {
         QMetaObject::invokeMethod(_qmlWindow, "fromScript", Qt::QueuedConnection, Q_ARG(QVariant, message));

--- a/interface/src/ui/InteractiveWindow.h
+++ b/interface/src/ui/InteractiveWindow.h
@@ -203,7 +203,6 @@ protected slots:
     void qmlToScript(const QVariant& message);
 
 private:
-    bool _dockedWindow { false };
     QPointer<QObject> _qmlWindow;
     std::shared_ptr<DockWidget> _dockWidget { nullptr };
 };


### PR DESCRIPTION
Fixes [this](https://highfidelity.atlassian.net/browse/BUGZ-188).