### PR TITLE
BUGZ-768: Keep config.json when updating to avoid relogin.

### DIFF
--- a/launchers/win32/LauncherDlg.cpp
+++ b/launchers/win32/LauncherDlg.cpp
@@ -174,19 +174,11 @@ void CLauncherDlg::startProcess() {
         theApp._manager.addToLog(_T("Starting Process Setup"));
         setDrawDialog(DrawStep::DrawProcessSetup);
     }
-    theApp._manager.addToLog(_T("Deleting directories before install"));
-
-    CString installDir;
-    theApp._manager.getAndCreatePaths(LauncherManager::PathType::Interface_Directory, installDir);
+    theApp._manager.addToLog(_T("Deleting download directory"));
     CString downloadDir;
     theApp._manager.getAndCreatePaths(LauncherManager::PathType::Download_Directory, downloadDir);
-
-    LauncherUtils::deleteDirectoriesOnThread(installDir, downloadDir, [&](int error) {
-        LauncherUtils::DeleteDirError deleteError = (LauncherUtils::DeleteDirError)error;
-        switch(error) { 
-        case LauncherUtils::DeleteDirError::NoErrorDeleting:
-            theApp._manager.addToLog(_T("Install directory deleted."));
-            theApp._manager.addToLog(_T("Downloads directory deleted."));
+    LauncherUtils::deleteDirectoryOnThread(downloadDir, [&](bool error) {
+        if (!error) {
             if (!theApp._manager.isLoggedIn()) {
                 theApp._manager.addToLog(_T("Downloading Content"));
                 theApp._manager.downloadContent();
@@ -194,23 +186,12 @@ void CLauncherDlg::startProcess() {
                 theApp._manager.addToLog(_T("Downloading App"));
                 theApp._manager.downloadApplication();
             }
-            break;
-        case LauncherUtils::DeleteDirError::ErrorDeletingBothDirs:
-            theApp._manager.addToLog(_T("Error deleting directories."));
-            break;
-        case LauncherUtils::DeleteDirError::ErrorDeletingApplicationDir:
-            theApp._manager.addToLog(_T("Error deleting application directory."));
-            break;
-        case LauncherUtils::DeleteDirError::ErrorDeletingDownloadsDir:
-            theApp._manager.addToLog(_T("Error deleting downloads directory."));
-            break;
-        default:
-            break;
-        }
-        if (error != LauncherUtils::DeleteDirError::NoErrorDeleting) {
+        } else {
+            theApp._manager.addToLog(_T("Error deleting download directory."));
             theApp._manager.setFailed(true);
         }
     });
+
 }
 
 BOOL CLauncherDlg::getHQInfo(const CString& orgname) {

--- a/launchers/win32/LauncherUtils.h
+++ b/launchers/win32/LauncherUtils.h
@@ -30,13 +30,6 @@ public:
         NoError
     };
 
-    enum DeleteDirError {
-        NoErrorDeleting = 0,
-        ErrorDeletingApplicationDir,
-        ErrorDeletingDownloadsDir,
-        ErrorDeletingBothDirs
-    };
-
     struct DownloadThreadData {
         int _type;
         CString _url;
@@ -60,10 +53,9 @@ public:
     };
 
     struct DeleteThreadData {
-        CString _applicationDir;
-        CString _downloadsDir;
-        std::function<void(int)> callback;
-        void setCallback(std::function<void(int)> fn) { callback = std::bind(fn, std::placeholders::_1); }
+        CString _dirPath;
+        std::function<void(bool)> callback;
+        void setCallback(std::function<void(bool)> fn) { callback = std::bind(fn, std::placeholders::_1); }
     };
 
     struct ProcessData {
@@ -91,9 +83,7 @@ public:
     static BOOL deleteRegistryKey(const CString& registryPath);
     static BOOL unzipFileOnThread(int type, const std::string& zipFile, const std::string& path, std::function<void(int, int)> callback);
     static BOOL downloadFileOnThread(int type, const CString& url, const CString& file, std::function<void(int, bool)> callback);
-    static BOOL deleteDirectoriesOnThread(const CString& applicationDir,
-                                              const CString& downloadsDir,
-                                              std::function<void(int)> callback);
+    static BOOL deleteDirectoryOnThread(const CString& dirPath, std::function<void(bool)> callback);
     static CString urlEncodeString(const CString& url);
     static HWND executeOnForeground(const CString& path, const CString& params);
 
@@ -101,5 +91,5 @@ private:
     // Threads
     static DWORD WINAPI unzipThread(LPVOID lpParameter);
     static DWORD WINAPI downloadThread(LPVOID lpParameter);
-    static DWORD WINAPI deleteDirectoriesThread(LPVOID lpParameter);
+    static DWORD WINAPI deleteDirectoryThread(LPVOID lpParameter);
 };


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-768
This PR force the launcher to keep a copy of the config.json file with the information about a user being logged or not.
This avoid the need of re-adding credentials after aborting the update process. 