### PR TITLE
(BUGZ-298) Fix crash calculating tangents without texcoords

### DIFF
--- a/libraries/model-baker/src/model-baker/CalculateBlendshapeTangentsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateBlendshapeTangentsTask.cpp
@@ -42,8 +42,8 @@ void CalculateBlendshapeTangentsTask::run(const baker::BakeContextPointer& conte
                 continue;
             }
 
-            // Check if we can and should calculate tangents (we need normals to calculate the tangents)
-            if (normals.empty()) {
+            // Check if we can calculate tangents (we need normals and texcoords to calculate the tangents)
+            if (normals.empty() || normals.size() != (size_t)mesh.texCoords.size()) {
                 continue;
             }
             tangentsOut.resize(normals.size());

--- a/libraries/model-baker/src/model-baker/CalculateMeshTangentsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateMeshTangentsTask.cpp
@@ -27,10 +27,10 @@ void CalculateMeshTangentsTask::run(const baker::BakeContextPointer& context, co
         auto& tangentsOut = tangentsPerMeshOut[tangentsPerMeshOut.size()-1];
 
         // Check if we already have tangents and therefore do not need to do any calculation
-        // Otherwise confirm if we have the normals needed, and need to calculate the tangents
+        // Otherwise confirm if we have the normals and texcoords needed
         if (!tangentsIn.empty()) {
             tangentsOut = tangentsIn.toStdVector();
-        } else if (!normals.empty()) {
+        } else if (!normals.empty() && mesh.vertices.size() == mesh.texCoords.size()) {
             tangentsOut.resize(normals.size());
             baker::calculateTangents(mesh,
             [&mesh, &normals, &tangentsOut](int firstIndex, int secondIndex, glm::vec3* outVertices, glm::vec2* outTexCoords, glm::vec3& outNormal) {


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-298

This PR makes it so we don't calculate tangents when a mesh doesn't have texcoords, as texcoords are needed for current tangent calculations.