### PR TITLE
BUGZ-158: Crash when switching audio devices on Mac

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -2162,6 +2162,8 @@ qint64 AudioClient::AudioOutputIODevice::readData(char * data, qint64 maxSize) {
         }
 
         bytesWritten = framesPopped * AudioConstants::SAMPLE_SIZE * deviceChannelCount;
+        assert(bytesWritten <= maxSize);
+
     } else {
         // nothing on network, don't grab anything from injectors, and just return 0s
         memset(data, 0, maxSize);
@@ -2173,7 +2175,6 @@ qint64 AudioClient::AudioOutputIODevice::readData(char * data, qint64 maxSize) {
         Lock lock(_recordMutex);
         _audio->_audioFileWav.addRawAudioChunk(reinterpret_cast<char*>(scratchBuffer), bytesWritten);
     }
-
 
     int bytesAudioOutputUnplayed = _audio->_audioOutput->bufferSize() - _audio->_audioOutput->bytesFree();
     float msecsAudioOutputUnplayed = bytesAudioOutputUnplayed / (float)_audio->_outputFormat.bytesForDuration(USECS_PER_MSEC);

--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -366,8 +366,9 @@ int InboundAudioStream::popSamples(int maxSamples, bool allOrNothing) {
             _consecutiveNotMixedCount++;
             //Kick PLC to generate a filler frame, reducing 'click'
             lostAudioData(allOrNothing ? (maxSamples - samplesAvailable) / _ringBuffer.getNumFrameSamples() : 1);
-            samplesPopped = _ringBuffer.samplesAvailable();
-            if (samplesPopped) {
+            samplesAvailable = _ringBuffer.samplesAvailable();
+            if (samplesAvailable > 0) {
+                samplesPopped = std::min(samplesAvailable, maxSamples);
                 popSamplesNoCheck(samplesPopped);
             } else {
                 // No samples available means a packet is currently being

--- a/libraries/audio/src/InboundAudioStream.cpp
+++ b/libraries/audio/src/InboundAudioStream.cpp
@@ -364,9 +364,17 @@ int InboundAudioStream::popSamples(int maxSamples, bool allOrNothing) {
             // buffer calculations.
             setToStarved();
             _consecutiveNotMixedCount++;
-            //Kick PLC to generate a filler frame, reducing 'click'
-            lostAudioData(allOrNothing ? (maxSamples - samplesAvailable) / _ringBuffer.getNumFrameSamples() : 1);
+
+            // use PLC to generate extrapolated audio data, to reduce clicking
+            if (allOrNothing) {
+                int samplesNeeded = maxSamples - samplesAvailable;
+                int packetsNeeded = (samplesNeeded + _ringBuffer.getNumFrameSamples() - 1) / _ringBuffer.getNumFrameSamples();
+                lostAudioData(packetsNeeded);
+            } else {
+                lostAudioData(1);
+            }
             samplesAvailable = _ringBuffer.samplesAvailable();
+
             if (samplesAvailable > 0) {
                 samplesPopped = std::min(samplesAvailable, maxSamples);
                 popSamplesNoCheck(samplesPopped);


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-158

A bug was introduced in PR #15530 where under rare conditions, the audio ringbuffer can return more than the max samples requested. On the Mac, CoreAudio may request a partial buffer after switching or starting a new audio device, which results in writing past the end of the audio callback buffer and eventually faulting in the CoreAudio subsystem.

### Test Plan ###

On a Mac, test on a poor wifi connection that has packet loss.
Repeatedly start Interface, or switch audio devices, and verify that Interface does not crash.