### PR TITLE
BUGZ-787: fix SafeLanding to load correct set of objects before enabling physics simulation

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6937,8 +6937,9 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType) {
         bool interstitialModeEnabled = DependencyManager::get<NodeList>()->getDomainHandler().getInterstitialModeEnabled();
 
         ConicalViewFrustum sphericalView;
-        sphericalView.set(_viewFrustum);
-        sphericalView.setSimpleRadius(INITIAL_QUERY_RADIUS);
+        AABox box = getMyAvatar()->getGlobalBoundingBox();
+        float radius = glm::max(INITIAL_QUERY_RADIUS, 0.5f * glm::length(box.getDimensions()));
+        sphericalView.setPositionAndSimpleRadius(box.calcCenter(), radius);
 
         if (interstitialModeEnabled) {
             ConicalViewFrustum farView;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1376,6 +1376,13 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     connect(myAvatar.get(), &MyAvatar::positionGoneTo,
         DependencyManager::get<AddressManager>().data(), &AddressManager::storeCurrentAddress);
 
+    connect(myAvatar.get(), &MyAvatar::positionGoneTo, this, [this] {
+        if (!_physicsEnabled) {
+            // when we arrive somewhere without physics enabled --> startSafeLanding
+            _octreeProcessor.startSafeLanding();
+        }
+    }, Qt::QueuedConnection);
+
     connect(myAvatar.get(), &MyAvatar::skeletonModelURLChanged, [](){
         QUrl avatarURL = qApp->getMyAvatar()->getSkeletonModelURL();
         setCrashAnnotation("avatar", avatarURL.toString().toStdString());
@@ -5931,9 +5938,7 @@ void Application::resetPhysicsReadyInformation() {
     _gpuTextureMemSizeStabilityCount = 0;
     _gpuTextureMemSizeAtLastCheck = 0;
     _physicsEnabled = false;
-    _octreeProcessor.startSafeLanding();
 }
-
 
 void Application::reloadResourceCaches() {
     resetPhysicsReadyInformation();
@@ -6932,6 +6937,7 @@ void Application::queryOctree(NodeType_t serverType, PacketType packetType) {
         bool interstitialModeEnabled = DependencyManager::get<NodeList>()->getDomainHandler().getInterstitialModeEnabled();
 
         ConicalViewFrustum sphericalView;
+        sphericalView.set(_viewFrustum);
         sphericalView.setSimpleRadius(INITIAL_QUERY_RADIUS);
 
         if (interstitialModeEnabled) {

--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -91,9 +91,7 @@ void SafeLanding::finishSequence(int first, int last) {
 
 void SafeLanding::addToSequence(int sequenceNumber) {
     Locker lock(_lock);
-    if (_trackingEntities) {
-        _sequenceNumbers.insert(sequenceNumber);
-    }
+    _sequenceNumbers.insert(sequenceNumber);
 }
 
 void SafeLanding::updateTracking() {

--- a/libraries/shared/src/shared/ConicalViewFrustum.cpp
+++ b/libraries/shared/src/shared/ConicalViewFrustum.cpp
@@ -145,7 +145,8 @@ int ConicalViewFrustum::deserialize(const unsigned char* sourceBuffer) {
     return sourceBuffer - startPosition;
 }
 
-void ConicalViewFrustum::setSimpleRadius(float radius) {
+void ConicalViewFrustum::setPositionAndSimpleRadius(const glm::vec3& position, float radius) {
+    _position = position;
     _radius = radius;
     _farClip = radius / 2.0f;
 }

--- a/libraries/shared/src/shared/ConicalViewFrustum.h
+++ b/libraries/shared/src/shared/ConicalViewFrustum.h
@@ -55,7 +55,7 @@ public:
     int deserialize(const unsigned char* sourceBuffer);
 
     // Just test for within radius.
-    void setSimpleRadius(float radius);
+    void setPositionAndSimpleRadius(const glm::vec3& position, float radius);
 
 private:
     glm::vec3 _position { 0.0f, 0.0f, 0.0f };


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-787

This PR fixes a problem where the `SafeLanding` logic would sometimes incorrectly allow `MyAvatar` to fall through the floor.