### PR TITLE
Allow microphone permission when debugging on the Mac

### DIFF
--- a/cmake/modules/MacOSXBundleInfo.plist.in
+++ b/cmake/modules/MacOSXBundleInfo.plist.in
@@ -53,5 +53,7 @@
 	</array>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
When Interface is launched from Xcode on the Mac, it doesn't trigger the microphone permission popup, making it impossible to use the mic while debugging. Fixed by adding the NSMicrophoneUsageDescription key to Info.plist.

See https://forums.developer.apple.com/thread/109759

### Test Plan ###
Build and launch Interface via Xcode. You should now get the "allow microphone" popup and be able to use the mic.