### PR TITLE
Case bugz-907: On launch default to non hmd device

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5435,7 +5435,6 @@ void Application::loadSettings() {
             isFirstPerson = (qApp->isHMDMode());
         } else {
             // if this is not the first run, the camera will be initialized differently depending on user settings
-
             if (qApp->isHMDMode()) {
                 // if the HMD is active, use first-person camera, unless the appropriate setting is checked
                 isFirstPerson = menu->isOptionChecked(MenuOption::FirstPersonHMD);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5418,8 +5418,7 @@ void Application::loadSettings() {
             }
         }
         isFirstPerson = (qApp->isHMDMode());
-    }
-    else {
+    } else {
         if (_firstRun.get()) {
             // If this is our first run, and no preferred devices were set, default to
             // an HMD device if available.
@@ -5434,15 +5433,13 @@ void Application::loadSettings() {
                 }
             }
             isFirstPerson = (qApp->isHMDMode());
-        }
-        else {
+        } else {
             // if this is not the first run, the camera will be initialized differently depending on user settings
 
             if (qApp->isHMDMode()) {
                 // if the HMD is active, use first-person camera, unless the appropriate setting is checked
                 isFirstPerson = menu->isOptionChecked(MenuOption::FirstPersonHMD);
-            }
-            else {
+            } else {
                 // if HMD is not active, only use first person if the menu option is checked
                 isFirstPerson = menu->isOptionChecked(MenuOption::FirstPerson);
             }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -8903,7 +8903,7 @@ void Application::updateDisplayMode() {
             // Menu might have been removed if the display plugin lost
             if (!action) {
                 continue;
-            } 
+            }
             if (action->isChecked()) {
                 newDisplayPlugin = displayPlugin;
                 break;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5409,9 +5409,10 @@ void Application::loadSettings() {
     if (_firstRun.get()) {
         // If this is our first run, and no preferred devices were set, default to
         // an HMD device if available.
+        // Based on feedback changing to non hmd device as default if not prefered
         auto displayPlugins = pluginManager->getDisplayPlugins();
         for (auto& plugin : displayPlugins) {
-            if (plugin->isHmd()) {
+            if (!plugin->isHmd()) {
                 if (auto action = menu->getActionForOption(plugin->getName())) {
                     action->setChecked(true);
                     action->trigger();
@@ -8891,7 +8892,7 @@ void Application::updateDisplayMode() {
             // Menu might have been removed if the display plugin lost
             if (!action) {
                 continue;
-            }
+            } //STOPPED HERE>>>>> HOW DO WE FIND OUT HOW THE ACTION->isChecked is set
             if (action->isChecked()) {
                 newDisplayPlugin = displayPlugin;
                 break;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5406,10 +5406,7 @@ void Application::loadSettings() {
     }
 
     bool isFirstPerson = false;
-    if (_firstRun.get()) {
-        // If this is our first run, and no preferred devices were set, default to
-        // an HMD device if available.
-        // Based on feedback changing to non hmd device as default if not prefered
+    if (arguments().contains("--no-launcher")) {
         auto displayPlugins = pluginManager->getDisplayPlugins();
         for (auto& plugin : displayPlugins) {
             if (!plugin->isHmd()) {
@@ -5420,18 +5417,35 @@ void Application::loadSettings() {
                 }
             }
         }
-
         isFirstPerson = (qApp->isHMDMode());
+    }
+    else {
+        if (_firstRun.get()) {
+            // If this is our first run, and no preferred devices were set, default to
+            // an HMD device if available.
+            auto displayPlugins = pluginManager->getDisplayPlugins();
+            for (auto& plugin : displayPlugins) {
+                if (plugin->isHmd()) {
+                    if (auto action = menu->getActionForOption(plugin->getName())) {
+                        action->setChecked(true);
+                        action->trigger();
+                        break;
+                    }
+                }
+            }
+            isFirstPerson = (qApp->isHMDMode());
+        }
+        else {
+            // if this is not the first run, the camera will be initialized differently depending on user settings
 
-    } else {
-        // if this is not the first run, the camera will be initialized differently depending on user settings
-
-        if (qApp->isHMDMode()) {
-            // if the HMD is active, use first-person camera, unless the appropriate setting is checked
-            isFirstPerson = menu->isOptionChecked(MenuOption::FirstPersonHMD);
-        } else {
-            // if HMD is not active, only use first person if the menu option is checked
-            isFirstPerson = menu->isOptionChecked(MenuOption::FirstPerson);
+            if (qApp->isHMDMode()) {
+                // if the HMD is active, use first-person camera, unless the appropriate setting is checked
+                isFirstPerson = menu->isOptionChecked(MenuOption::FirstPersonHMD);
+            }
+            else {
+                // if HMD is not active, only use first person if the menu option is checked
+                isFirstPerson = menu->isOptionChecked(MenuOption::FirstPerson);
+            }
         }
     }
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -8892,7 +8892,7 @@ void Application::updateDisplayMode() {
             // Menu might have been removed if the display plugin lost
             if (!action) {
                 continue;
-            } //STOPPED HERE>>>>> HOW DO WE FIND OUT HOW THE ACTION->isChecked is set
+            } 
             if (action->isChecked()) {
                 newDisplayPlugin = displayPlugin;
                 break;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-907

On every launch the app directed by the launcher, the default display is defaulted to desktop mode instead of hmd. 

Test case: 

1.  The app should ignore any settings change for default display and start in desktop mode.
2. rest app, should start in desktop mode
3. go to hmd mode
4. close app with hmd mode on
5. Open app, with launcher and app should open in desktop mode again. 
