### PR TITLE
BUGZ-721: nitpick: [mac] preserve symlinks when installing interface.app

### DIFF
--- a/tools/nitpick/src/TestRunnerDesktop.cpp
+++ b/tools/nitpick/src/TestRunnerDesktop.cpp
@@ -265,8 +265,8 @@ void TestRunnerDesktop::runInstaller() {
         folderName += QString(" - ") + getPRNumberFromURL(_url->text());
     }
 
-    script.write((QString("cp -rf \"$VOLUME/") + folderName + "/interface.app\" \"" + _workingFolder + "/High_Fidelity/\"\n").toStdString().c_str());
-    script.write((QString("cp -rf \"$VOLUME/") + folderName + "/Sandbox.app\" \""   + _workingFolder + "/High_Fidelity/\"\n").toStdString().c_str());
+    script.write((QString("cp -Rf \"$VOLUME/") + folderName + "/interface.app\" \"" + _workingFolder + "/High_Fidelity/\"\n").toStdString().c_str());
+    script.write((QString("cp -Rf \"$VOLUME/") + folderName + "/Sandbox.app\" \""   + _workingFolder + "/High_Fidelity/\"\n").toStdString().c_str());
     
     script.write("hdiutil detach \"$VOLUME\"\n");
     script.write("killall yes\n");


### PR DESCRIPTION
This should fix the QtWebEngineProcess dyld crashes that are appearing during nitpick runs, and will make WebEntities work properly during nitpick tests.

on macos -r is not a valid flag.  -R will cause symbolic links to be copied.  Which is necessary for the interface.app to function.