### PR TITLE
BUGZ-1069: fix crash in oven for lack of MaterialCache instance in DependencyManager

### DIFF
--- a/tools/oven/src/Oven.cpp
+++ b/tools/oven/src/Oven.cpp
@@ -21,6 +21,7 @@
 #include <ResourceManager.h>
 #include <ResourceRequestObserver.h>
 #include <ResourceCache.h>
+#include <material-networking/MaterialCache.h>
 #include <material-networking/TextureCache.h>
 #include <hfm/ModelFormatRegistry.h>
 #include <FBXSerializer.h>
@@ -42,6 +43,7 @@ Oven::Oven() {
     DependencyManager::set<ResourceRequestObserver>();
     DependencyManager::set<ResourceCacheSharedItems>();
     DependencyManager::set<TextureCache>();
+    DependencyManager::set<MaterialCache>();
 
     MaterialBaker::setNextOvenWorkerThreadOperator([] {
         return Oven::instance().getNextWorkerThread();


### PR DESCRIPTION
This PR to fix a crash in the **oven** executable when it could not find a `MaterialCache` instance:

https://highfidelity.atlassian.net/browse/BUGZ-1069