### PR TITLE
DEV-50: Add postbuild script

### DIFF
--- a/tools/ci-scripts/postbuild.py
+++ b/tools/ci-scripts/postbuild.py
@@ -1,0 +1,20 @@
+# Post build script
+import os
+import sys
+
+SOURCE_PATH = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..', '..'))
+BUILD_PATH = os.path.join(SOURCE_PATH, 'build')
+
+# FIXME move the helper python modules somewher other than the root of the repo
+sys.path.append(SOURCE_PATH)
+
+import hifi_utils
+
+#for var in sys.argv:
+#    print("{}".format(var))
+
+#for var in os.environ:
+#    print("{} = {}".format(var, os.environ[var]))
+
+print("Create ZIP version of installer archive")
+hifi_utils.executeSubprocess(['cpack', '-G', 'ZIP'], folder=BUILD_PATH)


### PR DESCRIPTION
[DEV-50](https://highfidelity.atlassian.net/browse/DEV-50):  Adds a new python script to be executed on the CI server after the build has run to do additional tasks.  Currently it's being used to create a single ZIP archive for installation.  Eventually it will be possible to use it to generate all the installers, plus take over the uploading of the binary symbols.