### PR TITLE
(BUGZ-416) Fix Application not checking window minimize state properly

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4155,8 +4155,14 @@ bool Application::eventFilter(QObject* object, QEvent* event) {
     }
 
     if (event->type() == QEvent::WindowStateChange) {
-        if (getWindow()->windowState() == Qt::WindowMinimized) {
+        if (getWindow()->windowState() & Qt::WindowMinimized) {
             getRefreshRateManager().setRefreshRateRegime(RefreshRateManager::RefreshRateRegime::MINIMIZED);
+        } else {
+            auto* windowStateChangeEvent = static_cast<QWindowStateChangeEvent*>(event);
+            if (windowStateChangeEvent->oldState() & Qt::WindowMinimized) {
+                getRefreshRateManager().setRefreshRateRegime(RefreshRateManager::RefreshRateRegime::FOCUS_ACTIVE);
+                getRefreshRateManager().resetInactiveTimer();
+            }
         }
     }
 


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-416

This PR fixes an issue where the application would be stuck at low framerate because the application still thought it was minimized. The bug seemed to only occur on Mac when the window was "smaller" (i.e. not stretched to full size). For a similar reason, the application would also not detect that it was minimized when the window was "larger" beforehand, leading to higher framerate than necessary when minimized. This PR fixes that as well.