### PR TITLE
BUGZ-964: fix for incorrect color curve when rendering 3D into QML

### DIFF
--- a/interface/src/ui/ResourceImageItem.h
+++ b/interface/src/ui/ResourceImageItem.h
@@ -22,6 +22,9 @@
 
 #include <TextureCache.h>
 
+class QOpenGLFramebufferObject;
+class QOpenGLShaderProgram;
+
 class ResourceImageItemRenderer : public QObject, public QQuickFramebufferObject::Renderer {
     Q_OBJECT
 public:
@@ -30,14 +33,16 @@ public:
     void synchronize(QQuickFramebufferObject* item) override;
     void render() override;
 private:
-    bool _ready;
+    bool _ready{ false };
     QString _url;
-    bool _visible;
+    bool _visible{ false };
 
     NetworkTexturePointer _networkTexture;
-    QQuickWindow* _window;
+    QQuickWindow* _window{ nullptr };
     QMutex _fboMutex;
+    uint32_t _vao{ 0 };
     QOpenGLFramebufferObject* _copyFbo { nullptr };
+    QOpenGLShaderProgram* _shader{ nullptr };
     GLsync _fenceSync { 0 };
     QTimer _updateTimer;
 public slots:


### PR DESCRIPTION
I can't seem to find anything that will allow the framebuffer blit to do the proper color conversion here, so I've converted the blit to a simple draw that does the color correction in the fragment shader.

