### PR TITLE
Packet dissectors: Don't read HMAC for 'nonverified' packets

### DIFF
--- a/tools/dissectors/1-hfudt.lua
+++ b/tools/dissectors/1-hfudt.lua
@@ -167,6 +167,19 @@ local unsourced_packet_types = {
   ["ICEServerHeartbeatACK"] = true
 }
 
+local nonverified_packet_types = {
+    ["NodeJsonStats"] = true,
+    ["EntityQuery"] = true,
+    ["OctreeDataNack"] = true,
+    ["EntityEditNack"] = true,
+    ["DomainListRequest"] = true,
+    ["StopNode"] = true,
+    ["DomainDisconnectRequest"] = true,
+    ["UsernameFromIDRequest"] = true,
+    ["NodeKickRequest"] = true,
+    ["NodeMuteRequest"] = true,
+}
+
 local fragments = {}
 
 local RFC_5389_MAGIC_COOKIE = 0x2112A442
@@ -304,9 +317,11 @@ function p_hfudt.dissector(buf, pinfo, tree)
       subtree:add_le(f_sender_id, sender_id)
       i = i + 2
 
-      -- read HMAC MD5 hash
-      subtree:add(f_hmac_hash, buf(i, 16))
-      i = i + 16
+    if nonverified_packet_types[packet_type_text] == nil then
+        -- read HMAC MD5 hash
+        subtree:add(f_hmac_hash, buf(i, 16))
+        i = i + 16
+        end
     end
 
     local payload_to_dissect = nil


### PR DESCRIPTION
For certain packets types we don't have a HMAC in the packet header. This can produce confusion in Wireshark traces as to where the start of the actual packet data is (e.g., in Entity Queries, which for some reason are not authenticated). This PR prevents the dissectors from decoding HMACs in such packets.

Related to https://highfidelity.atlassian.net/browse/BUGZ-1025
