### PR TITLE
Case BUGZ-277 :  Android build error (on windows host) stat properties missing (please review suggestion)

### DIFF
--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -320,6 +320,8 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(int, nodeListThreadQueueDepth, -1);
 #else
     STATS_PROPERTY(bool, eventQueueDebuggingOn, false)
+    STATS_PROPERTY(int, mainThreadQueueDepth, 0);
+    STATS_PROPERTY(int, nodeListThreadQueueDepth, 0);
 #endif // DEBUG_EVENT_QUEUE
 
 public:

--- a/interface/src/ui/Stats.h
+++ b/interface/src/ui/Stats.h
@@ -314,14 +314,13 @@ class Stats : public QQuickItem {
     STATS_PROPERTY(QVector3D, parabolaPicksUpdated, QVector3D(0, 0, 0))
     STATS_PROPERTY(QVector3D, collisionPicksUpdated, QVector3D(0, 0, 0))
 
-#ifdef DEBUG_EVENT_QUEUE
-    STATS_PROPERTY(bool, eventQueueDebuggingOn, true)
     STATS_PROPERTY(int, mainThreadQueueDepth, -1);
     STATS_PROPERTY(int, nodeListThreadQueueDepth, -1);
+
+#ifdef DEBUG_EVENT_QUEUE
+    STATS_PROPERTY(bool, eventQueueDebuggingOn, true)
 #else
     STATS_PROPERTY(bool, eventQueueDebuggingOn, false)
-    STATS_PROPERTY(int, mainThreadQueueDepth, 0);
-    STATS_PROPERTY(int, nodeListThreadQueueDepth, 0);
 #endif // DEBUG_EVENT_QUEUE
 
 public:


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-277

Android build is failing on windows host due to two properties missing because of the #ifdef block. Either the define is not correctly setup or automoc is ignoring the property referencing.

test case:
Android build succeeds.