### PR TITLE
BUGZ-771: Prevent duplicates from accumulating in EntityTree::_needsParentFixup

### DIFF
--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -2121,15 +2121,27 @@ void EntityTree::fixupNeedsParentFixups() {
         _needsParentFixup.clear();
     }
 
+    std::unordered_set<QUuid> seenEntityIds;
     QMutableVectorIterator<EntityItemWeakPointer> iter(entitiesToFixup);
     while (iter.hasNext()) {
-        EntityItemWeakPointer entityWP = iter.next();
+        const auto& entityWP = iter.next();
         EntityItemPointer entity = entityWP.lock();
         if (!entity) {
             // entity was deleted before we found its parent
             iter.remove();
             continue;
         }
+
+        const auto id = entity->getID();
+        // BUGZ-771 some entities seem to never be removed by the below logic and further seem to accumulate dupes within the _needsParentFixup list
+        // This block ensures that duplicates are removed from entitiesToFixup before it's re-appended to _needsParentFixup
+        if (0 != seenEntityIds.count(id)) {
+            // Entity was duplicated inside entitiesToFixup
+            iter.remove();
+            continue;
+        }
+
+        seenEntityIds.insert(id);
 
         entity->requiresRecalcBoxes();
         bool queryAACubeSuccess { false };


### PR DESCRIPTION
[BUGZ-771](https://highfidelity.atlassian.net/browse/BUGZ-771): Over time in the hifiqa-master domain with many bots running the game loop appears drop, while the simulation times goes up.  Tracing localized this behavior to a longer and longer runtime in the `EntityTree::fixupNeedsParentFixups` method.  Further customization of the function with additional tracing eventually identified that there are some entities that never get eliminated from the list of candidates to be fixed up (stored in `_needsParentFixup`).  Additionally, adding counters to the function revealed that in fact there are only a tiny number of such entities, perhaps only one, but that it can be added over and over again to the `_needsParentFixup` container.  With no condition for it's removal and repeated additions over time, the iteration takes longer and longer over time, thus causing the game rate to fall.

Ideally we should determine what this entity is and why it never gets processed, but an easy fix for now is to ensure that while iterating over the list, we keep track of entity IDs we've already seen and remove them from the list if we encounter them again within the same loop.  This means that `_needsParentFixup` won't continuously grow full of duplicates over time, thus preventing the slowdown.  