### PR TITLE
BUGZ-380: Revert skybox color behavior

### DIFF
--- a/libraries/graphics/src/graphics/skybox.slf
+++ b/libraries/graphics/src/graphics/skybox.slf
@@ -26,6 +26,14 @@ layout(location=0) in vec3  _normal;
 layout(location=0) out vec4 _fragColor;
 
 void main(void) {
-    vec3 skyboxColor = texture(cubeMap, normalize(_normal)).rgb;
-    _fragColor = vec4(mix(skybox.color.rgb, skyboxColor, skybox.color.a), 1.0);
+    // FIXME: For legacy reasons, when skybox.color.a is 0.5, this is equivalent to:
+    // skyboxColor * skyboxTexel
+    // It should actually be:
+    // mix(skyboxColor, skyboxTexel, skybox.color.a)
+    // and the blend factor should be user controlled
+
+    vec3 skyboxTexel = texture(cubeMap, normalize(_normal)).rgb;
+    vec3 skyboxColor = skybox.color.rgb;
+    _fragColor = vec4(mix(vec3(1.0), skyboxTexel, float(skybox.color.a > 0.0)) *
+                      mix(vec3(1.0), skyboxColor, float(skybox.color.a < 1.0)), 1.0);
 }


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-380

I misunderstood the skybox equation we were using and improperly simplified it (https://github.com/highfidelity/hifi/pull/15602/files#diff-007dba46bda166555bd60250e463ccbdR29).  The current behavior is wrong in my opinion, but for legacy reasons, we have to keep it for now and we'll deal with it later.

