### PR TITLE
BUGZ-512: rollback fixes for bugz512

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -256,28 +256,18 @@ void EntityTreeRenderer::clear() {
     }
 
     // reset the engine
+    if (_wantScripts && !_shuttingDown) {
+        resetEntitiesScriptEngine();
+    }
+    // remove all entities from the scene
     auto scene = _viewState->getMain3DScene();
-    if (_shuttingDown) {
-        if (scene) {
-            render::Transaction transaction;
-            for (const auto& entry :  _entitiesInScene) {
-                const auto& renderer = entry.second;
-                renderer->removeFromScene(scene, transaction);
-            }
-            scene->enqueueTransaction(transaction);
+    if (scene) {
+        for (const auto& entry :  _entitiesInScene) {
+            const auto& renderer = entry.second;
+            fadeOutRenderable(renderer);
         }
     } else {
-        if (_wantScripts) {
-            resetEntitiesScriptEngine();
-        }
-        if (scene) {
-            for (const auto& entry :  _entitiesInScene) {
-                const auto& renderer = entry.second;
-                fadeOutRenderable(renderer);
-            }
-        } else {
-            qCWarning(entitiesrenderer) << "EntitityTreeRenderer::clear(), Unexpected null scene";
-        }
+        qCWarning(entitiesrenderer) << "EntitityTreeRenderer::clear(), Unexpected null scene, possibly during application shutdown";
     }
     _entitiesInScene.clear();
     _renderablesToUpdate.clear();

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -7,7 +7,6 @@
 //
 
 #include "RenderableWebEntityItem.h"
-#include <atomic>
 
 #include <QtCore/QTimer>
 #include <QtGui/QOpenGLContext>
@@ -47,7 +46,7 @@ static uint64_t MAX_NO_RENDER_INTERVAL = 30 * USECS_PER_SECOND;
 static uint8_t YOUTUBE_MAX_FPS = 30;
 
 // Don't allow more than 20 concurrent web views
-static std::atomic<uint32_t> _currentWebCount(0);
+static uint32_t _currentWebCount { 0 };
 static const uint32_t MAX_CONCURRENT_WEB_VIEWS = 20;
 
 static QTouchDevice _touchDevice;
@@ -357,15 +356,16 @@ void WebEntityRenderer::buildWebSurface(const EntityItemPointer& entity, const Q
 
 void WebEntityRenderer::destroyWebSurface() {
     QSharedPointer<OffscreenQmlSurface> webSurface;
+    ContentType contentType = ContentType::NoContent;
     withWriteLock([&] {
         webSurface.swap(_webSurface);
-        _contentType = ContentType::NoContent;
-
-        if (webSurface) {
-            --_currentWebCount;
-            WebEntityRenderer::releaseWebSurface(webSurface, _cachedWebSurface, _connections);
-        }
+        _contentType = contentType;
     });
+
+    if (webSurface) {
+        --_currentWebCount;
+        WebEntityRenderer::releaseWebSurface(webSurface, _cachedWebSurface, _connections);
+    }
 }
 
 glm::vec2 WebEntityRenderer::getWindowSize(const TypedEntityPointer& entity) const {
@@ -467,12 +467,6 @@ void WebEntityRenderer::handlePointerEventAsMouse(const PointerEvent& event) {
 
     QMouseEvent mouseEvent(type, windowPoint, windowPoint, windowPoint, button, buttons, event.getKeyboardModifiers());
     QCoreApplication::sendEvent(_webSurface->getWindow(), &mouseEvent);
-}
-
-void WebEntityRenderer::onRemoveFromSceneTyped(const TypedEntityPointer& entity) {
-    // HACK: destroyWebSurface() here to avoid a crash on shutdown.
-    // TODO: fix the real problem: EntityRenderer<>::dtor never called on shutdown for smart-pointer resource leak.
-    destroyWebSurface();
 }
 
 void WebEntityRenderer::setProxyWindow(QWindow* proxyWindow) {

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.h
@@ -64,7 +64,6 @@ protected:
     void handlePointerEventAsTouch(const PointerEvent& event);
     void handlePointerEventAsMouse(const PointerEvent& event);
 
-    void onRemoveFromSceneTyped(const TypedEntityPointer& entity) override;
 private:
     void onTimeout();
     void buildWebSurface(const EntityItemPointer& entity, const QString& newSourceURL);


### PR DESCRIPTION
This PR rolls back #15754 which introduced a crash when changing domains with WebEntity in view.  The other PR was trying to fix BUGZ-512:

https://highfidelity.atlassian.net/browse/BUGZ-512