### PR TITLE
Disable handTouch.js to prevent finger twitching

### DIFF
--- a/interface/resources/qml/AnimStats.qml
+++ b/interface/resources/qml/AnimStats.qml
@@ -54,6 +54,9 @@ Item {
                         text: root.recenterText
                     }
                     StatText {
+                        text: root.overrideJointText
+                    }
+                    StatText {
                         text: "Anim Vars:--------------------------------------------------------------------------------"
                     }
                     ListView {
@@ -99,6 +102,9 @@ Item {
                         text: root.sittingText
                     }
                     StatText {
+                        text: root.flowText
+                    }
+                    StatText {
                         text: "State Machines:---------------------------------------------------------------------------"
                     }
                     ListView {
@@ -130,6 +136,9 @@ Item {
                     }
                     StatText {
                         text: root.walkingText
+                    }
+                    StatText {
+                        text: root.networkGraphText
                     }
                     StatText {
                         text: "Alpha Values:--------------------------------------------------------------------------"

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -6100,6 +6100,30 @@ QVariantList MyAvatar::getCollidingFlowJoints() {
     return result;
 }
 
+int MyAvatar::getOverrideJointCount() const {
+    if (_skeletonModel) {
+        return _skeletonModel->getRig().getOverrideJointCount();
+    } else {
+        return 0;
+    }
+}
+
+bool MyAvatar::getFlowActive() const {
+    if (_skeletonModel) {
+        return _skeletonModel->getRig().getFlowActive();
+    } else {
+        return false;
+    }
+}
+
+bool MyAvatar::getNetworkGraphActive() const {
+    if (_skeletonModel) {
+        return _skeletonModel->getRig().getNetworkGraphActive();
+    } else {
+        return false;
+    }
+}
+
 void MyAvatar::initFlowFromFST() {
     if (_skeletonModel->isLoaded()) {
         auto &flowData = _skeletonModel->getHFMModel().flowData;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1835,6 +1835,10 @@ public:
      */
     Q_INVOKABLE QVariantList getCollidingFlowJoints();
 
+    int getOverrideJointCount() const;
+    bool getFlowActive() const;
+    bool getNetworkGraphActive() const;
+
 public slots:
 
    /**jsdoc

--- a/interface/src/ui/AnimStats.cpp
+++ b/interface/src/ui/AnimStats.cpp
@@ -94,6 +94,21 @@ void AnimStats::updateStats(bool force) {
     }
     emit walkingTextChanged();
 
+    // print current overrideJointText
+    int overrideJointCount = myAvatar->getOverrideJointCount();
+    _overrideJointText = QString("Override Joint Count: %1").arg(overrideJointCount);
+    emit overrideJointTextChanged();
+
+    // print current flowText
+    bool flowActive = myAvatar->getFlowActive();
+    _flowText = QString("Flow: %1").arg(flowActive ? "enabled" : "disabled");
+    emit flowTextChanged();
+
+    // print current networkGraphText
+    bool networkGraphActive = myAvatar->getNetworkGraphActive();
+    _networkGraphText = QString("Network Graph: %1").arg(networkGraphActive ? "enabled" : "disabled");
+    emit networkGraphTextChanged();
+
     // update animation debug alpha values
     QStringList newAnimAlphaValues;
     qint64 now = usecTimestampNow();

--- a/interface/src/ui/AnimStats.h
+++ b/interface/src/ui/AnimStats.h
@@ -25,6 +25,9 @@ class AnimStats : public QQuickItem {
     Q_PROPERTY(QString recenterText READ recenterText NOTIFY recenterTextChanged)
     Q_PROPERTY(QString sittingText READ sittingText NOTIFY sittingTextChanged)
     Q_PROPERTY(QString walkingText READ walkingText NOTIFY walkingTextChanged)
+    Q_PROPERTY(QString overrideJointText READ overrideJointText NOTIFY overrideJointTextChanged)
+    Q_PROPERTY(QString flowText READ flowText NOTIFY flowTextChanged)
+    Q_PROPERTY(QString networkGraphText READ networkGraphText NOTIFY networkGraphTextChanged)
 
 public:
     static AnimStats* getInstance();
@@ -43,6 +46,9 @@ public:
     QString recenterText() const { return _recenterText; }
     QString sittingText() const { return _sittingText; }
     QString walkingText() const { return _walkingText; }
+    QString overrideJointText() const { return _overrideJointText; }
+    QString flowText() const { return _flowText; }
+    QString networkGraphText() const { return _networkGraphText; }
 
 public slots:
     void forceUpdateStats() { updateStats(true); }
@@ -58,6 +64,9 @@ signals:
     void recenterTextChanged();
     void sittingTextChanged();
     void walkingTextChanged();
+    void overrideJointTextChanged();
+    void flowTextChanged();
+    void networkGraphTextChanged();
 
 private:
     QStringList _animAlphaValues;
@@ -76,6 +85,9 @@ private:
     QString _recenterText;
     QString _sittingText;
     QString _walkingText;
+    QString _overrideJointText;
+    QString _flowText;
+    QString _networkGraphText;
 };
 
 #endif // hifi_AnimStats_h

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -2025,6 +2025,9 @@ void Rig::updateFromControllerParameters(const ControllerParameters& params, flo
     if (params.isTalking) {
         if (_talkIdleInterpTime < 1.0f) {
             _talkIdleInterpTime += dt / TOTAL_EASE_IN_TIME;
+            if (_talkIdleInterpTime > 1.0f) {
+                _talkIdleInterpTime = 1.0f;
+            }
             float easeOutInValue = _talkIdleInterpTime < 0.5f ? 4.0f * powf(_talkIdleInterpTime, 3.0f) : 4.0f * powf((_talkIdleInterpTime - 1.0f), 3.0f) + 1.0f;
             _animVars.set("idleOverlayAlpha", easeOutInValue);
         } else {
@@ -2033,6 +2036,9 @@ void Rig::updateFromControllerParameters(const ControllerParameters& params, flo
     } else {
         if (_talkIdleInterpTime < 1.0f) {
             _talkIdleInterpTime += dt / TOTAL_EASE_OUT_TIME;
+            if (_talkIdleInterpTime > 1.0f) {
+                _talkIdleInterpTime = 1.0f;
+            }
             float easeOutInValue = _talkIdleInterpTime < 0.5f ? 4.0f * powf(_talkIdleInterpTime, 3.0f) : 4.0f * powf((_talkIdleInterpTime - 1.0f), 3.0f) + 1.0f;
             float talkAlpha = 1.0f - easeOutInValue;
             _animVars.set("idleOverlayAlpha", talkAlpha);
@@ -2285,6 +2291,24 @@ void Rig::buildAbsoluteRigPoses(const AnimPoseVec& relativePoses, AnimPoseVec& a
             absolutePosesOut[i] = absolutePosesOut[parentIndex] * relativePoses[i];
         }
     }
+}
+
+int Rig::getOverrideJointCount() const {
+    int count = 0;
+    for (size_t i = 0; i < _internalPoseSet._overrideFlags.size(); i++) {
+        if (_internalPoseSet._overrideFlags[i]) {
+            count++;
+        }
+    }
+    return count;
+}
+
+bool Rig::getFlowActive() const {
+    return _internalFlow.getActive();
+}
+
+bool Rig::getNetworkGraphActive() const {
+    return _sendNetworkNode;
 }
 
 glm::mat4 Rig::getJointTransform(int jointIndex) const {

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -246,6 +246,10 @@ public:
     float getUnscaledEyeHeight() const;
     void buildAbsoluteRigPoses(const AnimPoseVec& relativePoses, AnimPoseVec& absolutePosesOut) const;
 
+    int getOverrideJointCount() const;
+    bool getFlowActive() const;
+    bool getNetworkGraphActive() const;
+
 signals:
     void onLoadComplete();
 

--- a/scripts/simplifiedUI/system/controllers/handTouch.js
+++ b/scripts/simplifiedUI/system/controllers/handTouch.js
@@ -17,7 +17,8 @@
 (function () {
 
     var LEAP_MOTION_NAME = "LeapMotion";
-    var handTouchEnabled = true;
+    // Hand touch is disabled due to twitchy finger bug when walking near walls or tables. see BUGZ-154.
+    var handTouchEnabled = false;
     var leapMotionEnabled = Controller.getRunningInputDeviceNames().indexOf(LEAP_MOTION_NAME) >= 0;
     var MSECONDS_AFTER_LOAD = 2000;
     var updateFingerWithIndex = 0;

--- a/scripts/system/controllers/handTouch.js
+++ b/scripts/system/controllers/handTouch.js
@@ -17,7 +17,8 @@
 (function () {
 
     var LEAP_MOTION_NAME = "LeapMotion";
-    var handTouchEnabled = true;
+    // Hand touch is disabled due to twitchy finger bug when walking near walls or tables. see BUGZ-154.
+    var handTouchEnabled = false;
     var leapMotionEnabled = Controller.getRunningInputDeviceNames().indexOf(LEAP_MOTION_NAME) >= 0;
     var MSECONDS_AFTER_LOAD = 2000;
     var updateFingerWithIndex = 0;


### PR DESCRIPTION
This PR disables handTouch.js. The handTouch.js script allows the fingers to animate on the surface of an object. However, it can sometimes detect collisions with walls or tables when the avatar is standing next to them. We will more properly fix handTouch.js in a future PR, but for now we will disable the functionality.

Secondly, a small bug fix was made to the Rig to prevent the idleOverlayAlpha from exceeding the 0.0 to 1.0 range. This can cause the fingers to bend incorrectly for a moment.

Also, three new items were added to the Developer > Show Animation Stats panel.

* Joint Override Count: displays the current count of joints that are overriden by MyAvatar.setJointRotation() JS API calls.
* Flow: displays if flow is active of disabled.
* Network Graph: displays if the network anim graph, used for teleportation, is enabled or disabled.

https://highfidelity.atlassian.net/browse/BUGZ-154