### PR TITLE
disabled P shortcut and re-enabled in metaverse

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4429,27 +4429,6 @@ void Application::keyPressEvent(QKeyEvent* event) {
                 }
                 break;
 
-            case Qt::Key_P: {
-                if (!isShifted && !isMeta && !isOption && !event->isAutoRepeat()) {
-                    AudioInjectorOptions options;
-                    options.localOnly = true;
-                    options.positionSet = false;    // system sound
-                    options.stereo = true;
-
-                    Setting::Handle<bool> notificationSounds{ MenuOption::NotificationSounds, true };
-                    Setting::Handle<bool> notificationSoundSnapshot{ MenuOption::NotificationSoundsSnapshot, true };
-                    if (notificationSounds.get() && notificationSoundSnapshot.get()) {
-                        if (_snapshotSoundInjector) {
-                            DependencyManager::get<AudioInjectorManager>()->setOptionsAndRestart(_snapshotSoundInjector, options);
-                        } else {
-                            _snapshotSoundInjector = DependencyManager::get<AudioInjectorManager>()->playSound(_snapshotSound, options);
-                        }
-                    }
-                    takeSnapshot(true);
-                }
-                break;
-            }
-
             case Qt::Key_Apostrophe: {
                 if (isMeta) {
                     auto cursor = Cursor::Manager::instance().getCursor();

--- a/scripts/system/keyboardShortcuts/keyboardShortcuts.js
+++ b/scripts/system/keyboardShortcuts/keyboardShortcuts.js
@@ -12,11 +12,19 @@
 //
 
 (function () { // BEGIN LOCAL_SCOPE
+    var snapActivateSound = SoundCache.getSound(Script.resourcesPath() + "sounds/snapshot/snap.wav");
     function keyPressEvent(event) {
         if (event.text.toUpperCase() === "B" && event.isControl) {
             Window.openWebBrowser();
         } else if (event.text.toUpperCase() === "N" && event.isControl) {
             Users.toggleIgnoreRadius();
+        } else if (event.text.toUpperCase() === "P") {
+            Audio.playSound(snapActivateSound, {
+                position: { x: MyAvatar.position.x, y: MyAvatar.position.y, z: MyAvatar.position.z },
+                localOnly: true,
+                volume: 0.5
+            });
+            Window.takeSnapshot(true);
         }
     }
 


### PR DESCRIPTION
disabled the P shortcut that takes a screenshot and re-enabled it for metaverse ui only.
https://highfidelity.atlassian.net/projects/BUGZ/issues/BUGZ-988