### PR TITLE
BUGZ-402: Don't request an OpenGL 2.0 context via the dock widget

### DIFF
--- a/libraries/ui/src/DockWidget.cpp
+++ b/libraries/ui/src/DockWidget.cpp
@@ -17,6 +17,7 @@
 #include <QtQml/QQmlEngine>
 #include <QtQml/QQmlContext>
 #include <QQuickView>
+#include <gl/GLHelpers.h>
 
 #include <PathUtils.h>
 
@@ -28,6 +29,7 @@ DockWidget::DockWidget(const QString& title, QWidget* parent) : QDockWidget(titl
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
     auto qmlEngine = offscreenUi->getSurfaceContext()->engine();
     _quickView = std::shared_ptr<QQuickView>(new QQuickView(qmlEngine, nullptr), quickViewDeleter);
+    _quickView->setFormat(getDefaultOpenGLSurfaceFormat());
     QWidget* widget = QWidget::createWindowContainer(_quickView.get());
     setWidget(widget);
     QWidget* headerWidget = new QWidget();


### PR DESCRIPTION
[BUGZ-402](https://highfidelity.atlassian.net/browse/BUGZ-402): Ensure we always request an OpenGL 4.5 context even when creating the dock widget `QQuickView`s
