### PR TITLE
Build openvr plugin on linux

### DIFF
--- a/BUILD_LINUX.md
+++ b/BUILD_LINUX.md
@@ -100,19 +100,19 @@ cd hifi/build
 
 Prepare makefiles:
 ```bash
-cmake ..
+cmake -DBUILD_SHARED_LIBS=ON ..
 ```
 
 *  If cmake fails with a vcpkg error - delete /tmp/hifi/vcpkg.  
 
 Start compilation of the server and get a cup of coffee:
 ```bash
-make domain-server assignment-client
+make -j$(nproc) domain-server assignment-client
 ```
 
 To compile interface:
 ```bash
-make interface
+make -j$(nproc) interface
 ```
 
 In a server, it does not make sense to compile interface

--- a/cmake/ports/hifi-client-deps/CONTROL
+++ b/cmake/ports/hifi-client-deps/CONTROL
@@ -1,4 +1,4 @@
 Source: hifi-client-deps
 Version: 0
 Description: Collected dependencies for High Fidelity applications
-Build-Depends: hifi-deps, glslang, nlohmann-json, openvr (windows), sdl2 (!android), spirv-cross (!android), spirv-tools (!android), vulkanmemoryallocator
+Build-Depends: hifi-deps, glslang, nlohmann-json, openvr (windows), openvr (linux), sdl2 (!android), spirv-cross (!android), spirv-tools (!android), vulkanmemoryallocator

--- a/cmake/ports/openvr/portfile.cmake
+++ b/cmake/ports/openvr/portfile.cmake
@@ -11,15 +11,23 @@ vcpkg_from_github(
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
-    set(ARCH_PATH "win64")
+    if(UNIX)
+        set(ARCH_PATH "linux64")
+    else()
+        set(ARCH_PATH "win64")
+    endif()
 elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-    set(ARCH_PATH "win32")
+    if(UNIX)
+        set(ARCH_PATH "linux32")
+    else()
+        set(ARCH_PATH "win32")
+    endif()
 else()
-    message(FATAL_ERROR "Package only supports x64 and x86 windows.")
+    message(FATAL_ERROR "Package only supports x64 and x86.")
 endif()
 
-if(VCPKG_CMAKE_SYSTEM_NAME)
-    message(FATAL_ERROR "Package only supports windows desktop.")
+if(VCPKG_CMAKE_SYSTEM_NAME AND NOT UNIX)
+    message(FATAL_ERROR "Package only supports windows and linux desktop.")
 endif()
 
 file(MAKE_DIRECTORY
@@ -28,18 +36,33 @@ file(MAKE_DIRECTORY
     ${CURRENT_PACKAGES_DIR}/debug/lib
     ${CURRENT_PACKAGES_DIR}/debug/bin
 )
-file(COPY ${SOURCE_PATH}/lib/${ARCH_PATH}/openvr_api.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
-file(COPY ${SOURCE_PATH}/lib/${ARCH_PATH}/openvr_api.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
-file(COPY
-    ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.dll
-    ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.pdb
-    DESTINATION ${CURRENT_PACKAGES_DIR}/bin
-)
-file(COPY
-    ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.dll
-    ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.pdb
-    DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
-)
+if(UNIX)
+    file(COPY ${SOURCE_PATH}/lib/${ARCH_PATH}/libopenvr_api.so DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+    file(COPY ${SOURCE_PATH}/lib/${ARCH_PATH}/libopenvr_api.so DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+    file(COPY
+        ${SOURCE_PATH}/bin/${ARCH_PATH}/libopenvr_api.so
+        ${SOURCE_PATH}/bin/${ARCH_PATH}/libopenvr_api.so.dbg
+        DESTINATION ${CURRENT_PACKAGES_DIR}/bin
+    )
+    file(COPY
+        ${SOURCE_PATH}/bin/${ARCH_PATH}/libopenvr_api.so
+        ${SOURCE_PATH}/bin/${ARCH_PATH}/libopenvr_api.so.dbg
+        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
+    )
+else()
+    file(COPY ${SOURCE_PATH}/lib/${ARCH_PATH}/openvr_api.lib DESTINATION ${CURRENT_PACKAGES_DIR}/lib)
+    file(COPY ${SOURCE_PATH}/lib/${ARCH_PATH}/openvr_api.lib DESTINATION ${CURRENT_PACKAGES_DIR}/debug/lib)
+    file(COPY
+        ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.dll
+        ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.pdb
+        DESTINATION ${CURRENT_PACKAGES_DIR}/bin
+    )
+    file(COPY
+        ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.dll
+        ${SOURCE_PATH}/bin/${ARCH_PATH}/openvr_api.pdb
+        DESTINATION ${CURRENT_PACKAGES_DIR}/debug/bin
+    )
+endif()
 file(COPY ${SOURCE_PATH}/headers DESTINATION ${CURRENT_PACKAGES_DIR})
 file(RENAME ${CURRENT_PACKAGES_DIR}/headers ${CURRENT_PACKAGES_DIR}/include)
 

--- a/plugins/openvr/CMakeLists.txt
+++ b/plugins/openvr/CMakeLists.txt
@@ -6,7 +6,7 @@
 #  See the accompanying file LICENSE or http:#www.apache.org/licenses/LICENSE-2.0.html
 #
 
-if (WIN32 AND (NOT USE_GLES))
+if ((WIN32 OR UNIX) AND (NOT USE_GLES))
     set(TARGET_NAME openvr)
     setup_hifi_plugin(Gui Qml Multimedia)
     link_hifi_libraries(shared task gl qml networking controllers ui 
@@ -15,5 +15,7 @@ if (WIN32 AND (NOT USE_GLES))
     include_hifi_library_headers(octree)
 
     target_openvr()
-    target_link_libraries(${TARGET_NAME} Winmm.lib)
+    if (WIN32)
+        target_link_libraries(${TARGET_NAME} Winmm.lib)
+    endif()
 endif()

--- a/plugins/openvr/CMakeLists.txt
+++ b/plugins/openvr/CMakeLists.txt
@@ -6,7 +6,7 @@
 #  See the accompanying file LICENSE or http:#www.apache.org/licenses/LICENSE-2.0.html
 #
 
-if ((WIN32 OR UNIX) AND (NOT USE_GLES))
+if ((WIN32 OR (CMAKE_SYSTEM_NAME MATCHES "Linux")) AND (NOT USE_GLES))
     set(TARGET_NAME openvr)
     setup_hifi_plugin(Gui Qml Multimedia)
     link_hifi_libraries(shared task gl qml networking controllers ui 

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -726,6 +726,7 @@ int OpenVrDisplayPlugin::getRequiredThreadCount() const {
 }
 
 QString OpenVrDisplayPlugin::getPreferredAudioInDevice() const {
+#if defined(Q_OS_WIN32)
     QString device = getVrSettingString(vr::k_pch_audio_Section, vr::k_pch_audio_OnPlaybackDevice_String);
     if (!device.isEmpty()) {
         static const WCHAR INIT = 0;
@@ -736,9 +737,13 @@ QString OpenVrDisplayPlugin::getPreferredAudioInDevice() const {
         device = AudioClient::getWinDeviceName(deviceW.data());
     }
     return device;
+#else
+    return QString();
+#endif
 }
 
 QString OpenVrDisplayPlugin::getPreferredAudioOutDevice() const {
+#if defined(Q_OS_WIN32)
     QString device = getVrSettingString(vr::k_pch_audio_Section, vr::k_pch_audio_OnRecordDevice_String);
     if (!device.isEmpty()) {
         static const WCHAR INIT = 0;
@@ -749,6 +754,9 @@ QString OpenVrDisplayPlugin::getPreferredAudioOutDevice() const {
         device = AudioClient::getWinDeviceName(deviceW.data());
     }
     return device;
+#else
+    return QString();
+#endif
 }
 
 QRectF OpenVrDisplayPlugin::getPlayAreaRect() {

--- a/plugins/openvr/src/OpenVrHelpers.h
+++ b/plugins/openvr/src/OpenVrHelpers.h
@@ -76,7 +76,7 @@ struct PoseData {
     }
 
     void update(const glm::mat4& resetMat) {
-        for (int i = 0; i < vr::k_unMaxTrackedDeviceCount; i++) {
+        for (uint32_t i = 0; i < vr::k_unMaxTrackedDeviceCount; i++) {
             if (!vrPoses[i].bPoseIsValid) {
                 continue;
             }
@@ -87,7 +87,7 @@ struct PoseData {
     }
 
     void resetToInvalid() {
-        for (int i = 0; i < vr::k_unMaxTrackedDeviceCount; i++) {
+        for (uint32_t i = 0; i < vr::k_unMaxTrackedDeviceCount; i++) {
             vrPoses[i].bPoseIsValid = false;
         }
     }

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -34,7 +34,7 @@
 #include <plugins/DisplayPlugin.h>
 
 #include <controllers/UserInputMapper.h>
-#include <Plugins/InputConfiguration.h>
+#include <plugins/InputConfiguration.h>
 #include <controllers/StandardControls.h>
 
 extern PoseData _nextSimPoseData;
@@ -984,11 +984,11 @@ void ViveControllerManager::InputDevice::printDeviceTrackingResultChange(uint32_
 }
 
 bool ViveControllerManager::InputDevice::checkForCalibrationEvent() {
-    auto& endOfMap = _buttonPressedMap.end();
-    auto& leftTrigger = _buttonPressedMap.find(controller::LT);
-    auto& rightTrigger = _buttonPressedMap.find(controller::RT);
-    auto& leftAppButton = _buttonPressedMap.find(LEFT_APP_MENU);
-    auto& rightAppButton = _buttonPressedMap.find(RIGHT_APP_MENU);
+    auto endOfMap = _buttonPressedMap.end();
+    auto leftTrigger = _buttonPressedMap.find(controller::LT);
+    auto rightTrigger = _buttonPressedMap.find(controller::RT);
+    auto leftAppButton = _buttonPressedMap.find(LEFT_APP_MENU);
+    auto rightAppButton = _buttonPressedMap.find(RIGHT_APP_MENU);
     return ((leftTrigger != endOfMap && leftAppButton != endOfMap) && (rightTrigger != endOfMap && rightAppButton != endOfMap));
 }
 

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -52,7 +52,7 @@ public:
     bool activate() override;
     void deactivate() override;
 
-    QString getDeviceName() { return QString::fromStdString(_inputDevice->_headsetName); }
+    QString getDeviceName() override { return QString::fromStdString(_inputDevice->_headsetName); }
 
     void pluginFocusOutEvent() override { _inputDevice->focusOutEvent(); }
     void pluginUpdate(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;


### PR DESCRIPTION
This fixes compiling issues and disables windows specific code in the openvr plugin with a linux target, and adds support to the openvr vcpkg for linux #10098 . Modified build instruction as solution for #15826 and to build faster.

The vcpkg CONTROL files while they support '&' for triplets they do not support '|'. I verified this in their source code. So 'openvr (windows|linux)' would not work, instead it worked to just have both 'openvr (windows), openvr (linux)'.
