### PR TITLE
BUGZ-399: Fix shutdown crash in AudioInjectorManager::stop()

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2759,7 +2759,6 @@ void Application::cleanupBeforeQuit() {
     // this must happen after QML, as there are unexplained audio crashes originating in qtwebengine
     QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(), "stop");
     DependencyManager::destroy<AudioClient>();
-    DependencyManager::destroy<AudioInjectorManager>();
     DependencyManager::destroy<AudioScriptingInterface>();
 
     // The PointerManager must be destroyed before the PickManager because when a Pointer is deleted,
@@ -2819,6 +2818,7 @@ Application::~Application() {
 
     DependencyManager::destroy<SoundCacheScriptingInterface>();
 
+    DependencyManager::destroy<AudioInjectorManager>();
     DependencyManager::destroy<AvatarManager>();
     DependencyManager::destroy<AnimationCacheScriptingInterface>();
     DependencyManager::destroy<AnimationCache>();


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-399

The threading changes in PR #15173 result in crash on shutdown if scripted injectors are still playing, due to `DependencyManager::get<AudioInjectorManager>()->stop(_injector)` getting called when injectors owned by script/QML are destroyed. Fixed by deferring `DependencyManager::destroy<AudioInjectorManager>()` until no longer referenced.