### PR TITLE
(BUGZ-262) Add debug tool for transitions

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -522,6 +522,12 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::ComputeBlendshapes, 0, true,
         DependencyManager::get<ModelBlender>().data(), SLOT(setComputeBlendshapes(bool)));
 
+    {
+        auto drawStatusConfig = qApp->getRenderEngine()->getConfiguration()->getConfig<render::DrawStatus>("RenderMainView.DrawStatus");
+        addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::HighlightTransitions, 0, false,
+            drawStatusConfig, SLOT(setShowFade(bool)));
+    }
+
     // Developer > Assets >>>
     // Menu item is not currently needed but code should be kept in case it proves useful again at some stage.
 //#define WANT_ASSET_MIGRATION

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -228,6 +228,7 @@ namespace MenuOption {
     const QString NotificationSoundsTablet = "play_notification_sounds_tablet";
     const QString ForceCoarsePicking = "Force Coarse Picking";
     const QString ComputeBlendshapes = "Compute Blendshapes";
+    const QString HighlightTransitions = "Highlight Transitions";
 }
 
 #endif // hifi_Menu_h

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -32,8 +32,8 @@
 using namespace render;
 using namespace render::entities;
 
-// These or the icon "name" used by the render item status value, they correspond to the atlas texture used by the DrawItemStatus
-// job in the current rendering pipeline defined as of now  (11/2015) in render-utils/RenderDeferredTask.cpp.
+// These or the icon "name" used by the render item status value, they correspond to the atlas texture used by the DrawStatus
+// job in the current rendering pipeline defined as of now  (2019/05) in render-utils/RenderDeferredTask.cpp.
 enum class RenderItemStatusIcon {
     ACTIVE_IN_BULLET = 0,
     PACKET_SENT = 1,

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -32,19 +32,6 @@
 using namespace render;
 using namespace render::entities;
 
-// These or the icon "name" used by the render item status value, they correspond to the atlas texture used by the DrawStatus
-// job in the current rendering pipeline defined as of now  (2019/05) in render-utils/RenderDeferredTask.cpp.
-enum class RenderItemStatusIcon {
-    ACTIVE_IN_BULLET = 0,
-    PACKET_SENT = 1,
-    PACKET_RECEIVED = 2,
-    SIMULATION_OWNER = 3,
-    HAS_ACTIONS = 4,
-    OTHER_SIMULATION_OWNER = 5,
-    ENTITY_HOST_TYPE = 6,
-    NONE = 255
-};
-
 void EntityRenderer::initEntityRenderers() {
     REGISTER_ENTITY_TYPE_WITH_FACTORY(Model, RenderableModelEntityItem::factory)
     REGISTER_ENTITY_TYPE_WITH_FACTORY(PolyVox, RenderablePolyVoxEntityItem::factory)
@@ -67,7 +54,7 @@ void EntityRenderer::makeStatusGetters(const EntityItemPointer& entity, Item::St
         return render::Item::Status::Value(1.0f - normalizedDelta, (normalizedDelta > 1.0f ?
             render::Item::Status::Value::GREEN :
             render::Item::Status::Value::RED),
-            (unsigned char)RenderItemStatusIcon::PACKET_RECEIVED);
+            (unsigned char)render::Item::Status::Icon::PACKET_RECEIVED);
     });
 
     statusGetters.push_back([entity] () -> render::Item::Status::Value {
@@ -79,17 +66,17 @@ void EntityRenderer::makeStatusGetters(const EntityItemPointer& entity, Item::St
         return render::Item::Status::Value(1.0f - normalizedDelta, (normalizedDelta > 1.0f ?
             render::Item::Status::Value::MAGENTA :
             render::Item::Status::Value::CYAN),
-            (unsigned char)RenderItemStatusIcon::PACKET_SENT);
+            (unsigned char)render::Item::Status::Icon::PACKET_SENT);
     });
 
     statusGetters.push_back([entity] () -> render::Item::Status::Value {
         ObjectMotionState* motionState = static_cast<ObjectMotionState*>(entity->getPhysicsInfo());
         if (motionState && motionState->isActive()) {
             return render::Item::Status::Value(1.0f, render::Item::Status::Value::BLUE,
-                (unsigned char)RenderItemStatusIcon::ACTIVE_IN_BULLET);
+                (unsigned char)render::Item::Status::Icon::ACTIVE_IN_BULLET);
         }
         return render::Item::Status::Value(0.0f, render::Item::Status::Value::BLUE,
-            (unsigned char)RenderItemStatusIcon::ACTIVE_IN_BULLET);
+            (unsigned char)render::Item::Status::Icon::ACTIVE_IN_BULLET);
     });
 
     statusGetters.push_back([entity, myNodeID] () -> render::Item::Status::Value {
@@ -98,39 +85,39 @@ void EntityRenderer::makeStatusGetters(const EntityItemPointer& entity, Item::St
 
         if (weOwnSimulation) {
             return render::Item::Status::Value(1.0f, render::Item::Status::Value::BLUE,
-                (unsigned char)RenderItemStatusIcon::SIMULATION_OWNER);
+                (unsigned char)render::Item::Status::Icon::SIMULATION_OWNER);
         } else if (otherOwnSimulation) {
             return render::Item::Status::Value(1.0f, render::Item::Status::Value::RED,
-                (unsigned char)RenderItemStatusIcon::OTHER_SIMULATION_OWNER);
+                (unsigned char)render::Item::Status::Icon::OTHER_SIMULATION_OWNER);
         }
         return render::Item::Status::Value(0.0f, render::Item::Status::Value::BLUE,
-            (unsigned char)RenderItemStatusIcon::SIMULATION_OWNER);
+            (unsigned char)render::Item::Status::Icon::SIMULATION_OWNER);
     });
 
     statusGetters.push_back([entity] () -> render::Item::Status::Value {
         if (entity->hasActions()) {
             return render::Item::Status::Value(1.0f, render::Item::Status::Value::GREEN,
-                (unsigned char)RenderItemStatusIcon::HAS_ACTIONS);
+                (unsigned char)render::Item::Status::Icon::HAS_ACTIONS);
         }
         return render::Item::Status::Value(0.0f, render::Item::Status::Value::GREEN,
-            (unsigned char)RenderItemStatusIcon::HAS_ACTIONS);
+            (unsigned char)render::Item::Status::Icon::HAS_ACTIONS);
     });
 
     statusGetters.push_back([entity, myNodeID] () -> render::Item::Status::Value {
         if (entity->isAvatarEntity()) {
             if (entity->getOwningAvatarID() == myNodeID) {
                 return render::Item::Status::Value(1.0f, render::Item::Status::Value::GREEN,
-                    (unsigned char)RenderItemStatusIcon::ENTITY_HOST_TYPE);
+                    (unsigned char)render::Item::Status::Icon::ENTITY_HOST_TYPE);
             } else {
                 return render::Item::Status::Value(1.0f, render::Item::Status::Value::RED,
-                    (unsigned char)RenderItemStatusIcon::ENTITY_HOST_TYPE);
+                    (unsigned char)render::Item::Status::Icon::ENTITY_HOST_TYPE);
             }
         } else if (entity->isLocalEntity()) {
             return render::Item::Status::Value(1.0f, render::Item::Status::Value::BLUE,
-                (unsigned char)RenderItemStatusIcon::ENTITY_HOST_TYPE);
+                (unsigned char)render::Item::Status::Icon::ENTITY_HOST_TYPE);
         }
         return render::Item::Status::Value(0.0f, render::Item::Status::Value::GREEN,
-            (unsigned char)RenderItemStatusIcon::ENTITY_HOST_TYPE);
+            (unsigned char)render::Item::Status::Icon::ENTITY_HOST_TYPE);
     });
 }
 

--- a/libraries/render/src/render/DrawStatus.cpp
+++ b/libraries/render/src/render/DrawStatus.cpp
@@ -143,7 +143,7 @@ void DrawStatus::run(const RenderContextPointer& renderContext, const Input& inp
 
                     Item::Status::Value status;
                     status.setColor(Item::Status::Value::CYAN);
-                    status.setIcon(3); // RenderItemStatusIcon::SIMULATION_OWNER (RenderableModelEntityItem.cpp)
+                    status.setIcon((unsigned char)Item::Status::Icon::SIMULATION_OWNER);
                     if (itemScene.getTransitionId() != INVALID_INDEX) {
                         // We have a transition. Show this icon.
                         status.setScale(1.0f);

--- a/libraries/render/src/render/DrawStatus.cpp
+++ b/libraries/render/src/render/DrawStatus.cpp
@@ -26,7 +26,7 @@
 using namespace render;
 
 void DrawStatusConfig::dirtyHelper() {
-    _isEnabled = showNetwork || showDisplay;
+    _isEnabled = showNetwork || showDisplay || showFade;
     emit dirty();
 }
 
@@ -79,6 +79,7 @@ const gpu::TexturePointer DrawStatus::getStatusIconMap() const {
 void DrawStatus::configure(const Config& config) {
     _showDisplay = config.showDisplay;
     _showNetwork = config.showNetwork;
+    _showFade = config.showFade;
 }
 
 void DrawStatus::run(const RenderContextPointer& renderContext, const Input& input) {
@@ -96,40 +97,70 @@ void DrawStatus::run(const RenderContextPointer& renderContext, const Input& inp
     int nbItems = 0;
     render::ItemBounds itemBounds;
     std::vector<std::pair<glm::ivec4, glm::ivec4>> itemStatus;
-    {
-        for (size_t i = 0; i < inItems.size(); ++i) {
-            const auto& item = inItems[i];
-            if (!item.bound.isInvalid()) {
-                if (!item.bound.isNull()) {
-                    itemBounds.emplace_back(render::ItemBound(item.id, item.bound));
-                } else {
-                    itemBounds.emplace_back(item.id, AABox(item.bound.getCorner(), 0.1f));
-                }
 
-                auto& itemScene = scene->getItem(item.id);
+    for (size_t i = 0; i < inItems.size(); ++i) {
+        const auto& item = inItems[i];
+        if (!item.bound.isInvalid()) {
+            if (!item.bound.isNull()) {
+                itemBounds.emplace_back(render::ItemBound(item.id, item.bound));
+            } else {
+                itemBounds.emplace_back(item.id, AABox(item.bound.getCorner(), 0.1f));
+            }
 
-                auto itemStatusPointer = itemScene.getStatus();
-                if (itemStatusPointer) {
-                    itemStatus.push_back(std::pair<glm::ivec4, glm::ivec4>());
-                    // Query the current status values, this is where the statusGetter lambda get called
-                    auto&& currentStatusValues = itemStatusPointer->getCurrentValues();
-                    int valueNum = 0;
-                    for (int vec4Num = 0; vec4Num < NUM_STATUS_VEC4_PER_ITEM; vec4Num++) {
-                        auto& value = (vec4Num ? itemStatus[nbItems].first : itemStatus[nbItems].second);
-                        value = glm::ivec4(Item::Status::Value::INVALID.getPackedData());
-                        for (int component = 0; component < VEC4_LENGTH; component++) {
-                            valueNum = vec4Num * VEC4_LENGTH + component;
-                            if (valueNum < (int)currentStatusValues.size()) {
-                                value[component] = currentStatusValues[valueNum].getPackedData();
+            auto& itemScene = scene->getItem(item.id);
+
+            if (_showNetwork || _showFade) {
+                const static auto invalid = glm::ivec4(Item::Status::Value::INVALID.getPackedData());
+                itemStatus.emplace_back(invalid, invalid);
+                int vec4Num = 0;
+                int vec4Component = 0;
+
+                if (_showNetwork) {
+                    auto itemStatusPointer = itemScene.getStatus();
+                    if (itemStatusPointer) {
+                        // Query the current status values, this is where the statusGetter lambda get called
+                        auto&& currentStatusValues = itemStatusPointer->getCurrentValues();
+                        for (const auto& statusValue : currentStatusValues) {
+                            if (vec4Num == NUM_STATUS_VEC4_PER_ITEM) {
+                                // Ran out of space
+                                break;
+                            }
+
+                            auto& value = (vec4Num == 0 ? itemStatus[nbItems].first : itemStatus[nbItems].second);
+                            value[vec4Component] = statusValue.getPackedData();
+
+                            ++vec4Component;
+                            if (vec4Component == VEC4_LENGTH) {
+                                vec4Component = 0;
+                                ++vec4Num;
                             }
                         }
                     }
-                } else {
-                    auto invalid = glm::ivec4(Item::Status::Value::INVALID.getPackedData());
-                    itemStatus.emplace_back(invalid, invalid);
                 }
-                nbItems++;
+
+                if (_showFade && vec4Num != NUM_STATUS_VEC4_PER_ITEM) {
+                    auto& value = (vec4Num == 0 ? itemStatus[nbItems].first : itemStatus[nbItems].second);
+
+                    Item::Status::Value status;
+                    status.setColor(Item::Status::Value::CYAN);
+                    status.setIcon(3); // RenderItemStatusIcon::SIMULATION_OWNER (RenderableModelEntityItem.cpp)
+                    if (itemScene.getTransitionId() != INVALID_INDEX) {
+                        // We have a transition. Show this icon.
+                        status.setScale(1.0f);
+                    } else {
+                        status.setScale(0.0f);
+                    }
+                    value[vec4Component] = status.getPackedData();
+
+                    ++vec4Component;
+                    if (vec4Component == VEC4_LENGTH) {
+                        vec4Component = 0;
+                        ++vec4Num;
+                    }
+                }
             }
+
+            nbItems++;
         }
     }
 
@@ -169,7 +200,7 @@ void DrawStatus::run(const RenderContextPointer& renderContext, const Input& inp
 
         batch.setPipeline(getDrawItemStatusPipeline());
 
-        if (_showNetwork) {
+        if (_showNetwork || _showFade) {
             if (!_instanceBuffer) {
                 _instanceBuffer = std::make_shared<gpu::Buffer>();
             }

--- a/libraries/render/src/render/DrawStatus.h
+++ b/libraries/render/src/render/DrawStatus.h
@@ -27,10 +27,12 @@ namespace render {
 
         bool showDisplay{ false };
         bool showNetwork{ false };
+        bool showFade{ false };
 
     public slots:
         void setShowDisplay(bool enabled) { showDisplay = enabled; dirtyHelper(); }
         void setShowNetwork(bool enabled) { showNetwork = enabled; dirtyHelper(); }
+        void setShowFade(bool enabled) { showFade = enabled; dirtyHelper(); }
 
     signals:
         void dirty();
@@ -57,6 +59,7 @@ namespace render {
     protected:
         bool _showDisplay; // initialized by Config
         bool _showNetwork; // initialized by Config
+        bool _showFade; // initialized by Config
 
         gpu::Stream::FormatPointer _drawItemFormat;
         gpu::PipelinePointer _drawItemBoundsPipeline;

--- a/libraries/render/src/render/Item.h
+++ b/libraries/render/src/render/Item.h
@@ -354,6 +354,17 @@ public:
     // This is Used for monitoring and dynamically adjust the quality
     class Status {
     public:
+        
+        enum class Icon {
+            ACTIVE_IN_BULLET = 0,
+            PACKET_SENT = 1,
+            PACKET_RECEIVED = 2,
+            SIMULATION_OWNER = 3,
+            HAS_ACTIONS = 4,
+            OTHER_SIMULATION_OWNER = 5,
+            ENTITY_HOST_TYPE = 6,
+            NONE = 255
+        };
 
         // Status::Value class is the data used to represent the transient information of a status as a square icon
         // The "icon" is a square displayed in the 3D scene over the render::Item AABB center.


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-262

This PR adds a new option to the "Developer" > "Render" menu called "Highlight Transitions." When enabled, this shows a light blue/cyan-colored icon next to every render item that currently has a transition.