### PR TITLE
(BUGZ-429) Fix stuck transition due to removing sub render items before parent

### DIFF
--- a/libraries/render/src/render/Scene.cpp
+++ b/libraries/render/src/render/Scene.cpp
@@ -558,14 +558,20 @@ void Scene::removeItemTransition(ItemID itemId) {
     auto& item = _items[itemId];
     TransitionStage::Index transitionId = item.getTransitionId();
     if (!render::TransitionStage::isIndexInvalid(transitionId)) {
-        auto finishedOperators = _transitionFinishedOperatorMap[transitionId];
-        for (auto finishedOperator : finishedOperators) {
-            if (finishedOperator) {
-                finishedOperator();
+        const auto& transition = transitionStage->getTransition(transitionId);
+        const auto transitionOwner = transition.itemId;
+        if (transitionOwner == itemId) {
+            // No more items will be using this transition. Clean it up.
+            auto finishedOperators = _transitionFinishedOperatorMap[transitionId];
+            for (auto finishedOperator : finishedOperators) {
+                if (finishedOperator) {
+                    finishedOperator();
+                }
             }
+            _transitionFinishedOperatorMap.erase(transitionId);
+            transitionStage->removeTransition(transitionId);
         }
-        _transitionFinishedOperatorMap.erase(transitionId);
-        transitionStage->removeTransition(transitionId);
+
         setItemTransition(itemId, render::TransitionStage::INVALID_INDEX);
     }
 }


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-429

This PR fixes the most reproducible case of the stuck avatar fade bug, where MyAvatar would randomly have a single stuck transition in a release build when first logging in, particularly frequently when many things are loading.