### PR TITLE
Enable the globalOpenGLLock for ALL platforms.

### DIFF
--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -36,9 +36,7 @@ bool gl::disableGl45() {
 #endif
 }
 
-#ifdef Q_OS_MAC
 #define SERIALIZE_GL_RENDERING
-#endif
 
 #ifdef SERIALIZE_GL_RENDERING
 


### PR DESCRIPTION
This is a test to see if the SharedObject deadlocks still occur on Intel and AMD integrated graphics after this change.

This is to help diagnose https://highfidelity.atlassian.net/browse/BUGZ-402