### PR TITLE
case BUGZ-103: HMD Mouse rendering

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1345,9 +1345,22 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     connect(this, &QCoreApplication::aboutToQuit, addressManager.data(), &AddressManager::storeCurrentAddress);
 
     connect(this, &Application::activeDisplayPluginChanged, this, &Application::updateThreadPoolCount);
-    connect(this, &Application::activeDisplayPluginChanged, this, [](){
+    connect(this, &Application::activeDisplayPluginChanged, this, [=](){
         qApp->setProperty(hifi::properties::HMD, qApp->isHMDMode());
         auto displayPlugin = qApp->getActiveDisplayPlugin();
+
+        if (displayPlugin->isHmd()) {
+            if (_preferredCursor.get() == Cursor::Manager::getIconName(Cursor::Icon::RETICLE)) {
+                setPreferredCursor(Cursor::Manager::getIconName(Cursor::Icon::RETICLE));
+            }
+            else {
+                setPreferredCursor(Cursor::Manager::getIconName(Cursor::Icon::ARROW));
+            }
+        }
+        else {
+            setPreferredCursor(Cursor::Manager::getIconName(Cursor::Icon::SYSTEM));
+        }
+
         setCrashAnnotation("display_plugin", displayPlugin->getName().toStdString());
         setCrashAnnotation("hmd", displayPlugin->isHmd() ? "1" : "0");
     });


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-103

Because hmd has no system mouse, forcing to use arrow on active display plugin change.  This bug was caused by switching from default mouse to system mouse due to eco mode causing mouse trails.  

Test case:

1. Reset the app. 
2.  App should start in hmd mode without preview
3. Put on your hmd and look for the mouse. Please note that the mouse position math can get really wonky at Y =1 or Y=0 values. (it will orbit the Y axis instead of follow your path).  
4. Move the mouse around a bunch until you see the cursor, it might be anywhere the first time you use it. Sometimes takes a bit of work to find it.
5. Take off your hmd and make sure your system mouse now works normal.
6. Put on the hmd again and make sure the cursor renders. Again you might have to hunt it down.  
