### PR TITLE
BUGZ-985: Guard against AudioInjectorManager takedown in scripted audio injector destructor

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2824,6 +2824,7 @@ void Application::cleanupBeforeQuit() {
 
     // destroy Audio so it and its threads have a chance to go down safely
     // this must happen after QML, as there are unexplained audio crashes originating in qtwebengine
+    AudioInjector::setLocalAudioInterface(nullptr);
     DependencyManager::destroy<AudioClient>();
     DependencyManager::destroy<AudioScriptingInterface>();
 

--- a/libraries/script-engine/src/ScriptAudioInjector.cpp
+++ b/libraries/script-engine/src/ScriptAudioInjector.cpp
@@ -33,5 +33,9 @@ ScriptAudioInjector::ScriptAudioInjector(const AudioInjectorPointer& injector) :
 }
 
 ScriptAudioInjector::~ScriptAudioInjector() {
-    DependencyManager::get<AudioInjectorManager>()->stop(_injector);
+    const auto audioInjectorManager = DependencyManager::get<AudioInjectorManager>();
+    // AudioInjectorManager may have been destroyed on application shutdown.
+    if (audioInjectorManager) {
+        audioInjectorManager->stop(_injector);
+    }
 }


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-985

Fixes for a couple of crashes on Interface shutdown:
1. If a ScriptAudioInjector is destructed via the QQmlEngine destructor then it can reference the AudioInjectorManager after it's destroyed (appears to be macOS-only). This is the bug in the ticket.
2. The AudioInjector class itself has a static pointer to the local audio interface that can be used after the interface is destructed. The pointer use is guarded but the pointer was not being cleared. I hit this crash when trying to repro the ticket's crash.
