### PR TITLE
Limit the stats-dump rate on packet error

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -450,13 +450,16 @@ qint64 LimitedNodeList::sendPacket(std::unique_ptr<NLPacket> packet, const HifiS
         auto size = sendUnreliablePacket(*packet, sockAddr, hmacAuth);
         if (size < 0) {
             auto now = usecTimestampNow();
-            eachNode([now](const SharedNodePointer & node) {
-                qCDebug(networking) << "Stats for " << node->getPublicSocket() << "\n"
-                    << "    Last Heard Microstamp: " << node->getLastHeardMicrostamp() << " (" << (now - node->getLastHeardMicrostamp()) << "usec ago)\n"
-                    << "    Outbound Kbps: " << node->getOutboundKbps() << "\n"
-                    << "    Inbound Kbps: " << node->getInboundKbps() << "\n"
-                    << "    Ping: " << node->getPingMs();
-            });
+            if (now - _sendErrorStatsTime > ERROR_STATS_PERIOD_US) {
+                _sendErrorStatsTime = now;
+                eachNode([now](const SharedNodePointer& node) {
+                    qCDebug(networking) << "Stats for " << node->getPublicSocket() << "\n"
+                        << "    Last Heard Microstamp: " << node->getLastHeardMicrostamp() << " (" << (now - node->getLastHeardMicrostamp()) << "usec ago)\n"
+                        << "    Outbound Kbps: " << node->getOutboundKbps() << "\n"
+                        << "    Inbound Kbps: " << node->getInboundKbps() << "\n"
+                        << "    Ping: " << node->getPingMs();
+                });
+            }
         }
         return size;
     }

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -499,7 +499,7 @@ private:
     bool _dropOutgoingNodeTraffic { false };
 
     quint64 _sendErrorStatsTime { (quint64)0 };
-    static const quint64 ERROR_STATS_PERIOD_US { 2 * USECS_PER_SECOND };
+    static const quint64 ERROR_STATS_PERIOD_US { 1 * USECS_PER_SECOND };
 };
 
 #endif // hifi_LimitedNodeList_h

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -497,6 +497,9 @@ private:
     float _outboundKbps { 0.0f };
 
     bool _dropOutgoingNodeTraffic { false };
+
+    quint64 _sendErrorStatsTime { (quint64)0 };
+    static const quint64 ERROR_STATS_PERIOD_US { 2 * USECS_PER_SECOND };
 };
 
 #endif // hifi_LimitedNodeList_h


### PR DESCRIPTION
Dumping stats for all Nodes on every packet-send error is overwhelming some logs, and probably the ACs also. This limits the rate of the dump to a period of 2 s.

https://highfidelity.atlassian.net/browse/BUGZ-743