### PR TITLE
BUGZ-753: bad skyboxes on Intel GPUs

### DIFF
--- a/libraries/gl/src/gl/GLHelpers.h
+++ b/libraries/gl/src/gl/GLHelpers.h
@@ -55,6 +55,7 @@ namespace gl {
     bool checkGLErrorDebug(const char* name);
 
     bool disableGl45();
+    void setDisableGl45(bool disable);
 
     uint16_t getTargetVersion();
 

--- a/tests-manual/gpu/CMakeLists.txt
+++ b/tests-manual/gpu/CMakeLists.txt
@@ -6,7 +6,7 @@ set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Tests/manual-tests/")
 link_hifi_libraries(
     shared task networking gl 
     ktx shaders gpu procedural octree image 
-    graphics model-networking fbx hfm animation 
+    graphics model-networking fbx hfm animation material-networking
     script-engine render render-utils 
     ${PLATFORM_GL_BACKEND}
 )


### PR DESCRIPTION
[BUGZ-753](https://highfidelity.atlassian.net/browse/BUGZ-753) Intel has known issues with cubemap texture uploading, and a variety of other OpenGL DSA functionality.  This PR will attempt to detect an Intel GPU and, if found, forcibly disable OpenGL 4.5, in favor of the OpenGL 4.1 backend.  

## Testing

This PR should be tested on at least one system with only an Intel GPU.  Ideally we should try to match the target hardware from the bug, specifically an Intel HD 620 GPU, but failing that we should at least verify that moving to the OpenGL 4.1 backend doesn't tank rendering overall.  