### PR TITLE
BUGZ-506: more correct audio device selection and fallback

### DIFF
--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -382,13 +382,13 @@ void Audio::handlePushedToTalk(bool enabled) {
 
 void Audio::setInputDevice(const QAudioDeviceInfo& device, bool isHMD) {
     withWriteLock([&] {
-        _devices.chooseInputDevice(device, isHMD);
+        _devices.chooseDevice(QAudio::AudioInput, isHMD, device);
     });
 }
 
 void Audio::setOutputDevice(const QAudioDeviceInfo& device, bool isHMD) {
     withWriteLock([&] {
-        _devices.chooseOutputDevice(device, isHMD);
+        _devices.chooseDevice(QAudio::AudioOutput, isHMD, device);
     });
 }
 

--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -71,48 +71,23 @@ static QString getTargetDevice(bool hmd, QAudio::Mode mode) {
 Qt::ItemFlags AudioDeviceList::_flags { Qt::ItemIsSelectable | Qt::ItemIsEnabled };
 
 AudioDeviceList::AudioDeviceList(QAudio::Mode mode) : _mode(mode) {
-    auto& setting1 = getSetting(true, QAudio::AudioInput);
-    if (setting1.isSet()) {
-        qDebug() << "Device name in settings for HMD, Input" << setting1.get();
+    QString modeString = (_mode == QAudio::AudioInput) ? "input" : "output";
+    auto& desktopSetting = getSetting(false, mode);
+    if (desktopSetting.isSet()) {
+        qDebug() << "Device name in settings for desktop" << modeString << "is" << desktopSetting.get();
     } else {
-        qDebug() << "Device name in settings for HMD, Input not set";
+        qDebug() << "Device name in settings for desktop" << modeString << "is not set";
     }
 
-    auto& setting2 = getSetting(true, QAudio::AudioOutput);
-    if (setting2.isSet()) {
-        qDebug() << "Device name in settings for HMD, Output" << setting2.get();
+    auto& hmdSetting = getSetting(true, mode);
+    if (hmdSetting.isSet()) {
+        qDebug() << "Device name in settings for HMD" << modeString << "is" << hmdSetting.get();
     } else {
-        qDebug() << "Device name in settings for HMD, Output not set";
-    }
-
-    auto& setting3 = getSetting(false, QAudio::AudioInput);
-    if (setting3.isSet()) {
-        qDebug() << "Device name in settings for Desktop, Input" << setting3.get();
-    } else {
-        qDebug() << "Device name in settings for Desktop, Input not set";
-    }
-
-    auto& setting4 = getSetting(false, QAudio::AudioOutput);
-    if (setting4.isSet()) {
-        qDebug() << "Device name in settings for Desktop, Output" << setting4.get();
-    } else {
-        qDebug() << "Device name in settings for Desktop, Output not set";
+        qDebug() << "Device name in settings for HMD" << modeString << " is not set";
     }
 }
 
 AudioDeviceList::~AudioDeviceList() {
-    //save all selected devices
-    auto& settingHMD = getSetting(true, _mode);
-    auto& settingDesktop = getSetting(false, _mode);
-    // store the selected device
-    foreach(std::shared_ptr<AudioDevice> adevice, _devices) {
-        if (adevice->selectedDesktop) {
-            settingDesktop.set(adevice->info.deviceName());
-        }
-        if (adevice->selectedHMD) {
-            settingHMD.set(adevice->info.deviceName());
-        }
-    }
 }
 
 QVariant AudioDeviceList::data(const QModelIndex& index, int role) const {
@@ -179,21 +154,21 @@ void AudioDeviceList::resetDevice(bool contextIsHMD) {
 #endif
 }
 
-void AudioDeviceList::onDeviceChanged(const QAudioDeviceInfo& device, bool isHMD) {
-    QAudioDeviceInfo& selectedDevice = isHMD ? _selectedHMDDevice : _selectedDesktopDevice;
-    selectedDevice = device;
+void AudioDeviceList::onDeviceChanged(const QAudioDeviceInfo& newDeviceInfo, bool isHMD) {
+    QAudioDeviceInfo& currentDeviceInfo = isHMD ? _hmdDevice : _desktopDevice;
+    currentDeviceInfo = newDeviceInfo;
 
+    // walk _devices and update "isSelected" on its various entries
     for (auto i = 0; i < _devices.size(); ++i) {
         std::shared_ptr<AudioDevice> device = _devices[i];
         bool& isSelected = isHMD ? device->selectedHMD : device->selectedDesktop;
-        if (isSelected && device->info != selectedDevice) {
+        if (isSelected && device->info != currentDeviceInfo) {
             isSelected = false;
-        } else if (device->info == selectedDevice) {
+        } else if (device->info == currentDeviceInfo) {
             isSelected = true;
         }
     }
 
-    emit deviceChanged(selectedDevice);
     emit dataChanged(createIndex(0, 0), createIndex(rowCount() - 1, 0));
 }
 
@@ -231,6 +206,7 @@ int levenshteinDistance(const QString& s1, const QString& s2) {
     return cost[n];
 }
 
+/*
 std::shared_ptr<scripting::AudioDevice> getSimilarDevice(const QString& deviceName, const QList<std::shared_ptr<scripting::AudioDevice>>& devices) {
 
     int minDistance = INT_MAX;
@@ -246,88 +222,185 @@ std::shared_ptr<scripting::AudioDevice> getSimilarDevice(const QString& deviceNa
 
     return devices[minDistanceIndex];
 }
+*/
 
-void AudioDeviceList::onDevicesChanged(const QList<QAudioDeviceInfo>& devices) {
+int32_t getSimilarDeviceIndex(const QString& deviceName, const QList<std::shared_ptr<scripting::AudioDevice>>& devices) {
+    int minDistance = INT_MAX;
+    int minDistanceIndex = 0;
+    for (int32_t i = 0; i < devices.length(); ++i) {
+        auto distance = levenshteinDistance(deviceName, devices[i]->info.deviceName());
+        if (distance < minDistance) {
+            minDistance = distance;
+            minDistanceIndex = i;
+        }
+    }
+    return minDistanceIndex;
+}
+
+AudioDevice::AudioDevice(const QAudioDeviceInfo& deviceInfo) {
+    info = deviceInfo;
+    display = deviceInfo.deviceName()
+        .replace("High Definition", "HD")
+        .remove("Device")
+        .replace(" )", ")");
+}
+
+void AudioDeviceList::computePreferredDeviceName(bool isHMD, QString& deviceName) const {
+    auto& setting = getSetting(isHMD, _mode);
+    if (setting.isSet()) {
+        deviceName = setting.get();
+    } else if (isHMD) {
+        if (_mode == QAudio::AudioInput) {
+            deviceName = qApp->getActiveDisplayPlugin()->getPreferredAudioInDevice();
+        } else { // _mode == QAudio::AudioOutput
+            deviceName = qApp->getActiveDisplayPlugin()->getPreferredAudioOutDevice();
+        }
+    }
+}
+
+int32_t AudioDeviceList::findBestDeviceIndex(bool isHMD, QString deviceName) const {
+    computePreferredDeviceName(isHMD, deviceName);
+    return getSimilarDeviceIndex(deviceName, _devices);
+}
+
+void AudioDeviceList::onDevicesChanged(const QList<QAudioDeviceInfo>& deviceInfos, bool isHMD) {
+    // This is called when the list of available devices has changed.
+    // If a used device has been removed/disabled --> fall back to preferred settings if possible.
+    // Or maybe a new device has been added/enabled --> switch to it.
+
     beginResetModel();
 
-    QList<std::shared_ptr<AudioDevice>> newDevices;
-    bool hmdIsSelected = false;
-    bool desktopIsSelected = false;
+    // these are the previous names
+    QString previousDesktopDeviceName(_desktopDevice.deviceName());
+    QString previousHMDDeviceName(_hmdDevice.deviceName());
 
-    foreach(const QAudioDeviceInfo& deviceInfo, devices) {
-        for (bool isHMD : {false, true}) {
-            auto& backupSelectedDeviceName = isHMD ? _backupSelectedHMDDeviceName : _backupSelectedDesktopDeviceName;
-            if (deviceInfo.deviceName() == backupSelectedDeviceName) {
-                QAudioDeviceInfo& selectedDevice = isHMD ? _selectedHMDDevice : _selectedDesktopDevice;
-                selectedDevice = deviceInfo;
-                backupSelectedDeviceName.clear();
+    auto& setting = getSetting(isHMD, _mode);
+    QString preferredDeviceName = setting.get();
+
+    int32_t desktopDeviceIndex = -1;
+    int32_t hmdDeviceIndex = -1;
+
+    // hunt for new devices as we build a fresh _devices list...
+    QList<std::shared_ptr<AudioDevice>> devices;
+    int32_t preferredDeviceIndex = -1;
+    int32_t freshDeviceIndex = -1;
+    foreach(const QAudioDeviceInfo& deviceInfo, deviceInfos) {
+        AudioDevice device(deviceInfo);
+
+        // if device not in old list then it was recently plugged in or enabled
+        // and we assume the user intended to switch to it
+        QString deviceName = deviceInfo.deviceName();
+        bool isNewDevice = true;
+        for (auto& oldDevice : _devices) {
+            if (oldDevice->info.deviceName() == deviceName) {
+                isNewDevice = false;
+                break;
             }
         }
+        if (isNewDevice) {
+            // a new device has been discovered --> assume we want to switch to it
+            desktopDeviceIndex = devices.size();
+            hmdDeviceIndex = desktopDeviceIndex;
+        }
+        if (deviceName == preferredDeviceName) {
+            preferredDeviceIndex = devices.size();
+        }
+        devices.push_back(newDevice(device));
+    }
+    _devices.swap(devices);
+
+    if (_devices.empty()) {
+        _desktopDevice = QAudioDeviceInfo();
+        _hmdDevice = QAudioDeviceInfo();
+    } else {
+        // desktop
+        if (desktopDeviceIndex == -1) {
+            desktopDeviceIndex = findBestDeviceIndex(false, previousDesktopDeviceName);
+        } else {
+            // a new device has been found and we will switch to it unless...
+            // the device for this context has been saved to settings
+            // AND that preferred device is available
+            if (preferredDeviceIndex != -1) {
+                desktopDeviceIndex = preferredDeviceIndex;
+            }
+        }
+        _desktopDevice = _devices[desktopDeviceIndex]->info;
+        _devices[desktopDeviceIndex]->selectedDesktop = true;
+
+        // similarly for HMD
+        if (hmdDeviceIndex == -1) {
+            hmdDeviceIndex = findBestDeviceIndex(true, previousHMDDeviceName);
+        } else {
+            if (preferredDeviceIndex != -1) {
+                hmdDeviceIndex = preferredDeviceIndex;
+            }
+        }
+        _hmdDevice = _devices[hmdDeviceIndex]->info;
+        _devices[hmdDeviceIndex]->selectedHMD = true;
     }
 
-    foreach(const QAudioDeviceInfo& deviceInfo, devices) {
-        AudioDevice device;
-        device.info = deviceInfo;
-        device.display = device.info.deviceName()
-            .replace("High Definition", "HD")
-            .remove("Device")
-            .replace(" )", ")");
-
-        for (bool isHMD : {false, true}) {
-            QAudioDeviceInfo& selectedDevice = isHMD ? _selectedHMDDevice : _selectedDesktopDevice;
-            bool& isSelected = isHMD ? device.selectedHMD : device.selectedDesktop;
-
-            if (!selectedDevice.isNull()) {
-                isSelected = (device.info == selectedDevice);
-            }
-            else {
-                //no selected device for context. fallback to saved
-                const QString& savedDeviceName = isHMD ? _hmdSavedDeviceName : _desktopSavedDeviceName;
-                isSelected = (device.info.deviceName() == savedDeviceName);
-            }
-
-            if (isSelected) {
-                if (isHMD) {
-                    hmdIsSelected = isSelected;
-                } else {
-                    desktopIsSelected = isSelected;
-                }
-
-                // check if this device *is not* in old devices list - it means it was just re-plugged so needs to be selected explicitly
-                bool isNewDevice = true;
-                for (auto& oldDevice : _devices) {
-                    if (oldDevice->info.deviceName() == device.info.deviceName()) {
-                        isNewDevice = false;
-                        break;
-                    }
-                }
-
-                if (isNewDevice) {
-                    emit selectedDevicePlugged(device.info, isHMD);
-                }
-            }
-        }
-
-        newDevices.push_back(newDevice(device));
-    }
-
-    if (!newDevices.isEmpty()) {
-        if (!hmdIsSelected) {
-            _backupSelectedHMDDeviceName = !_selectedHMDDevice.isNull() ? _selectedHMDDevice.deviceName() : _hmdSavedDeviceName;
-            auto device = getSimilarDevice(_backupSelectedHMDDeviceName, newDevices);
-            device->selectedHMD = true;
-            emit selectedDevicePlugged(device->info, true);
-        }
-        if (!desktopIsSelected) {
-            _backupSelectedDesktopDeviceName = !_selectedDesktopDevice.isNull() ? _selectedDesktopDevice.deviceName() : _desktopSavedDeviceName;
-            auto device = getSimilarDevice(_backupSelectedDesktopDeviceName, newDevices);
-            device->selectedDesktop = true;
-            emit selectedDevicePlugged(device->info, false);
+    bool somethingChanged = false;
+    if (_desktopDevice.deviceName() != previousDesktopDeviceName) {
+        somethingChanged = true;
+        if (!isHMD) {
+            auto client = DependencyManager::get<AudioClient>().data();
+            QMetaObject::invokeMethod(client, "switchAudioDevice",
+                Q_ARG(QAudio::Mode, _mode),
+                Q_ARG(QString, _desktopDevice.deviceName()));
         }
     }
+    if (_hmdDevice.deviceName() != previousHMDDeviceName) {
+        somethingChanged = true;
+        if (isHMD) {
+            auto client = DependencyManager::get<AudioClient>().data();
+            QMetaObject::invokeMethod(client, "switchAudioDevice",
+                Q_ARG(QAudio::Mode, _mode),
+                Q_ARG(QString, _hmdDevice.deviceName()));
+        }
+    }
+    if (somethingChanged) {
+        emit dataChanged(createIndex(0, 0), createIndex(rowCount() - 1, 0));
+    }
 
-    _devices.swap(newDevices);
     endResetModel();
+}
+
+void AudioDeviceList::initDevices(const QList<QAudioDeviceInfo>& deviceInfos, bool isHMD) {
+    // while we build a fresh _devices list...
+    // find the current devices and cache whether it is "selected" or not
+    bool foundDesktopDevice = false;
+    bool foundHMDDevice = false;
+
+    QString desktopName = _desktopDevice.deviceName();
+    QString hmdName = _hmdDevice.deviceName();
+
+    QList<std::shared_ptr<AudioDevice>> newDeviceList;
+    foreach(const QAudioDeviceInfo& deviceInfo, deviceInfos) {
+        AudioDevice device(deviceInfo);
+        QString deviceName = deviceInfo.deviceName();
+        if (!foundDesktopDevice && deviceName == desktopName) {
+            foundDesktopDevice = true;
+            device.selectedDesktop = true;
+        }
+        if (!foundHMDDevice && deviceName == hmdName) {
+            foundHMDDevice = true;
+            device.selectedHMD = true;
+        }
+        newDeviceList.push_back(newDevice(device));
+    }
+    _devices.swap(newDeviceList);
+
+    // now that _devices is initialized we call onDevicesChanged()
+    // which will redo most of this work but will also try to switch to preferred devices
+    onDevicesChanged(deviceInfos, isHMD);
+
+    emit dataChanged(createIndex(0, 0), createIndex(rowCount() - 1, 0));
+}
+
+void AudioDeviceList::setPreferredDevice(const QAudioDeviceInfo device, bool isHMD) {
+    // save to settings
+    auto& setting = getSetting(isHMD, _mode);
+    setting.set(device.deviceName());
 }
 
 bool AudioInputDeviceList::peakValuesAvailable() {
@@ -366,16 +439,17 @@ AudioDevices::AudioDevices(bool& contextIsHMD) : _contextIsHMD(contextIsHMD) {
     connect(client, &AudioClient::devicesChanged, this, &AudioDevices::onDevicesChanged, Qt::QueuedConnection);
     connect(client, &AudioClient::peakValueListChanged, &_inputs, &AudioInputDeviceList::onPeakValueListChanged, Qt::QueuedConnection);
 
-    _inputs.onDeviceChanged(client->getActiveAudioDevice(QAudio::AudioInput), contextIsHMD);
-    _outputs.onDeviceChanged(client->getActiveAudioDevice(QAudio::AudioOutput), contextIsHMD);
+    // slam the AudioDeviceLists' current devices to the default
+    _inputs._desktopDevice = client->getActiveAudioDevice(QAudio::AudioInput);
+    _inputs._hmdDevice = _inputs._desktopDevice;
+    _outputs._desktopDevice = client->getActiveAudioDevice(QAudio::AudioOutput);
+    _outputs._hmdDevice = _outputs._desktopDevice;
 
-    // connections are made after client is initialized, so we must also fetch the devices
-    const QList<QAudioDeviceInfo>& devicesInput = client->getAudioDevices(QAudio::AudioInput);
-    const QList<QAudioDeviceInfo>& devicesOutput = client->getAudioDevices(QAudio::AudioOutput);
-
-    //setup devices
-    _inputs.onDevicesChanged(devicesInput);
-    _outputs.onDevicesChanged(devicesOutput);
+    // populate the device lists with the current state
+    const QList<QAudioDeviceInfo>& inputDevices = client->getAudioDevices(QAudio::AudioInput);
+    _inputs.initDevices(inputDevices, _contextIsHMD);
+    const QList<QAudioDeviceInfo>& outputDevices = client->getAudioDevices(QAudio::AudioOutput);
+    _outputs.initDevices(outputDevices, _contextIsHMD);
 }
 
 AudioDevices::~AudioDevices() {}
@@ -388,14 +462,14 @@ void AudioDevices::onContextChanged(const QString& context) {
 void AudioDevices::onDeviceSelected(QAudio::Mode mode, const QAudioDeviceInfo& device,
                                     const QAudioDeviceInfo& previousDevice, bool isHMD) {
     QString deviceName = device.isNull() ? QString() : device.deviceName();
-
     auto& setting = getSetting(isHMD, mode);
-
-    // check for a previous device
     auto wasDefault = setting.get().isNull();
 
-    // store the selected device
-    setting.set(deviceName);
+    // only store the selected device to settings if it matches the targetDevice
+    QString targetDeviceName = getTargetDevice(isHMD, mode);
+    if (targetDeviceName == deviceName) {
+        setting.set(deviceName);
+    }
 
     // log the selected device
     if (!device.isNull()) {
@@ -426,7 +500,7 @@ void AudioDevices::onDeviceChanged(QAudio::Mode mode, const QAudioDeviceInfo& de
     if (mode == QAudio::AudioInput) {
         if (_requestedInputDevice == device) {
             onDeviceSelected(QAudio::AudioInput, device,
-                             _contextIsHMD ? _inputs._selectedHMDDevice : _inputs._selectedDesktopDevice,
+                             _contextIsHMD ? _inputs._hmdDevice : _inputs._desktopDevice,
                              _contextIsHMD);
             _requestedInputDevice = QAudioDeviceInfo();
         }
@@ -434,7 +508,7 @@ void AudioDevices::onDeviceChanged(QAudio::Mode mode, const QAudioDeviceInfo& de
     } else { // if (mode == QAudio::AudioOutput)
         if (_requestedOutputDevice == device) {
             onDeviceSelected(QAudio::AudioOutput, device,
-                             _contextIsHMD ? _outputs._selectedHMDDevice : _outputs._selectedDesktopDevice,
+                             _contextIsHMD ? _outputs._hmdDevice : _outputs._desktopDevice,
                              _contextIsHMD);
             _requestedOutputDevice = QAudioDeviceInfo();
         }
@@ -443,84 +517,26 @@ void AudioDevices::onDeviceChanged(QAudio::Mode mode, const QAudioDeviceInfo& de
 }
 
 void AudioDevices::onDevicesChanged(QAudio::Mode mode, const QList<QAudioDeviceInfo>& devices) {
-    static std::once_flag once;
-    std::call_once(once, [&] {
-        //readout settings
-        auto client = DependencyManager::get<AudioClient>().data();
-
-        _inputs._hmdSavedDeviceName = getTargetDevice(true, QAudio::AudioInput);
-        _inputs._desktopSavedDeviceName = getTargetDevice(false, QAudio::AudioInput);
-
-        //fallback to default device
-        if (_inputs._desktopSavedDeviceName.isEmpty()) {
-            _inputs._desktopSavedDeviceName = client->getActiveAudioDevice(QAudio::AudioInput).deviceName();
-        }
-        //fallback to desktop device
-        if (_inputs._hmdSavedDeviceName.isEmpty()) {
-            _inputs._hmdSavedDeviceName = _inputs._desktopSavedDeviceName;
-        }
-
-        _outputs._hmdSavedDeviceName = getTargetDevice(true, QAudio::AudioOutput);
-        _outputs._desktopSavedDeviceName = getTargetDevice(false, QAudio::AudioOutput);
-
-        if (_outputs._desktopSavedDeviceName.isEmpty()) {
-            _outputs._desktopSavedDeviceName = client->getActiveAudioDevice(QAudio::AudioOutput).deviceName();
-        }
-        if (_outputs._hmdSavedDeviceName.isEmpty()) {
-            _outputs._hmdSavedDeviceName = _outputs._desktopSavedDeviceName;
-        }
-        onContextChanged(QString());
-    });
 
     //set devices for both contexts
     if (mode == QAudio::AudioInput) {
-        _inputs.onDevicesChanged(devices);
-
-        static std::once_flag onceAfterInputDevicesChanged;
-        std::call_once(onceAfterInputDevicesChanged, [&] { // we only want 'selectedDevicePlugged' signal to be handled after initial list of input devices was populated
-            connect(&_inputs, &AudioDeviceList::selectedDevicePlugged, this, &AudioDevices::chooseInputDevice);
-        });
+        _inputs.onDevicesChanged(devices, _contextIsHMD);
     } else { // if (mode == QAudio::AudioOutput)
-        _outputs.onDevicesChanged(devices);
-
-        static std::once_flag onceAfterOutputDevicesChanged;
-        std::call_once(onceAfterOutputDevicesChanged, [&] { // we only want 'selectedDevicePlugged' signal to be handled after initial list of output devices was populated
-            connect(&_outputs, &AudioDeviceList::selectedDevicePlugged, this, &AudioDevices::chooseOutputDevice);
-        });
+        _outputs.onDevicesChanged(devices, _contextIsHMD);
     }
 }
 
-
-void AudioDevices::chooseInputDevice(const QAudioDeviceInfo& device, bool isHMD) {
-    //check if current context equals device to change
-    if (_contextIsHMD == isHMD) {
-        auto client = DependencyManager::get<AudioClient>().data();
-        _requestedInputDevice = device;
-        QMetaObject::invokeMethod(client, "switchAudioDevice",
-                                  Q_ARG(QAudio::Mode, QAudio::AudioInput),
-                                  Q_ARG(const QAudioDeviceInfo&, device));
+void AudioDevices::chooseDevice(QAudio::Mode mode, bool isHMD, const QAudioDeviceInfo& device) {
+    if (mode == QAudio::AudioInput) {
+        _inputs.setPreferredDevice(device, isHMD);
     } else {
-        //context is different. just save device in settings
-        onDeviceSelected(QAudio::AudioInput, device,
-                         isHMD ? _inputs._selectedHMDDevice : _inputs._selectedDesktopDevice,
-                         isHMD);
-        _inputs.onDeviceChanged(device, isHMD);
+        _outputs.setPreferredDevice(device, isHMD);
     }
-}
-
-void AudioDevices::chooseOutputDevice(const QAudioDeviceInfo& device, bool isHMD) {
-    //check if current context equals device to change
     if (_contextIsHMD == isHMD) {
+        // inside context we switchAudioDevice
         auto client = DependencyManager::get<AudioClient>().data();
-        _requestedOutputDevice = device;
         QMetaObject::invokeMethod(client, "switchAudioDevice",
-                                  Q_ARG(QAudio::Mode, QAudio::AudioOutput),
+                                  Q_ARG(QAudio::Mode, mode),
                                   Q_ARG(const QAudioDeviceInfo&, device));
-    } else {
-        //context is different. just save device in settings
-        onDeviceSelected(QAudio::AudioOutput, device,
-                         isHMD ? _outputs._selectedHMDDevice : _outputs._selectedDesktopDevice,
-                         isHMD);
-        _outputs.onDeviceChanged(device, isHMD);
     }
 }

--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -443,18 +443,9 @@ void AudioDevices::onContextChanged(const QString& context) {
 
 void AudioDevices::onDeviceSelected(QAudio::Mode mode, const QAudioDeviceInfo& device,
                                     const QAudioDeviceInfo& previousDevice, bool isHMD) {
-    QString deviceName = device.isNull() ? QString() : device.deviceName();
-    auto& setting = getSetting(isHMD, mode);
-    auto wasDefault = setting.get().isNull();
-
-    // only store the selected device to settings if it matches the targetDevice
-    QString targetDeviceName = getTargetDevice(isHMD, mode);
-    if (targetDeviceName == deviceName) {
-        setting.set(deviceName);
-    }
-
-    // log the selected device
     if (!device.isNull()) {
+        // log the selected device
+
         QJsonObject data;
 
         const QString MODE = "audio_mode";
@@ -470,8 +461,13 @@ void AudioDevices::onDeviceSelected(QAudio::Mode mode, const QAudioDeviceInfo& d
         const QString DEVICE = "device";
         const QString PREVIOUS_DEVICE = "previous_device";
         const QString WAS_DEFAULT = "was_default";
+
+        QString deviceName = device.isNull() ? QString() : device.deviceName();
         data[DEVICE] = deviceName;
         data[PREVIOUS_DEVICE] = previousDevice.deviceName();
+
+        auto& setting = getSetting(isHMD, mode);
+        auto wasDefault = setting.get().isNull();
         data[WAS_DEFAULT] = wasDefault;
 
         UserActivityLogger::getInstance().logAction("selected_audio_device", data);

--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -265,7 +265,6 @@ void AudioDeviceList::onDevicesChanged(const QList<QAudioDeviceInfo>& deviceInfo
     // hunt for new devices as we build a fresh _devices list...
     QList<std::shared_ptr<AudioDevice>> devices;
     int32_t preferredDeviceIndex = -1;
-    int32_t freshDeviceIndex = -1;
     foreach(const QAudioDeviceInfo& deviceInfo, deviceInfos) {
         AudioDevice device(deviceInfo);
 

--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -206,24 +206,6 @@ int levenshteinDistance(const QString& s1, const QString& s2) {
     return cost[n];
 }
 
-/*
-std::shared_ptr<scripting::AudioDevice> getSimilarDevice(const QString& deviceName, const QList<std::shared_ptr<scripting::AudioDevice>>& devices) {
-
-    int minDistance = INT_MAX;
-    int minDistanceIndex = 0;
-
-    for (auto i = 0; i < devices.length(); ++i) {
-        auto distance = levenshteinDistance(deviceName, devices[i]->info.deviceName());
-        if (distance < minDistance) {
-            minDistance = distance;
-            minDistanceIndex = i;
-        }
-    }
-
-    return devices[minDistanceIndex];
-}
-*/
-
 int32_t getSimilarDeviceIndex(const QString& deviceName, const QList<std::shared_ptr<scripting::AudioDevice>>& devices) {
     int minDistance = INT_MAX;
     int minDistanceIndex = 0;

--- a/interface/src/scripting/AudioDevices.h
+++ b/interface/src/scripting/AudioDevices.h
@@ -65,7 +65,6 @@ protected slots:
 protected:
     friend class AudioDevices;
     void initDevices(const QList<QAudioDeviceInfo>& deviceInfos, bool isHMD);
-    void computePreferredDeviceName(bool isHMD, QString& deviceName) const;
     int32_t findBestDeviceIndex(bool isHMD, QString deviceName) const;
 
     static QHash<int, QByteArray> _roles;

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -372,6 +372,9 @@ AudioClient::AudioClient() :
             _solo.resend();
         }
     });
+
+    _inputDevices = getAvailableDevices(QAudio::AudioInput);
+    _outputDevices = getAvailableDevices(QAudio::AudioOutput);
 }
 
 AudioClient::~AudioClient() {
@@ -430,7 +433,6 @@ QAudioDeviceInfo getNamedAudioDeviceForMode(QAudio::Mode mode, const QString& de
             break;
         }
     }
-
     return result;
 }
 
@@ -560,10 +562,10 @@ QAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode) {
         CoUninitialize();
     }
 
+    QAudioDeviceInfo defaultDeviceInfo = getNamedAudioDeviceForMode(mode, deviceName);
     qCDebug(audioclient) << "defaultAudioDeviceForMode mode: " << (mode == QAudio::AudioOutput ? "Output" : "Input")
-        << " [" << deviceName << "] [" << getNamedAudioDeviceForMode(mode, deviceName).deviceName() << "]";
-
-    return getNamedAudioDeviceForMode(mode, deviceName);
+        << " [" << deviceName << "] [" << defaultDeviceInfo.deviceName() << "]";
+    return defaultDeviceInfo;
 #endif
 
 #if defined (Q_OS_ANDROID)


### PR DESCRIPTION
This PR fixes a bug where a pre-existing VR audio device, re-enabled while interface client is running, is not automatically selected.

https://highfidelity.atlassian.net/browse/BUGZ-506