### PR TITLE
BUGZ-512: fix MacOS crash in FakeAudioInputStream on domain-change and shutdown

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2935,8 +2935,10 @@ void Application::initializeGL() {
 
 #if !defined(DISABLE_QML)
     QStringList chromiumFlags;
+    // HACK: re-expose mic and camera to prevent crash on domain-change in chromium's media::FakeAudioInputStream::ReadAudioFromSource()
     // Bug 21993: disable microphone and camera input
-    chromiumFlags << "--use-fake-device-for-media-stream";
+    //chromiumFlags << "--use-fake-device-for-media-stream";
+
     // Disable signed distance field font rendering on ATI/AMD GPUs, due to
     // https://highfidelity.manuscript.com/f/cases/13677/Text-showing-up-white-on-Marketplace-app
     std::string vendor{ (const char*)glGetString(GL_VENDOR) };

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -256,18 +256,28 @@ void EntityTreeRenderer::clear() {
     }
 
     // reset the engine
-    if (_wantScripts && !_shuttingDown) {
-        resetEntitiesScriptEngine();
-    }
-    // remove all entities from the scene
     auto scene = _viewState->getMain3DScene();
-    if (scene) {
-        for (const auto& entry :  _entitiesInScene) {
-            const auto& renderer = entry.second;
-            fadeOutRenderable(renderer);
+    if (_shuttingDown) {
+        if (scene) {
+            render::Transaction transaction;
+            for (const auto& entry :  _entitiesInScene) {
+                const auto& renderer = entry.second;
+                renderer->removeFromScene(scene, transaction);
+            }
+            scene->enqueueTransaction(transaction);
         }
     } else {
-        qCWarning(entitiesrenderer) << "EntitityTreeRenderer::clear(), Unexpected null scene, possibly during application shutdown";
+        if (_wantScripts) {
+            resetEntitiesScriptEngine();
+        }
+        if (scene) {
+            for (const auto& entry :  _entitiesInScene) {
+                const auto& renderer = entry.second;
+                fadeOutRenderable(renderer);
+            }
+        } else {
+            qCWarning(entitiesrenderer) << "EntitityTreeRenderer::clear(), Unexpected null scene";
+        }
     }
     _entitiesInScene.clear();
     _renderablesToUpdate.clear();

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -1066,10 +1066,14 @@ void EntityTreeRenderer::fadeOutRenderable(const EntityRendererPointer& renderab
     render::Transaction transaction;
     auto scene = _viewState->getMain3DScene();
 
-    transaction.setTransitionFinishedOperator(renderable->getRenderItemID(), [scene, renderable]() {
-        render::Transaction transaction;
-        renderable->removeFromScene(scene, transaction);
-        scene->enqueueTransaction(transaction);
+    EntityRendererWeakPointer weakRenderable = renderable;
+    transaction.setTransitionFinishedOperator(renderable->getRenderItemID(), [scene, weakRenderable]() {
+        auto renderable = weakRenderable.lock();
+        if (renderable) {
+            render::Transaction transaction;
+            renderable->removeFromScene(scene, transaction);
+            scene->enqueueTransaction(transaction);
+        }
     });
 
     scene->enqueueTransaction(transaction);


### PR DESCRIPTION
This PR stops putting entity renderables on the fade-out list on shutdown.  This work is what can be salvaged from my failed attempts to understand and fix BUGZ-512.