### PR TITLE
DEV-50: Fix release build zip name

### DIFF
--- a/tools/ci-scripts/postbuild.py
+++ b/tools/ci-scripts/postbuild.py
@@ -32,7 +32,7 @@ elif sys.platform == "darwin":
 def computeArchiveName():
     RELEASE_TYPE = os.getenv("RELEASE_TYPE", "DEV")
     RELEASE_NUMBER = os.getenv("RELEASE_NUMBER", "")
-    GIT_PR_COMMIT_SHORT = os.getenv("GIT_PR_COMMIT_SHORT", "")
+    GIT_PR_COMMIT_SHORT = os.getenv("SHA7", "")
 
     if RELEASE_TYPE == "PRODUCTION":
         BUILD_VERSION = "{}-{}".format(RELEASE_NUMBER, GIT_PR_COMMIT_SHORT)


### PR DESCRIPTION
The env variable `GIT_PR_COMMIT_SHORT` used to construct the output name is only present in PR builds.  The `SHA7` environment variable is present in both release and PR builds.  This PR switches to using the latter so that the zip output names include the commit hash.  