### PR TITLE
BUGZ-250: Don't crash on trying to add items to non-existent menus

### DIFF
--- a/libraries/ui-plugins/src/ui-plugins/PluginContainer.cpp
+++ b/libraries/ui-plugins/src/ui-plugins/PluginContainer.cpp
@@ -72,6 +72,11 @@ struct MenuCache {
         }
         flushCache(menu);
         MenuWrapper* parentItem = menu->getMenu(path);
+        if (!parentItem) {
+            qWarning() << "Attempted to add item to non-existent path " << path;
+            return;
+        }
+
         QAction* action = menu->addActionToQMenuAndActionHash(parentItem, name);
         if (!groupName.isEmpty()) {
             QActionGroup* group{ nullptr };


### PR DESCRIPTION
[BUGZ-250](https://highfidelity.atlassian.net/browse/BUGZ-250): Crashing from the VR button is because VR plugins want to add to a now non-existent `Display` menu.  