### PR TITLE
Avatar verify-failed banner should click to appropriate app

### DIFF
--- a/scripts/system/clickToAvatarApp.js
+++ b/scripts/system/clickToAvatarApp.js
@@ -1,7 +1,17 @@
 (function () {
     var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
     this.clickDownOnEntity = function (entityID, mouseEvent) {
-        tablet.loadQMLSource("hifi/AvatarApp.qml");
+        var runningSimplified = false;
+        var scripts = ScriptDiscoveryService.getRunning();
+        for (var i = 0; i < scripts.length; ++i) {
+            if (scripts[i].name == "simplifiedUI.js") {
+                runningSimplified = true;
+                break;
+            }
+        }
+
+        var avatarAppQML = runningSimplified ? "hifi/simplifiedUI/avatarApp/AvatarApp.qml" : "hifi/AvatarApp.qml";
+        tablet.loadQMLSource(avatarAppQML);
     };
 }
 );


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-206 (in part).

Clicking on the banner (actually a local entity with a script) should open the appropriate app, depending whether or not simplifiedUI is running.