### PR TITLE
Make Create app use Ctrl key to duplicate entities instead of Alt

### DIFF
--- a/scripts/system/create/entitySelectionTool/entitySelectionTool.js
+++ b/scripts/system/create/entitySelectionTool/entitySelectionTool.js
@@ -2039,10 +2039,10 @@ SelectionDisplay = (function() {
                     Vec3.print("    pickResult.intersection", pickResult.intersection);
                 }
 
-                // Duplicate entities if alt is pressed.  This will make a
+                // Duplicate entities if Ctrl is pressed.  This will make a
                 // copy of the selected entities and move the _original_ entities, not
                 // the new ones.
-                if (event.isAlt || doDuplicate) {
+                if (event.isControl || doDuplicate) {
                     duplicatedEntityIDs = SelectionManager.duplicateSelection();
                     var ids = [];
                     for (var i = 0; i < duplicatedEntityIDs.length; ++i) {
@@ -2265,10 +2265,10 @@ SelectionDisplay = (function() {
         addHandleTool(overlay, {
             mode: mode,
             onBegin: function(event, pickRay, pickResult) {
-                // Duplicate entities if alt is pressed.  This will make a
+                // Duplicate entities if Ctrl is pressed.  This will make a
                 // copy of the selected entities and move the _original_ entities, not
                 // the new ones.
-                if (event.isAlt) {
+                if (event.isControl) {
                     duplicatedEntityIDs = SelectionManager.duplicateSelection();
                     var ids = [];
                     for (var i = 0; i < duplicatedEntityIDs.length; ++i) {

--- a/scripts/system/create/entitySelectionTool/entitySelectionTool.js
+++ b/scripts/system/create/entitySelectionTool/entitySelectionTool.js
@@ -1118,6 +1118,11 @@ SelectionDisplay = (function() {
             return false;
         }
 
+        // No action if the Alt key is pressed.
+        if (event.isAlt) {
+            return;
+        }
+
         var pickRay = generalComputePickRay(event.x, event.y);
         // TODO_Case6491:  Move this out to setup just to make it once
         var interactiveOverlays = getMainTabletIDs();


### PR DESCRIPTION
Changes:

1) Make Create use Ctrl key to duplicate entities instead of Alt
The reason to do this is because using Alt conflicts with the inspect.js script (and 3rd party derivatives). 
The effect is that entities are often unexpectedly duplicated in desktop mode when the Create app is running and you use inspect.js to move your camera view.

2) Disable Create's entity transforms (translate, rotate, scale handles; x-z body translation) when the Alt key is pressed.
The reason to do this is the same: both the transform is done and the camera view is moved by inspect.js unless the Alt key is disabled.
