### PR TITLE
BUGZ-543:Fix avatar picking not working on some avatars

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -490,7 +490,7 @@ void AvatarManager::buildPhysicsTransaction(PhysicsEngine::Transaction& transact
     _myAvatar->getCharacterController()->buildPhysicsTransaction(transaction);
     for (auto avatar : _otherAvatarsToChangeInPhysics) {
         bool isInPhysics = avatar->isInPhysicsSimulation();
-        if (isInPhysics != avatar->shouldBeInPhysicsSimulation()) {
+        if (isInPhysics != avatar->shouldBeInPhysicsSimulation() || avatar->_needsReinsertion) {
             if (isInPhysics) {
                 transaction.objectsToRemove.push_back(avatar->_motionState);
                 avatar->_motionState = nullptr;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-543
This PR fixes the bug where detailed motion states on some avatars were not reseting properly when the workload zone changes. This was creating a problem when picking some avatars.

