### PR TITLE
BUGZ-373, BUGZ-407: Put avatar spheres in R3 in simulation

### DIFF
--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -219,7 +219,7 @@ bool OtherAvatar::isInPhysicsSimulation() const {
 }
 
 bool OtherAvatar::shouldBeInPhysicsSimulation() const {
-    return !isDead() && _workloadRegion < workload::Region::R3;
+    return !isDead() && _workloadRegion <= workload::Region::R3;
 }
 
 bool OtherAvatar::needsPhysicsUpdate() const {


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-373
https://highfidelity.atlassian.net/browse/BUGZ-407

I am not sure if this fixes this:
https://highfidelity.atlassian.net/browse/BUGZ-543
It sounds more like some avatars are not getting added to the physics simulation at all, since they are nearby, and other close avatars are clickable?