### PR TITLE
restore node silence threshold to original value

### DIFF
--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -49,7 +49,7 @@
 
 const int INVALID_PORT = -1;
 
-const quint64 NODE_SILENCE_THRESHOLD_MSECS = 10 * 1000;
+const quint64 NODE_SILENCE_THRESHOLD_MSECS = 5 * 1000;
 
 static const size_t DEFAULT_MAX_CONNECTION_RATE { std::numeric_limits<size_t>::max() };
 


### PR DESCRIPTION
Now that we've fixed other bugs (such as by https://github.com/highfidelity/hifi/pull/15648), let's set the timing of NODE_SILENCE_THRESHOLD_MSECS back to what it has been for a long time, consistent with MAX_SILENT_DOMAIN_SERVER_CHECK_INS * DOMAIN_SERVER_CHECK_IN_MSECS.