### PR TITLE
Crash fix for ResourceCache::getResource()

### DIFF
--- a/libraries/networking/src/ResourceCache.cpp
+++ b/libraries/networking/src/ResourceCache.cpp
@@ -346,7 +346,7 @@ void ResourceCache::setRequestLimit(uint32_t limit) {
 QSharedPointer<Resource> ResourceCache::getResource(const QUrl& url, const QUrl& fallback, void* extra, size_t extraHash) {
     QSharedPointer<Resource> resource;
     {
-        QReadLocker locker(&_resourcesLock);
+        QWriteLocker locker(&_resourcesLock);
         auto& resourcesWithExtraHash = _resources[url];
         auto resourcesWithExtraHashIter = resourcesWithExtraHash.find(extraHash);
         if (resourcesWithExtraHashIter != resourcesWithExtraHash.end()) {


### PR DESCRIPTION
A wrong 'read' locker is used around a critical section that actually modifies the _resources QHash.
This can result in memory corruption and seg faults.

https://highfidelity.atlassian.net/browse/BUGZ-503