### PR TITLE
Removed secondary camera tone mapping compensation

### DIFF
--- a/interface/src/ui/Snapshot.cpp
+++ b/interface/src/ui/Snapshot.cpp
@@ -143,10 +143,6 @@ void Snapshot::save360Snapshot(const glm::vec3& cameraPosition,
         secondaryCameraRenderConfig->enableSecondaryCameraRenderConfigs(true);
     }
 
-    // Initialize some secondary camera render config options for 360 snapshot capture
-    static_cast<ToneMappingConfig*>(qApp->getRenderEngine()->getConfiguration()->getConfig("SecondaryCameraJob.ToneMapping"))
-        ->setCurve(0);
-
     secondaryCameraRenderConfig->resetSizeSpectatorCamera(static_cast<int>(CUBEMAP_SIDE_PIXEL_DIMENSION),
                                                           static_cast<int>(CUBEMAP_SIDE_PIXEL_DIMENSION));
     secondaryCameraRenderConfig->setProperty("attachedEntityId", "");
@@ -209,7 +205,6 @@ void Snapshot::takeNextSnapshot() {
 
         // Reset secondary camera render config
         SecondaryCameraJobConfig* config = static_cast<SecondaryCameraJobConfig*>(qApp->getRenderEngine()->getConfiguration()->getConfig("SecondaryCamera"));
-        static_cast<ToneMappingConfig*>(qApp->getRenderEngine()->getConfiguration()->getConfig("SecondaryCameraJob.ToneMapping"))->setCurve(1);
         config->resetSizeSpectatorCamera(qApp->getWindow()->geometry().width(), qApp->getWindow()->geometry().height());
         config->setProperty("attachedEntityId", _oldAttachedEntityId);
         config->setProperty("vFoV", _oldvFoV);


### PR DESCRIPTION
Similar to my PR #432 on highfidelity/hifi-content and PR #417 on highfidelity/hifi_tests. Removes compensation for the secondary camera being too light, an issue I fixed in PR #15862. In this repo, we were only doing this when a 360 screenshot was taken.