### PR TITLE
BUGZ-223 - Physics was not starting in TheSpot-dev

### DIFF
--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -170,7 +170,7 @@ bool SafeLanding::isEntityPhysicsReady(const EntityItemPointer& entity) {
             entity->getAABox(hasAABox);
             if (hasAABox && downloadedCollisionTypes.count(modelEntity->getShapeType()) != 0) {
                 auto space = _entityTreeRenderer->getWorkloadSpace();
-                uint8_t region = space ? space->getRegion(entity->getSpaceIndex()) : workload::Region::INVALID;
+                uint8_t region = space ? space->getRegion(entity->getSpaceIndex()) : (uint8_t)workload::Region::INVALID;
                 bool shouldBePhysical = region < workload::Region::R3 && entity->shouldBePhysical();
                 return (!shouldBePhysical || entity->isInPhysicsSimulation() || modelEntity->computeShapeFailedToLoad());
             }

--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -10,7 +10,6 @@
 //
 
 #include "SafeLanding.h"
-
 #include <SharedUtil.h>
 
 #include "EntityTreeRenderer.h"
@@ -35,24 +34,26 @@ bool SafeLanding::SequenceLessThan::operator()(const int& a, const int& b) const
 }
 
 void SafeLanding::startEntitySequence(QSharedPointer<EntityTreeRenderer> entityTreeRenderer) {
-    auto entityTree = entityTreeRenderer->getTree();
 
-    if (entityTree) {
-        Locker lock(_lock);
-        _entityTree = entityTree;
-        _trackedEntities.clear();
-        _trackingEntities = true;
-        _maxTrackedEntityCount = 0;
-        connect(std::const_pointer_cast<EntityTree>(_entityTree).get(),
-            &EntityTree::addingEntity, this, &SafeLanding::addTrackedEntity);
-        connect(std::const_pointer_cast<EntityTree>(_entityTree).get(),
-            &EntityTree::deletingEntity, this, &SafeLanding::deleteTrackedEntity);
+    if (!entityTreeRenderer.isNull()) {
+        auto entityTree = entityTreeRenderer->getTree();
+        if (entityTree) {
+            Locker lock(_lock);
+            _entityTreeRenderer = entityTreeRenderer;
+            _trackedEntities.clear();
+            _trackingEntities = true;
+            _maxTrackedEntityCount = 0;
+            connect(std::const_pointer_cast<EntityTree>(entityTree).get(),
+                &EntityTree::addingEntity, this, &SafeLanding::addTrackedEntity, Qt::DirectConnection);
+            connect(std::const_pointer_cast<EntityTree>(entityTree).get(),
+                &EntityTree::deletingEntity, this, &SafeLanding::deleteTrackedEntity);
 
-        _sequenceNumbers.clear();
-        _initialStart = INVALID_SEQUENCE;
-        _initialEnd = INVALID_SEQUENCE;
-        _startTime = usecTimestampNow();
-        EntityTreeRenderer::setEntityLoadingPriorityFunction(&ElevatedPriority);
+            _sequenceNumbers.clear();
+            _initialStart = INVALID_SEQUENCE;
+            _initialEnd = INVALID_SEQUENCE;
+            _startTime = usecTimestampNow();
+            EntityTreeRenderer::setEntityLoadingPriorityFunction(&ElevatedPriority);
+        }
     }
 }
 
@@ -70,7 +71,7 @@ void SafeLanding::stopEntitySequence() {
 void SafeLanding::addTrackedEntity(const EntityItemID& entityID) {
     if (_trackingEntities) {
         Locker lock(_lock);
-        EntityItemPointer entity = _entityTree->findEntityByID(entityID);
+        EntityItemPointer entity = _entityTreeRenderer->getTree()->findEntityByID(entityID);
 
         if (entity && !entity->isLocalEntity() && entity->getCreated() < _startTime) {
 
@@ -111,7 +112,7 @@ bool SafeLanding::isLoadSequenceComplete() {
         Locker lock(_lock);
         _initialStart = INVALID_SEQUENCE;
         _initialEnd = INVALID_SEQUENCE;
-        _entityTree = nullptr;
+        _entityTreeRenderer.clear();
         _trackingEntities = false; // Don't track anything else that comes in.
         EntityTreeRenderer::setEntityLoadingPriorityFunction(StandardPriority);
     }
@@ -158,7 +159,7 @@ bool SafeLanding::isSequenceNumbersComplete() {
     return false;
 }
 
-bool isEntityPhysicsReady(const EntityItemPointer& entity) {
+bool SafeLanding::isEntityPhysicsReady(const EntityItemPointer& entity) {
     if (entity && !entity->getCollisionless()) {
         const auto& entityType = entity->getType();
         if (entityType == EntityTypes::Model) {
@@ -168,7 +169,10 @@ bool isEntityPhysicsReady(const EntityItemPointer& entity) {
             bool hasAABox;
             entity->getAABox(hasAABox);
             if (hasAABox && downloadedCollisionTypes.count(modelEntity->getShapeType()) != 0) {
-                return (!entity->shouldBePhysical() || entity->isInPhysicsSimulation() || modelEntity->computeShapeFailedToLoad());
+                auto space = _entityTreeRenderer->getWorkloadSpace();
+                uint8_t region = space ? space->getRegion(entity->getSpaceIndex()) : workload::Region::INVALID;
+                bool shouldBePhysical = region < workload::Region::R3 && entity->shouldBePhysical();
+                return (!shouldBePhysical || entity->isInPhysicsSimulation() || modelEntity->computeShapeFailedToLoad());
             }
         }
     }

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -38,13 +38,14 @@ private slots:
 
 private:
     bool isSequenceNumbersComplete();
+    bool isEntityPhysicsReady(const EntityItemPointer& entity);
     void debugDumpSequenceIDs() const;
     bool isEntityLoadingComplete();
 
     std::mutex _lock;
     using Locker = std::lock_guard<std::mutex>;
     bool _trackingEntities { false };
-    EntityTreePointer _entityTree;
+    QSharedPointer<EntityTreeRenderer> _entityTreeRenderer;
     using EntityMap = std::map<EntityItemID, EntityItemPointer>;
     EntityMap _trackedEntities;
 


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-223

This was caused by two issues involving the SafeLanding system:
* Race condition on domain load
The domain is hard-reset twice during typical start, first after
login completes, and second, when ice/domain renegotiation occurs
Entities added during the first reset caused an add to the safe landing
system which, because those adds were queued, possibly happened after
the second hard reset.

Second, Safe landing checks whether physics is ready on entities before
letting physics start.  Physics is ready when the entities have a
physics shape associated with them if they're static meshes.  The
physics shape is only generated if the entity is in Region 1 or 2.
Safe landing, however, was not checking the region of the entity
and was therefore waiting on entities that were not in region 1 or 2