### PR TITLE
Defer avatar PoP check

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -204,7 +204,10 @@ void AvatarMixerClientData::processSetTraitsMessage(ReceivedMessage& message,
                 if (traitType == AvatarTraits::SkeletonModelURL) {
                     // special handling for skeleton model URL, since we need to make sure it is in the whitelist
                     checkSkeletonURLAgainstWhitelist(slaveSharedData, sendingNode, packetTraitVersion);
+#ifdef AVATAR_POP_CHECK
+                    // Deferred for UX work. With no PoP check, no need to get the .fst.
                     _avatar->fetchAvatarFST();
+#endif
                 }
 
                 anyTraitsChanged = true;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-230

Dev-tested as follows:
1. Ran local server with this code (i.e., without the fst fetch)
2. Get certified avatar and remove all scripts.
3. Restart interface as in 2. Observe no problems and no theft banner.
4. Put the .fst fetch back in, recompile, and restart local server.
5. On entry as in 2, get theft banner.