### PR TITLE
BUGZ 345: avoid resource leak in AvatarManger::_otherAvatarsToChangeInPhysics

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -521,6 +521,7 @@ void AvatarManager::buildPhysicsTransaction(PhysicsEngine::Transaction& transact
             }
         }
     }
+    _otherAvatarsToChangeInPhysics.clear();
 }
 
 void AvatarManager::handleProcessedPhysicsTransaction(PhysicsEngine::Transaction& transaction) {
@@ -645,7 +646,7 @@ void AvatarManager::clearOtherAvatars() {
 }
 
 void AvatarManager::deleteAllAvatars() {
-    assert(_otherAvatarsToChangeInPhysics.empty());
+    _otherAvatarsToChangeInPhysics.clear();
     QReadLocker locker(&_hashLock);
     AvatarHash::iterator avatarIterator = _avatarHash.begin();
     while (avatarIterator != _avatarHash.end()) {


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-345

This PR fixes a resource leak (and crash in assert on shutdown in debug mode) because `AvatarManger::_otherAvatarsToChangeInPhysics` was never getting cleared.