### PR TITLE
BUGZ-420: guard MyAvatar::_scriptEngine with mutex

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -325,8 +325,8 @@ MyAvatar::MyAvatar(QThread* thread) :
 
 MyAvatar::~MyAvatar() {
     _lookAtTargetAvatar.reset();
-    delete _myScriptEngine;
-    _myScriptEngine = nullptr;
+    delete _scriptEngine;
+    _scriptEngine = nullptr;
 }
 
 QString MyAvatar::getDominantHand() const {
@@ -1598,8 +1598,8 @@ void MyAvatar::handleChangedAvatarEntityData() {
                 blobFailed = true; // blob doesn't exist
                 return;
             }
-            std::lock_guard<std::mutex> guard(_myScriptEngineLock);
-            if (!EntityItemProperties::blobToProperties(*_myScriptEngine, itr.value(), properties)) {
+            std::lock_guard<std::mutex> guard(_scriptEngineLock);
+            if (!EntityItemProperties::blobToProperties(*_scriptEngine, itr.value(), properties)) {
                 blobFailed = true; // blob is corrupt
             }
         });
@@ -1631,8 +1631,8 @@ void MyAvatar::handleChangedAvatarEntityData() {
                 skip = true;
                 return;
             }
-            std::lock_guard<std::mutex> guard(_myScriptEngineLock);
-            if (!EntityItemProperties::blobToProperties(*_myScriptEngine, itr.value(), properties)) {
+            std::lock_guard<std::mutex> guard(_scriptEngineLock);
+            if (!EntityItemProperties::blobToProperties(*_scriptEngine, itr.value(), properties)) {
                 skip = true;
             }
         });
@@ -1740,8 +1740,8 @@ bool MyAvatar::updateStaleAvatarEntityBlobs() const {
             ++numFound;
             QByteArray blob;
             {
-                std::lock_guard<std::mutex> guard(_myScriptEngineLock);
-                EntityItemProperties::propertiesToBlob(*_myScriptEngine, getID(), properties, blob);
+                std::lock_guard<std::mutex> guard(_scriptEngineLock);
+                EntityItemProperties::propertiesToBlob(*_scriptEngine, getID(), properties, blob);
             }
             _avatarEntitiesLock.withWriteLock([&] {
                 _cachedAvatarEntityBlobs[id] = blob;
@@ -1888,8 +1888,8 @@ void MyAvatar::avatarEntityDataToJson(QJsonObject& root) const {
 }
 
 void MyAvatar::loadData() {
-    if (!_myScriptEngine) {
-        _myScriptEngine = new QScriptEngine();
+    if (!_scriptEngine) {
+        _scriptEngine = new QScriptEngine();
     }
     getHead()->setBasePitch(_headPitchSetting.get());
 
@@ -2488,9 +2488,9 @@ QVariantList MyAvatar::getAvatarEntitiesVariant() {
             QVariantMap avatarEntityData;
             avatarEntityData["id"] = entityID;
             {
-                std::lock_guard<std::mutex> guard(_myScriptEngineLock);
+                std::lock_guard<std::mutex> guard(_scriptEngineLock);
                 EntityItemProperties entityProperties = entity->getProperties(desiredProperties);
-                QScriptValue scriptProperties = EntityItemPropertiesToScriptValue(_myScriptEngine, entityProperties);
+                QScriptValue scriptProperties = EntityItemPropertiesToScriptValue(_scriptEngine, entityProperties);
                 avatarEntityData["properties"] = scriptProperties.toVariant();
             }
             avatarEntitiesData.append(QVariant(avatarEntityData));

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2487,12 +2487,13 @@ QVariantList MyAvatar::getAvatarEntitiesVariant() {
             desiredProperties += PROP_LOCAL_ROTATION;
             QVariantMap avatarEntityData;
             avatarEntityData["id"] = entityID;
+            EntityItemProperties entityProperties = entity->getProperties(desiredProperties);
+            QScriptValue scriptProperties;
             {
                 std::lock_guard<std::mutex> guard(_scriptEngineLock);
-                EntityItemProperties entityProperties = entity->getProperties(desiredProperties);
-                QScriptValue scriptProperties = EntityItemPropertiesToScriptValue(_scriptEngine, entityProperties);
-                avatarEntityData["properties"] = scriptProperties.toVariant();
+                scriptProperties = EntityItemPropertiesToScriptValue(_scriptEngine, entityProperties);
             }
+            avatarEntityData["properties"] = scriptProperties.toVariant();
             avatarEntitiesData.append(QVariant(avatarEntityData));
         }
     }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2741,8 +2741,8 @@ private:
     mutable std::set<QUuid> _staleCachedAvatarEntityBlobs;
     //
     // keep a ScriptEngine around so we don't have to instantiate on the fly (these are very slow to create/delete)
-    mutable std::mutex _myScriptEngineLock;
-    QScriptEngine* _myScriptEngine { nullptr };
+    mutable std::mutex _scriptEngineLock;
+    QScriptEngine* _scriptEngine { nullptr };
     bool _needToSaveAvatarEntitySettings { false };
 };
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2741,6 +2741,7 @@ private:
     mutable std::set<QUuid> _staleCachedAvatarEntityBlobs;
     //
     // keep a ScriptEngine around so we don't have to instantiate on the fly (these are very slow to create/delete)
+    mutable std::mutex _myScriptEngineLock;
     QScriptEngine* _myScriptEngine { nullptr };
     bool _needToSaveAvatarEntitySettings { false };
 };


### PR DESCRIPTION
This PR fixes a crash in interface where `MyAvatar::_scriptEngine` is corrupted via multithreaded access:

https://highfidelity.atlassian.net/browse/BUGZ-420