### PR TITLE
Add logging for silent node kills

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -869,6 +869,8 @@ void LimitedNodeList::removeSilentNodes() {
 
     QSet<SharedNodePointer> killedNodes;
 
+    auto startedAt = usecTimestampNow();
+
     eachNodeHashIterator([&](NodeHash::iterator& it){
         SharedNodePointer node = it->second;
         node->getMutex().lock();
@@ -889,7 +891,15 @@ void LimitedNodeList::removeSilentNodes() {
     });
 
     foreach(const SharedNodePointer& killedNode, killedNodes) {
-        qCDebug(networking_ice) << "Removing silent node" << killedNode;
+        auto now = usecTimestampNow();
+        qCDebug(networking_ice) << "Removing silent node" << *killedNode << "\n"
+            << "    Now: " << now << "\n"
+            << "    Started at: " << startedAt << " (" << (now - startedAt) << "us ago)\n"
+            << "    Last Heard Microstamp: " << killedNode->getLastHeardMicrostamp() << " (" << (now - killedNode->getLastHeardMicrostamp()) << "us ago)\n"
+            << "    Forced Never Silent: " << killedNode->isForcedNeverSilent() << "\n"
+            << "    Inbound PPS: " << killedNode->getInboundPPS() << "\n"
+            << "    Inbound Kbps: " << killedNode->getInboundKbps() << "\n"
+            << "    Ping: " << killedNode->getPingMs();
         handleNodeKill(killedNode);
     }
 }


### PR DESCRIPTION
```
Removing silent node "Avatar Mixer" (W) {ad82e1a3-f0db-4728-84de-f5095fdc4c23}(38155) 50.239.52.242:39999 / 10.246.56.114:39999 
    Now: 1559264158626377
    Started at: 1559264158626334 (43us ago)
    Last Heard Microstamp: 1559264139130932 (19495445us ago)
    Forced Never Silent: false
    Inbound PPS: 0
    Inbound Kbps: 0
    Ping: -1
```