### PR TITLE
BUGZ-894: Propagate a Node's public address change, part 2

### DIFF
--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -754,6 +754,7 @@ SharedNodePointer LimitedNodeList::addOrUpdateNode(const QUuid& uuid, NodeType_t
     connect(newNodePointer.data(), &NetworkPeer::socketUpdated, this, [this, weakPtr] {
         emit nodeSocketUpdated(weakPtr);
     });
+    connect(newNodePointer.data(), &NetworkPeer::socketUpdated, &_nodeSocket, &udt::Socket::handleRemoteAddressChange);
 
     return newNodePointer;
 }

--- a/libraries/networking/src/udt/Socket.h
+++ b/libraries/networking/src/udt/Socket.h
@@ -99,14 +99,14 @@ signals:
 public slots:
     void cleanupConnection(HifiSockAddr sockAddr);
     void clearConnections();
-    
+    void handleRemoteAddressChange(HifiSockAddr previousAddress, HifiSockAddr currentAddress);
+
 private slots:
     void readPendingDatagrams();
     void checkForReadyReadBackup();
 
     void handleSocketError(QAbstractSocket::SocketError socketError);
     void handleStateChanged(QAbstractSocket::SocketState socketState);
-    void handleRemoteAddressChange(HifiSockAddr previousAddress, HifiSockAddr currentAddress);
 
 private:
     void setSystemBufferSizes();


### PR DESCRIPTION
Ticket: https://highfidelity.atlassian.net/browse/BUGZ-894
Relates to: https://highfidelity.atlassian.net/browse/BUGZ-762

The previous PR for BUGZ-762 missed part of the signal-chain for notifying the reliable connection class of the remote address chain. This PR rectifies that.
