### PR TITLE
case Bugz-968 adding a null check to the display plugin. Possible that display plug…

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2772,7 +2772,8 @@ void Application::cleanupBeforeQuit() {
         DependencyManager::get<AccountManager>()->removeAccountFromFile();
     }
 
-    _displayPlugin.reset();
+    DependencyManager::destroy<HMDScriptingInterface>();
+    
     PluginManager::getInstance()->shutdown();
 
     // Cleanup all overlays after the scripts, as scripts might add more
@@ -2810,6 +2811,8 @@ void Application::cleanupBeforeQuit() {
 
     DependencyManager::destroy<OffscreenQmlSurfaceCache>();
 
+    _displayPlugin.reset();
+    
     _snapshotSoundInjector = nullptr;
 
     // destroy Audio so it and its threads have a chance to go down safely

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2772,8 +2772,6 @@ void Application::cleanupBeforeQuit() {
         DependencyManager::get<AccountManager>()->removeAccountFromFile();
     }
 
-    DependencyManager::destroy<HMDScriptingInterface>();
-    
     PluginManager::getInstance()->shutdown();
 
     // Cleanup all overlays after the scripts, as scripts might add more

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2807,6 +2807,7 @@ void Application::cleanupBeforeQuit() {
     DependencyManager::destroy<TabletScriptingInterface>();
     DependencyManager::destroy<ToolbarScriptingInterface>();
     DependencyManager::destroy<OffscreenUi>();
+    
     DependencyManager::destroy<OffscreenQmlSurfaceCache>();
 
     _snapshotSoundInjector = nullptr;

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2772,6 +2772,7 @@ void Application::cleanupBeforeQuit() {
         DependencyManager::get<AccountManager>()->removeAccountFromFile();
     }
 
+    _displayPlugin.reset();
     PluginManager::getInstance()->shutdown();
 
     // Cleanup all overlays after the scripts, as scripts might add more
@@ -2806,11 +2807,8 @@ void Application::cleanupBeforeQuit() {
     DependencyManager::destroy<TabletScriptingInterface>();
     DependencyManager::destroy<ToolbarScriptingInterface>();
     DependencyManager::destroy<OffscreenUi>();
-
     DependencyManager::destroy<OffscreenQmlSurfaceCache>();
 
-    _displayPlugin.reset();
-    
     _snapshotSoundInjector = nullptr;
 
     // destroy Audio so it and its threads have a chance to go down safely

--- a/libraries/display-plugins/src/display-plugins/AbstractHMDScriptingInterface.cpp
+++ b/libraries/display-plugins/src/display-plugins/AbstractHMDScriptingInterface.cpp
@@ -47,5 +47,12 @@ void AbstractHMDScriptingInterface::setIPDScale(float IPDScale) {
 }
 
 bool AbstractHMDScriptingInterface::isHMDMode() const {
-    return PluginContainer::getInstance().getActiveDisplayPlugin()->isHmd();
+    
+    auto displayPlugin = PluginContainer::getInstance().getActiveDisplayPlugin();
+    
+    if (displayPlugin) {
+        return displayPlugin->isHmd();
+    }
+
+    return false;
 }

--- a/libraries/display-plugins/src/display-plugins/AbstractHMDScriptingInterface.cpp
+++ b/libraries/display-plugins/src/display-plugins/AbstractHMDScriptingInterface.cpp
@@ -47,12 +47,9 @@ void AbstractHMDScriptingInterface::setIPDScale(float IPDScale) {
 }
 
 bool AbstractHMDScriptingInterface::isHMDMode() const {
-    
     auto displayPlugin = PluginContainer::getInstance().getActiveDisplayPlugin();
-    
     if (displayPlugin) {
         return displayPlugin->isHmd();
     }
-
     return false;
 }


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-968

dangling pointer crash noted in backtrace on QMetaProperty::read for the AbstractHMDScriptingInterface::isHMDMode().  The function gets the activedisplay plugin which may or may not be active especially if the app was requested to shut down as based on bugz info.  

Found that display plugin is destroyed pretty early before scripting interface and qml overlays including offscreenui.  There's potential here that scripts could be referencing display plugin after its been destroyed. 

Test case:

1. Start the app
2. Switch to hmd mode
3. Very quickly shut down the app and watch for a crash from the HDMScriptign interface referencing displayplugin->isHmd()


As a side effect, watch for other crashes that could be caused because display plugin .reset() call is moved after scripting and qml destroy calls. 