### PR TITLE
BUGZ-413: Re-enable Quest 3D Keyboard

### DIFF
--- a/interface/src/ui/Keyboard.h
+++ b/interface/src/ui/Keyboard.h
@@ -180,11 +180,7 @@ private:
     mutable ReadWriteLockable _preferMalletsOverLasersSettingLock;
     mutable ReadWriteLockable _ignoreItemsLock;
 
-#ifdef Q_OS_ANDROID
-    Setting::Handle<bool> _use3DKeyboard { "use3DKeyboard", false };
-#else
     Setting::Handle<bool> _use3DKeyboard { "use3DKeyboard", true };
-#endif
 
     QString _typedCharacters;
     TextDisplay _textDisplay;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-413

Re-enables the quest keyboard.  It was originally disabled for performance reasons that have since been addressed.