### PR TITLE
BUGZ-223 - Fix crash when adding a tracked entity to the safe landing code

### DIFF
--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -71,6 +71,11 @@ void SafeLanding::stopEntitySequence() {
 void SafeLanding::addTrackedEntity(const EntityItemID& entityID) {
     if (_trackingEntities) {
         Locker lock(_lock);
+
+        if (_entityTreeRenderer.isNull() || _entityTreeRenderer->getTree() == nullptr) {
+            return;
+        }
+
         EntityItemPointer entity = _entityTreeRenderer->getTree()->findEntityByID(entityID);
 
         if (entity && !entity->isLocalEntity() && entity->getCreated() < _startTime) {


### PR DESCRIPTION
Fix crash when adding a tracked entity to the safe landing code when it's not been fully set up yet.