### PR TITLE
BUGZ-926: use the correct gl format when creating the initial platform window

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1465,6 +1465,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         _saveAvatarOverrideUrl = true;
     }
 
+    // setDefaultFormat has no effect after the platform window has been created, so call it here.
+    QSurfaceFormat::setDefaultFormat(getDefaultOpenGLSurfaceFormat());
+
     _glWidget = new GLCanvas();
     getApplicationCompositor().setRenderingWidget(_glWidget);
     _window->setCentralWidget(_glWidget);


### PR DESCRIPTION
- use the correct gl format when creating the initial platform window

This doesn't require much testing.  If interface still launches on each platform, it should be enough.


https://highfidelity.atlassian.net/browse/BUGZ-926