### PR TITLE
Fix for crash in QScriptEngine garbage collection routines

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1345,7 +1345,7 @@ void ScriptEngine::callAnimationStateHandler(QScriptValue callback, AnimVariantM
 }
 
 void ScriptEngine::updateMemoryCost(const qint64& deltaSize) {
-    if (deltaSize > 0) {
+    if (deltaSize > 0 && _isRunning) {
         reportAdditionalMemoryCost(deltaSize);
     }
 }


### PR DESCRIPTION
Not sure if this is a complete fix, but I did notice that the NetworkResource updateSize slot gets sent to the ScriptEngine::updateMemoryCost slot.  When this happens after the ScriptEngine has stopped this can result in a crash.  Now we check to see if the ScriptEngine is actually running before calling this method.

This does fix the crash when using the Developer > Network > Reload Content menu.
However, I'm not 100% sure if this will fix the other instances of this crash that we are seeing.

https://highfidelity.atlassian.net/browse/BUGZ-46