### PR TITLE
BUGZ-702: fix crash in btCollisionWorld on shutdown

### DIFF
--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -274,7 +274,9 @@ public slots:
 protected:
     AvatarSharedPointer addAvatar(const QUuid& sessionUUID, const QWeakPointer<Node>& mixerWeakPointer) override;
     DetailedMotionState* createDetailedMotionState(OtherAvatarPointer avatar, int32_t jointIndex);
-    void rebuildAvatarPhysics(PhysicsEngine::Transaction& transaction, OtherAvatarPointer avatar);
+    void rebuildAvatarPhysics(PhysicsEngine::Transaction& transaction, const OtherAvatarPointer& avatar);
+    void removeDetailedAvatarPhysics(PhysicsEngine::Transaction& transaction, const OtherAvatarPointer& avatar);
+    void rebuildDetailedAvatarPhysics(PhysicsEngine::Transaction& transaction, const OtherAvatarPointer& avatar);
 
 private:
     explicit AvatarManager(QObject* parent = 0);

--- a/interface/src/avatar/MyCharacterController.cpp
+++ b/interface/src/avatar/MyCharacterController.cpp
@@ -398,13 +398,11 @@ DetailedMotionState* MyCharacterController::createDetailedMotionStateForJoint(in
 }
 
 void MyCharacterController::clearDetailedMotionStates() {
+    // we don't actually clear the MotionStates here
+    // instead we twiddle some flags as a signal of what to do later
     _pendingFlags |= PENDING_FLAG_REMOVE_DETAILED_FROM_SIMULATION; 
     // We make sure we don't add them again
     _pendingFlags &= ~PENDING_FLAG_ADD_DETAILED_TO_SIMULATION;
-}
-
-void MyCharacterController::resetDetailedMotionStates() {
-    _detailedMotionStates.clear();
 }
 
 void MyCharacterController::buildPhysicsTransaction(PhysicsEngine::Transaction& transaction) {
@@ -416,6 +414,8 @@ void MyCharacterController::buildPhysicsTransaction(PhysicsEngine::Transaction& 
         for (size_t i = 0; i < _detailedMotionStates.size(); i++) {
             transaction.objectsToRemove.push_back(_detailedMotionStates[i]);
         }
+        // NOTE: the DetailedMotionStates are deleted after being added to PhysicsEngine::Transaction::_objectsToRemove
+        // See AvatarManager::handleProcessedPhysicsTransaction()
         _detailedMotionStates.clear();
     }
     if (_pendingFlags & PENDING_FLAG_ADD_DETAILED_TO_SIMULATION) {

--- a/interface/src/avatar/MyCharacterController.h
+++ b/interface/src/avatar/MyCharacterController.h
@@ -48,7 +48,6 @@ public:
     DetailedMotionState* createDetailedMotionStateForJoint(int32_t jointIndex);
     std::vector<DetailedMotionState*>& getDetailedMotionStates() { return _detailedMotionStates; }
     void clearDetailedMotionStates();
-    void resetDetailedMotionStates();
 
     void buildPhysicsTransaction(PhysicsEngine::Transaction& transaction);
 

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -177,7 +177,7 @@ const btCollisionShape* OtherAvatar::createCollisionShape(int32_t jointIndex, bo
     return ObjectMotionState::getShapeManager()->getShape(shapeInfo);
 }
 
-void OtherAvatar::resetDetailedMotionStates() {
+void OtherAvatar::forgetDetailedMotionStates() {
     // NOTE: the DetailedMotionStates are deleted after being added to PhysicsEngine::Transaction::_objectsToRemove
     // See AvatarManager::handleProcessedPhysicsTransaction()
     _detailedMotionStates.clear();
@@ -209,7 +209,7 @@ void OtherAvatar::computeShapeLOD() {
     if (newLOD != _bodyLOD) {
         _bodyLOD = newLOD;
         if (isInPhysicsSimulation()) {
-            _needsReinsertion = true;
+            _needsDetailedRebuild = true;
         }
     }
 }
@@ -224,14 +224,14 @@ bool OtherAvatar::shouldBeInPhysicsSimulation() const {
 
 bool OtherAvatar::needsPhysicsUpdate() const {
     constexpr uint32_t FLAGS_OF_INTEREST = Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS | Simulation::DIRTY_POSITION | Simulation::DIRTY_COLLISION_GROUP;
-    return (_needsReinsertion || (_motionState && (bool)(_motionState->getIncomingDirtyFlags() & FLAGS_OF_INTEREST)));
+    return (_needsDetailedRebuild || (_motionState && (bool)(_motionState->getIncomingDirtyFlags() & FLAGS_OF_INTEREST)));
 }
 
 void OtherAvatar::rebuildCollisionShape() {
     if (_motionState) {
         // do not actually rebuild here, instead flag for later
         _motionState->addDirtyFlags(Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS);
-        _needsReinsertion = true;
+        _needsDetailedRebuild = true;
     }
 }
 

--- a/interface/src/avatar/OtherAvatar.h
+++ b/interface/src/avatar/OtherAvatar.h
@@ -54,7 +54,7 @@ public:
 
     const btCollisionShape* createCollisionShape(int32_t jointIndex, bool& isBound, std::vector<int32_t>& boundJoints);
     std::vector<DetailedMotionState*>& getDetailedMotionStates() { return _detailedMotionStates; }
-    void resetDetailedMotionStates();
+    void forgetDetailedMotionStates();
     BodyLOD getBodyLOD() { return _bodyLOD; }
     void computeShapeLOD();
 
@@ -90,7 +90,7 @@ protected:
     int32_t _spaceIndex { -1 };
     uint8_t _workloadRegion { workload::Region::INVALID };
     BodyLOD _bodyLOD { BodyLOD::Sphere };
-    bool _needsReinsertion { false };
+    bool _needsDetailedRebuild { false };
 };
 
 using OtherAvatarPointer = std::shared_ptr<OtherAvatar>;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-702

This PR fixes a crash on shutdown caused by dangling pointers to `btCollisionObjects` in `btCollisionWorld`.  It also provides a more correct fix for BUGZ-543.

https://highfidelity.atlassian.net/browse/BUGZ-543