### PR TITLE
BUGZ-996: Android app crashes on startup

### DIFF
--- a/libraries/platform/src/platform/backend/PlatformInstance.cpp
+++ b/libraries/platform/src/platform/backend/PlatformInstance.cpp
@@ -42,7 +42,8 @@ void Instance::enumerateNics() {
 
 json Instance::getCPU(int index) {
     assert(index <(int) _cpus.size());
-    if (index >= (int)_cpus.size())
+
+    if (index <= 0 || (int) _cpus.size() <= index)
         return json();
 
     return _cpus.at(index);
@@ -51,7 +52,7 @@ json Instance::getCPU(int index) {
 json Instance::getGPU(int index) {
     assert(index <(int) _gpus.size());
 
-    if (index >=(int) _gpus.size())
+    if (index <= 0 || (int) _gpus.size() <= index)
         return json();
     
     return _gpus.at(index);
@@ -60,7 +61,7 @@ json Instance::getGPU(int index) {
 json Instance::getDisplay(int index) {
     assert(index <(int) _displays.size());
     
-    if (index >=(int) _displays.size())
+    if (index <= 0 || (int) _displays.size() <= index)
         return json();
 
     return _displays.at(index);

--- a/libraries/platform/src/platform/backend/PlatformInstance.cpp
+++ b/libraries/platform/src/platform/backend/PlatformInstance.cpp
@@ -43,7 +43,7 @@ void Instance::enumerateNics() {
 json Instance::getCPU(int index) {
     assert(index <(int) _cpus.size());
 
-    if (index <= 0 || (int) _cpus.size() <= index)
+    if (index < 0 || (int) _cpus.size() <= index)
         return json();
 
     return _cpus.at(index);
@@ -52,7 +52,7 @@ json Instance::getCPU(int index) {
 json Instance::getGPU(int index) {
     assert(index <(int) _gpus.size());
 
-    if (index <= 0 || (int) _gpus.size() <= index)
+    if (index < 0 || (int) _gpus.size() <= index)
         return json();
     
     return _gpus.at(index);
@@ -61,7 +61,7 @@ json Instance::getGPU(int index) {
 json Instance::getDisplay(int index) {
     assert(index <(int) _displays.size());
     
-    if (index <= 0 || (int) _displays.size() <= index)
+    if (index < 0 || (int) _displays.size() <= index)
         return json();
 
     return _displays.at(index);


### PR DESCRIPTION
On Android, we do not pull information about the CPU, GPU or display in order to set the performance level of Interface. So when getting that information, the index is -1, but the bounds checking logic did not handle that case, causing a bad memory access.
https://highfidelity.atlassian.net/browse/BUGZ-996