### PR TITLE
BUGZ-1022: Restore avatar theft functionality to Lilypad

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -204,10 +204,8 @@ void AvatarMixerClientData::processSetTraitsMessage(ReceivedMessage& message,
                 if (traitType == AvatarTraits::SkeletonModelURL) {
                     // special handling for skeleton model URL, since we need to make sure it is in the whitelist
                     checkSkeletonURLAgainstWhitelist(slaveSharedData, sendingNode, packetTraitVersion);
-#ifdef AVATAR_POP_CHECK
                     // Deferred for UX work. With no PoP check, no need to get the .fst.
                     _avatar->fetchAvatarFST();
-#endif
                 }
 
                 anyTraitsChanged = true;

--- a/scripts/system/clickToAvatarApp.js
+++ b/scripts/system/clickToAvatarApp.js
@@ -6,7 +6,9 @@
         var scripts = ScriptDiscoveryService.getRunning();
        
         var runningSimplified =
-            !scripts.every(function(item){ return item.name !== "simplifiedUI.js"; });
+            !scripts.every(function (item) {
+                return item.name !== "simplifiedUI.js";
+            });
 
         var avatarAppQML = runningSimplified ? "hifi/simplifiedUI/avatarApp/AvatarApp.qml" : "hifi/AvatarApp.qml";
         tablet.loadQMLSource(avatarAppQML);

--- a/scripts/system/clickToAvatarApp.js
+++ b/scripts/system/clickToAvatarApp.js
@@ -1,7 +1,15 @@
 (function () {
     var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
+    
+    
     this.clickDownOnEntity = function (entityID, mouseEvent) {
-        tablet.loadQMLSource("hifi/AvatarApp.qml");
+        var scripts = ScriptDiscoveryService.getRunning();
+       
+        var runningSimplified =
+            !scripts.every(function(item){ return item.name !== "simplifiedUI.js"; });
+
+        var avatarAppQML = runningSimplified ? "hifi/simplifiedUI/avatarApp/AvatarApp.qml" : "hifi/AvatarApp.qml";
+        tablet.loadQMLSource(avatarAppQML);
     };
 }
 );


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1022

Mostly combines https://github.com/highfidelity/hifi/pull/15930 & https://github.com/highfidelity/hifi/pull/15574.
Regarding Tony's comment https://github.com/highfidelity/hifi/pull/15574#pullrequestreview-239202210: I attempted using Array.prototype.find (or findIndex) but they do not appear to be supported by Qt's JS as they are recent language additions. Instead I've used Array.prototype.every, which is a little cleaner than just a loop.