### PR TITLE
AvatarData: Fix avatarDataByteArray max size computation

### DIFF
--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -399,7 +399,7 @@ QByteArray AvatarData::toByteArray(AvatarDataDetail dataDetail, quint64 lastSent
         AvatarDataPacket::maxFaceTrackerInfoSize(_headData->getBlendshapeCoefficients().size()) +
         AvatarDataPacket::maxJointDataSize(_jointData.size()) +
         AvatarDataPacket::maxJointDefaultPoseFlagsSize(_jointData.size()) +
-        FAR_GRAB_JOINTS_SIZE;
+        AvatarDataPacket::FAR_GRAB_JOINTS_SIZE;
 
     if (maxDataSize == 0) {
         maxDataSize = (int)byteArraySize;

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -398,6 +398,7 @@ QByteArray AvatarData::toByteArray(AvatarDataDetail dataDetail, quint64 lastSent
     const size_t byteArraySize = AvatarDataPacket::MAX_CONSTANT_HEADER_SIZE + NUM_BYTES_RFC4122_UUID +
          AvatarDataPacket::maxFaceTrackerInfoSize(_headData->getBlendshapeCoefficients().size()) +
          AvatarDataPacket::maxJointDataSize(_jointData.size()) +
+         FAR_GRAB_JOINTS_SIZE +
          AvatarDataPacket::maxJointDefaultPoseFlagsSize(_jointData.size());
 
     if (maxDataSize == 0) {

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -396,10 +396,10 @@ QByteArray AvatarData::toByteArray(AvatarDataDetail dataDetail, quint64 lastSent
     }
 
     const size_t byteArraySize = AvatarDataPacket::MAX_CONSTANT_HEADER_SIZE + NUM_BYTES_RFC4122_UUID +
-         AvatarDataPacket::maxFaceTrackerInfoSize(_headData->getBlendshapeCoefficients().size()) +
-         AvatarDataPacket::maxJointDataSize(_jointData.size()) +
-         FAR_GRAB_JOINTS_SIZE +
-         AvatarDataPacket::maxJointDefaultPoseFlagsSize(_jointData.size());
+        AvatarDataPacket::maxFaceTrackerInfoSize(_headData->getBlendshapeCoefficients().size()) +
+        AvatarDataPacket::maxJointDataSize(_jointData.size()) +
+        AvatarDataPacket::maxJointDefaultPoseFlagsSize(_jointData.size()) +
+        FAR_GRAB_JOINTS_SIZE;
 
     if (maxDataSize == 0) {
         maxDataSize = (int)byteArraySize;

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -302,6 +302,15 @@ namespace AvatarDataPacket {
     const size_t AVATAR_LOCAL_POSITION_SIZE = 12;
     static_assert(sizeof(AvatarLocalPosition) == AVATAR_LOCAL_POSITION_SIZE, "AvatarDataPacket::AvatarLocalPosition size doesn't match.");
 
+    PACKED_BEGIN struct HandControllers {
+        SixByteQuat leftHandRotation;
+        SixByteTrans leftHandTranslation;
+        SixByteQuat rightHandRotation;
+        SixByteTrans rightHandTranslation;
+    } PACKED_END;
+    static const size_t HAND_CONTROLLERS_SIZE = 24;
+    static_assert(sizeof(HandControllers) == HAND_CONTROLLERS_SIZE, "AvatarDataPacket::HandControllers size doesn't match.");
+
     const size_t MAX_CONSTANT_HEADER_SIZE = HEADER_SIZE +
         AVATAR_GLOBAL_POSITION_SIZE +
         AVATAR_BOUNDING_BOX_SIZE +
@@ -312,17 +321,8 @@ namespace AvatarDataPacket {
         SENSOR_TO_WORLD_SIZE +
         ADDITIONAL_FLAGS_SIZE +
         PARENT_INFO_SIZE +
-        AVATAR_LOCAL_POSITION_SIZE;
-
-    PACKED_BEGIN struct HandControllers {
-        SixByteQuat leftHandRotation;
-        SixByteTrans leftHandTranslation;
-        SixByteQuat rightHandRotation;
-        SixByteTrans rightHandTranslation;
-    } PACKED_END;
-    static const size_t HAND_CONTROLLERS_SIZE = 24;
-    static_assert(sizeof(HandControllers) == HAND_CONTROLLERS_SIZE, "AvatarDataPacket::HandControllers size doesn't match.");
-
+        AVATAR_LOCAL_POSITION_SIZE +
+        HAND_CONTROLLERS_SIZE;
 
     // variable length structure follows
 


### PR DESCRIPTION
The previous size calculation did not take the presence of the hand controller section into account.
This could sometimes result in a buffer overrun of the network buffer as identified in a debug build.

https://highfidelity.atlassian.net/browse/BUGZ-526