### PR TITLE
Make sure the send thread terminates before delete

### DIFF
--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -1292,6 +1292,7 @@ void OctreeServer::aboutToFinish() {
     for (auto& it : _sendThreads) {
         auto& sendThread = *it.second;
         sendThread.setIsShuttingDown();
+        sendThread.terminate();
     }
 
     // Clear will destruct all the unique_ptr to OctreeSendThreads which will call the GenericThread's dtor


### PR DESCRIPTION
This fixes a crash on shutdown I experienced several times while debugging something else.