### PR TITLE
BUGZ-781: Remove loading-orb upon killing of avatar

### DIFF
--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -574,6 +574,7 @@ void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar
 
     avatar->die();
     queuePhysicsChange(avatar);
+    avatar->removeOrb();
 
     // remove this avatar's entities from the tree now, if we wait (as we did previously) for this Avatar's destructor
     // it might not fire until after we create a new instance for the same remote avatar, which creates a race

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -75,6 +75,7 @@ void OtherAvatar::createOrb() {
         properties.setType(EntityTypes::Sphere);
         properties.setAlpha(1.0f);
         properties.setColor(getLoadingOrbColor(_loadingStatus));
+        properties.setName("Loading Avatar " + getID().toString());
         properties.setPrimitiveMode(PrimitiveMode::LINES);
         properties.getPulse().setMin(0.5f);
         properties.getPulse().setMax(1.0f);


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-781

I think in certain cases the destructor for OtherAvatar is not called at the end of its fade-out (possibly due to avatar shared-pointers in the scene). This workaround should ensure the loading orb (a local sphere entity) is always removed.
It also has a debugging assist in which the avatar UUID is recorded in the orb's name.
