### PR TITLE
BUGZ-297: QT - Crash when opening a menu that spawns a desktop popup window while in VR (running scripts, settings, etc)

### DIFF
--- a/interface/resources/qml/hifi/tablet/Edit.qml
+++ b/interface/resources/qml/hifi/tablet/Edit.qml
@@ -34,7 +34,8 @@ StackView {
     }
 
     function pushSource(path) {
-        editRoot.push(Qt.resolvedUrl("../../" + path), itemProperties,
+        var item = Qt.createComponent(Qt.resolvedUrl("../../" + path));
+        editRoot.push(item, itemProperties,
                       StackView.Immediate);
         editRoot.currentItem.sendToScript.connect(editRoot.sendToScript);
     }

--- a/interface/resources/qml/hifi/tablet/EditTools.qml
+++ b/interface/resources/qml/hifi/tablet/EditTools.qml
@@ -37,7 +37,8 @@ StackView {
     }
 
     function pushSource(path) {
-        editRoot.push(Qt.resolvedUrl("../../" + path), itemProperties,
+        var item = Qt.createComponent(Qt.resolvedUrl("../../" + path));
+        editRoot.push(item, itemProperties,
                       StackView.Immediate);
         editRoot.currentItem.sendToScript.connect(editRoot.sendToScript);
     }

--- a/interface/resources/qml/hifi/tablet/TabletAudioBuffers.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAudioBuffers.qml
@@ -24,7 +24,8 @@ StackView {
     signal sendToScript(var message);
 
     function pushSource(path) {
-        profileRoot.push(Qt.resolvedUrl(path));
+        var item = Qt.createComponent(Qt.resolvedUrl(path));
+        profileRoot.push(item);
     }
 
     function popSource() {

--- a/interface/resources/qml/hifi/tablet/TabletAvatarPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAvatarPreferences.qml
@@ -22,7 +22,8 @@ StackView {
     signal sendToScript(var message);
 
     function pushSource(path) {
-        profileRoot.push(Qt.resolvedUrl(path));
+        var item = Qt.createComponent(Qt.resolvedUrl(path));
+        profileRoot.push(item);
     }
 
     function popSource() {

--- a/interface/resources/qml/hifi/tablet/TabletAvatarPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAvatarPreferences.qml
@@ -22,7 +22,7 @@ StackView {
     signal sendToScript(var message);
 
     function pushSource(path) {
-        profileRoot.push(Qt.reslovedUrl(path));
+        profileRoot.push(Qt.resolvedUrl(path));
     }
 
     function popSource() {

--- a/interface/resources/qml/hifi/tablet/TabletGeneralPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletGeneralPreferences.qml
@@ -22,7 +22,8 @@ StackView {
     signal sendToScript(var message);
 
     function pushSource(path) {
-        profileRoot.push(Qt.resolvedUrl(path));
+        var item = Qt.createComponent(Qt.resolvedUrl(path));
+        profileRoot.push(item);
     }
 
     function popSource() {

--- a/interface/resources/qml/hifi/tablet/TabletGraphicsPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletGraphicsPreferences.qml
@@ -22,7 +22,8 @@ StackView {
     signal sendToScript(var message);
 
     function pushSource(path) {
-        profileRoot.push(Qt.resolvedUrl(path));
+        var item = Qt.createComponent(Qt.resolvedUrl(path));
+        profileRoot.push(item);
     }
 
     function popSource() {

--- a/interface/resources/qml/hifi/tablet/TabletLodPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletLodPreferences.qml
@@ -22,7 +22,8 @@ StackView {
     signal sendToScript(var message);
 
     function pushSource(path) {
-        profileRoot.push(Qt.resolvedUrl(path));
+        var item = Qt.createComponent(Qt.resolvedUrl(path));
+        profileRoot.push(item);
     }
 
     function popSource() {

--- a/interface/resources/qml/hifi/tablet/TabletNetworkingPreferences.qml
+++ b/interface/resources/qml/hifi/tablet/TabletNetworkingPreferences.qml
@@ -22,7 +22,8 @@ StackView {
     signal sendToScript(var message);
 
     function pushSource(path) {
-        profileRoot.push(Qt.resolvedUrl(path));
+        var item = Qt.createComponent(Qt.resolvedUrl(path));
+        profileRoot.push(item);
     }
 
     function popSource() {


### PR DESCRIPTION
Applying Tony's workaround for the Qt StackView push bug to all pushSource methods in our qml files.