### PR TITLE
Fix crash using Settings in the Tablet in VR

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
+++ b/interface/resources/qml/hifi/tablet/TabletMenuStack.qml
@@ -49,7 +49,10 @@ Item {
         }
 
         function pushSource(path) {
-            d.push(Qt.resolvedUrl("../../" + path));
+            // Workaround issue https://bugreports.qt.io/browse/QTBUG-75516 in Qt 5.12.3
+            // by creating the manually, instead of letting StackView do it for us.
+            var item = Qt.createComponent(Qt.resolvedUrl("../../" + path));
+            d.push(item);
             if (d.currentItem.sendToScript !== undefined) {
                 d.currentItem.sendToScript.connect(tabletMenu.sendToScript);
             }


### PR DESCRIPTION
This was introduced in Qt5.12.3.  There are several issues in their bug tracker about this issue.

https://bugreports.qt.io/browse/QTBUG-75516
https://bugreports.qt.io/browse/QTBUG-75335

To workaround this, we call Qt.createComponent() manually, instead of letting StackView do it for us.