### PR TITLE
Don't send AvatarIdentity from mixer if socket inactive

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -365,7 +365,7 @@ void AvatarMixer::manageIdentityData(const SharedNodePointer& node) {
 
     // there is no need to manage identity data we haven't received yet
     // so bail early if we've never received an identity packet for this avatar
-    if (!nodeData || !nodeData->getAvatar().hasProcessedFirstIdentity()) {
+    if (!nodeData || !nodeData->getAvatar().hasProcessedFirstIdentity() || !node->getActiveSocket()) {
         return;
     }
 


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-286

https://highfidelity.atlassian.net/browse/BUGZ-286?focusedCommentId=12033&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-12033

From a packet trace to HQ this appeared to be at least one of the causes of this bug.
I've checked the main send-loop (not sending back to source) is already guarded for this case, in ` AvatarMixerSlave::broadcastAvatarData()`.