### PR TITLE
Fix blender::run crash

### DIFF
--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -291,6 +291,7 @@ public:
 class Model {
 public:
     using Pointer = std::shared_ptr<Model>;
+    using ConstPointer = std::shared_ptr<const Model>;
 
     QString originalURL;
     QString author;

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -46,6 +46,7 @@ public:
     bool isHFMModelLoaded() const { return (bool)_hfmModel; }
 
     const HFMModel& getHFMModel() const { return *_hfmModel; }
+    const HFMModel::ConstPointer& getConstHFMModelPointer() const { return _hfmModel; }
     const MaterialMapping& getMaterialMapping() const { return _materialMapping; }
     const GeometryMeshes& getMeshes() const { return *_meshes; }
     const std::shared_ptr<NetworkMaterial> getShapeMaterial(int shapeID) const;
@@ -59,7 +60,7 @@ public:
 
 protected:
     // Shared across all geometries, constant throughout lifetime
-    std::shared_ptr<const HFMModel> _hfmModel;
+    HFMModel::ConstPointer _hfmModel;
     MaterialMapping _materialMapping;
     std::shared_ptr<const GeometryMeshes> _meshes;
     std::shared_ptr<const GeometryMeshParts> _meshParts;

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -76,7 +76,6 @@ void CauterizedModel::createRenderItemSet() {
         // Run through all of the meshes, and place them into their segregated, but unsorted buckets
         int shapeID = 0;
         uint32_t numMeshes = (uint32_t)meshes.size();
-        const HFMModel& hfmModel = getHFMModel();
         for (uint32_t i = 0; i < numMeshes; i++) {
             const auto& mesh = meshes.at(i);
             if (!mesh) {

--- a/libraries/render-utils/src/CauterizedModel.cpp
+++ b/libraries/render-utils/src/CauterizedModel.cpp
@@ -86,8 +86,6 @@ void CauterizedModel::createRenderItemSet() {
             // Create the render payloads
             int numParts = (int)mesh->getNumParts();
             for (int partIndex = 0; partIndex < numParts; partIndex++) {
-                initializeBlendshapes(hfmModel.meshes[i], i);
-
                 auto ptr = std::make_shared<CauterizedMeshPartPayload>(shared_from_this(), i, partIndex, shapeID, transform, offset);
                 _modelMeshRenderItems << std::static_pointer_cast<ModelMeshPartPayload>(ptr);
                 auto material = getGeometry()->getShapeMaterial(shapeID);
@@ -96,7 +94,6 @@ void CauterizedModel::createRenderItemSet() {
                 shapeID++;
             }
         }
-        _blendshapeOffsetsInitialized = true;
     } else {
         Model::createRenderItemSet();
     }
@@ -181,7 +178,7 @@ void CauterizedModel::updateClusterMatrices() {
 
     // post the blender if we're not currently waiting for one to finish
     auto modelBlender = DependencyManager::get<ModelBlender>();
-    if (_blendshapeOffsetsInitialized && modelBlender->shouldComputeBlendshapes() && hfmModel.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
+    if (modelBlender->shouldComputeBlendshapes() && hfmModel.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
         _blendedBlendshapeCoefficients = _blendshapeCoefficients;
         modelBlender->noteRequiresBlend(getThisPointer());
     }

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -314,10 +314,8 @@ bool Model::updateGeometry() {
             state.clusterDualQuaternions.resize(mesh.clusters.size());
             state.clusterMatrices.resize(mesh.clusters.size());
             _meshStates.push_back(state);
-            initializeBlendshapes(mesh, i);
             i++;
         }
-        _blendshapeOffsetsInitialized = true;
         needFullUpdate = true;
         emit rigReady();
     }
@@ -1022,9 +1020,6 @@ void Model::removeFromScene(const render::ScenePointer& scene, render::Transacti
     _modelMeshRenderItemShapes.clear();
     _priorityMap.clear();
 
-    _blendshapeOffsets.clear();
-    _blendshapeOffsetsInitialized = false;
-
     _addedToScene = false;
 
     _renderInfoVertexCount = 0;
@@ -1415,7 +1410,7 @@ void Model::updateClusterMatrices() {
 
     // post the blender if we're not currently waiting for one to finish
     auto modelBlender = DependencyManager::get<ModelBlender>();
-    if (_blendshapeOffsetsInitialized && modelBlender->shouldComputeBlendshapes() && hfmModel.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
+    if (modelBlender->shouldComputeBlendshapes() && hfmModel.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
         _blendedBlendshapeCoefficients = _blendshapeCoefficients;
         modelBlender->noteRequiresBlend(getThisPointer());
     }
@@ -1423,8 +1418,6 @@ void Model::updateClusterMatrices() {
 
 void Model::deleteGeometry() {
     _deleteGeometryCounter++;
-    _blendshapeOffsets.clear();
-    _blendshapeOffsetsInitialized = false;
     _meshStates.clear();
     _rig.destroyAnimGraph();
     _blendedBlendshapeCoefficients.clear();
@@ -1494,7 +1487,6 @@ void Model::createRenderItemSet() {
         // Create the render payloads
         int numParts = (int)mesh->getNumParts();
         for (int partIndex = 0; partIndex < numParts; partIndex++) {
-            initializeBlendshapes(hfmModel.meshes[i], i);
             _modelMeshRenderItems << std::make_shared<ModelMeshPartPayload>(shared_from_this(), i, partIndex, shapeID, transform, offset);
             auto material = getGeometry()->getShapeMaterial(shapeID);
             _modelMeshMaterialNames.push_back(material ? material->getName() : "");
@@ -1502,7 +1494,6 @@ void Model::createRenderItemSet() {
             shapeID++;
         }
     }
-    _blendshapeOffsetsInitialized = true;
 }
 
 bool Model::isRenderable() const {
@@ -1722,117 +1713,103 @@ void packBlendshapeOffsetTo_Pos_F32_3xSN10_Nor_3xSN10_Tan_3xSN10(glm::uvec4& pac
 class Blender : public QRunnable {
 public:
 
-    Blender(ModelPointer model, int blendNumber, const Geometry::WeakPointer& geometry, const QVector<float>& blendshapeCoefficients);
+    Blender(ModelPointer model, HFMModel::ConstPointer hfmModel, int blendNumber, const QVector<float>& blendshapeCoefficients);
 
     virtual void run() override;
 
 private:
-
     ModelPointer _model;
+    HFMModel::ConstPointer _hfmModel;
     int _blendNumber;
-    Geometry::WeakPointer _geometry;
     QVector<float> _blendshapeCoefficients;
 };
 
-Blender::Blender(ModelPointer model, int blendNumber, const Geometry::WeakPointer& geometry, const QVector<float>& blendshapeCoefficients) :
+Blender::Blender(ModelPointer model, HFMModel::ConstPointer hfmModel, int blendNumber, const QVector<float>& blendshapeCoefficients) :
     _model(model),
+    _hfmModel(hfmModel),
     _blendNumber(blendNumber),
-    _geometry(geometry),
     _blendshapeCoefficients(blendshapeCoefficients) {
 }
 
 void Blender::run() {
-    QVector<BlendshapeOffset> blendshapeOffsets;
+    DETAILED_PROFILE_RANGE_EX(simulation_animation, __FUNCTION__, 0xFFFF0000, 0, { { "url", _model->getURL().toString() } });
+    int numBlendshapeOffsets = 0;  // number of offsets required for all meshes.
+    int numMeshes = 0;  // number of meshes in this model.
+    int maxVertsInMesh = 0;  // number of vertices in the largest mesh.
+    for (auto meshIter = _hfmModel->meshes.cbegin(); meshIter != _hfmModel->meshes.cend(); ++meshIter) {
+        numMeshes++;
+        int numVertsInMesh = meshIter->vertices.size();
+        numBlendshapeOffsets += numVertsInMesh;
+    }
+
+    // all elements are default constructed to zero offsets.
+    QVector<BlendshapeOffset> packedBlendshapeOffsets(numBlendshapeOffsets);
+    QVector<BlendshapeOffsetUnpacked> unpackedBlendshapeOffsets(numBlendshapeOffsets);
+
+    // allocate the required size
     QVector<int> blendedMeshSizes;
-    if (_model && _model->isLoaded()) {
-        DETAILED_PROFILE_RANGE_EX(simulation_animation, __FUNCTION__, 0xFFFF0000, 0, { { "url", _model->getURL().toString() } });
-        int offset = 0;
-        const auto& meshes = _model->getHFMModel().meshes;
-        int meshIndex = 0;
-        for(const HFMMesh& mesh : meshes) {
-            auto modelMeshBlendshapeOffsets = _model->_blendshapeOffsets.find(meshIndex++);
-            if (mesh.blendshapes.isEmpty() || modelMeshBlendshapeOffsets == _model->_blendshapeOffsets.end()) {
-                // Not blendshaped or not initialized
-                blendedMeshSizes.push_back(0);
+    blendedMeshSizes.reserve(numMeshes);
+
+    int offset = 0;
+    for (auto meshIter = _hfmModel->meshes.cbegin(); meshIter != _hfmModel->meshes.cend(); ++meshIter) {
+        if (meshIter->blendshapes.isEmpty()) {
+            blendedMeshSizes.push_back(0);
+            continue;
+        }
+        int numVertsInMesh = meshIter->vertices.size();
+        blendedMeshSizes.push_back(numVertsInMesh);
+
+        // for each blendshape in this mesh, accumulate the offsets into unpackedBlendshapeOffsets.
+        const float NORMAL_COEFFICIENT_SCALE = 0.01f;
+        for (int i = 0, n = qMin(_blendshapeCoefficients.size(), meshIter->blendshapes.size()); i < n; i++) {
+            float vertexCoefficient = _blendshapeCoefficients.at(i);
+            const float EPSILON = 0.0001f;
+            if (vertexCoefficient < EPSILON) {
                 continue;
             }
 
-            if (mesh.vertices.size() != modelMeshBlendshapeOffsets->second.size()) {
-                // Mesh sizes don't match.  Something has gone wrong
-                blendedMeshSizes.push_back(0);
-                continue;
-            }
+            float normalCoefficient = vertexCoefficient * NORMAL_COEFFICIENT_SCALE;
+            const HFMBlendshape& blendshape = meshIter->blendshapes.at(i);
+            for (int j = 0; j < blendshape.indices.size(); ++j) {
+                int index = blendshape.indices.at(j);
 
-            blendshapeOffsets += modelMeshBlendshapeOffsets->second;
-            BlendshapeOffset* meshBlendshapeOffsets = blendshapeOffsets.data() + offset;
-            int numVertices = modelMeshBlendshapeOffsets->second.size();
-            blendedMeshSizes.push_back(numVertices);
-            offset += numVertices;
-            std::vector<BlendshapeOffsetUnpacked> unpackedBlendshapeOffsets(modelMeshBlendshapeOffsets->second.size());
-
-            const float NORMAL_COEFFICIENT_SCALE = 0.01f;
-            for (int i = 0, n = qMin(_blendshapeCoefficients.size(), mesh.blendshapes.size()); i < n; i++) {
-                float vertexCoefficient = _blendshapeCoefficients.at(i);
-                const float EPSILON = 0.0001f;
-                if (vertexCoefficient < EPSILON) {
-                    continue;
-                }
-
-                float normalCoefficient = vertexCoefficient * NORMAL_COEFFICIENT_SCALE;
-                const HFMBlendshape& blendshape = mesh.blendshapes.at(i);
-                for (int j = 0; j < blendshape.indices.size(); ++j) {
-                    int index = blendshape.indices.at(j);
-
-                    auto& currentBlendshapeOffset = unpackedBlendshapeOffsets[index];
-                    currentBlendshapeOffset.positionOffset += blendshape.vertices.at(j) * vertexCoefficient;
-
-                    currentBlendshapeOffset.normalOffset += blendshape.normals.at(j) * normalCoefficient;
-                    if (j < blendshape.tangents.size()) {
-                        currentBlendshapeOffset.tangentOffset += blendshape.tangents.at(j) * normalCoefficient;
-                    }
-                }
-            }
-
-            // Blendshape offsets are generrated, now let's pack it on its way to gpu
-            // FIXME it feels like we could be more effectively using SIMD here
-            {
-                auto unpacked = unpackedBlendshapeOffsets.data();
-                auto packed = meshBlendshapeOffsets;
-                for (int j = 0; j < (int)unpackedBlendshapeOffsets.size(); ++j) {
-                    packBlendshapeOffsetTo_Pos_F32_3xSN10_Nor_3xSN10_Tan_3xSN10((*packed).packedPosNorTan, (*unpacked));
-                    ++unpacked;
-                    ++packed;
+                auto& currentBlendshapeOffset = unpackedBlendshapeOffsets[offset + index];
+                currentBlendshapeOffset.positionOffset += blendshape.vertices.at(j) * vertexCoefficient;
+                currentBlendshapeOffset.normalOffset += blendshape.normals.at(j) * normalCoefficient;
+                if (j < blendshape.tangents.size()) {
+                    currentBlendshapeOffset.tangentOffset += blendshape.tangents.at(j) * normalCoefficient;
                 }
             }
         }
+        offset += numVertsInMesh;
     }
+
+    // convert unpackedBlendshapeOffsets into packedBlendshapeOffsets for the gpu.
+    // FIXME it feels like we could be more effectively using SIMD here
+    {
+        auto unpacked = unpackedBlendshapeOffsets.data();
+        auto packed = packedBlendshapeOffsets.data();
+        for (int i = 0; i < unpackedBlendshapeOffsets.size(); ++i) {
+            packBlendshapeOffsetTo_Pos_F32_3xSN10_Nor_3xSN10_Tan_3xSN10((*packed).packedPosNorTan, (*unpacked));
+            ++unpacked;
+            ++packed;
+        }
+    }
+
     // post the result to the ModelBlender, which will dispatch to the model if still alive
     QMetaObject::invokeMethod(DependencyManager::get<ModelBlender>().data(), "setBlendedVertices",
-        Q_ARG(ModelPointer, _model), Q_ARG(int, _blendNumber), Q_ARG(QVector<BlendshapeOffset>, blendshapeOffsets), Q_ARG(QVector<int>, blendedMeshSizes));
+                              Q_ARG(ModelPointer, _model), Q_ARG(int, _blendNumber),
+                              Q_ARG(QVector<BlendshapeOffset>, packedBlendshapeOffsets),
+                              Q_ARG(QVector<int>, blendedMeshSizes));
 }
 
 bool Model::maybeStartBlender() {
     if (isLoaded()) {
-        QThreadPool::globalInstance()->start(new Blender(getThisPointer(), ++_blendNumber, _renderGeometry, _blendshapeCoefficients));
+        QThreadPool::globalInstance()->start(new Blender(getThisPointer(), getGeometry()->getConstHFMModelPointer(),
+                                                         ++_blendNumber, _blendshapeCoefficients));
         return true;
     }
     return false;
-}
-
-void Model::initializeBlendshapes(const HFMMesh& mesh, int index) {
-    if (mesh.blendshapes.empty()) {
-        // mesh doesn't have blendshape, did we allocate one though ?
-        if (_blendshapeOffsets.find(index) != _blendshapeOffsets.end()) {
-            qWarning() << "Mesh does not have Blendshape yet the blendshapeOffsets are allocated ?";
-        }
-        return;
-    }
-    // Mesh has blendshape, let s allocate the local buffer if not done yet
-    if (_blendshapeOffsets.find(index) == _blendshapeOffsets.end()) {
-        QVector<BlendshapeOffset> blendshapeOffset;
-        blendshapeOffset.fill(BlendshapeOffset(), mesh.vertices.size());
-        _blendshapeOffsets[index] = blendshapeOffset;
-    }
 }
 
 ModelBlender::ModelBlender() :

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1477,7 +1477,6 @@ void Model::createRenderItemSet() {
     // Run through all of the meshes, and place them into their segregated, but unsorted buckets
     int shapeID = 0;
     uint32_t numMeshes = (uint32_t)meshes.size();
-    auto& hfmModel = getHFMModel();
     for (uint32_t i = 0; i < numMeshes; i++) {
         const auto& mesh = meshes.at(i);
         if (!mesh) {
@@ -1735,7 +1734,6 @@ void Blender::run() {
     DETAILED_PROFILE_RANGE_EX(simulation_animation, __FUNCTION__, 0xFFFF0000, 0, { { "url", _model->getURL().toString() } });
     int numBlendshapeOffsets = 0;  // number of offsets required for all meshes.
     int numMeshes = 0;  // number of meshes in this model.
-    int maxVertsInMesh = 0;  // number of vertices in the largest mesh.
     for (auto meshIter = _hfmModel->meshes.cbegin(); meshIter != _hfmModel->meshes.cend(); ++meshIter) {
         numMeshes++;
         int numVertsInMesh = meshIter->vertices.size();

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -363,8 +363,6 @@ public:
     void addMaterial(graphics::MaterialLayer material, const std::string& parentMaterialName);
     void removeMaterial(graphics::MaterialPointer material, const std::string& parentMaterialName);
 
-    std::unordered_map<int, QVector<BlendshapeOffset>> _blendshapeOffsets;
-
 public slots:
     void loadURLFinished(bool success);
 
@@ -446,7 +444,6 @@ protected:
     QVector<float> _blendshapeCoefficients;
     QVector<float> _blendedBlendshapeCoefficients;
     int _blendNumber { 0 };
-    bool _blendshapeOffsetsInitialized { false };
 
     mutable QMutex _mutex{ QMutex::Recursive };
 
@@ -508,8 +505,6 @@ protected:
     bool _cauterized { false };
 
     bool shouldInvalidatePayloadShapeKey(int meshIndex);
-
-    void initializeBlendshapes(const HFMMesh& mesh, int index);
 
 private:
     float _loadingPriority { 0.0f };

--- a/libraries/render-utils/src/SoftAttachmentModel.cpp
+++ b/libraries/render-utils/src/SoftAttachmentModel.cpp
@@ -71,7 +71,7 @@ void SoftAttachmentModel::updateClusterMatrices() {
 
     // post the blender if we're not currently waiting for one to finish
     auto modelBlender = DependencyManager::get<ModelBlender>();
-    if (_blendshapeOffsetsInitialized && modelBlender->shouldComputeBlendshapes() && hfmModel.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
+    if (modelBlender->shouldComputeBlendshapes() && hfmModel.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
         _blendedBlendshapeCoefficients = _blendshapeCoefficients;
         modelBlender->noteRequiresBlend(getThisPointer());
     }


### PR DESCRIPTION
Pass a shared_ptr of the HFMModel to the Blender.  This will prevent the HFMModel from being destroyed on the main thread if an Avatar changes their skeletonModelURL.

Also the _blendshapeOffset hash in Model has been eliminated, it was not necessary and was also a source of data races.

The body of Blender::run has been updated slightly to reduce the number of allocation necessary for temporary QVectors.

https://highfidelity.atlassian.net/browse/BUGZ-159