### PR TITLE
BUGZ-164: fix crash when processing physics simulation ownership bids

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6401,6 +6401,7 @@ void Application::update(float deltaTime) {
         PerformanceTimer perfTimer("simulation");
 
         getEntities()->preUpdate();
+        _entitySimulation->removeDeadEntities();
 
         auto t0 = std::chrono::high_resolution_clock::now();
         auto t1 = t0;

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -214,6 +214,7 @@ void PhysicalEntitySimulation::clearEntitiesInternal() {
     _entitiesToRemoveFromPhysics.clear();
     _entitiesToAddToPhysics.clear();
     _incomingChanges.clear();
+    _entitiesToDeleteLater.clear();
 }
 
 // virtual

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -218,11 +218,21 @@ void PhysicalEntitySimulation::clearEntitiesInternal() {
 
 // virtual
 void PhysicalEntitySimulation::prepareEntityForDelete(EntityItemPointer entity) {
+    // this can be called on any thread
     assert(entity);
     assert(entity->isDead());
     QMutexLocker lock(&_mutex);
-    entity->clearActions(getThisPointer());
-    removeEntityInternal(entity);
+    _entitiesToDeleteLater.push_back(entity);
+}
+
+void PhysicalEntitySimulation::removeDeadEntities() {
+    // only ever call this on the main thread
+    QMutexLocker lock(&_mutex);
+    for (auto& entity : _entitiesToDeleteLater) {
+        entity->clearActions(getThisPointer());
+        removeEntityInternal(entity);
+    }
+    _entitiesToDeleteLater.clear();
 }
 // end EntitySimulation overrides
 

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -80,6 +80,7 @@ protected: // only called by EntitySimulation
 
 public:
     virtual void prepareEntityForDelete(EntityItemPointer entity) override;
+    void removeDeadEntities();
 
     void buildPhysicsTransaction(PhysicsEngine::Transaction& transaction);
     void handleProcessedPhysicsTransaction(PhysicsEngine::Transaction& transaction);
@@ -121,6 +122,7 @@ private:
     VectorOfEntityMotionStates _owned;
     VectorOfEntityMotionStates _bids;
     SetOfEntities _deadAvatarEntities;
+    std::vector<EntityItemPointer> _entitiesToDeleteLater;
     workload::SpacePointer _space;
     uint64_t _nextBidExpiry;
     uint32_t _lastStepSendPackets { 0 };


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-164

This PR fixes a crash bug in the physics simulation ownership logic.