### PR TITLE
[BUGZ 798] :: updated lifetime

### DIFF
--- a/scripts/simplifiedUI/ui/simplifiedNametag/resources/modules/nameTagListManager.js
+++ b/scripts/simplifiedUI/ui/simplifiedNametag/resources/modules/nameTagListManager.js
@@ -19,7 +19,8 @@ var HALF = 0.5;
 var CLEAR_ENTITY_EDIT_PROPS = true;
 var MILISECONDS_IN_SECOND = 1000;
 var SECONDS_IN_MINUTE = 60;
-var ALWAYS_ON_MAX_LIFETIME_IN_SECONDS = 20 * SECONDS_IN_MINUTE; // Delete after 20 minutes in case a nametag is hanging around in on mode 
+// Delete after 5 minutes in case a nametag is hanging around in on mode 
+var ALWAYS_ON_MAX_LIFETIME_IN_SECONDS = 5 * SECONDS_IN_MINUTE;
 
 // *************************************
 // START UTILTY
@@ -376,6 +377,11 @@ function maybeAddOrRemoveIntervalCheck() {
                 if (avatar && avatarNametagMode === "alwaysOn" && !(avatar in _this.avatars) && avatarDistance < MAX_RADIUS_IGNORE_METERS) {
                     add(avatar);
                     return;
+                }
+                if (avatar in _this.avatars) {
+                    var entity = _this.avatars[avatar].nametag;
+                    var age = entity.get("age");
+                    entity.edit('lifetime', age + ALWAYS_ON_MAX_LIFETIME_IN_SECONDS);
                 }
                 if (avatarDistance > MAX_RADIUS_IGNORE_METERS) {
                     maybeRemove(avatar);


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-798

Testplan: 
Nametags on always on will delete after 5 minutes on default.  This is in case something happens where it doesn't delete for one side effect or another in the engine.  

If you are in front of someone with always on nametags and they stay up for longer than 5 minutes, then it is working.  