### PR TITLE
Fix ScriptEngines::loadScript invoke call

### DIFF
--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -461,7 +461,8 @@ ScriptEnginePointer ScriptEngines::loadScript(const QUrl& scriptFilename, bool i
             Q_ARG(bool, isUserLoaded),
             Q_ARG(bool, loadScriptFromEditor),
             Q_ARG(bool, activateMainWindow),
-            Q_ARG(bool, reload));
+            Q_ARG(bool, reload),
+            Q_ARG(bool, quitWhenFinished));
         return result;
     }
     QUrl scriptUrl;


### PR DESCRIPTION
`quitWhenFinished` parameter wasn't being used

Test plan:
- In the console, run `ScriptDiscoveryService.loadScript("https://gist.githubusercontent.com/SamGondelman/b9fe3cec613e1b644e779e4f64207865/raw/7ac88ccc794a90681cea0be7071585185f74f5bb/QuitWhenFinished.js", true, false, false, false, true);`
- Interface should close cleanly.

https://highfidelity.atlassian.net/browse/BUGZ-1007