### PR TITLE
BUGZ-1080: Changing the default Intel GPU platform profile from mid to low

### DIFF
--- a/libraries/platform/src/platform/Profiler.cpp
+++ b/libraries/platform/src/platform/Profiler.cpp
@@ -97,8 +97,8 @@ bool filterOnProcessors(const platform::json& computer, const platform::json& cp
 
         // intel integrated graphics
         if (gpuVendor.find(keys::gpu::vendor_Intel) != std::string::npos) {
-            // go mid because GPU
-            tier = Profiler::Tier::MID;
+            // go LOW because Intel GPU
+            tier = Profiler::Tier::LOW;
             return true;
         }
         // AMD gpu


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1080

When profiling PC on windows if the master GPU detected is Intel then pick LOW profile 