### PR TITLE
DEV-279: Add rendering API information to the platform JSON object

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2996,6 +2996,9 @@ void Application::initializeGL() {
         qCWarning(interfaceapp, "Unable to make window context current");
     }
 
+    // Populate the global OpenGL context based on the information for the primary window GL context
+    gl::ContextInfo::get(true);
+
 #if !defined(DISABLE_QML)
     QStringList chromiumFlags;
     // HACK: re-expose mic and camera to prevent crash on domain-change in chromium's media::FakeAudioInputStream::ReadAudioFromSource()

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1659,7 +1659,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         // The value will be 0 if the user blew away settings this session, which is both a feature and a bug.
         static const QString TESTER = "HIFI_TESTER";
         auto gpuIdent = GPUIdent::getInstance();
-        auto glContextData = getGLContextData();
+        auto glContextData = gl::ContextInfo::get();
         QJsonObject properties = {
             { "version", applicationVersion() },
             { "tester", QProcessEnvironment::systemEnvironment().contains(TESTER) || isTester },
@@ -1676,11 +1676,11 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
             { "gpu_name", gpuIdent->getName() },
             { "gpu_driver", gpuIdent->getDriver() },
             { "gpu_memory", static_cast<qint64>(gpuIdent->getMemory()) },
-            { "gl_version_int", glVersionToInteger(glContextData.value("version").toString()) },
-            { "gl_version", glContextData["version"] },
-            { "gl_vender", glContextData["vendor"] },
-            { "gl_sl_version", glContextData["sl_version"] },
-            { "gl_renderer", glContextData["renderer"] },
+            { "gl_version_int", glVersionToInteger(glContextData.version.c_str()) },
+            { "gl_version", glContextData.version.c_str() },
+            { "gl_vender", glContextData.vendor.c_str() },
+            { "gl_sl_version", glContextData.shadingLanguageVersion.c_str() },
+            { "gl_renderer", glContextData.renderer.c_str() },
             { "ideal_thread_count", QThread::idealThreadCount() }
         };
         auto macVersion = QSysInfo::macVersion();
@@ -2282,8 +2282,13 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         properties["active_display_plugin"] = getActiveDisplayPlugin()->getName();
         properties["using_hmd"] = isHMDMode();
 
-        auto glInfo = getGLContextData();
-        properties["gl_info"] = glInfo;
+        auto contextInfo = gl::ContextInfo::get();
+        properties["gl_info"] = QJsonObject{
+            { "version", contextInfo.version.c_str() },
+            { "sl_version", contextInfo.shadingLanguageVersion.c_str() },
+            { "vendor", contextInfo.vendor.c_str() },
+            { "renderer", contextInfo.renderer.c_str() },
+        };
         properties["gpu_used_memory"] = (int)BYTES_TO_MB(gpu::Context::getUsedGPUMemSize());
         properties["gpu_free_memory"] = (int)BYTES_TO_MB(gpu::Context::getFreeGPUMemSize());
         properties["gpu_frame_time"] = (float)(qApp->getGPUContext()->getFrameTimerGPUAverage());

--- a/libraries/gl/src/gl/GLHelpers.cpp
+++ b/libraries/gl/src/gl/GLHelpers.cpp
@@ -304,21 +304,6 @@ int glVersionToInteger(QString glVersion) {
     return (majorNumber << 16) | minorNumber;
 }
 
-const QJsonObject& getGLContextData() {
-    static QJsonObject result;
-    static std::once_flag once;
-    std::call_once(once, [] {
-        auto contextInfo = gl::ContextInfo::get();
-        result = QJsonObject {
-            { "version", contextInfo.version.c_str() },
-            { "sl_version", contextInfo.shadingLanguageVersion.c_str() },
-            { "vendor", contextInfo.vendor.c_str() },
-            { "renderer", contextInfo.renderer.c_str() },
-        };
-    });
-    return result;
-}
-
 QThread* RENDER_THREAD = nullptr;
 
 bool isRenderThread() {

--- a/libraries/gl/src/gl/GLHelpers.h
+++ b/libraries/gl/src/gl/GLHelpers.h
@@ -29,7 +29,6 @@ class QGLFormat;
 size_t evalGLFormatSwapchainPixelSize(const QSurfaceFormat& format);
 
 const QSurfaceFormat& getDefaultOpenGLSurfaceFormat();
-const QJsonObject& getGLContextData();
 int glVersionToInteger(QString glVersion);
 
 bool isRenderThread();

--- a/libraries/gl/src/gl/GLHelpers.h
+++ b/libraries/gl/src/gl/GLHelpers.h
@@ -29,7 +29,7 @@ class QGLFormat;
 size_t evalGLFormatSwapchainPixelSize(const QSurfaceFormat& format);
 
 const QSurfaceFormat& getDefaultOpenGLSurfaceFormat();
-QJsonObject getGLContextData();
+const QJsonObject& getGLContextData();
 int glVersionToInteger(QString glVersion);
 
 bool isRenderThread();
@@ -39,6 +39,26 @@ bool isRenderThread();
 #define GL_GET_MAJOR_VERSION(glversion) ((glversion & 0xFF00) >> 8)
 
 namespace gl {
+    struct ContextInfo {
+        std::string version;
+        std::string shadingLanguageVersion;
+        std::string vendor;
+        std::string renderer;
+        std::vector<std::string> extensions;
+
+        ContextInfo& init();
+        operator bool() const { return !version.empty(); }
+
+        static const ContextInfo& get(bool init = false);
+    };
+
+#define LOG_GL_CONTEXT_INFO(category, contextInfo) \
+    qCDebug(category) << "GL Version: " << contextInfo.version.c_str(); \
+    qCDebug(category) << "GL Shader Language Version: " << contextInfo.shadingLanguageVersion.c_str(); \
+    qCDebug(category) << "GL Vendor: " << contextInfo.vendor.c_str(); \
+    qCDebug(category) << "GL Renderer: " << contextInfo.renderer.c_str();
+
+
     void globalLock();
     void globalRelease(bool finish = true);
 

--- a/libraries/gl/src/gl/GLWindow.cpp
+++ b/libraries/gl/src/gl/GLWindow.cpp
@@ -33,14 +33,12 @@ GLWindow::~GLWindow() {
 bool GLWindow::makeCurrent() {
     bool makeCurrentResult = _context->makeCurrent();
     Q_ASSERT(makeCurrentResult);
-    
-    std::call_once(_reportOnce, []{
-        qCDebug(glLogging) << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
-        qCDebug(glLogging) << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
-        qCDebug(glLogging) << "GL Vendor: " << QString((const char*) glGetString(GL_VENDOR));
-        qCDebug(glLogging) << "GL Renderer: " << QString((const char*) glGetString(GL_RENDERER));
-    });
-    
+
+    if (makeCurrentResult) {
+        std::call_once(_reportOnce, []{
+            LOG_GL_CONTEXT_INFO(glLogging, gl::ContextInfo().init());
+        });
+    }
     return makeCurrentResult;
 }
 

--- a/libraries/gl/src/gl/OffscreenGLCanvas.cpp
+++ b/libraries/gl/src/gl/OffscreenGLCanvas.cpp
@@ -73,13 +73,9 @@ bool OffscreenGLCanvas::create(QOpenGLContext* sharedContext) {
 
 bool OffscreenGLCanvas::makeCurrent() {
     bool result = _context->makeCurrent(_offscreenSurface);
-    if (glGetString) {
+    if (result) {
         std::call_once(_reportOnce, [] {
-            qCDebug(glLogging) << "GL Version: " << QString((const char*)glGetString(GL_VERSION));
-            qCDebug(glLogging) << "GL Shader Language Version: "
-                               << QString((const char*)glGetString(GL_SHADING_LANGUAGE_VERSION));
-            qCDebug(glLogging) << "GL Vendor: " << QString((const char*)glGetString(GL_VENDOR));
-            qCDebug(glLogging) << "GL Renderer: " << QString((const char*)glGetString(GL_RENDERER));
+            LOG_GL_CONTEXT_INFO(glLogging, gl::ContextInfo().init());
         });
     }
 

--- a/libraries/gpu-gl-common/src/gpu/gl/GLBackend.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLBackend.cpp
@@ -117,9 +117,10 @@ void GLBackend::init() {
     static std::once_flag once;
     std::call_once(once, [] {
 
-
-        QString vendor{ (const char*)glGetString(GL_VENDOR) };
-        QString renderer{ (const char*)glGetString(GL_RENDERER) };
+        ::gl::ContextInfo contextInfo;
+        contextInfo.init();
+        QString vendor { contextInfo.vendor.c_str() };
+        QString renderer { contextInfo.renderer.c_str() };
 
         // Textures
         GL_GET_INTEGER(MAX_TEXTURE_IMAGE_UNITS);
@@ -131,10 +132,7 @@ void GLBackend::init() {
         GL_GET_INTEGER(MAX_UNIFORM_BLOCK_SIZE);
         GL_GET_INTEGER(UNIFORM_BUFFER_OFFSET_ALIGNMENT);
 
-        qCDebug(gpugllogging) << "GL Version: " << QString((const char*) glGetString(GL_VERSION));
-        qCDebug(gpugllogging) << "GL Shader Language Version: " << QString((const char*) glGetString(GL_SHADING_LANGUAGE_VERSION));
-        qCDebug(gpugllogging) << "GL Vendor: " << vendor;
-        qCDebug(gpugllogging) << "GL Renderer: " << renderer;
+        LOG_GL_CONTEXT_INFO(gpugllogging, contextInfo);
         GPUIdent* gpu = GPUIdent::getInstance(vendor, renderer); 
         // From here on, GPUIdent::getInstance()->getMumble() should efficiently give the same answers.
         qCDebug(gpugllogging) << "GPU:";

--- a/libraries/platform/CMakeLists.txt
+++ b/libraries/platform/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TARGET_NAME platform)
 
 setup_hifi_library()
-link_hifi_libraries(shared)
+link_hifi_libraries(shared gl)
 
 GroupSources("src")
 target_json()
@@ -15,4 +15,4 @@ if (APPLE)
 
 elseif(WIN32)
     target_link_libraries(${TARGET_NAME} Iphlpapi.lib)
-endif ()
+endif()

--- a/libraries/platform/src/platform/PlatformKeys.h
+++ b/libraries/platform/src/platform/PlatformKeys.h
@@ -34,6 +34,43 @@ namespace platform { namespace keys{
         extern const char*  displays;
         extern const char*  isMaster;
     }
+    namespace renderingApis {
+        extern const char* apiOpenGL;
+        extern const char* apiVulkan;
+        extern const char* apiDirect3D11;
+        extern const char* apiDirect3D12;
+        extern const char* apiMetal;
+        namespace gl {
+            extern const char* version;
+            extern const char* shadingLanguageVersion;
+            extern const char* vendor;
+            extern const char* renderer;
+            extern const char* extensions;
+        }
+        namespace vk {
+            extern const char* version;
+            extern const char* devices;
+            namespace device {
+                extern const char* apiVersion;
+                extern const char* driverVersion;
+                extern const char* deviceType;
+                extern const char* vendor;
+                extern const char* name;
+                extern const char* formats;
+                extern const char* extensions;
+                extern const char* queues;
+                extern const char* heaps;
+                namespace heap {
+                    extern const char* flags;
+                    extern const char* size;
+                }
+                namespace queue {
+                    extern const char* flags;
+                    extern const char* count;
+                }
+            }
+        }
+    }
     namespace nic {
         extern const char* mac;
         extern const char* name;
@@ -78,6 +115,7 @@ namespace platform { namespace keys{
     // Keys for categories used in json returned by getAll()
     extern const char*  CPUS;
     extern const char*  GPUS;
+    extern const char*  RENDERING_APIS;
     extern const char*  DISPLAYS;
     extern const char*  NICS;
     extern const char*  MEMORY;

--- a/libraries/platform/src/platform/PlatformKeys.h
+++ b/libraries/platform/src/platform/PlatformKeys.h
@@ -34,21 +34,21 @@ namespace platform { namespace keys{
         extern const char*  displays;
         extern const char*  isMaster;
     }
-    namespace renderingApis {
+    namespace graphicsAPI {
+        extern const char* name;
+        extern const char* version;
         extern const char* apiOpenGL;
         extern const char* apiVulkan;
         extern const char* apiDirect3D11;
         extern const char* apiDirect3D12;
         extern const char* apiMetal;
         namespace gl {
-            extern const char* version;
             extern const char* shadingLanguageVersion;
             extern const char* vendor;
             extern const char* renderer;
             extern const char* extensions;
         }
         namespace vk {
-            extern const char* version;
             extern const char* devices;
             namespace device {
                 extern const char* apiVersion;
@@ -115,7 +115,7 @@ namespace platform { namespace keys{
     // Keys for categories used in json returned by getAll()
     extern const char*  CPUS;
     extern const char*  GPUS;
-    extern const char*  RENDERING_APIS;
+    extern const char*  GRAPHICS_APIS;
     extern const char*  DISPLAYS;
     extern const char*  NICS;
     extern const char*  MEMORY;

--- a/libraries/platform/src/platform/backend/MACOSPlatform.cpp
+++ b/libraries/platform/src/platform/backend/MACOSPlatform.cpp
@@ -322,3 +322,8 @@ void MACOSInstance::enumerateComputer(){
 
 }
 
+void MACOSInstance::enumerateRenderingApis() {
+    Instance::enumerateRenderingApis();
+
+    // TODO imeplement Metal query
+}

--- a/libraries/platform/src/platform/backend/MACOSPlatform.cpp
+++ b/libraries/platform/src/platform/backend/MACOSPlatform.cpp
@@ -322,8 +322,8 @@ void MACOSInstance::enumerateComputer(){
 
 }
 
-void MACOSInstance::enumerateRenderingApis() {
-    Instance::enumerateRenderingApis();
+void MACOSInstance::enumerateGraphicsApis() {
+    Instance::enumerateGraphicsApis();
 
     // TODO imeplement Metal query
 }

--- a/libraries/platform/src/platform/backend/MACOSPlatform.h
+++ b/libraries/platform/src/platform/backend/MACOSPlatform.h
@@ -19,7 +19,7 @@ namespace platform {
         void enumerateGpusAndDisplays() override;
         void enumerateMemory() override;
         void enumerateComputer() override;
-        void enumerateRenderingApis() override;
+        void enumerateGraphicsApis() override;
     };
 
 }  // namespace platform

--- a/libraries/platform/src/platform/backend/MACOSPlatform.h
+++ b/libraries/platform/src/platform/backend/MACOSPlatform.h
@@ -19,6 +19,7 @@ namespace platform {
         void enumerateGpusAndDisplays() override;
         void enumerateMemory() override;
         void enumerateComputer() override;
+        void enumerateRenderingApis() override;
     };
 
 }  // namespace platform

--- a/libraries/platform/src/platform/backend/Platform.cpp
+++ b/libraries/platform/src/platform/backend/Platform.cpp
@@ -117,7 +117,7 @@ namespace platform { namespace keys {
 
     const char*  CPUS = "cpus";
     const char*  GPUS = "gpus";
-    const char*  GRAPHICS_APIS = "graphicsAPIS";
+    const char*  GRAPHICS_APIS = "graphicsAPIs";
     const char*  DISPLAYS = "displays";
     const char*  NICS = "nics";
     const char*  MEMORY = "memory";

--- a/libraries/platform/src/platform/backend/Platform.cpp
+++ b/libraries/platform/src/platform/backend/Platform.cpp
@@ -35,7 +35,10 @@ namespace platform { namespace keys {
         const char*  displays = "displays";
         const char*  isMaster = "isMaster";
     }
-    namespace renderingApis {
+    namespace graphicsAPI {
+        const char* name = "name";
+        const char* version = "version";
+
         const char* apiOpenGL = "OpenGL";
         const char* apiVulkan = "Vulkan";
         const char* apiDirect3D11 = "D3D11";
@@ -116,7 +119,7 @@ namespace platform { namespace keys {
 
     const char*  CPUS = "cpus";
     const char*  GPUS = "gpus";
-    const char*  RENDERING_APIS = "renderingApis";
+    const char*  GRAPHICS_APIS = "graphicsAPIS";
     const char*  DISPLAYS = "displays";
     const char*  NICS = "nics";
     const char*  MEMORY = "memory";

--- a/libraries/platform/src/platform/backend/Platform.cpp
+++ b/libraries/platform/src/platform/backend/Platform.cpp
@@ -35,6 +35,44 @@ namespace platform { namespace keys {
         const char*  displays = "displays";
         const char*  isMaster = "isMaster";
     }
+    namespace renderingApis {
+        const char* apiOpenGL = "OpenGL";
+        const char* apiVulkan = "Vulkan";
+        const char* apiDirect3D11 = "D3D11";
+        const char* apiDirect3D12 = "D3D12";
+        const char* apiMetal = "Metal";
+
+        namespace gl {
+            const char* version = "version";
+            const char* shadingLanguageVersion = "shadingLanguageVersion";
+            const char* vendor = "vendor";
+            const char* renderer = "renderer";
+            const char* extensions = "extensions";
+        }
+        namespace vk {
+            const char* version = "version";
+            const char* devices = "devices";
+            namespace device {
+                const char* apiVersion = "apiVersion";
+                const char* driverVersion = "driverVersion";
+                const char* deviceType = "deviceType";
+                const char* vendor = "vendor";
+                const char* name = "name";
+                const char* formats = "formats";
+                const char* extensions = "extensions";
+                const char* heaps = "heaps";
+                namespace heap {
+                    const char* flags = "flags";
+                    const char* size = "size";
+                }
+                const char* queues = "queues";
+                namespace queue {
+                    const char* flags = "flags";
+                    const char* count = "count";
+                }
+            }
+        }
+    }
     namespace nic {
         const char* mac = "mac";
         const char* name = "name";
@@ -78,6 +116,7 @@ namespace platform { namespace keys {
 
     const char*  CPUS = "cpus";
     const char*  GPUS = "gpus";
+    const char*  RENDERING_APIS = "renderingApis";
     const char*  DISPLAYS = "displays";
     const char*  NICS = "nics";
     const char*  MEMORY = "memory";

--- a/libraries/platform/src/platform/backend/Platform.cpp
+++ b/libraries/platform/src/platform/backend/Platform.cpp
@@ -46,14 +46,12 @@ namespace platform { namespace keys {
         const char* apiMetal = "Metal";
 
         namespace gl {
-            const char* version = "version";
             const char* shadingLanguageVersion = "shadingLanguageVersion";
             const char* vendor = "vendor";
             const char* renderer = "renderer";
             const char* extensions = "extensions";
         }
         namespace vk {
-            const char* version = "version";
             const char* devices = "devices";
             namespace device {
                 const char* apiVersion = "apiVersion";

--- a/libraries/platform/src/platform/backend/PlatformInstance.cpp
+++ b/libraries/platform/src/platform/backend/PlatformInstance.cpp
@@ -39,7 +39,7 @@ bool Instance::enumeratePlatform() {
     enumerateCpus();
     enumerateGpusAndDisplays();
     enumerateNics();
-    enumerateRenderingApis();
+    enumerateGraphicsApis();
     
     // eval the master index for each platform scopes
     updateMasterIndices();
@@ -122,7 +122,7 @@ static std::string vkVersionToString(uint32_t version) {
 #endif
 
 
-void Instance::enumerateRenderingApis() {
+void Instance::enumerateGraphicsApis() {
     // OpenGL rendering API is supported on all platforms
     {
         auto& glContextInfo = gl::ContextInfo::get();

--- a/libraries/platform/src/platform/backend/PlatformInstance.h
+++ b/libraries/platform/src/platform/backend/PlatformInstance.h
@@ -44,7 +44,7 @@ public:
     void virtual enumerateNics();
     void virtual enumerateMemory() = 0;
     void virtual enumerateComputer()=0;
-    virtual void enumerateRenderingApis();
+    virtual void enumerateGraphicsApis();
     
     virtual ~Instance();
 

--- a/libraries/platform/src/platform/backend/PlatformInstance.h
+++ b/libraries/platform/src/platform/backend/PlatformInstance.h
@@ -58,7 +58,7 @@ protected:
     std::vector<json>  _gpus;
     std::vector<json>  _displays;
     std::vector<json>  _nics;
-    json  _renderingApis;
+    json  _graphicsApis;
     json  _memory;
     json  _computer;
 

--- a/libraries/platform/src/platform/backend/PlatformInstance.h
+++ b/libraries/platform/src/platform/backend/PlatformInstance.h
@@ -44,6 +44,7 @@ public:
     void virtual enumerateNics();
     void virtual enumerateMemory() = 0;
     void virtual enumerateComputer()=0;
+    virtual void enumerateRenderingApis();
     
     virtual ~Instance();
 
@@ -57,6 +58,7 @@ protected:
     std::vector<json>  _gpus;
     std::vector<json>  _displays;
     std::vector<json>  _nics;
+    json  _renderingApis;
     json  _memory;
     json  _computer;
 

--- a/libraries/platform/src/platform/backend/WINPlatform.cpp
+++ b/libraries/platform/src/platform/backend/WINPlatform.cpp
@@ -251,3 +251,9 @@ void WINInstance::enumerateNics() {
     }
 #endif
 }
+
+void WINInstance::enumerateRenderingApis() {
+    Instance::enumerateRenderingApis();
+
+    // TODO imeplement D3D 11/12 queries
+}

--- a/libraries/platform/src/platform/backend/WINPlatform.cpp
+++ b/libraries/platform/src/platform/backend/WINPlatform.cpp
@@ -252,8 +252,8 @@ void WINInstance::enumerateNics() {
 #endif
 }
 
-void WINInstance::enumerateRenderingApis() {
-    Instance::enumerateRenderingApis();
+void WINInstance::enumerateGraphicsApis() {
+    Instance::enumerateGraphicsApis();
 
     // TODO imeplement D3D 11/12 queries
 }

--- a/libraries/platform/src/platform/backend/WINPlatform.h
+++ b/libraries/platform/src/platform/backend/WINPlatform.h
@@ -20,7 +20,7 @@ namespace platform {
         void enumerateMemory() override;
         void enumerateComputer () override;
         void enumerateNics() override;
-        void enumerateRenderingApis() override;
+        void enumerateGraphicsApis() override;
     };
 }  // namespace platform
 

--- a/libraries/platform/src/platform/backend/WINPlatform.h
+++ b/libraries/platform/src/platform/backend/WINPlatform.h
@@ -20,6 +20,7 @@ namespace platform {
         void enumerateMemory() override;
         void enumerateComputer () override;
         void enumerateNics() override;
+        void enumerateRenderingApis() override;
     };
 }  // namespace platform
 

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -264,7 +264,19 @@ void OffscreenQmlSurface::initializeEngine(QQmlEngine* engine) {
     }
 
     auto rootContext = engine->rootContext();
-    rootContext->setContextProperty("GL", ::getGLContextData());
+
+    static QJsonObject QML_GL_INFO;
+    static std::once_flag once_gl_info;
+    std::call_once(once_gl_info, [] {
+        const auto& contextInfo = gl::ContextInfo::get();
+        QML_GL_INFO = QJsonObject {
+            { "version", contextInfo.version.c_str() },
+            { "sl_version", contextInfo.shadingLanguageVersion.c_str() },
+            { "vendor", contextInfo.vendor.c_str() },
+            { "renderer", contextInfo.renderer.c_str() },
+        };
+    });
+    rootContext->setContextProperty("GL", QML_GL_INFO);
     rootContext->setContextProperty("urlHandler", new UrlHandler(rootContext));
     rootContext->setContextProperty("resourceDirectoryUrl", QUrl::fromLocalFile(PathUtils::resourcesPath()));
     rootContext->setContextProperty("ApplicationInterface", qApp);


### PR DESCRIPTION
Per [DEV-279](https://highfidelity.atlassian.net/browse/DEV-279), this PR adds information about the available rendering APIs and versions to the platform information that's copyable to the clipboard from the about dialog.  


Example output (from a local build with Vulkan enabled:

```
    "graphicsAPIS": [
        {
            "extensions": [
                "GL_AMD_multi_draw_indirect",
                "GL_AMD_seamless_cubemap_per_texture",
                "GL_AMD_vertex_shader_viewport_index",
                "GL_AMD_vertex_shader_layer",
                "GL_ARB_arrays_of_arrays",
                "GL_ARB_base_instance",
                "GL_ARB_bindless_texture",
                "GL_ARB_blend_func_extended",
                "GL_ARB_buffer_storage",
                "GL_ARB_clear_buffer_object",
                "GL_ARB_clear_texture",
                "GL_ARB_clip_control",
                "GL_ARB_color_buffer_float",
                "GL_ARB_compressed_texture_pixel_storage",
                "GL_ARB_conservative_depth",
                "GL_ARB_compute_shader",
                "GL_ARB_compute_variable_group_size",
                "GL_ARB_conditional_render_inverted",
                "GL_ARB_copy_buffer",
                "GL_ARB_copy_image",
                "GL_ARB_cull_distance",
                "GL_ARB_debug_output",
                "GL_ARB_depth_buffer_float",
                "GL_ARB_depth_clamp",
                "GL_ARB_depth_texture",
                "GL_ARB_derivative_control",
                "GL_ARB_direct_state_access",
                "GL_ARB_draw_buffers",
                "GL_ARB_draw_buffers_blend",
                "GL_ARB_draw_indirect",
                "GL_ARB_draw_elements_base_vertex",
                "GL_ARB_draw_instanced",
                "GL_ARB_enhanced_layouts",
                "GL_ARB_ES2_compatibility",
                "GL_ARB_ES3_compatibility",
                "GL_ARB_ES3_1_compatibility",
                "GL_ARB_ES3_2_compatibility",
                "GL_ARB_explicit_attrib_location",
                "GL_ARB_explicit_uniform_location",
                "GL_ARB_fragment_coord_conventions",
                "GL_ARB_fragment_layer_viewport",
                "GL_ARB_fragment_program",
                "GL_ARB_fragment_program_shadow",
                "GL_ARB_fragment_shader",
                "GL_ARB_fragment_shader_interlock",
                "GL_ARB_framebuffer_no_attachments",
                "GL_ARB_framebuffer_object",
                "GL_ARB_framebuffer_sRGB",
                "GL_ARB_geometry_shader4",
                "GL_ARB_get_program_binary",
                "GL_ARB_get_texture_sub_image",
                "GL_ARB_gl_spirv",
                "GL_ARB_gpu_shader5",
                "GL_ARB_gpu_shader_fp64",
                "GL_ARB_gpu_shader_int64",
                "GL_ARB_half_float_pixel",
                "GL_ARB_half_float_vertex",
                "GL_ARB_imaging",
                "GL_ARB_indirect_parameters",
                "GL_ARB_instanced_arrays",
                "GL_ARB_internalformat_query",
                "GL_ARB_internalformat_query2",
                "GL_ARB_invalidate_subdata",
                "GL_ARB_map_buffer_alignment",
                "GL_ARB_map_buffer_range",
                "GL_ARB_multi_bind",
                "GL_ARB_multi_draw_indirect",
                "GL_ARB_multisample",
                "GL_ARB_multitexture",
                "GL_ARB_occlusion_query",
                "GL_ARB_occlusion_query2",
                "GL_ARB_parallel_shader_compile",
                "GL_ARB_pipeline_statistics_query",
                "GL_ARB_pixel_buffer_object",
                "GL_ARB_point_parameters",
                "GL_ARB_point_sprite",
                "GL_ARB_polygon_offset_clamp",
                "GL_ARB_post_depth_coverage",
                "GL_ARB_program_interface_query",
                "GL_ARB_provoking_vertex",
                "GL_ARB_query_buffer_object",
                "GL_ARB_robust_buffer_access_behavior",
                "GL_ARB_robustness",
                "GL_ARB_sample_locations",
                "GL_ARB_sample_shading",
                "GL_ARB_sampler_objects",
                "GL_ARB_seamless_cube_map",
                "GL_ARB_seamless_cubemap_per_texture",
                "GL_ARB_separate_shader_objects",
                "GL_ARB_shader_atomic_counter_ops",
                "GL_ARB_shader_atomic_counters",
                "GL_ARB_shader_ballot",
                "GL_ARB_shader_bit_encoding",
                "GL_ARB_shader_clock",
                "GL_ARB_shader_draw_parameters",
                "GL_ARB_shader_group_vote",
                "GL_ARB_shader_image_load_store",
                "GL_ARB_shader_image_size",
                "GL_ARB_shader_objects",
                "GL_ARB_shader_precision",
                "GL_ARB_shader_storage_buffer_object",
                "GL_ARB_shader_subroutine",
                "GL_ARB_shader_texture_image_samples",
                "GL_ARB_shader_texture_lod",
                "GL_ARB_shading_language_100",
                "GL_ARB_shader_viewport_layer_array",
                "GL_ARB_shading_language_420pack",
                "GL_ARB_shading_language_include",
                "GL_ARB_shading_language_packing",
                "GL_ARB_shadow",
                "GL_ARB_sparse_buffer",
                "GL_ARB_sparse_texture",
                "GL_ARB_sparse_texture2",
                "GL_ARB_sparse_texture_clamp",
                "GL_ARB_spirv_extensions",
                "GL_ARB_stencil_texturing",
                "GL_ARB_sync",
                "GL_ARB_tessellation_shader",
                "GL_ARB_texture_barrier",
                "GL_ARB_texture_border_clamp",
                "GL_ARB_texture_buffer_object",
                "GL_ARB_texture_buffer_object_rgb32",
                "GL_ARB_texture_buffer_range",
                "GL_ARB_texture_compression",
                "GL_ARB_texture_compression_bptc",
                "GL_ARB_texture_compression_rgtc",
                "GL_ARB_texture_cube_map",
                "GL_ARB_texture_cube_map_array",
                "GL_ARB_texture_env_add",
                "GL_ARB_texture_env_combine",
                "GL_ARB_texture_env_crossbar",
                "GL_ARB_texture_env_dot3",
                "GL_ARB_texture_filter_anisotropic",
                "GL_ARB_texture_filter_minmax",
                "GL_ARB_texture_float",
                "GL_ARB_texture_gather",
                "GL_ARB_texture_mirror_clamp_to_edge",
                "GL_ARB_texture_mirrored_repeat",
                "GL_ARB_texture_multisample",
                "GL_ARB_texture_non_power_of_two",
                "GL_ARB_texture_query_levels",
                "GL_ARB_texture_query_lod",
                "GL_ARB_texture_rectangle",
                "GL_ARB_texture_rg",
                "GL_ARB_texture_rgb10_a2ui",
                "GL_ARB_texture_stencil8",
                "GL_ARB_texture_storage",
                "GL_ARB_texture_storage_multisample",
                "GL_ARB_texture_swizzle",
                "GL_ARB_texture_view",
                "GL_ARB_timer_query",
                "GL_ARB_transform_feedback2",
                "GL_ARB_transform_feedback3",
                "GL_ARB_transform_feedback_instanced",
                "GL_ARB_transform_feedback_overflow_query",
                "GL_ARB_transpose_matrix",
                "GL_ARB_uniform_buffer_object",
                "GL_ARB_vertex_array_bgra",
                "GL_ARB_vertex_array_object",
                "GL_ARB_vertex_attrib_64bit",
                "GL_ARB_vertex_attrib_binding",
                "GL_ARB_vertex_buffer_object",
                "GL_ARB_vertex_program",
                "GL_ARB_vertex_shader",
                "GL_ARB_vertex_type_10f_11f_11f_rev",
                "GL_ARB_vertex_type_2_10_10_10_rev",
                "GL_ARB_viewport_array",
                "GL_ARB_window_pos",
                "GL_ATI_draw_buffers",
                "GL_ATI_texture_float",
                "GL_ATI_texture_mirror_once",
                "GL_S3_s3tc",
                "GL_EXT_texture_env_add",
                "GL_EXT_abgr",
                "GL_EXT_bgra",
                "GL_EXT_bindable_uniform",
                "GL_EXT_blend_color",
                "GL_EXT_blend_equation_separate",
                "GL_EXT_blend_func_separate",
                "GL_EXT_blend_minmax",
                "GL_EXT_blend_subtract",
                "GL_EXT_compiled_vertex_array",
                "GL_EXT_Cg_shader",
                "GL_EXT_depth_bounds_test",
                "GL_EXT_direct_state_access",
                "GL_EXT_draw_buffers2",
                "GL_EXT_draw_instanced",
                "GL_EXT_draw_range_elements",
                "GL_EXT_fog_coord",
                "GL_EXT_framebuffer_blit",
                "GL_EXT_framebuffer_multisample",
                "GL_EXTX_framebuffer_mixed_formats",
                "GL_EXT_framebuffer_multisample_blit_scaled",
                "GL_EXT_framebuffer_object",
                "GL_EXT_framebuffer_sRGB",
                "GL_EXT_geometry_shader4",
                "GL_EXT_gpu_program_parameters",
                "GL_EXT_gpu_shader4",
                "GL_EXT_multi_draw_arrays",
                "GL_EXT_packed_depth_stencil",
                "GL_EXT_packed_float",
                "GL_EXT_packed_pixels",
                "GL_EXT_pixel_buffer_object",
                "GL_EXT_point_parameters",
                "GL_EXT_polygon_offset_clamp",
                "GL_EXT_post_depth_coverage",
                "GL_EXT_provoking_vertex",
                "GL_EXT_raster_multisample",
                "GL_EXT_rescale_normal",
                "GL_EXT_secondary_color",
                "GL_EXT_separate_shader_objects",
                "GL_EXT_separate_specular_color",
                "GL_EXT_shader_image_load_formatted",
                "GL_EXT_shader_image_load_store",
                "GL_EXT_shader_integer_mix",
                "GL_EXT_shadow_funcs",
                "GL_EXT_sparse_texture2",
                "GL_EXT_stencil_two_side",
                "GL_EXT_stencil_wrap",
                "GL_EXT_texture3D",
                "GL_EXT_texture_array",
                "GL_EXT_texture_buffer_object",
                "GL_EXT_texture_compression_dxt1",
                "GL_EXT_texture_compression_latc",
                "GL_EXT_texture_compression_rgtc",
                "GL_EXT_texture_compression_s3tc",
                "GL_EXT_texture_cube_map",
                "GL_EXT_texture_edge_clamp",
                "GL_EXT_texture_env_combine",
                "GL_EXT_texture_env_dot3",
                "GL_EXT_texture_filter_anisotropic",
                "GL_EXT_texture_filter_minmax",
                "GL_EXT_texture_integer",
                "GL_EXT_texture_lod",
                "GL_EXT_texture_lod_bias",
                "GL_EXT_texture_mirror_clamp",
                "GL_EXT_texture_object",
                "GL_EXT_texture_shared_exponent",
                "GL_EXT_texture_sRGB",
                "GL_EXT_texture_sRGB_R8",
                "GL_EXT_texture_sRGB_decode",
                "GL_EXT_texture_storage",
                "GL_EXT_texture_swizzle",
                "GL_EXT_timer_query",
                "GL_EXT_transform_feedback2",
                "GL_EXT_vertex_array",
                "GL_EXT_vertex_array_bgra",
                "GL_EXT_vertex_attrib_64bit",
                "GL_EXT_window_rectangles",
                "GL_EXT_import_sync_object",
                "GL_IBM_rasterpos_clip",
                "GL_IBM_texture_mirrored_repeat",
                "GL_KHR_context_flush_control",
                "GL_KHR_debug",
                "GL_EXT_memory_object",
                "GL_EXT_memory_object_win32",
                "GL_EXT_win32_keyed_mutex",
                "GL_KHR_parallel_shader_compile",
                "GL_KHR_no_error",
                "GL_KHR_robust_buffer_access_behavior",
                "GL_KHR_robustness",
                "GL_EXT_semaphore",
                "GL_EXT_semaphore_win32",
                "GL_KTX_buffer_region",
                "GL_NV_alpha_to_coverage_dither_control",
                "GL_NV_bindless_multi_draw_indirect",
                "GL_NV_bindless_multi_draw_indirect_count",
                "GL_NV_bindless_texture",
                "GL_NV_blend_equation_advanced",
                "GL_NV_blend_equation_advanced_coherent",
                "GL_NVX_blend_equation_advanced_multi_draw_buffers",
                "GL_NV_blend_minmax_factor",
                "GL_NV_blend_square",
                "GL_NV_clip_space_w_scaling",
                "GL_NV_command_list",
                "GL_NV_compute_program5",
                "GL_NV_compute_shader_derivatives",
                "GL_NV_conditional_render",
                "GL_NV_conservative_raster",
                "GL_NV_conservative_raster_dilate",
                "GL_NV_conservative_raster_pre_snap",
                "GL_NV_conservative_raster_pre_snap_triangles",
                "GL_NV_conservative_raster_underestimation",
                "GL_NV_copy_depth_to_color",
                "GL_NV_copy_image",
                "GL_NV_depth_buffer_float",
                "GL_NV_depth_clamp",
                "GL_NV_draw_texture",
                "GL_NV_draw_vulkan_image",
                "GL_NV_ES1_1_compatibility",
                "GL_NV_ES3_1_compatibility",
                "GL_NV_explicit_multisample",
                "GL_NV_feature_query",
                "GL_NV_fence",
                "GL_NV_fill_rectangle",
                "GL_NV_float_buffer",
                "GL_NV_fog_distance",
                "GL_NV_fragment_coverage_to_color",
                "GL_NV_fragment_program",
                "GL_NV_fragment_program_option",
                "GL_NV_fragment_program2",
                "GL_NV_fragment_shader_barycentric",
                "GL_NV_fragment_shader_interlock",
                "GL_NV_framebuffer_mixed_samples",
                "GL_NV_framebuffer_multisample_coverage",
                "GL_NV_geometry_shader4",
                "GL_NV_geometry_shader_passthrough",
                "GL_NV_gpu_program4",
                "GL_NV_internalformat_sample_query",
                "GL_NV_gpu_program4_1",
                "GL_NV_gpu_program5",
                "GL_NV_gpu_program5_mem_extended",
                "GL_NV_gpu_program_fp64",
                "GL_NV_gpu_shader5",
                "GL_NV_half_float",
                "GL_NV_light_max_exponent",
                "GL_NV_memory_attachment",
                "GL_NV_mesh_shader",
                "GL_NV_multisample_coverage",
                "GL_NV_multisample_filter_hint",
                "GL_NV_occlusion_query",
                "GL_NV_packed_depth_stencil",
                "GL_NV_parameter_buffer_object",
                "GL_NV_parameter_buffer_object2",
                "GL_NV_path_rendering",
                "GL_NV_path_rendering_shared_edge",
                "GL_NV_pixel_data_range",
                "GL_NV_point_sprite",
                "GL_NV_primitive_restart",
                "GL_NV_query_resource",
                "GL_NV_query_resource_tag",
                "GL_NV_register_combiners",
                "GL_NV_register_combiners2",
                "GL_NV_representative_fragment_test",
                "GL_NV_sample_locations",
                "GL_NV_sample_mask_override_coverage",
                "GL_NV_scissor_exclusive",
                "GL_NV_shader_atomic_counters",
                "GL_NV_shader_atomic_float",
                "GL_NV_shader_atomic_float64",
                "GL_NV_shader_atomic_fp16_vector",
                "GL_NV_shader_atomic_int64",
                "GL_NV_shader_buffer_load",
                "GL_NV_shader_storage_buffer_object",
                "GL_NV_shader_texture_footprint",
                "GL_NV_shading_rate_image",
                "GL_NV_stereo_view_rendering",
                "GL_NV_texgen_reflection",
                "GL_NV_texture_barrier",
                "GL_NV_texture_compression_vtc",
                "GL_NV_texture_env_combine4",
                "GL_NV_texture_multisample",
                "GL_NV_texture_rectangle",
                "GL_NV_texture_rectangle_compressed",
                "GL_NV_texture_shader",
                "GL_NV_texture_shader2",
                "GL_NV_texture_shader3",
                "GL_NV_transform_feedback",
                "GL_NV_transform_feedback2",
                "GL_NV_uniform_buffer_unified_memory",
                "GL_NV_vertex_array_range",
                "GL_NV_vertex_array_range2",
                "GL_NV_vertex_attrib_integer_64bit",
                "GL_NV_vertex_buffer_unified_memory",
                "GL_NV_vertex_program",
                "GL_NV_vertex_program1_1",
                "GL_NV_vertex_program2",
                "GL_NV_vertex_program2_option",
                "GL_NV_vertex_program3",
                "GL_NV_viewport_array2",
                "GL_NV_viewport_swizzle",
                "GL_NVX_conditional_render",
                "GL_NVX_gpu_memory_info",
                "GL_NVX_multigpu_info",
                "GL_NVX_nvenc_interop",
                "GL_NV_shader_thread_group",
                "GL_NV_shader_thread_shuffle",
                "GL_KHR_blend_equation_advanced",
                "GL_KHR_blend_equation_advanced_coherent",
                "GL_OVR_multiview",
                "GL_OVR_multiview2",
                "GL_SGIS_generate_mipmap",
                "GL_SGIS_texture_lod",
                "GL_SGIX_depth_texture",
                "GL_SGIX_shadow",
                "GL_SUN_slice_accum",
                "GL_WIN_swap_hint",
                "WGL_EXT_swap_control"
            ],
            "name": "OpenGL",
            "renderer": "GeForce RTX 2080/PCIe/SSE2",
            "shadingLanguageVersion": "4.50 NVIDIA",
            "vendor": "NVIDIA Corporation",
            "version": "4.5.0 NVIDIA 430.86"
        },
        {
            "devices": [
                {
                    "apiVersion": "1.1.99",
                    "deviceType": "DiscreteGpu",
                    "driverVersion": "430.344.0",
                    "extensions": [
                        "VK_KHR_8bit_storage",
                        "VK_KHR_16bit_storage",
                        "VK_KHR_bind_memory2",
                        "VK_KHR_create_renderpass2",
                        "VK_KHR_dedicated_allocation",
                        "VK_KHR_depth_stencil_resolve",
                        "VK_KHR_descriptor_update_template",
                        "VK_KHR_device_group",
                        "VK_KHR_draw_indirect_count",
                        "VK_KHR_driver_properties",
                        "VK_KHR_external_fence",
                        "VK_KHR_external_fence_win32",
                        "VK_KHR_external_memory",
                        "VK_KHR_external_memory_win32",
                        "VK_KHR_external_semaphore",
                        "VK_KHR_external_semaphore_win32",
                        "VK_KHR_get_memory_requirements2",
                        "VK_KHR_image_format_list",
                        "VK_KHR_maintenance1",
                        "VK_KHR_maintenance2",
                        "VK_KHR_maintenance3",
                        "VK_KHR_multiview",
                        "VK_KHR_push_descriptor",
                        "VK_KHR_relaxed_block_layout",
                        "VK_KHR_sampler_mirror_clamp_to_edge",
                        "VK_KHR_sampler_ycbcr_conversion",
                        "VK_KHR_shader_atomic_int64",
                        "VK_KHR_shader_draw_parameters",
                        "VK_KHR_shader_float16_int8",
                        "VK_KHR_shader_float_controls",
                        "VK_KHR_storage_buffer_storage_class",
                        "VK_KHR_swapchain",
                        "VK_KHR_swapchain_mutable_format",
                        "VK_KHR_variable_pointers",
                        "VK_KHR_vulkan_memory_model",
                        "VK_KHR_win32_keyed_mutex",
                        "VK_EXT_blend_operation_advanced",
                        "VK_EXT_buffer_device_address",
                        "VK_EXT_conditional_rendering",
                        "VK_EXT_conservative_rasterization",
                        "VK_EXT_depth_clip_enable",
                        "VK_EXT_depth_range_unrestricted",
                        "VK_EXT_descriptor_indexing",
                        "VK_EXT_discard_rectangles",
                        "VK_EXT_external_memory_host",
                        "VK_EXT_hdr_metadata",
                        "VK_EXT_host_query_reset",
                        "VK_EXT_inline_uniform_block",
                        "VK_EXT_memory_budget",
                        "VK_EXT_memory_priority",
                        "VK_EXT_pci_bus_info",
                        "VK_EXT_post_depth_coverage",
                        "VK_EXT_sample_locations",
                        "VK_EXT_sampler_filter_minmax",
                        "VK_EXT_scalar_block_layout",
                        "VK_EXT_shader_subgroup_ballot",
                        "VK_EXT_shader_subgroup_vote",
                        "VK_EXT_shader_viewport_index_layer",
                        "VK_EXT_transform_feedback",
                        "VK_EXT_vertex_attribute_divisor",
                        "VK_NV_clip_space_w_scaling",
                        "VK_NV_compute_shader_derivatives",
                        "VK_NV_cooperative_matrix",
                        "VK_NV_corner_sampled_image",
                        "VK_NV_dedicated_allocation",
                        "VK_NV_dedicated_allocation_image_aliasing",
                        "VK_NV_device_diagnostic_checkpoints",
                        "VK_NV_external_memory",
                        "VK_NV_external_memory_win32",
                        "VK_NV_fill_rectangle",
                        "VK_NV_fragment_coverage_to_color",
                        "VK_NV_fragment_shader_barycentric",
                        "VK_NV_framebuffer_mixed_samples",
                        "VK_NV_geometry_shader_passthrough",
                        "VK_NV_mesh_shader",
                        "VK_NV_sample_mask_override_coverage",
                        "VK_NV_representative_fragment_test",
                        "VK_NV_scissor_exclusive",
                        "VK_NV_shader_image_footprint",
                        "VK_NV_shader_subgroup_partitioned",
                        "VK_NV_shading_rate_image",
                        "VK_NV_viewport_array2",
                        "VK_NV_viewport_swizzle",
                        "VK_NV_win32_keyed_mutex",
                        "VK_NVX_binary_import",
                        "VK_NVX_device_generated_commands",
                        "VK_NVX_image_view_handle",
                        "VK_NVX_multiview_per_view_attributes",
                        "VK_NV_ray_tracing"
                    ],
                    "heaps": [
                        {
                            "flags": "DeviceLocal | ",
                            "size": 8399093760
                        },
                        {
                            "flags": "{}",
                            "size": 17124442112
                        }
                    ],
                    "name": "GeForce RTX 2080",
                    "queues": [
                        {
                            "count": 16,
                            "flags": "Graphics | Compute | Transfer | SparseBinding | "
                        },
                        {
                            "count": 2,
                            "flags": "Transfer | "
                        },
                        {
                            "count": 8,
                            "flags": "Compute | "
                        }
                    ],
                    "vendor": 4318
                }
            ],
            "name": "Vulkan",
            "version": "1.1.0"
        }
    ],
```
