### PR TITLE
BUGS 665: Audio client crash on timer during shutdown

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2775,7 +2775,6 @@ void Application::cleanupBeforeQuit() {
 
     // destroy Audio so it and its threads have a chance to go down safely
     // this must happen after QML, as there are unexplained audio crashes originating in qtwebengine
-    QMetaObject::invokeMethod(DependencyManager::get<AudioClient>().data(), "stop");
     DependencyManager::destroy<AudioClient>();
     DependencyManager::destroy<AudioScriptingInterface>();
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1,4 +1,4 @@
-//
+tttttt//
 //  AudioClient.cpp
 //  interface/src
 //
@@ -375,6 +375,9 @@ AudioClient::AudioClient() :
 }
 
 AudioClient::~AudioClient() {
+
+    stop();
+
     if (_codec && _encoder) {
         _codec->releaseEncoder(_encoder);
         _encoder = nullptr;

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1,4 +1,4 @@
-tttttt//
+//
 //  AudioClient.cpp
 //  interface/src
 //


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-665

Moving audio client stop call to dtor to ensure its called during shutdown. 

This is one of various stack traces when logging out. Specifically with AudioClient not stopping the peakVolume timers. 

Test case:   
It occurs occasionally on mac shutdown when logging out.

1. Seems to happen on fresh install without a .config and /launcher/content
2. Log in and connect to HQ
3. Log out
4. Rinse and repeat until you crash with Audio thread (crash report will tell specifically what Thread # crashed).
Fail condition for this would be if QAudioDevicesFactory::availableDevices(QAudio::mode); is in the stack
