### PR TITLE
Dissectors: Limit message number & position values

### DIFF
--- a/tools/dissectors/1-hfudt.lua
+++ b/tools/dissectors/1-hfudt.lua
@@ -158,7 +158,13 @@ local packet_types = {
 }
 
 local unsourced_packet_types = {
-  ["DomainList"] = true
+  ["DomainList"] = true,
+  ["DomainConnectRequest"] = true,
+  ["ICEPing"] = true,
+  ["ICEPingReply"] = true,
+  ["DomainServerConnectionToken"] = true,
+  ["DomainSettingsRequest"] = true,
+  ["ICEServerHeartbeatACK"] = true
 }
 
 local fragments = {}

--- a/tools/dissectors/1-hfudt.lua
+++ b/tools/dissectors/1-hfudt.lua
@@ -307,7 +307,7 @@ function p_hfudt.dissector(buf, pinfo, tree)
 
     -- check if we have part of a message that we need to re-assemble
     -- before it can be dissected
-    if message_bit == 1 and message_position ~= 0 then
+    if message_bit == 1 and message_position ~= 0 and message_number < 50 and message_part_number < 10 then
       if fragments[message_number] == nil then
         fragments[message_number] = {}
       end

--- a/tools/dissectors/1-hfudt.lua
+++ b/tools/dissectors/1-hfudt.lua
@@ -313,7 +313,10 @@ function p_hfudt.dissector(buf, pinfo, tree)
 
     -- check if we have part of a message that we need to re-assemble
     -- before it can be dissected
-    if message_bit == 1 and message_position ~= 0 and message_number < 50 and message_part_number < 10 then
+    -- limit array indices to prevent lock-up with arbitrary data
+    if message_bit == 1 and message_position ~= 0 and message_number < 100
+      and message_part_number < 100 then
+
       if fragments[message_number] == nil then
         fragments[message_number] = {}
       end


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-579

With arbitrary captured packets the dissectors were locking up due to lua array-use with random 32-bit values. One packet was enough to break it.
I'm open to cleaner fixes, though I think we rarely need to analyze multi-part messages.
