### PR TITLE
BUGZ-352: Persist the audio volume settings across sessions

### DIFF
--- a/interface/src/scripting/Audio.cpp
+++ b/interface/src/scripting/Audio.cpp
@@ -213,6 +213,11 @@ void Audio::setPTTHMD(bool enabled) {
 }
 
 void Audio::saveData() {
+    _avatarGainSetting.set(getAvatarGain());
+    _injectorGainSetting.set(getInjectorGain());
+    _localInjectorGainSetting.set(getLocalInjectorGain());
+    _systemInjectorGainSetting.set(getSystemInjectorGain());
+
     _mutedDesktopSetting.set(getMutedDesktop());
     _mutedHMDSetting.set(getMutedHMD());
     _pttDesktopSetting.set(getPTTDesktop());
@@ -220,6 +225,11 @@ void Audio::saveData() {
 }
 
 void Audio::loadData() {
+    setAvatarGain(_avatarGainSetting.get());
+    setInjectorGain(_injectorGainSetting.get());
+    setLocalInjectorGain(_localInjectorGainSetting.get());
+    setSystemInjectorGain(_systemInjectorGainSetting.get());
+
     setMutedDesktop(_mutedDesktopSetting.get());
     setMutedHMD(_mutedHMDSetting.get());
     setPTTDesktop(_pttDesktopSetting.get());

--- a/interface/src/scripting/Audio.h
+++ b/interface/src/scripting/Audio.h
@@ -521,6 +521,10 @@ private:
     bool _settingsLoaded { false };
     float _inputVolume { 1.0f };
     float _inputLevel { 0.0f };
+    Setting::Handle<float> _avatarGainSetting { QStringList { Audio::AUDIO, "AvatarGain" }, 0.0f };
+    Setting::Handle<float> _injectorGainSetting { QStringList { Audio::AUDIO, "InjectorGain" }, 0.0f };
+    Setting::Handle<float> _localInjectorGainSetting { QStringList { Audio::AUDIO, "LocalInjectorGain" }, 0.0f };
+    Setting::Handle<float> _systemInjectorGainSetting { QStringList { Audio::AUDIO, "SystemInjectorGain" }, 0.0f };
     float _localInjectorGain { 0.0f };      // in dB
     float _systemInjectorGain { 0.0f };     // in dB
     float _pttOutputGainDesktop { 0.0f };   // in dB

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -1143,6 +1143,10 @@ void NodeList::maybeSendIgnoreSetToNode(SharedNodePointer newNode) {
 }
 
 void NodeList::setAvatarGain(const QUuid& nodeID, float gain) {
+    if (nodeID.isNull()) {
+        _avatarGain = gain;
+    }
+
     // cannot set gain of yourself
     if (getSessionUUID() != nodeID) {
         auto audioMixer = soloNodeOfType(NodeType::AudioMixer);
@@ -1160,7 +1164,6 @@ void NodeList::setAvatarGain(const QUuid& nodeID, float gain) {
                 qCDebug(networking) << "Sending Set MASTER Avatar Gain packet with Gain:" << gain;
 
                 sendPacket(std::move(setAvatarGainPacket), *audioMixer);
-                _avatarGain = gain;
 
             } else {
                 qCDebug(networking) << "Sending Set Avatar Gain packet with UUID:" << uuidStringWithoutCurlyBraces(nodeID) << "Gain:" << gain;
@@ -1192,6 +1195,8 @@ float NodeList::getAvatarGain(const QUuid& nodeID) {
 }
 
 void NodeList::setInjectorGain(float gain) {
+    _injectorGain = gain;
+
     auto audioMixer = soloNodeOfType(NodeType::AudioMixer);
     if (audioMixer) {
         // setup the packet
@@ -1203,7 +1208,6 @@ void NodeList::setInjectorGain(float gain) {
         qCDebug(networking) << "Sending Set Injector Gain packet with Gain:" << gain;
 
         sendPacket(std::move(setInjectorGainPacket), *audioMixer);
-        _injectorGain = gain;
 
     } else {
         qWarning() << "Couldn't find audio mixer to send set gain request";


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-352

Implemented in the engine instead of UI scripts, to solve tricky synchronization issues and to work regardless of UI.

### Test Plan
Verify that when Interface is closed and restarted, all volume sliders are preserved.