### PR TITLE
case #BUGZ-608: App Shutdown toolbar undefined crash 

### DIFF
--- a/scripts/simplifiedUI/ui/simplifiedUI.js
+++ b/scripts/simplifiedUI/ui/simplifiedUI.js
@@ -535,7 +535,7 @@ function shutdown() {
 
         if (!HMD.active) {
             var toolbar = Toolbars.getToolbar(TOOLBAR_NAME);
-            if (typeof toolbar !== 'undefined') {
+            if (toolbar) {
                 toolbar.writeProperty("visible", true);
             } 
         }

--- a/scripts/simplifiedUI/ui/simplifiedUI.js
+++ b/scripts/simplifiedUI/ui/simplifiedUI.js
@@ -535,7 +535,9 @@ function shutdown() {
 
         if (!HMD.active) {
             var toolbar = Toolbars.getToolbar(TOOLBAR_NAME);
-            toolbar.writeProperty("visible", true);
+            if (typeof toolbar !== 'undefined') {
+                toolbar.writeProperty("visible", true);
+            } 
         }
     }
     


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-608

undefined exception thrown on toolbar object in the simplifiedUI.js on app shutdown. the object is already undefined at the time of the call. 

Test case:

Open app. 
Let the domain load 
Open the log
Click to close the app
Watch the output for the error in the bug
(It might be easier running from VS due to log closing out too early)