### PR TITLE
(BUGZ-563) Fix crash using null DisplayPlugin in GraphicsEngine

### DIFF
--- a/interface/src/graphics/GraphicsEngine.cpp
+++ b/interface/src/graphics/GraphicsEngine.cpp
@@ -132,6 +132,10 @@ static const int THROTTLED_SIM_FRAME_PERIOD_MS = MSECS_PER_SECOND / THROTTLED_SI
 
 bool GraphicsEngine::shouldPaint() const {
     auto displayPlugin = qApp->getActiveDisplayPlugin();
+    if (!displayPlugin) {
+        // We're shutting down
+        return false;
+    }
 
 #ifdef DEBUG_PAINT_DELAY
         static uint64_t paintDelaySamples{ 0 };
@@ -175,6 +179,10 @@ void GraphicsEngine::render_performFrame() {
     {
         PROFILE_RANGE(render, "/getActiveDisplayPlugin");
         displayPlugin = qApp->getActiveDisplayPlugin();
+        if (!displayPlugin) {
+            // We're shutting down
+            return;
+        }
     }
 
     {


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-563

This PR fixes a crash with the Present Thread attempting to access the _hudOperator of the Display Plugin pointer during shutdown.