### PR TITLE
BUGZ-712 potential fix for crash in NLPacket::localHeaderSize()

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -629,7 +629,7 @@ bool DomainServer::isPacketVerified(const udt::Packet& packet) {
         DomainGatekeeper::sendProtocolMismatchConnectionDenial(packet.getSenderSockAddr());
     }
 
-    if (!PacketTypeEnum::getNonSourcedPackets().contains(headerType)) {
+    if (!PacketTypeEnum::isNonSourcedPacketType(headerType)) {
         // this is a sourced packet - first check if we have a node that matches
         Node::LocalID localSourceID = NLPacket::sourceIDInHeader(packet);
         SharedNodePointer sourceNode = nodeList->nodeWithLocalID(localSourceID);

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -245,7 +245,7 @@ bool LimitedNodeList::packetVersionMatch(const udt::Packet& packet) {
         const HifiSockAddr& senderSockAddr = packet.getSenderSockAddr();
         QUuid sourceID;
 
-        if (PacketTypeEnum::getNonSourcedPackets().contains(headerType)) {
+        if (PacketTypeEnum::isNonSourcedPacketType(headerType)) {
             hasBeenOutput = versionDebugSuppressMap.contains(senderSockAddr, headerType);
 
             if (!hasBeenOutput) {
@@ -284,7 +284,7 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
 
     PacketType headerType = NLPacket::typeInHeader(packet);
 
-    if (PacketTypeEnum::getNonSourcedPackets().contains(headerType)) {
+    if (PacketTypeEnum::isNonSourcedPacketType(headerType)) {
         if (PacketTypeEnum::getReplicatedPacketMapping().key(headerType) != PacketType::Unknown) {
             // this is a replicated packet type - make sure the socket that sent it to us matches
             // one from one of our current upstream nodes
@@ -329,14 +329,14 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
             !isDomainServer() &&
             sourceLocalID == getDomainLocalID() &&
             packet.getSenderSockAddr() == getDomainSockAddr() &&
-            PacketTypeEnum::getDomainSourcedPackets().contains(headerType)) {
+            PacketTypeEnum::isDomainSourcedPacketType(headerType)) {
             // This is a packet sourced by the domain server
             return true;
         }
 
         if (sourceNode) {
-            bool verifiedPacket = !PacketTypeEnum::getNonVerifiedPackets().contains(headerType);
-            bool verificationEnabled = !(isDomainServer() && PacketTypeEnum::getDomainIgnoredVerificationPackets().contains(headerType))
+            bool verifiedPacket = !PacketTypeEnum::isNonVerifiedPacketType(headerType);
+            bool verificationEnabled = !(isDomainServer() && PacketTypeEnum::isDomainIgnoredVerificationPacketType(headerType))
                 && _useAuthentication;
 
             if (verifiedPacket && verificationEnabled) {
@@ -380,13 +380,13 @@ bool LimitedNodeList::packetSourceAndHashMatchAndTrackBandwidth(const udt::Packe
 }
 
 void LimitedNodeList::fillPacketHeader(const NLPacket& packet, HMACAuth* hmacAuth) {
-    if (!PacketTypeEnum::getNonSourcedPackets().contains(packet.getType())) {
+    if (!PacketTypeEnum::isNonSourcedPacketType(packet.getType())) {
         packet.writeSourceID(getSessionLocalID());
     }
 
     if (_useAuthentication && hmacAuth
-        && !PacketTypeEnum::getNonSourcedPackets().contains(packet.getType())
-        && !PacketTypeEnum::getNonVerifiedPackets().contains(packet.getType())) {
+        && !PacketTypeEnum::isNonSourcedPacketType(packet.getType())
+        && !PacketTypeEnum::isNonVerifiedPacketType(packet.getType())) {
         packet.writeVerificationHash(*hmacAuth);
     }
 }

--- a/libraries/networking/src/PacketReceiver.cpp
+++ b/libraries/networking/src/PacketReceiver.cpp
@@ -32,7 +32,7 @@ bool PacketReceiver::registerListenerForTypes(PacketTypeList types, QObject* lis
     
     // Partition types based on whether they are sourced or not (non sourced in front)
     auto middle = std::partition(std::begin(types), std::end(types), [](PacketType type) {
-        return PacketTypeEnum::getNonSourcedPackets().contains(type);
+        return PacketTypeEnum::isNonSourcedPacketType(type);
     });
     
     QMetaMethod nonSourcedMethod, sourcedMethod;
@@ -123,7 +123,7 @@ QMetaMethod PacketReceiver::matchingMethodForListener(PacketType type, QObject* 
         SIGNATURE_TEMPLATE.arg(slot, NON_SOURCED_MESSAGE_LISTENER_PARAMETERS)
     };
 
-    if (!PacketTypeEnum::getNonSourcedPackets().contains(type)) {
+    if (!PacketTypeEnum::isNonSourcedPacketType(type)) {
         static const QString SOURCED_MESSAGE_LISTENER_PARAMETERS = "QSharedPointer<ReceivedMessage>,QSharedPointer<Node>";
         static const QString TYPEDEF_SOURCED_MESSAGE_LISTENER_PARAMETERS = "QSharedPointer<ReceivedMessage>,SharedNodePointer";
 

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -151,58 +151,83 @@ public:
         return REPLICATED_PACKET_MAPPING;
     }
 
-    const static QSet<PacketTypeEnum::Value> getNonVerifiedPackets() {
-        const static QSet<PacketTypeEnum::Value> NON_VERIFIED_PACKETS = QSet<PacketTypeEnum::Value>()
-            << PacketTypeEnum::Value::NodeJsonStats
-            << PacketTypeEnum::Value::EntityQuery
-            << PacketTypeEnum::Value::OctreeDataNack
-            << PacketTypeEnum::Value::EntityEditNack
-            << PacketTypeEnum::Value::DomainListRequest
-            << PacketTypeEnum::Value::StopNode
-            << PacketTypeEnum::Value::DomainDisconnectRequest
-            << PacketTypeEnum::Value::UsernameFromIDRequest
-            << PacketTypeEnum::Value::NodeKickRequest
-            << PacketTypeEnum::Value::NodeMuteRequest;
-        return NON_VERIFIED_PACKETS;
+    static bool isNonVerifiedPacketType(PacketTypeEnum::Value type) {
+        switch (type) {
+            case PacketTypeEnum::Value::NodeJsonStats:
+            case PacketTypeEnum::Value::EntityQuery:
+            case PacketTypeEnum::Value::OctreeDataNack:
+            case PacketTypeEnum::Value::EntityEditNack:
+            case PacketTypeEnum::Value::DomainListRequest:
+            case PacketTypeEnum::Value::StopNode:
+            case PacketTypeEnum::Value::DomainDisconnectRequest:
+            case PacketTypeEnum::Value::UsernameFromIDRequest:
+            case PacketTypeEnum::Value::NodeKickRequest:
+            case PacketTypeEnum::Value::NodeMuteRequest:
+                return true;
+        }
+        return false;
     }
 
-    const static QSet<PacketTypeEnum::Value> getNonSourcedPackets() {
-        const static QSet<PacketTypeEnum::Value> NON_SOURCED_PACKETS = QSet<PacketTypeEnum::Value>()
-            << PacketTypeEnum::Value::StunResponse << PacketTypeEnum::Value::CreateAssignment
-            << PacketTypeEnum::Value::RequestAssignment << PacketTypeEnum::Value::DomainServerRequireDTLS
-            << PacketTypeEnum::Value::DomainConnectRequest << PacketTypeEnum::Value::DomainList
-            << PacketTypeEnum::Value::DomainConnectionDenied << PacketTypeEnum::Value::DomainServerPathQuery
-            << PacketTypeEnum::Value::DomainServerPathResponse << PacketTypeEnum::Value::DomainServerAddedNode
-            << PacketTypeEnum::Value::DomainServerConnectionToken << PacketTypeEnum::Value::DomainSettingsRequest
-            << PacketTypeEnum::Value::OctreeDataFileRequest << PacketTypeEnum::Value::OctreeDataFileReply
-            << PacketTypeEnum::Value::OctreeDataPersist << PacketTypeEnum::Value::DomainContentReplacementFromUrl
-            << PacketTypeEnum::Value::DomainSettings << PacketTypeEnum::Value::ICEServerPeerInformation
-            << PacketTypeEnum::Value::ICEServerQuery << PacketTypeEnum::Value::ICEServerHeartbeat
-            << PacketTypeEnum::Value::ICEServerHeartbeatACK << PacketTypeEnum::Value::ICEPing
-            << PacketTypeEnum::Value::ICEPingReply << PacketTypeEnum::Value::ICEServerHeartbeatDenied
-            << PacketTypeEnum::Value::AssignmentClientStatus << PacketTypeEnum::Value::StopNode
-            << PacketTypeEnum::Value::DomainServerRemovedNode << PacketTypeEnum::Value::UsernameFromIDReply
-            << PacketTypeEnum::Value::OctreeFileReplacement << PacketTypeEnum::Value::ReplicatedMicrophoneAudioNoEcho
-            << PacketTypeEnum::Value::ReplicatedMicrophoneAudioWithEcho << PacketTypeEnum::Value::ReplicatedInjectAudio
-            << PacketTypeEnum::Value::ReplicatedSilentAudioFrame << PacketTypeEnum::Value::ReplicatedAvatarIdentity
-            << PacketTypeEnum::Value::ReplicatedKillAvatar << PacketTypeEnum::Value::ReplicatedBulkAvatarData;
-        return NON_SOURCED_PACKETS;
+    static bool isNonSourcedPacketType(PacketTypeEnum::Value type) {
+        switch (type) {
+            case PacketTypeEnum::Value::StunResponse:
+            case PacketTypeEnum::Value::CreateAssignment:
+            case PacketTypeEnum::Value::RequestAssignment:
+            case PacketTypeEnum::Value::DomainServerRequireDTLS:
+            case PacketTypeEnum::Value::DomainConnectRequest:
+            case PacketTypeEnum::Value::DomainList:
+            case PacketTypeEnum::Value::DomainConnectionDenied:
+            case PacketTypeEnum::Value::DomainServerPathQuery:
+            case PacketTypeEnum::Value::DomainServerPathResponse:
+            case PacketTypeEnum::Value::DomainServerAddedNode:
+            case PacketTypeEnum::Value::DomainServerConnectionToken:
+            case PacketTypeEnum::Value::DomainSettingsRequest:
+            case PacketTypeEnum::Value::OctreeDataFileRequest:
+            case PacketTypeEnum::Value::OctreeDataFileReply:
+            case PacketTypeEnum::Value::OctreeDataPersist:
+            case PacketTypeEnum::Value::DomainContentReplacementFromUrl:
+            case PacketTypeEnum::Value::DomainSettings:
+            case PacketTypeEnum::Value::ICEServerPeerInformation:
+            case PacketTypeEnum::Value::ICEServerQuery:
+            case PacketTypeEnum::Value::ICEServerHeartbeat:
+            case PacketTypeEnum::Value::ICEServerHeartbeatACK:
+            case PacketTypeEnum::Value::ICEPing:
+            case PacketTypeEnum::Value::ICEPingReply:
+            case PacketTypeEnum::Value::ICEServerHeartbeatDenied:
+            case PacketTypeEnum::Value::AssignmentClientStatus:
+            case PacketTypeEnum::Value::StopNode:
+            case PacketTypeEnum::Value::DomainServerRemovedNode:
+            case PacketTypeEnum::Value::UsernameFromIDReply:
+            case PacketTypeEnum::Value::OctreeFileReplacement:
+            case PacketTypeEnum::Value::ReplicatedMicrophoneAudioNoEcho:
+            case PacketTypeEnum::Value::ReplicatedMicrophoneAudioWithEcho:
+            case PacketTypeEnum::Value::ReplicatedInjectAudio:
+            case PacketTypeEnum::Value::ReplicatedSilentAudioFrame:
+            case PacketTypeEnum::Value::ReplicatedAvatarIdentity:
+            case PacketTypeEnum::Value::ReplicatedKillAvatar:
+            case PacketTypeEnum::Value::ReplicatedBulkAvatarData:
+                return true;
+        }
+        return false;
     }
 
-    const static QSet<PacketTypeEnum::Value> getDomainSourcedPackets() {
-        const static QSet<PacketTypeEnum::Value> DOMAIN_SOURCED_PACKETS = QSet<PacketTypeEnum::Value>()
-            << PacketTypeEnum::Value::AssetMappingOperation
-            << PacketTypeEnum::Value::AssetGet
-            << PacketTypeEnum::Value::AssetUpload;
-        return DOMAIN_SOURCED_PACKETS;
+    static bool isDomainSourcedPacketType(PacketTypeEnum::Value type) {
+        switch (type) {
+            case PacketTypeEnum::Value::AssetMappingOperation:
+            case PacketTypeEnum::Value::AssetGet:
+                return true;
+        }
+        return false;
     }
 
-    const static QSet<PacketTypeEnum::Value> getDomainIgnoredVerificationPackets() {
-        const static QSet<PacketTypeEnum::Value> DOMAIN_IGNORED_VERIFICATION_PACKETS = QSet<PacketTypeEnum::Value>()
-            << PacketTypeEnum::Value::AssetMappingOperationReply
-            << PacketTypeEnum::Value::AssetGetReply
-            << PacketTypeEnum::Value::AssetUploadReply;
-        return DOMAIN_IGNORED_VERIFICATION_PACKETS;
+    static bool isDomainIgnoredVerificationPacketType(PacketTypeEnum::Value type) {
+        switch (type) {
+            case PacketTypeEnum::Value::AssetMappingOperationReply:
+            case PacketTypeEnum::Value::AssetGetReply:
+            case PacketTypeEnum::Value::AssetUploadReply:
+                return true;
+        }
+        return false;
     }
 };
 

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -164,6 +164,8 @@ public:
             case PacketTypeEnum::Value::NodeKickRequest:
             case PacketTypeEnum::Value::NodeMuteRequest:
                 return true;
+            default:
+                break;
         }
         return false;
     }
@@ -207,6 +209,8 @@ public:
             case PacketTypeEnum::Value::ReplicatedKillAvatar:
             case PacketTypeEnum::Value::ReplicatedBulkAvatarData:
                 return true;
+            default:
+                break;
         }
         return false;
     }
@@ -217,6 +221,8 @@ public:
             case PacketTypeEnum::Value::AssetGet:
             case PacketTypeEnum::Value::AssetUpload:
                 return true;
+            default:
+                break;
         }
         return false;
     }
@@ -227,6 +233,8 @@ public:
             case PacketTypeEnum::Value::AssetGetReply:
             case PacketTypeEnum::Value::AssetUploadReply:
                 return true;
+            default:
+                break;
         }
         return false;
     }

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -215,6 +215,7 @@ public:
         switch (type) {
             case PacketTypeEnum::Value::AssetMappingOperation:
             case PacketTypeEnum::Value::AssetGet:
+            case PacketTypeEnum::Value::AssetUpload:
                 return true;
         }
         return false;


### PR DESCRIPTION
This PR uses a `switch` rather than `QSet<>::contains()` to answer the question: "Is this enum value in such-and-such group or not?"  If the callstack on the BUGZ-712 crash mode is to be believed then I would expect this to fix it.

https://highfidelity.atlassian.net/browse/BUGZ-712