### PR TITLE
bugz-709: don't try to create collision shape before compound shape resource is finished loading

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -368,6 +368,10 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& shapeInfo) {
     }
 
     if (type == SHAPE_TYPE_COMPOUND) {
+        if (!_compoundShapeResource || !_compoundShapeResource->isLoaded()) {
+            return;
+        }
+
         updateModelBounds();
 
         // should never fall in here when collision model not fully loaded


### PR DESCRIPTION
- don't try to create collision shape before compound shape resource is finished loading

https://highfidelity.atlassian.net/browse/BUGZ-709
