### PR TITLE
Use STUN RFC magic number to filter for such packets

### DIFF
--- a/tools/dissectors/1-hfudt.lua
+++ b/tools/dissectors/1-hfudt.lua
@@ -163,10 +163,13 @@ local unsourced_packet_types = {
 
 local fragments = {}
 
+local RFC_5389_MAGIC_COOKIE = 0x2112A442
+
 function p_hfudt.dissector(buf, pinfo, tree)
 
    -- make sure this isn't a STUN packet - those don't follow HFUDT format
-  if pinfo.dst == Address.ip("stun.highfidelity.io") then return end
+  -- if pinfo.dst == Address.ip("stun.highfidelity.io") then return end
+  if buf(4, 4):uint() == RFC_5389_MAGIC_COOKIE then return end
 
   -- validate that the packet length is at least the minimum control packet size
   if buf:len() < 4 then return end

--- a/tools/dissectors/1-hfudt.lua
+++ b/tools/dissectors/1-hfudt.lua
@@ -167,9 +167,10 @@ local RFC_5389_MAGIC_COOKIE = 0x2112A442
 
 function p_hfudt.dissector(buf, pinfo, tree)
 
-   -- make sure this isn't a STUN packet - those don't follow HFUDT format
-  -- if pinfo.dst == Address.ip("stun.highfidelity.io") then return end
-  if buf:len() >= 8 and buf(4, 4):uint() == RFC_5389_MAGIC_COOKIE then return end
+  -- make sure this isn't a STUN packet - those don't follow HFUDT format
+  if buf:len() >= 8 and buf(4, 4):uint() == RFC_5389_MAGIC_COOKIE then
+    return 0
+  end
 
   -- validate that the packet length is at least the minimum control packet size
   if buf:len() < 4 then return end

--- a/tools/dissectors/1-hfudt.lua
+++ b/tools/dissectors/1-hfudt.lua
@@ -169,7 +169,7 @@ function p_hfudt.dissector(buf, pinfo, tree)
 
    -- make sure this isn't a STUN packet - those don't follow HFUDT format
   -- if pinfo.dst == Address.ip("stun.highfidelity.io") then return end
-  if buf(4, 4):uint() == RFC_5389_MAGIC_COOKIE then return end
+  if buf:len() >= 8 and buf(4, 4):uint() == RFC_5389_MAGIC_COOKIE then return end
 
   -- validate that the packet length is at least the minimum control packet size
   if buf:len() < 4 then return end


### PR DESCRIPTION
The STUN packets are used to discover each Node's public addr/port. We use the IP standard format rather than our own NL packets. These packets were causing the wireshark dissectors to hang. The packets contain a magic number, as noted around `LimitedNodeList.cpp:944`.

i.e., Why isn't the existing address check working? How do we get them still decoded by wireshark?

https://highfidelity.atlassian.net/browse/BUGZ-438