### PR TITLE
BUGZ-145: Fix Window innerWidth and innerHeight after support for Docked window

### DIFF
--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -414,11 +414,11 @@ QString WindowScriptingInterface::protocolSignature() {
 }
 
 int WindowScriptingInterface::getInnerWidth() {
-    return qApp->getWindow()->geometry().width();
+    return qApp->getPrimaryWidget()->geometry().width();
 }
 
 int WindowScriptingInterface::getInnerHeight() {
-    return qApp->getWindow()->geometry().height() - qApp->getPrimaryMenu()->geometry().height();
+    return qApp->getPrimaryWidget()->geometry().height();
 }
 
 glm::vec2 WindowScriptingInterface::getDeviceSize() const {


### PR DESCRIPTION
Instead of returning the main window dimension  (modulo the height of the menu bar) let s return the size of the actual 3d viewport widget

https://highfidelity.atlassian.net/browse/BUGZ-145
