### PR TITLE
BUGZ-658: Actually write some code that doesn't let the user switch avatar models to Woody

### DIFF
--- a/interface/resources/qml/hifi/simplifiedUI/topBar/SimplifiedTopBar.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/topBar/SimplifiedTopBar.qml
@@ -48,7 +48,8 @@ Rectangle {
         onSkeletonModelURLChanged: {
             root.updatePreviewUrl();
 
-            if (MyAvatar.skeletonModelURL.indexOf("defaultAvatar" > -1) && topBarInventoryModel.count > 0) {
+            if ((MyAvatar.skeletonModelURL.indexOf("defaultAvatar") > -1 || MyAvatar.skeletonModelURL.indexOf("fst") === -1) &&
+                topBarInventoryModel.count > 0) {
                 Settings.setValue("simplifiedUI/alreadyAutoSelectedAvatar", true);
                 MyAvatar.skeletonModelURL = topBarInventoryModel.get(0).download_url;
             }
@@ -100,7 +101,8 @@ Rectangle {
                 inventoryFullyReceived = true;
 
                 // If we have an avatar in our inventory AND we haven't already auto-selected an avatar...
-                if (!Settings.getValue("simplifiedUI/alreadyAutoSelectedAvatar", false) && topBarInventoryModel.count > 0) {
+                if ((!Settings.getValue("simplifiedUI/alreadyAutoSelectedAvatar", false) ||
+                    MyAvatar.skeletonModelURL.indexOf("defaultAvatar") > -1 || MyAvatar.skeletonModelURL.indexOf("fst") === -1) && topBarInventoryModel.count > 0) {
                     Settings.setValue("simplifiedUI/alreadyAutoSelectedAvatar", true);
                     MyAvatar.skeletonModelURL = topBarInventoryModel.get(0).download_url;
                 }


### PR DESCRIPTION
[BUGZ-658](https://highfidelity.atlassian.net/browse/BUGZ-658)

The previous PR that fixed this bug was buggy, and I accidentally merged it. Here's a better fix.