### PR TITLE
(BUGZ-167) Always calculate tangents

### DIFF
--- a/libraries/model-baker/src/model-baker/Baker.cpp
+++ b/libraries/model-baker/src/model-baker/Baker.cpp
@@ -27,7 +27,7 @@ namespace baker {
     class GetModelPartsTask {
     public:
         using Input = hfm::Model::Pointer;
-        using Output = VaryingSet6<std::vector<hfm::Mesh>, hifi::URL, baker::MeshIndicesToModelNames, baker::BlendshapesPerMesh, QHash<QString, hfm::Material>, std::vector<hfm::Joint>>;
+        using Output = VaryingSet5<std::vector<hfm::Mesh>, hifi::URL, baker::MeshIndicesToModelNames, baker::BlendshapesPerMesh, std::vector<hfm::Joint>>;
         using JobModel = Job::ModelIO<GetModelPartsTask, Input, Output>;
 
         void run(const BakeContextPointer& context, const Input& input, Output& output) {
@@ -40,8 +40,7 @@ namespace baker {
             for (int i = 0; i < hfmModelIn->meshes.size(); i++) {
                 blendshapesPerMesh.push_back(hfmModelIn->meshes[i].blendshapes.toStdVector());
             }
-            output.edit4() = hfmModelIn->materials;
-            output.edit5() = hfmModelIn->joints.toStdVector();
+            output.edit4() = hfmModelIn->joints.toStdVector();
         }
     };
 
@@ -134,17 +133,16 @@ namespace baker {
             const auto url = modelPartsIn.getN<GetModelPartsTask::Output>(1);
             const auto meshIndicesToModelNames = modelPartsIn.getN<GetModelPartsTask::Output>(2);
             const auto blendshapesPerMeshIn = modelPartsIn.getN<GetModelPartsTask::Output>(3);
-            const auto materials = modelPartsIn.getN<GetModelPartsTask::Output>(4);
-            const auto jointsIn = modelPartsIn.getN<GetModelPartsTask::Output>(5);
+            const auto jointsIn = modelPartsIn.getN<GetModelPartsTask::Output>(4);
 
             // Calculate normals and tangents for meshes and blendshapes if they do not exist
             // Note: Normals are never calculated here for OBJ models. OBJ files optionally define normals on a per-face basis, so for consistency normals are calculated beforehand in OBJSerializer.
             const auto normalsPerMesh = model.addJob<CalculateMeshNormalsTask>("CalculateMeshNormals", meshesIn);
-            const auto calculateMeshTangentsInputs = CalculateMeshTangentsTask::Input(normalsPerMesh, meshesIn, materials).asVarying();
+            const auto calculateMeshTangentsInputs = CalculateMeshTangentsTask::Input(normalsPerMesh, meshesIn).asVarying();
             const auto tangentsPerMesh = model.addJob<CalculateMeshTangentsTask>("CalculateMeshTangents", calculateMeshTangentsInputs);
             const auto calculateBlendshapeNormalsInputs = CalculateBlendshapeNormalsTask::Input(blendshapesPerMeshIn, meshesIn).asVarying();
             const auto normalsPerBlendshapePerMesh = model.addJob<CalculateBlendshapeNormalsTask>("CalculateBlendshapeNormals", calculateBlendshapeNormalsInputs);
-            const auto calculateBlendshapeTangentsInputs = CalculateBlendshapeTangentsTask::Input(normalsPerBlendshapePerMesh, blendshapesPerMeshIn, meshesIn, materials).asVarying();
+            const auto calculateBlendshapeTangentsInputs = CalculateBlendshapeTangentsTask::Input(normalsPerBlendshapePerMesh, blendshapesPerMeshIn, meshesIn).asVarying();
             const auto tangentsPerBlendshapePerMesh = model.addJob<CalculateBlendshapeTangentsTask>("CalculateBlendshapeTangents", calculateBlendshapeTangentsInputs);
 
             // Build the graphics::MeshPointer for each hfm::Mesh

--- a/libraries/model-baker/src/model-baker/CalculateBlendshapeTangentsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateBlendshapeTangentsTask.cpp
@@ -19,7 +19,6 @@ void CalculateBlendshapeTangentsTask::run(const baker::BakeContextPointer& conte
     const auto& normalsPerBlendshapePerMesh = input.get0();
     const auto& blendshapesPerMesh = input.get1();
     const auto& meshes = input.get2();
-    const auto& materials = input.get3();
     auto& tangentsPerBlendshapePerMeshOut = output;
     
     tangentsPerBlendshapePerMeshOut.reserve(normalsPerBlendshapePerMesh.size());
@@ -29,16 +28,6 @@ void CalculateBlendshapeTangentsTask::run(const baker::BakeContextPointer& conte
         const auto& mesh = meshes[i];
         tangentsPerBlendshapePerMeshOut.emplace_back();
         auto& tangentsPerBlendshapeOut = tangentsPerBlendshapePerMeshOut[tangentsPerBlendshapePerMeshOut.size()-1];
-
-        // Check if we actually need to calculate the tangents, or just append empty arrays
-        bool needTangents = false;
-        for (const auto& meshPart : mesh.parts) {
-            auto materialIt = materials.find(meshPart.materialID);
-            if (materialIt != materials.end() && (*materialIt).needTangentSpace()) {
-                needTangents = true;
-                break;
-            }
-        }
 
         for (size_t j = 0; j < blendshapes.size(); j++) {
             const auto& blendshape = blendshapes[j];
@@ -54,7 +43,7 @@ void CalculateBlendshapeTangentsTask::run(const baker::BakeContextPointer& conte
             }
 
             // Check if we can and should calculate tangents (we need normals to calculate the tangents)
-            if (normals.empty() || !needTangents) {
+            if (normals.empty()) {
                 continue;
             }
             tangentsOut.resize(normals.size());

--- a/libraries/model-baker/src/model-baker/CalculateBlendshapeTangentsTask.h
+++ b/libraries/model-baker/src/model-baker/CalculateBlendshapeTangentsTask.h
@@ -18,7 +18,7 @@
 // Calculate blendshape tangents if not already present in the blendshape
 class CalculateBlendshapeTangentsTask {
 public:
-    using Input = baker::VaryingSet4<std::vector<baker::NormalsPerBlendshape>, baker::BlendshapesPerMesh, std::vector<hfm::Mesh>, QHash<QString, hfm::Material>>;
+    using Input = baker::VaryingSet3<std::vector<baker::NormalsPerBlendshape>, baker::BlendshapesPerMesh, std::vector<hfm::Mesh>>;
     using Output = std::vector<baker::TangentsPerBlendshape>;
     using JobModel = baker::Job::ModelIO<CalculateBlendshapeTangentsTask, Input, Output>;
 

--- a/libraries/model-baker/src/model-baker/CalculateMeshTangentsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateMeshTangentsTask.cpp
@@ -13,21 +13,9 @@
 
 #include "ModelMath.h"
 
-bool needTangents(const hfm::Mesh& mesh, const QHash<QString, hfm::Material>& materials) {
-    // Check if we actually need to calculate the tangents
-    for (const auto& meshPart : mesh.parts) {
-        auto materialIt = materials.find(meshPart.materialID);
-        if (materialIt != materials.end() && (*materialIt).needTangentSpace()) {
-            return true;
-        }
-    }
-    return false;
-}
-
 void CalculateMeshTangentsTask::run(const baker::BakeContextPointer& context, const Input& input, Output& output) {
     const auto& normalsPerMesh = input.get0();
     const std::vector<hfm::Mesh>& meshes = input.get1();
-    const auto& materials = input.get2();
     auto& tangentsPerMeshOut = output;
 
     tangentsPerMeshOut.reserve(meshes.size());
@@ -42,7 +30,7 @@ void CalculateMeshTangentsTask::run(const baker::BakeContextPointer& context, co
         // Otherwise confirm if we have the normals needed, and need to calculate the tangents
         if (!tangentsIn.empty()) {
             tangentsOut = tangentsIn.toStdVector();
-        } else if (!normals.empty() && needTangents(mesh, materials)) {
+        } else if (!normals.empty()) {
             tangentsOut.resize(normals.size());
             baker::calculateTangents(mesh,
             [&mesh, &normals, &tangentsOut](int firstIndex, int secondIndex, glm::vec3* outVertices, glm::vec2* outTexCoords, glm::vec3& outNormal) {

--- a/libraries/model-baker/src/model-baker/CalculateMeshTangentsTask.h
+++ b/libraries/model-baker/src/model-baker/CalculateMeshTangentsTask.h
@@ -22,7 +22,7 @@ class CalculateMeshTangentsTask {
 public:
     using NormalsPerMesh = std::vector<std::vector<glm::vec3>>;
 
-    using Input = baker::VaryingSet3<baker::NormalsPerMesh, std::vector<hfm::Mesh>, QHash<QString, hfm::Material>>;
+    using Input = baker::VaryingSet2<baker::NormalsPerMesh, std::vector<hfm::Mesh>>;
     using Output = baker::TangentsPerMesh;
     using JobModel = baker::Job::ModelIO<CalculateMeshTangentsTask, Input, Output>;
 


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-167

Tangents were not being calculated unless the model itself had a normal map. With material mappings in baked FST files, and material entities potentially being added on-the-fly, there is simply no situation where a model should not have tangents. Therefore, in this PR, always calculate tangents for models if they are not present.