### PR TITLE
Possible fix for shader compilation error

### DIFF
--- a/libraries/render-utils/src/ssao_gather.slf
+++ b/libraries/render-utils/src/ssao_gather.slf
@@ -20,8 +20,6 @@
 // the source occlusion texture
 LAYOUT(binding=RENDER_UTILS_TEXTURE_SSAO_OCCLUSION) uniform sampler2DArray occlusionMaps;
 
-layout(location=0) in vec4 varTexCoord0;
-
 layout(location=0) out vec4 outFragColor;
 
 void main(void) {


### PR DESCRIPTION
This might fix AO? (edit: this does not fix AO)

Seth was seeing:
```
[07/12 16:04:42] [DEBUG] [hifi.gl] GLShader::compileProgram -  failed to LINK the gl program object :
[07/12 16:04:42] [DEBUG] [hifi.gl] error: vertex shader output `varTexCoord0' declared as type `vec2', but fragment shader input declared as type `vec4'
```

varTexCoord0 is a vec4 in two places: ssao_bilateralBlur.slf and ssao_gather.slf.  ssao_bilateralBlur.slv outputs a vec4, but ssao_gather.slp uses gpu::vertex::DrawViewportQuadTransformTexcoord which outputs a vec2.  varTexCoord0 isn't even used in ssao_gather.slf so we can just remove it.