### PR TITLE
BUGZ-874: Don't shut down launcher's splash screen until interface's window is shown

### DIFF
--- a/launchers/win32/LauncherApp.cpp
+++ b/launchers/win32/LauncherApp.cpp
@@ -34,7 +34,7 @@ CLauncherApp theApp;
 BOOL CLauncherApp::InitInstance() {
     // Close interface if is running
     int interfacePID = -1;
-    if (LauncherUtils::IsProcessRunning(L"interface.exe", interfacePID)) {
+    if (LauncherUtils::isProcessRunning(L"interface.exe", interfacePID)) {
         LauncherUtils::shutdownProcess(interfacePID, 0);
     }
     int iNumOfArgs;

--- a/launchers/win32/LauncherDlg.cpp
+++ b/launchers/win32/LauncherDlg.cpp
@@ -629,8 +629,7 @@ void CLauncherDlg::OnTimer(UINT_PTR nIDEvent) {
                         ::SetForegroundWindow(_applicationWND);
                         ::SetActiveWindow(_applicationWND);
                     }
-                    int interfacePID = -1;
-                    if (LauncherUtils::IsProcessRunning(L"interface.exe", interfacePID)) {
+                    if (LauncherUtils::isProcessWindowOpened(L"interface.exe")) {
                         exit(0);
                     }
                 }
@@ -654,8 +653,7 @@ void CLauncherDlg::OnTimer(UINT_PTR nIDEvent) {
             }
             _splashStep++;
         } else if (theApp._manager.shouldShutDown()) {
-            int interfacePID = -1;
-            if (LauncherUtils::IsProcessRunning(L"interface.exe", interfacePID)) {
+            if (LauncherUtils::isProcessWindowOpened(L"interface.exe")) {
                 exit(0);
             }
         }

--- a/launchers/win32/LauncherManager.cpp
+++ b/launchers/win32/LauncherManager.cpp
@@ -111,7 +111,7 @@ BOOL LauncherManager::installLauncher() {
             // Kill of running before self-copy
             addToLog(_T("Installing Launcher."));
             int launcherPID = -1;
-            if (LauncherUtils::IsProcessRunning(LAUNCHER_EXE_FILENAME, launcherPID)) {
+            if (LauncherUtils::isProcessRunning(LAUNCHER_EXE_FILENAME, launcherPID)) {
                 if (!LauncherUtils::shutdownProcess(launcherPID, 0)) {
                     addToLog(_T("Error shutting down the Launcher"));
                 }
@@ -151,7 +151,7 @@ BOOL LauncherManager::createShortcuts() {
     CString installDir;
     getAndCreatePaths(PathType::Launcher_Directory, installDir);
     CString installPath = installDir + LAUNCHER_EXE_FILENAME;
-    if (!LauncherUtils::CreateLink(installPath, (LPCSTR)CStringA(desktopLnkPath), _T("CLick to Setup and Launch HQ."))) {
+    if (!LauncherUtils::createLink(installPath, (LPCSTR)CStringA(desktopLnkPath), _T("CLick to Setup and Launch HQ."))) {
         return FALSE;
     }
     CString startLinkPath;
@@ -159,13 +159,13 @@ BOOL LauncherManager::createShortcuts() {
     CString appStartLinkPath = startLinkPath + _T("HQ Launcher.lnk");
     CString uniStartLinkPath = startLinkPath + _T("Uninstall HQ.lnk");
     CString uniLinkPath = installDir + _T("Uninstall HQ.lnk");
-    if (!LauncherUtils::CreateLink(installPath, (LPCSTR)CStringA(appStartLinkPath), _T("CLick to Setup and Launch HQ."))) {
+    if (!LauncherUtils::createLink(installPath, (LPCSTR)CStringA(appStartLinkPath), _T("CLick to Setup and Launch HQ."))) {
         return FALSE;
     }
-    if (!LauncherUtils::CreateLink(installPath, (LPCSTR)CStringA(uniStartLinkPath), _T("CLick to Uninstall HQ."), _T("--uninstall"))) {
+    if (!LauncherUtils::createLink(installPath, (LPCSTR)CStringA(uniStartLinkPath), _T("CLick to Uninstall HQ."), _T("--uninstall"))) {
         return FALSE;
     }
-    if (!LauncherUtils::CreateLink(installPath, (LPCSTR)CStringA(uniLinkPath), _T("CLick to Uninstall HQ."), _T("--uninstall"))) {
+    if (!LauncherUtils::createLink(installPath, (LPCSTR)CStringA(uniLinkPath), _T("CLick to Uninstall HQ."), _T("--uninstall"))) {
         return FALSE;
     }
     return TRUE;

--- a/launchers/win32/LauncherUtils.cpp
+++ b/launchers/win32/LauncherUtils.cpp
@@ -49,13 +49,36 @@ BOOL LauncherUtils::shutdownProcess(DWORD dwProcessId, UINT uExitCode) {
     return result;
 }
 
-BOOL LauncherUtils::IsProcessRunning(const wchar_t *processName, int& processID) {
+BOOL CALLBACK LauncherUtils::isWindowOpenedCallback(HWND hWnd, LPARAM lparam) {
+    ProcessData* processData = reinterpret_cast<ProcessData*>(lparam);
+    if (processData) {
+        DWORD idptr;
+        GetWindowThreadProcessId(hWnd, &idptr);
+        if (idptr && (int)(idptr) == processData->processID) {
+            processData->isOpened = IsWindowVisible(hWnd);
+            return FALSE;
+        }
+    }
+    return TRUE;
+}
+
+BOOL LauncherUtils::isProcessWindowOpened(const wchar_t *processName) {
+    ProcessData processData;
+    BOOL result = isProcessRunning(processName, processData.processID);
+    if (result) {
+        EnumWindows(LauncherUtils::isWindowOpenedCallback, reinterpret_cast<LPARAM>(&processData));
+        return processData.isOpened;
+    }
+    return result;
+}
+
+BOOL LauncherUtils::isProcessRunning(const wchar_t *processName, int& processID) {
     bool exists = false;
     PROCESSENTRY32 entry;
     entry.dwSize = sizeof(PROCESSENTRY32);
 
     HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, NULL);
-
+    
     if (Process32First(snapshot, &entry)) {
         while (Process32Next(snapshot, &entry)) {
             if (!_wcsicmp(entry.szExeFile, processName)) {
@@ -69,7 +92,7 @@ BOOL LauncherUtils::IsProcessRunning(const wchar_t *processName, int& processID)
     return exists;
 }
 
-HRESULT LauncherUtils::CreateLink(LPCWSTR lpszPathObj, LPCSTR lpszPathLink, LPCWSTR lpszDesc, LPCWSTR lpszArgs) {
+HRESULT LauncherUtils::createLink(LPCWSTR lpszPathObj, LPCSTR lpszPathLink, LPCWSTR lpszDesc, LPCWSTR lpszArgs) {
     IShellLink* psl;
 
     // Get a pointer to the IShellLink interface. It is assumed that CoInitialize

--- a/launchers/win32/LauncherUtils.h
+++ b/launchers/win32/LauncherUtils.h
@@ -66,6 +66,11 @@ public:
         void setCallback(std::function<void(int)> fn) { callback = std::bind(fn, std::placeholders::_1); }
     };
 
+    struct ProcessData {
+        int processID = -1;
+        BOOL isOpened = FALSE;
+    };
+
     static BOOL parseJSON(const CString& jsonTxt, Json::Value& jsonObject);
     static ResponseError makeHTTPCall(const CString& callerName, const CString& mainUrl,
         const CString& dirUrl, const CString& contentType,
@@ -73,12 +78,14 @@ public:
     static std::string cStringToStd(CString cstring);
     static BOOL getFont(const CString& fontName, int fontSize, bool isBold, CFont& fontOut);
     static BOOL launchApplication(LPCWSTR lpApplicationName, LPTSTR cmdArgs = _T(""));
-    static BOOL IsProcessRunning(const wchar_t *processName, int& processID);
+    static BOOL CALLBACK isWindowOpenedCallback(HWND hWnd, LPARAM lparam);
+    static BOOL isProcessRunning(const wchar_t *processName, int& processID);
+    static BOOL isProcessWindowOpened(const wchar_t *processName);
     static BOOL shutdownProcess(DWORD dwProcessId, UINT uExitCode);
     static BOOL insertRegistryKey(const std::string& regPath, const std::string& name, const std::string& value);
     static BOOL insertRegistryKey(const std::string& regPath, const std::string& name, DWORD value);
     static BOOL deleteFileOrDirectory(const CString& dirPath, bool noRecycleBin = true);
-    static HRESULT CreateLink(LPCWSTR lpszPathObj, LPCSTR lpszPathLink, LPCWSTR lpszDesc, LPCWSTR lpszArgs = _T(""));
+    static HRESULT createLink(LPCWSTR lpszPathObj, LPCSTR lpszPathLink, LPCWSTR lpszDesc, LPCWSTR lpszArgs = _T(""));
     static BOOL hMac256(const CString& message, const char* key, CString& hashOut);
     static uint64_t extractZip(const std::string& zipFile, const std::string& path, std::vector<std::string>& files);
     static BOOL deleteRegistryKey(const CString& registryPath);


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-874

The windows launcher now waits for interface's window to be visible before it shuts down.