### PR TITLE
Bug fix for crash in QScriptEngine::reportAdditionalMemoryCost()

### DIFF
--- a/cmake/ports/bullet3/portfile.cmake
+++ b/cmake/ports/bullet3/portfile.cmake
@@ -1,4 +1,7 @@
+# Updated June 6th, 2019, to force new vckpg hash
+#
 # Common Ambient Variables:
+#
 #   CURRENT_BUILDTREES_DIR    = ${VCPKG_ROOT_DIR}\buildtrees\${PORT}
 #   CURRENT_PACKAGES_DIR      = ${VCPKG_ROOT_DIR}\packages\${PORT}_${TARGET_TRIPLET}
 #   CURRENT_PORT_DIR          = ${VCPKG_ROOT_DIR}\ports\${PORT}
@@ -8,7 +11,6 @@
 #   VCPKG_LIBRARY_LINKAGE     = target library linkage type (static, dynamic)
 #   VCPKG_ROOT_DIR            = <C:\path\to\current\vcpkg>
 #   VCPKG_TARGET_ARCHITECTURE = target architecture (x64, x86, arm)
-#
 #
 
 include(vcpkg_common_functions)

--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -254,9 +254,9 @@ endif()
 
             url = 'NOT DEFINED'
             if platform.system() == 'Windows':
-                url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-windows2.tar.gz'
+                url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-windows3.tar.gz'
             elif platform.system() == 'Darwin':
-                url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-macos2.tar.gz'
+                url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-macos3.tar.gz'
             elif platform.system() == 'Linux':
                 if platform.linux_distribution()[1][:3] == '16.':
                     url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-ubuntu-16.04.tar.gz'

--- a/libraries/script-engine/src/ArrayBufferClass.cpp
+++ b/libraries/script-engine/src/ArrayBufferClass.cpp
@@ -76,8 +76,10 @@ QScriptValue ArrayBufferClass::newInstance(qint32 size) {
         engine()->evaluate("throw \"ArgumentError: absurd length\"");
         return QScriptValue();
     }
-    
+    // We've patched qt to fix https://highfidelity.atlassian.net/browse/BUGZ-46 on mac and windows only.
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
     engine()->reportAdditionalMemoryCost(size);
+#endif
     QScriptEngine* eng = engine();
     QVariant variant = QVariant::fromValue(QByteArray(size, 0));
     QScriptValue data =  eng->newVariant(variant);

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -1346,7 +1346,10 @@ void ScriptEngine::callAnimationStateHandler(QScriptValue callback, AnimVariantM
 
 void ScriptEngine::updateMemoryCost(const qint64& deltaSize) {
     if (deltaSize > 0) {
+        // We've patched qt to fix https://highfidelity.atlassian.net/browse/BUGZ-46 on mac and windows only.
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
         reportAdditionalMemoryCost(deltaSize);
+#endif
     }
 }
 

--- a/tools/qt-builder/README.md
+++ b/tools/qt-builder/README.md
@@ -1,7 +1,8 @@
 # General
 This document describes the process to build Qt 5.12.3.
-Note that there are two patches.  The first (to qfloat16.h) is needed to compile QT 5.12.3 on Visual Studio 2017 due to a bug in Visual Studio (*bitset* will not compile.  Note that there is a change in CMakeLists.txt to support this.  
+Note that there are three patches.  The first (to qfloat16.h) is needed to compile QT 5.12.3 on Visual Studio 2017 due to a bug in Visual Studio (*bitset* will not compile.  Note that there is a change in CMakeLists.txt to support this.  
 The second patch is to OpenSL ES audio.
+The third is a patch to QScriptEngine to prevent crashes in QScriptEnginePrivate::reportAdditionalMemoryCost, during garbage collection.  See https://bugreports.qt.io/browse/QTBUG-76176
 ## Requirements
 ### Windows
 1.  Visual Studio 2017  
@@ -125,11 +126,12 @@ Also, make sure the directory that you are using to build qt is not deeply neste
   
 *  Copy the **patches** folder to qt5  
 *  Copy the **qt5vars.bat** file to qt5  
-*  Apply the two patches to Qt  
+*  Apply the patches to Qt  
 
 `cd qt5`  
 `git apply --ignore-space-change --ignore-whitespace patches/qfloat16.patch`  
 `git apply --ignore-space-change --ignore-whitespace patches/aec.patch`  
+`git apply --ignore-space-change --ignore-whitespace patches/qtscript-crash-fix.patch`  
 `cd ..`  
 #### Configuring  
 `mkdir qt5-install`  
@@ -151,8 +153,8 @@ The *.prl* files have an absolute path that needs to be removed (see http://www.
 `find . -name \*.prl -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;`  
 1.   Copy *qt.conf* to *qt5-install\bin*  
 #### Uploading
-Create a tar file called qt5-install-5.12.3-windows.tar.gz from the qt5-install folder
-Upload qt5-install-5.12.3-windows.tar.gz to our Amazon S3 hifi-public bucket, under the dependencies/vckpg directory
+Create a tar file called qt5-install-5.12.3-windows.tar.gz from the qt5-install folder.
+Upload qt5-install-5.12.3-windows.tar.gz to our Amazon S3 hifi-public bucket, under the dependencies/vckpg directory.
 Update hifi_vcpkg.py to use this new URL. Additionally, you should make a small change to any file in the hifi/cmake/ports directory to force the re-download of the qt-install.tar.gz during the build process for hifi.
 #### Preparing Symbols
 Run `python3 prepare-windows-symbols-for-backtrace.py qt5-install` to scan the qt5-install directory for any dlls and pdbs.  After running this command the backtrace directory will be created.  Zip this directory up, but make sure that all dlls and pdbs are in the root of the zip file, not under a sub-directory.  This file can then be uploaded to backtrace here: https://highfidelity.sp.backtrace.io/p/Interface/settings/symbol/upload
@@ -161,9 +163,10 @@ Run `python3 prepare-windows-symbols-for-backtrace.py qt5-install` to scan the q
 `git clone --recursive git://code.qt.io/qt/qt5.git -b 5.12.3 --single-branch`  
   
 *  Copy the **patches** folder to qt5  
-*   Apply one patch to Qt  
+*   Apply patches to Qt  
 `cd qt5`  
 `git apply --ignore-space-change --ignore-whitespace patches/aec.patch`  
+`git apply --ignore-space-change --ignore-whitespace patches/qtscript-crash-fix.patch`  
 `cd ..`
 #### Configuring
 `mkdir qt5-install`  
@@ -215,9 +218,10 @@ Run `python3 prepare-windows-symbols-for-backtrace.py qt5-install` to scan the q
 git clone --recursive git://code.qt.io/qt/qt5.git -b 5.12.3 --single-branch    
   
 *  Copy the **patches** folder to qt5  
-*   Apply one patch to Qt  
+*   Apply the patches to Qt  
 `cd qt5`  
 `git apply --ignore-space-change --ignore-whitespace patches/aec.patch`  
+`git apply --ignore-space-change --ignore-whitespace patches/qtscript-crash-fix.patch`  
 `cd ..`  
 #### Configuring
 `mkdir qt5-install`  

--- a/tools/qt-builder/patches/qtscript-crash-fix.patch
+++ b/tools/qt-builder/patches/qtscript-crash-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/qtscript/src/script/api/qscriptengine.cpp b/qtscript/src/script/api/qscriptengine.cpp
+index c5f437b..942833e 100644
+--- a/qtscript/src/script/api/qscriptengine.cpp
++++ b/qtscript/src/script/api/qscriptengine.cpp
+@@ -1332,8 +1332,10 @@ void QScriptEnginePrivate::collectGarbage()
+ 
+ void QScriptEnginePrivate::reportAdditionalMemoryCost(int size)
+ {
+-    if (size > 0)
++    if (size > 0) {
++        QScript::APIShim shim(this);
+         globalData->heap.reportExtraMemoryCost(size);
++    }
+ }
+ 
+ QScript::TimeoutCheckerProxy *QScriptEnginePrivate::timeoutChecker() const

--- a/tools/qt-builder/prepare-windows-symbols-for-backtrace.py
+++ b/tools/qt-builder/prepare-windows-symbols-for-backtrace.py
@@ -4,7 +4,7 @@
 # usage
 #   python prepare-windows-symbols-for-backrace.py QT_INSTALL_DIR
 #
-# QT_BUILD_DIR should be the directory where qt is installed after running `jom install` or `nmake install`
+# QT_INSTALL_DIR should be the directory where qt is installed after running `jom install` or `nmake install`
 # see hifi/tools/qt-builder/README.md for more info
 #
 


### PR DESCRIPTION
This fix requires a patch to qt.  This build includs a new pre-built Qt 5.12.3 with the patch applied.
See tools/qt5-builder/qtscript-crash-fix.patch to see actual patch applied.

* Touched bullet3 portfile to create new vckpg hash
* New urls for qt assets which include qscript patch hifi_vcpkg.py
* Updated tools/qt5-builder/ with qscript patch and README.md directions.

https://highfidelity.atlassian.net/browse/BUGZ-46

A qt bug was filed to hopefully get this bug fixed upstream.
https://bugreports.qt.io/browse/QTBUG-76176