### PR TITLE
Fix for DependencyManager crash on shutdown on Mac

### DIFF
--- a/libraries/baking/src/MaterialBaker.cpp
+++ b/libraries/baking/src/MaterialBaker.cpp
@@ -72,7 +72,7 @@ void MaterialBaker::loadMaterial() {
         _materialResource->parsedMaterials = NetworkMaterialResource::parseJSONMaterials(QJsonDocument::fromJson(_materialData.toUtf8()), QUrl());
     } else {
         qCDebug(material_baking) << "Downloading material" << _materialData;
-        _materialResource = MaterialCache::instance().getMaterial(_materialData);
+        _materialResource = DependencyManager::get<MaterialCache>()->getMaterial(_materialData);
     }
 
     if (_materialResource) {

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -172,7 +172,7 @@ void MaterialEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPo
         }
 
         if (urlChanged && !usingMaterialData) {
-            _networkMaterial = MaterialCache::instance().getMaterial(_materialURL);
+            _networkMaterial = DependencyManager::get<MaterialCache>()->getMaterial(_materialURL);
             auto onMaterialRequestFinished = [this, oldParentID, oldParentMaterialName, newCurrentMaterialName](bool success) {
                 if (success) {
                     deleteMaterial(oldParentID, oldParentMaterialName);

--- a/libraries/material-networking/src/material-networking/MaterialCache.cpp
+++ b/libraries/material-networking/src/material-networking/MaterialCache.cpp
@@ -441,11 +441,6 @@ std::pair<std::string, std::shared_ptr<NetworkMaterial>> NetworkMaterialResource
     return std::pair<std::string, std::shared_ptr<NetworkMaterial>>(name, material);
 }
 
-MaterialCache& MaterialCache::instance() {
-    static MaterialCache _instance;
-    return _instance;
-}
-
 NetworkMaterialResourcePointer MaterialCache::getMaterial(const QUrl& url) {
     return ResourceCache::getResource(url).staticCast<NetworkMaterialResource>();
 }

--- a/libraries/material-networking/src/material-networking/MaterialCache.h
+++ b/libraries/material-networking/src/material-networking/MaterialCache.h
@@ -110,10 +110,11 @@ using NetworkMaterialResourcePointer = QSharedPointer<NetworkMaterialResource>;
 using MaterialMapping = std::vector<std::pair<std::string, NetworkMaterialResourcePointer>>;
 Q_DECLARE_METATYPE(MaterialMapping)
 
-class MaterialCache : public ResourceCache {
-public:
-    static MaterialCache& instance();
+class MaterialCache : public ResourceCache, public Dependency {
+    Q_OBJECT
+    SINGLETON_DEPENDENCY
 
+public:
     NetworkMaterialResourcePointer getMaterial(const QUrl& url);
 
 protected:

--- a/libraries/model-baker/src/model-baker/ParseMaterialMappingTask.cpp
+++ b/libraries/model-baker/src/model-baker/ParseMaterialMappingTask.cpp
@@ -61,7 +61,7 @@ void processMaterialMapping(MaterialMapping& materialMapping, const QJsonObject&
         } else if (mappingJSON.isString()) {
             auto mappingValue = mappingJSON.toString();
             materialMapping.push_back(std::pair<std::string, NetworkMaterialResourcePointer>(mapping.toStdString(),
-                                                                MaterialCache::instance().getMaterial(url.resolved(mappingValue))));
+                DependencyManager::get<MaterialCache>()->getMaterial(url.resolved(mappingValue))));
         }
     }
 }

--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -92,6 +92,7 @@ const QString DOUBLE_SLASH_SUBSTITUTE = "slashslash";
 const QString ACCOUNT_MANAGER_REQUESTED_SCOPE = "owner";
 
 void AccountManager::logout() {
+
     // a logout means we want to delete the DataServerAccountInfo we currently have for this URL, in-memory and in file
     _accountInfo = DataServerAccountInfo();
 


### PR DESCRIPTION
On Mac, it is possible to crash when shutting down, it is not clear if this is due to shutting down the app on another thread during logout or something that can happen during normal shutdown, because it is so difficult to reproduce.

However, from looking at the stack traces it is possible for a `-[NSApplication terminate:]` event to get processed while `Appliction::aboutToQuit()` is calling `ScriptEngine::waitTillDoneRunning()`. This causes AppKit to invoke the static destructors too early. Which in turn, causes the DependencyManager destructor to fire while there are still many dependencies running. Unfortunately, the order of destruction is not deterministic, causing them to get shutdown in an incorrect order, and call deep into Qt during destruction.

To workaround this, we delay the call to `QCoreApplication::processEvents()` as late as possible, in the Application destructor. Theoretically, this will be a safe time for the static destructors to be invoked, because it is after all of the DependencyManager's dependencies have been manually destroyed.

However, this is only a speculative fix, because this is so difficult to reproduce.

https://highfidelity.atlassian.net/browse/BUGZ-712
https://highfidelity.atlassian.net/browse/BUGZ-619