### PR TITLE
BUGZ-471: Support AirPods on MacOS

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -616,23 +616,25 @@ bool adjustedFormatForAudioDevice(const QAudioDeviceInfo& audioDevice,
 
     qCDebug(audioclient) << "The desired format for audio I/O is" << desiredAudioFormat;
 
-#if defined(Q_OS_ANDROID) || defined(Q_OS_OSX)
-    // As of Qt5.6, Android returns the native OpenSLES sample rate when possible, else 48000
-    // Mac OSX returns the preferred CoreAudio format
-    if (nativeFormatForAudioDevice(audioDevice, adjustedAudioFormat)) {
-        return true;
-    }
-#endif
-
 #if defined(Q_OS_WIN)
     if (IsWindows8OrGreater()) {
         // On Windows using WASAPI shared-mode, returns the internal mix format
-        if (nativeFormatForAudioDevice(audioDevice, adjustedAudioFormat)) {
-            return true;
-        }
-    }
+        return nativeFormatForAudioDevice(audioDevice, adjustedAudioFormat);
+    }   // else enumerate formats
 #endif
-
+    
+#if defined(Q_OS_MAC)
+    // Mac OSX returns the preferred CoreAudio format
+    return nativeFormatForAudioDevice(audioDevice, adjustedAudioFormat);
+#endif
+    
+#if defined(Q_OS_ANDROID)
+    // As of Qt5.6, Android returns the native OpenSLES sample rate when possible, else 48000
+    if (nativeFormatForAudioDevice(audioDevice, adjustedAudioFormat)) {
+        return true;
+    }   // else enumerate formats
+#endif
+    
     adjustedAudioFormat = desiredAudioFormat;
 
     //


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-471
https://highfidelity.atlassian.net/browse/BUGZ-395
https://highfidelity.atlassian.net/browse/BUGZ-494

This PR (along with PR #15663) enables AirPods and other Bluetooth headsets to work reliably on MacOS and Windows.

### NOTE: there are intrinsic limitations of Bluetooth headsets to keep in mind ###
1) Bluetooth operates at 2.4GHz and may cause severe interference with 2.4GHz wifi. If possible, create a separate 5GHz-only network on your router and connect only to that. Or use wired Ethernet.
2) On the MacBook, selecting "Internal Mic" as your microphone will allow the AirPods to run in A2DP (Headphone) profile with much better output quality (AAC codec, 48KHz sample rate, stereo). You can further improve the quality by using Bluetooth Explorer (in Xcode developer tools) to increase the AAC bitrate used by the encoder.
3) When AirPods are used for both mic and output, they switch to HFP (Hands Free Profile) and the output quality is very poor (low-bitrate 16KHz mono). There is nothing we can do about this.
4) Using AirPods instead of wired headphones/mic will add several hundred milliseconds to your audio latency.