### PR TITLE
BUGZ-178: avoid crash for RenderableModelEntityItem with invalid model (redux)

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -363,7 +363,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& shapeInfo) {
     ShapeType type = getShapeType();
 
     auto model = getModel();
-    if (!model) {
+    if (!model || !model->isLoaded()) {
         type = SHAPE_TYPE_NONE;
     }
 


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-178

This PR fixes a crash when trying to build ShapeInfo for a ModelEntityItem with incomplete geometry.