### PR TITLE
add workload::Region::R4 to differentiate from workload::Region::UNKNOWN

### DIFF
--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -201,6 +201,7 @@ void OtherAvatar::computeShapeLOD() {
         break;
     case workload::Region::UNKNOWN:
     case workload::Region::INVALID:
+    case workload::Region::R4:
     case workload::Region::R3:
     default:
         newLOD = BodyLOD::Sphere;
@@ -219,7 +220,7 @@ bool OtherAvatar::isInPhysicsSimulation() const {
 }
 
 bool OtherAvatar::shouldBeInPhysicsSimulation() const {
-    return !isDead() && _workloadRegion <= workload::Region::R3;
+    return !isDead() && _workloadRegion < workload::Region::R3;
 }
 
 bool OtherAvatar::needsPhysicsUpdate() const {

--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -176,8 +176,8 @@ bool SafeLanding::isEntityPhysicsReady(const EntityItemPointer& entity) {
             if (hasAABox && downloadedCollisionTypes.count(modelEntity->getShapeType()) != 0) {
                 auto space = _entityTreeRenderer->getWorkloadSpace();
                 uint8_t region = space ? space->getRegion(entity->getSpaceIndex()) : (uint8_t)workload::Region::INVALID;
-                bool shouldBePhysical = region < workload::Region::R3 && entity->shouldBePhysical();
-                return (!shouldBePhysical || entity->isInPhysicsSimulation() || modelEntity->computeShapeFailedToLoad());
+                bool definitelyNotPhysical = (region > workload::Region::R2 && region != workload::Region::UNKNOWN) || !entity->shouldBePhysical();
+                return (definitelyNotPhysical || entity->isInPhysicsSimulation() || modelEntity->computeShapeFailedToLoad());
             }
         }
     }

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -49,9 +49,9 @@ void PhysicalEntitySimulation::addEntityInternal(EntityItemPointer entity) {
     assert(entity);
     assert(!entity->isDead());
     uint8_t region = _space->getRegion(entity->getSpaceIndex());
-    bool shouldBePhysical = region < workload::Region::R3 && entity->shouldBePhysical();
+    bool maybeShouldBePhysical = (region < workload::Region::R3 || region == workload::Region::UNKNOWN) && entity->shouldBePhysical();
     bool canBeKinematic = region <= workload::Region::R3;
-    if (shouldBePhysical) {
+    if (maybeShouldBePhysical) {
         EntityMotionState* motionState = static_cast<EntityMotionState*>(entity->getPhysicsInfo());
         if (motionState) {
             motionState->setRegion(region);
@@ -309,20 +309,39 @@ void PhysicalEntitySimulation::buildMotionStatesForEntitiesThatNeedThem() {
     SetOfEntities::iterator entityItr = _entitiesToAddToPhysics.begin();
     while (entityItr != _entitiesToAddToPhysics.end()) {
         EntityItemPointer entity = (*entityItr);
-        assert(!entity->getPhysicsInfo());
         if (entity->isDead()) {
             prepareEntityForDelete(entity);
             entityItr = _entitiesToAddToPhysics.erase(entityItr);
-        } else if (!entity->shouldBePhysical()) {
-            // this entity should no longer be on _entitiesToAddToPhysics
+            continue;
+        }
+        if (entity->getPhysicsInfo()) {
             entityItr = _entitiesToAddToPhysics.erase(entityItr);
+            continue;
+        }
+        if (!entity->shouldBePhysical()) {
+            // this entity should no longer be on _entitiesToAddToPhysics
             if (entity->isMovingRelativeToParent()) {
                 SetOfEntities::iterator itr = _simpleKinematicEntities.find(entity);
                 if (itr == _simpleKinematicEntities.end()) {
                     _simpleKinematicEntities.insert(entity);
                 }
             }
-        } else if (entity->isReadyToComputeShape()) {
+            entityItr = _entitiesToAddToPhysics.erase(entityItr);
+            continue;
+        }
+
+        uint8_t region = _space->getRegion(entity->getSpaceIndex());
+        if (region == workload::Region::UNKNOWN) {
+            // the workload hasn't categorized it yet --> skip for later
+            ++entityItr;
+            continue;
+        }
+        if (region > workload::Region::R2) {
+            // not in physical zone --> remove from list
+            entityItr = _entitiesToAddToPhysics.erase(entityItr);
+            continue;
+        }
+        if (entity->isReadyToComputeShape()) {
             ShapeRequest shapeRequest(entity);
             ShapeRequests::iterator  requestItr = _shapeRequests.find(shapeRequest);
             if (requestItr == _shapeRequests.end()) {
@@ -332,18 +351,7 @@ void PhysicalEntitySimulation::buildMotionStatesForEntitiesThatNeedThem() {
                 uint32_t requestCount = ObjectMotionState::getShapeManager()->getWorkRequestCount();
                 btCollisionShape* shape = const_cast<btCollisionShape*>(ObjectMotionState::getShapeManager()->getShape(shapeInfo));
                 if (shape) {
-                    EntityMotionState* motionState = static_cast<EntityMotionState*>(entity->getPhysicsInfo());
-                    if (!motionState) {
                         buildMotionState(shape, entity);
-                    } else {
-                        // Is it possible to fall in here?
-                        // entity shouldn't be on _entitiesToAddToPhysics list if it already has a motionState.
-                        // but just in case...
-                        motionState->setShape(shape);
-                        motionState->setRegion(_space->getRegion(entity->getSpaceIndex()));
-                        _physicalObjects.insert(motionState);
-                        _incomingChanges.insert(motionState);
-                    }
                 } else if (requestCount != ObjectMotionState::getShapeManager()->getWorkRequestCount()) {
                     // shape doesn't exist but a new worker has been spawned to build it --> add to shapeRequests and wait
                     shapeRequest.shapeHash = shapeInfo.getHash();
@@ -354,6 +362,7 @@ void PhysicalEntitySimulation::buildMotionStatesForEntitiesThatNeedThem() {
             }
             entityItr = _entitiesToAddToPhysics.erase(entityItr);
         } else {
+            // skip for later
             ++entityItr;
         }
     }

--- a/libraries/workload/src/workload/Region.h
+++ b/libraries/workload/src/workload/Region.h
@@ -21,6 +21,7 @@ public:
         R1 = 0,
         R2,
         R3,
+        R4,
         UNKNOWN,
         INVALID,
     };

--- a/libraries/workload/src/workload/RegionState.cpp
+++ b/libraries/workload/src/workload/RegionState.cpp
@@ -28,7 +28,9 @@ void RegionState::run(const workload::WorkloadContextPointer& renderContext, con
     // ...
     // inputs[2N] = vector of ids exiting region N
     // inputs[2N + 1] = vector of ids entering region N
-    assert(inputs.size() == 2 * Region::UNKNOWN);
+    //
+    // But we only pass inputs for R1 through R3
+    assert(inputs.size() == 2 * (int32_t)(Region::R3 + 1));
 
     // The id's in each vector are sorted in ascending order
     // because the source vectors are scanned in ascending order.

--- a/libraries/workload/src/workload/RegionState.h
+++ b/libraries/workload/src/workload/RegionState.h
@@ -54,7 +54,7 @@ namespace workload {
         using JobModel = workload::Job::ModelI<RegionState, Inputs, Config>;
 
         RegionState() {
-            _state.resize(Region::UNKNOWN);
+            _state.resize(Region::R3 + 1);
         }
 
         void configure(const Config& config);

--- a/libraries/workload/src/workload/RegionTracker.cpp
+++ b/libraries/workload/src/workload/RegionTracker.cpp
@@ -33,15 +33,15 @@ void RegionTracker::run(const WorkloadContextPointer& context, Outputs& outputs)
         //Changes changes;
         space->categorizeAndGetChanges(outChanges);
 
-        // use exit/enter lists for each region less than Region::UNKNOWN
+        // use exit/enter lists for each region less than Region::R4
         outRegionChanges.resize(2 * (workload::Region::NUM_CLASSIFICATIONS - 1));
         for (uint32_t i = 0; i < outChanges.size(); ++i) {
             Space::Change& change = outChanges[i];
-            if (change.prevRegion < Region::UNKNOWN) {
+            if (change.prevRegion < Region::R4) {
                 // EXIT list index = 2 * regionIndex
                 outRegionChanges[2 * change.prevRegion].push_back(change.proxyId);
             }
-            if (change.region < Region::UNKNOWN) {
+            if (change.region < Region::R4) {
                 // ENTER list index = 2 * regionIndex + 1
                 outRegionChanges[2 * change.region + 1].push_back(change.proxyId);
             }

--- a/libraries/workload/src/workload/Space.cpp
+++ b/libraries/workload/src/workload/Space.cpp
@@ -99,7 +99,7 @@ void Space::categorizeAndGetChanges(std::vector<Space::Change>& changes) {
         if (proxy.region < Region::INVALID) {
             glm::vec3 proxyCenter = glm::vec3(proxy.sphere);
             float proxyRadius = proxy.sphere.w;
-            uint8_t region = Region::UNKNOWN;
+            uint8_t region = Region::R4;
             for (uint32_t j = 0; j < numViews; ++j) {
                 auto& view = _views[j];
                 // for each 'view' we need only increment 'k' below the current value of 'region'


### PR DESCRIPTION
This PR has experimental unfinished work to address the problem with avatars falling through the floor: BUGZ-401:

https://highfidelity.atlassian.net/browse/BUGZ-401

I'm posting this publicly to help other devs workaround an assert that is blocking their work.