### PR TITLE
reduce time in which you see yourself going away

### DIFF
--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -49,7 +49,7 @@
 
 const int INVALID_PORT = -1;
 
-const quint64 NODE_SILENCE_THRESHOLD_MSECS = 20 * 1000;
+const quint64 NODE_SILENCE_THRESHOLD_MSECS = 10 * 1000;
 
 static const size_t DEFAULT_MAX_CONNECTION_RATE { std::numeric_limits<size_t>::max() };
 


### PR DESCRIPTION
We don’t do well when asked to do multiple disconnect/reconnect things at once. https://highfidelity.atlassian.net/browse/BUGZ-134 extended the timeout so that remove silent nodes and domain disconnect don’t trigger at the same time, by moving the former from 5 to 20 seconds.  

But I think this is causing https://highfidelity.atlassian.net/browse/BUGZ-264 so bringing it down to 10.