### PR TITLE
BUGZ-322 - high_resolution_clock behaves differently on windows and linux

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1174,8 +1174,8 @@ void DomainServer::sendDomainListToNode(const SharedNodePointer& node, quint64 r
     extendedHeaderStream << node->getPermissions();
     extendedHeaderStream << limitedNodeList->getAuthenticatePackets();
     extendedHeaderStream << nodeData->getLastDomainCheckinTimestamp();
-    extendedHeaderStream << requestPacketReceiveTime;
-    extendedHeaderStream << quint64(duration_cast<microseconds>(p_high_resolution_clock::now().time_since_epoch()).count());
+    extendedHeaderStream << duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+    extendedHeaderStream << quint64(duration_cast<microseconds>(p_high_resolution_clock::now().time_since_epoch()).count()) - requestPacketReceiveTime;
     auto domainListPackets = NLPacketList::create(PacketType::DomainList, extendedHeader);
 
     // always send the node their own UUID back

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1174,7 +1174,7 @@ void DomainServer::sendDomainListToNode(const SharedNodePointer& node, quint64 r
     extendedHeaderStream << node->getPermissions();
     extendedHeaderStream << limitedNodeList->getAuthenticatePackets();
     extendedHeaderStream << nodeData->getLastDomainCheckinTimestamp();
-    extendedHeaderStream << duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+    extendedHeaderStream << quint64(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count());
     extendedHeaderStream << quint64(duration_cast<microseconds>(p_high_resolution_clock::now().time_since_epoch()).count()) - requestPacketReceiveTime;
     auto domainListPackets = NLPacketList::create(PacketType::DomainList, extendedHeader);
 

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -416,7 +416,7 @@ void NodeList::sendDomainServerCheckIn() {
             packetStream << FingerprintUtils::getMachineFingerprint();
         }
 
-        packetStream << quint64(duration_cast<microseconds>(p_high_resolution_clock::now().time_since_epoch()).count());
+        packetStream << quint64(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count());
 
         // pack our data to send to the domain-server including
         // the hostname information (so the domain-server can see which place name we came in on)
@@ -649,21 +649,20 @@ void NodeList::processDomainServerList(QSharedPointer<ReceivedMessage> message) 
     bool isAuthenticated;
     packetStream >> isAuthenticated;
 
-    qint64 now = qint64(duration_cast<microseconds>(p_high_resolution_clock::now().time_since_epoch()).count());
+    qint64 now = qint64(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count());
 
     quint64 connectRequestTimestamp;
     packetStream >> connectRequestTimestamp;
 
-    quint64 domainServerRequestReceiveTime;
-    packetStream >> domainServerRequestReceiveTime;
-
     quint64 domainServerPingSendTime;
     packetStream >> domainServerPingSendTime;
 
+    quint64 domainServerCheckinProcessingTime;
+    packetStream >> domainServerCheckinProcessingTime;
+
     qint64 pingLagTime = (now - qint64(connectRequestTimestamp)) / qint64(USECS_PER_MSEC);
 
-    qint64 domainServerRequestLag = (qint64(domainServerRequestReceiveTime) - qint64(connectRequestTimestamp)) / qint64(USECS_PER_MSEC);
-    quint64 domainServerCheckinProcessingTime = domainServerPingSendTime - domainServerRequestReceiveTime;
+    qint64 domainServerRequestLag = (qint64(domainServerPingSendTime - domainServerCheckinProcessingTime) - qint64(connectRequestTimestamp)) / qint64(USECS_PER_MSEC);;
     qint64 domainServerResponseLag = (now - qint64(domainServerPingSendTime)) / qint64(USECS_PER_MSEC);
 
     if (_domainHandler.getSockAddr().isNull()) {


### PR DESCRIPTION
on linux, time_since_epoch returns time since linux epoch,
on windows, it returns time since system start.
Math between those values on two different types of machines
was coming out bad.

To deal with this problem, the processing time for domain checkins is calculated on the domain server using the high_resolution_clock, as that is what is used to tag incoming packets with their timestamps.  That value is sent to the interface for logging.  Other calculations are done via the system_clock, for which time_since_epoch always returns time since UNIX epoch.