### PR TITLE
Fix BUGZ-146: Clicking on the gear icon causes three click sounds

### DIFF
--- a/interface/resources/qml/hifi/simplifiedUI/simplifiedControls/Switch.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/simplifiedControls/Switch.qml
@@ -70,8 +70,6 @@ Item {
         }
 
         onCheckedChanged: {
-            root.checkedChanged();
-            Tablet.playSound(TabletEnums.ButtonClick);
             originalSwitch.changeColor();
         }
 


### PR DESCRIPTION
Fixes [BUGZ-146](https://highfidelity.atlassian.net/browse/BUGZ-146).

The cause of this was some code that wasn't supposed to be there.

The repro before was not JUST to click on the "Settings" icon and hear three clicks, but rather the number of clicks you heard depended on whether or not you had TTS on AND/OR if your microphone was muted. Whew!