### PR TITLE
Update jsdoc to avoid breakage with recent node

### DIFF
--- a/tools/jsdoc/package.json
+++ b/tools/jsdoc/package.json
@@ -5,7 +5,7 @@
     "cheerio": "^1.0.0-rc.2",
     "dedent-js": "^1.0.1",
     "htmlclean": "^3.0.8",
-    "jsdoc": "^3.5.5",
+    "jsdoc": "^3.6.2",
     "pretty": "^2.0.0",
     "request": "^2.85.0",
     "rimraf": "^2.6.2"


### PR DESCRIPTION
jsdoc 3.5.5 has a dependency on a version of requizzle which is broken on recent node: https://github.com/hegemonic/requizzle/issues/6, which breaks compilation of interface on Archlinux.

I have only compile tested this change on Archlinux. I don't know if the new jsdoc version breaks anything at runtime.