### PR TITLE
BUGZ-828: Color banding showing up in recent builds

### DIFF
--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -174,6 +174,10 @@ float HmdDisplayPlugin::getLeftCenterPixel() const {
     return leftCenterPixel;
 }
 
+gpu::PipelinePointer HmdDisplayPlugin::getRenderTexturePipeline() {
+    return _SRGBToLinearPipeline;
+}
+
 void HmdDisplayPlugin::internalPresent() {
     PROFILE_RANGE_EX(render, __FUNCTION__, 0xff00ff00, (uint64_t)presentCount())
 

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.h
@@ -51,6 +51,8 @@ public:
     std::function<void(gpu::Batch&, const gpu::TexturePointer&, bool mirror)> getHUDOperator() override;
     virtual StencilMaskMode getStencilMaskMode() const override { return StencilMaskMode::PAINT; }
 
+    virtual gpu::PipelinePointer getRenderTexturePipeline() override;
+
 signals:
     void hmdMountedChanged();
     void hmdVisibleChanged(bool visible);

--- a/plugins/oculus/src/OculusDisplayPlugin.cpp
+++ b/plugins/oculus/src/OculusDisplayPlugin.cpp
@@ -124,15 +124,6 @@ void OculusDisplayPlugin::uncustomizeContext() {
     Parent::uncustomizeContext();
 }
 
-gpu::PipelinePointer OculusDisplayPlugin::getRenderTexturePipeline() {
-    //return _SRGBToLinearPipeline;
-    return _drawTexturePipeline;
-}
-
-gpu::PipelinePointer OculusDisplayPlugin::getCompositeScenePipeline() {
-    return _SRGBToLinearPipeline;
-}
-
 static const uint64_t FRAME_BUDGET = (11 * USECS_PER_MSEC);
 static const uint64_t FRAME_OVER_BUDGET = (15 * USECS_PER_MSEC);
 
@@ -172,7 +163,7 @@ void OculusDisplayPlugin::hmdPresent() {
             batch.setStateScissorRect(ivec4(uvec2(), _outputFramebuffer->getSize()));
             batch.resetViewTransform();
             batch.setProjectionTransform(mat4());
-            batch.setPipeline(_drawTexturePipeline);
+            batch.setPipeline(_SRGBToLinearPipeline);
             batch.setResourceTexture(0, _compositeFramebuffer->getRenderBuffer(0));
             batch.draw(gpu::TRIANGLE_STRIP, 4);
         });

--- a/plugins/oculus/src/OculusDisplayPlugin.h
+++ b/plugins/oculus/src/OculusDisplayPlugin.h
@@ -24,9 +24,6 @@ public:
 
     virtual QJsonObject getHardwareStats() const;
 
-    virtual gpu::PipelinePointer getRenderTexturePipeline() override;
-    virtual gpu::PipelinePointer getCompositeScenePipeline() override;
-
 protected:
     QThread::Priority getPresentPriority() override { return QThread::TimeCriticalPriority; }
 


### PR DESCRIPTION
My PR #15815 got rid of the color banding on desktop that PR #15797 accidentally introduced, but I also noticed a similar issue in the Rift hmd display and the Rift desktop preview. I've fixed that in this PR.

I will be messing a lot with the display plugins in the next few days for BUGZ-850, but I wanted to push this fix for the Rift stuff so it's not broken while I work on the more deep-seated issues.