### PR TITLE
Fix spurious error from prebuilt script

### DIFF
--- a/prebuild.py
+++ b/prebuild.py
@@ -114,7 +114,7 @@ def main():
     args = parse_args()
 
     if args.ci_build:
-        logging.basicConfig(datefmt='%s', format='%(asctime)s %(guid)s %(message)s', level=logging.INFO)
+        logging.basicConfig(datefmt='%H:%M:%S', format='%(asctime)s %(guid)s %(message)s', level=logging.INFO)
 
     logger.info('sha=%s' % headSha())
     logger.info('start')


### PR DESCRIPTION
on the Jenkins build hosts, all builds are showing an error similar to this:

    15:58:18 ValueError: Invalid format string

This doesn't actually break anything, but it's distracting and misleading when trying to diagnose actual errors.  The error is caused by passing `%s` as the `datefmt` parameter to the logger.  Per the documentation this string must be compatible with the `time.strftime` function, but it is not.  This PR will instead change the format to `%H:%M:%S` which is a valid time format.  