### PR TITLE
(BUGZ-1059) Improve debug API for picks/pointers

### DIFF
--- a/interface/src/avatar/MyAvatarHeadTransformNode.cpp
+++ b/interface/src/avatar/MyAvatarHeadTransformNode.cpp
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 8/14/2018
+//  Created by Sabrina Shanman 2018/08/14
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/interface/src/avatar/MyAvatarHeadTransformNode.cpp
+++ b/interface/src/avatar/MyAvatarHeadTransformNode.cpp
@@ -22,3 +22,9 @@ Transform MyAvatarHeadTransformNode::getTransform() {
 
     return Transform(ori, scale, pos);
 }
+
+QVariantMap MyAvatarHeadTransformNode::toVariantMap() const {
+    QVariantMap map;
+    map["joint"] = "Avatar";
+    return map;
+}

--- a/interface/src/avatar/MyAvatarHeadTransformNode.h
+++ b/interface/src/avatar/MyAvatarHeadTransformNode.h
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 8/14/2018
+//  Created by Sabrina Shanman 2018/08/14
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.
@@ -14,6 +14,7 @@ class MyAvatarHeadTransformNode : public TransformNode {
 public:
     MyAvatarHeadTransformNode() { }
     Transform getTransform() override;
+    QVariantMap toVariantMap() const override;
 };
 
 #endif // hifi_MyAvatarHeadTransformNode_h

--- a/interface/src/raypick/CollisionPick.cpp
+++ b/interface/src/raypick/CollisionPick.cpp
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 7/16/2018
+//  Created by Sabrina Shanman 2018/07/16
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/interface/src/raypick/CollisionPick.h
+++ b/interface/src/raypick/CollisionPick.h
@@ -49,6 +49,7 @@ class CollisionPick : public Pick<CollisionRegion> {
 public:
     CollisionPick(const PickFilter& filter, float maxDistance, bool enabled, bool scaleWithParent, CollisionRegion collisionRegion, PhysicsEnginePointer physicsEngine);
 
+    PickType getType() const override { return PickType::Collision; }
     CollisionRegion getMathematicalPick() const override;
     PickResultPointer getDefaultResult(const QVariantMap& pickVariant) const override {
         return std::make_shared<CollisionPickResult>(pickVariant, std::vector<ContactTestResult>(), std::vector<ContactTestResult>());

--- a/interface/src/raypick/CollisionPick.h
+++ b/interface/src/raypick/CollisionPick.h
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 7/11/2018
+//  Created by Sabrina Shanman 2018/07/11
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -27,6 +27,10 @@ LaserPointer::LaserPointer(const QVariant& rayProps, const RenderStateMap& rende
 {
 }
 
+PickQuery::PickType LaserPointer::getType() const {
+    return PickQuery::PickType::Ray;
+}
+
 void LaserPointer::editRenderStatePath(const std::string& state, const QVariant& pathProps) {
     auto renderState = std::static_pointer_cast<RenderState>(_renderStates[state]);
     if (renderState) {

--- a/interface/src/raypick/LaserPointer.cpp
+++ b/interface/src/raypick/LaserPointer.cpp
@@ -47,7 +47,7 @@ PickResultPointer LaserPointer::getPickResultCopy(const PickResultPointer& pickR
 }
 
 QVariantMap LaserPointer::toVariantMap() const {
-    QVariantMap qVariantMap;
+    QVariantMap qVariantMap = Parent::toVariantMap();
 
     QVariantMap qRenderStates;
     for (auto iter = _renderStates.cbegin(); iter != _renderStates.cend(); iter++) {

--- a/interface/src/raypick/LaserPointer.h
+++ b/interface/src/raypick/LaserPointer.h
@@ -42,6 +42,8 @@ public:
     LaserPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates, bool hover, const PointerTriggers& triggers,
         bool faceAvatar, bool followNormal, float followNormalStrength, bool centerEndY, bool lockEnd, bool distanceScaleEnd, bool scaleWithParent, bool enabled);
 
+    PickQuery::PickType getType() const override;
+
     QVariantMap toVariantMap() const override;
 
     static std::shared_ptr<StartEndRenderState> buildRenderState(const QVariantMap& propMap);

--- a/interface/src/raypick/LaserPointerScriptingInterface.cpp
+++ b/interface/src/raypick/LaserPointerScriptingInterface.cpp
@@ -23,7 +23,7 @@ void LaserPointerScriptingInterface::setIncludeItems(unsigned int uid, const QSc
 }
 
 unsigned int LaserPointerScriptingInterface::createLaserPointer(const QVariant& properties) const {
-    return DependencyManager::get<PointerScriptingInterface>()->createLaserPointer(properties);
+    return DependencyManager::get<PointerScriptingInterface>()->createPointer(PickQuery::PickType::Ray, properties);
 }
 
 void LaserPointerScriptingInterface::editRenderState(unsigned int uid, const QString& renderState, const QVariant& properties) const {

--- a/interface/src/raypick/MouseTransformNode.cpp
+++ b/interface/src/raypick/MouseTransformNode.cpp
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 8/14/2018
+//  Created by Sabrina Shanman 2018/08/14
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/interface/src/raypick/MouseTransformNode.cpp
+++ b/interface/src/raypick/MouseTransformNode.cpp
@@ -25,3 +25,9 @@ Transform MouseTransformNode::getTransform() {
 
     return Transform();
 }
+
+QVariantMap MouseTransformNode::toVariantMap() const {
+    QVariantMap map;
+    map["joint"] = "Mouse";
+    return map;
+}

--- a/interface/src/raypick/MouseTransformNode.h
+++ b/interface/src/raypick/MouseTransformNode.h
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 8/14/2018
+//  Created by Sabrina Shanman 2018/08/14
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.
@@ -13,6 +13,7 @@
 class MouseTransformNode : public TransformNode {
 public:
     Transform getTransform() override;
+    QVariantMap toVariantMap() const override;
 };
 
 #endif // hifi_MouseTransformNode_h

--- a/interface/src/raypick/ParabolaPick.h
+++ b/interface/src/raypick/ParabolaPick.h
@@ -92,6 +92,8 @@ class ParabolaPick : public Pick<PickParabola> {
 public:
     ParabolaPick(const glm::vec3& position, const glm::vec3& direction, float speed, const glm::vec3& acceleration, bool rotateAccelerationWithAvatar, bool rotateAccelerationWithParent, bool scaleWithParent, const PickFilter& filter, float maxDistance, bool enabled);
 
+    PickType getType() const override { return PickType::Parabola; }
+    
     PickParabola getMathematicalPick() const override;
 
     PickResultPointer getDefaultResult(const QVariantMap& pickVariant) const override { return std::make_shared<ParabolaPickResult>(pickVariant); }

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -72,7 +72,7 @@ void ParabolaPointer::editRenderStatePath(const std::string& state, const QVaria
 }
 
 QVariantMap ParabolaPointer::toVariantMap() const {
-    QVariantMap qVariantMap;
+    QVariantMap qVariantMap = Parent::toVariantMap();
 
     QVariantMap qRenderStates;
     for (auto iter = _renderStates.cbegin(); iter != _renderStates.cend(); iter++) {

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -30,6 +30,10 @@ ParabolaPointer::ParabolaPointer(const QVariant& rayProps, const RenderStateMap&
 {
 }
 
+PickQuery::PickType ParabolaPointer::getType() const {
+    return PickQuery::PickType::Parabola;
+}
+
 PickResultPointer ParabolaPointer::getPickResultCopy(const PickResultPointer& pickResult) const {
     auto parabolaPickResult = std::dynamic_pointer_cast<ParabolaPickResult>(pickResult);
     if (!parabolaPickResult) {

--- a/interface/src/raypick/ParabolaPointer.h
+++ b/interface/src/raypick/ParabolaPointer.h
@@ -101,6 +101,8 @@ public:
     ParabolaPointer(const QVariant& rayProps, const RenderStateMap& renderStates, const DefaultRenderStateMap& defaultRenderStates, bool hover, const PointerTriggers& triggers,
         bool faceAvatar, bool followNormal, float followNormalStrength, bool centerEndY, bool lockEnd, bool distanceScaleEnd, bool scaleWithAvatar, bool enabled);
 
+    PickQuery::PickType getType() const override;
+
     QVariantMap toVariantMap() const override;
 
     static std::shared_ptr<StartEndRenderState> buildRenderState(const QVariantMap& propMap);

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -400,8 +400,8 @@ QVariantMap PickScriptingInterface::getPickScriptParameters(unsigned int uid) co
     return DependencyManager::get<PickManager>()->getPickScriptParameters(uid);
 }
 
-QVector<unsigned int> PickScriptingInterface::getCreatedPicks() const {
-    return DependencyManager::get<PickManager>()->getCreatedPicks();
+QVector<unsigned int> PickScriptingInterface::getPicks() const {
+    return DependencyManager::get<PickManager>()->getPicks();
 }
 
 QVariantMap PickScriptingInterface::getPrevPickResult(unsigned int uid) {

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -34,18 +34,35 @@ static const float WEB_TOUCH_Y_OFFSET = 0.105f;  // how far forward (or back wit
 static const glm::vec3 TIP_OFFSET = glm::vec3(0.0f, StylusPick::WEB_STYLUS_LENGTH - WEB_TOUCH_Y_OFFSET, 0.0f);
 
 unsigned int PickScriptingInterface::createPick(const PickQuery::PickType type, const QVariant& properties) {
+    std::shared_ptr<PickQuery> pick;
+    QVariantMap propMap = properties.toMap();
+
     switch (type) {
         case PickQuery::PickType::Ray:
-            return createRayPick(properties);
+            pick = buildRayPick(propMap);
+            break;
         case PickQuery::PickType::Stylus:
-            return createStylusPick(properties);
+            pick = buildStylusPick(propMap);
+            break;
         case PickQuery::PickType::Parabola:
-            return createParabolaPick(properties);
+            pick = buildParabolaPick(propMap);
+            break;
         case PickQuery::PickType::Collision:
-            return createCollisionPick(properties);
+            pick = buildCollisionPick(propMap);
+            break;
         default:
-            return PickManager::INVALID_PICK_ID;
+            break;
     }
+
+    if (!pick) {
+        return PickManager::INVALID_PICK_ID;
+    }
+
+    propMap["type"] = (int)type;
+
+    pick->setScriptParameters(propMap);
+
+    return DependencyManager::get<PickManager>()->addPick(type, pick);
 }
 
 PickFilter getPickFilter(unsigned int filter) {
@@ -82,17 +99,18 @@ PickFilter getPickFilter(unsigned int filter) {
  * @property {Vec3} [dirOffset] - Synonym for <code>direction</code>.
  * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the 
  *     default <code>direction</code> value.
+ * @property {PickType} type - The type of pick when getting these properties from {@link Picks.getPickProperties}. A ray pick's type is {@link PickType.Ray}.
+ * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale (usually an avatar or an entity).
+ *     Its value is the original scale of the parent at the moment the pick was created, and is used to scale the pointer which owns this pick, if any.
  */
-unsigned int PickScriptingInterface::createRayPick(const QVariant& properties) {
-    QVariantMap propMap = properties.toMap();
-
+std::shared_ptr<PickQuery> PickScriptingInterface::buildRayPick(const QVariantMap& propMap) {
 #if defined (Q_OS_ANDROID)
     QString jointName { "" };
     if (propMap["joint"].isValid()) {
         QString jointName = propMap["joint"].toString();
         const QString MOUSE_JOINT = "Mouse";
         if (jointName == MOUSE_JOINT) {
-            return PointerEvent::INVALID_POINTER_ID;
+            return nullptr;
         }
     }
 #endif
@@ -134,7 +152,7 @@ unsigned int PickScriptingInterface::createRayPick(const QVariant& properties) {
     auto rayPick = std::make_shared<RayPick>(position, direction, filter, maxDistance, enabled);
     setParentTransform(rayPick, propMap);
 
-    return DependencyManager::get<PickManager>()->addPick(PickQuery::Ray, rayPick);
+    return rayPick;
 }
 
 /**jsdoc
@@ -152,10 +170,9 @@ unsigned int PickScriptingInterface::createRayPick(const QVariant& properties) {
  *     means no maximum.
  * @property {Vec3} [tipOffset=0,0.095,0] - The position of the stylus tip relative to the hand position at default avatar 
  *     scale.
+ * @property {PickType} type - The type of pick when getting these properties from {@link Picks.getPickProperties}. A stylus pick's type is {@link PickType.Stylus}.
  */
-unsigned int PickScriptingInterface::createStylusPick(const QVariant& properties) {
-    QVariantMap propMap = properties.toMap();
-
+std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVariantMap& propMap) {
     bilateral::Side side = bilateral::Side::Invalid;
     {
         QVariant handVar = propMap["hand"];
@@ -184,7 +201,7 @@ unsigned int PickScriptingInterface::createStylusPick(const QVariant& properties
         tipOffset = vec3FromVariant(propMap["tipOffset"]);
     }
 
-    return DependencyManager::get<PickManager>()->addPick(PickQuery::Stylus, std::make_shared<StylusPick>(side, filter, maxDistance, enabled, tipOffset));
+    return std::make_shared<StylusPick>(side, filter, maxDistance, enabled, tipOffset);
 }
 
 // NOTE: Laser pointer still uses scaleWithAvatar. Until scaleWithAvatar is also deprecated for pointers, scaleWithAvatar should not be removed from the pick API.
@@ -228,10 +245,11 @@ unsigned int PickScriptingInterface::createStylusPick(const QVariant& properties
  *     with the avatar or other parent.
  * @property {boolean} [scaleWithAvatar=true] - Synonym for <code>scalewithParent</code>.
  *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
+ * @property {PickType} type - The type of pick when getting these properties from {@link Picks.getPickProperties}. A parabola pick's type is {@link PickType.Parabola}.
+ * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale (usually an avatar or an entity).
+ *     Its value is the original scale of the parent at the moment the pick was created, and is used to rescale the pick, and/or the pointer which owns this pick, if any.
  */
-unsigned int PickScriptingInterface::createParabolaPick(const QVariant& properties) {
-    QVariantMap propMap = properties.toMap();
-
+std::shared_ptr<PickQuery> PickScriptingInterface::buildParabolaPick(const QVariantMap& propMap) {
     bool enabled = false;
     if (propMap["enabled"].isValid()) {
         enabled = propMap["enabled"].toBool();
@@ -292,7 +310,7 @@ unsigned int PickScriptingInterface::createParabolaPick(const QVariant& properti
     auto parabolaPick = std::make_shared<ParabolaPick>(position, direction, speed, accelerationAxis,
         rotateAccelerationWithAvatar, rotateAccelerationWithParent, scaleWithParent, filter, maxDistance, enabled);
     setParentTransform(parabolaPick, propMap);
-    return DependencyManager::get<PickManager>()->addPick(PickQuery::Parabola, parabolaPick);
+    return parabolaPick;
 }
 
 
@@ -326,10 +344,11 @@ unsigned int PickScriptingInterface::createParabolaPick(const QVariant& properti
  *     the collision region. The depth is in world coordinates but scales with the parent if defined.
  * @property {CollisionMask} [collisionGroup=8] - The type of objects the collision region collides as. Objects whose collision
  *     masks overlap with the region's collision group are considered to be colliding with the region.
+ * @property {PickType} type - The type of pick when getting these properties from {@link Picks.getPickProperties}. A collision pick's type is {@link PickType.Collision}.
+ * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale (usually an avatar or an entity).
+ *     Its value is the original scale of the parent at the moment the pick was created, and is used to rescale the pick, and/or the pointer which owns this pick, if any.
  */
-unsigned int PickScriptingInterface::createCollisionPick(const QVariant& properties) {
-    QVariantMap propMap = properties.toMap();
-
+std::shared_ptr<PickQuery> PickScriptingInterface::buildCollisionPick(const QVariantMap& propMap) {
     bool enabled = false;
     if (propMap["enabled"].isValid()) {
         enabled = propMap["enabled"].toBool();
@@ -354,7 +373,7 @@ unsigned int PickScriptingInterface::createCollisionPick(const QVariant& propert
     auto collisionPick = std::make_shared<CollisionPick>(filter, maxDistance, enabled, scaleWithParent, collisionRegion, qApp->getPhysicsEngine());
     setParentTransform(collisionPick, propMap);
 
-    return DependencyManager::get<PickManager>()->addPick(PickQuery::Collision, collisionPick);
+    return collisionPick;
 }
 
 void PickScriptingInterface::enablePick(unsigned int uid) {
@@ -365,8 +384,24 @@ void PickScriptingInterface::disablePick(unsigned int uid) {
     DependencyManager::get<PickManager>()->disablePick(uid);
 }
 
+bool PickScriptingInterface::isPickEnabled(unsigned int uid) const {
+    return DependencyManager::get<PickManager>()->isPickEnabled(uid);
+}
+
 void PickScriptingInterface::removePick(unsigned int uid) {
     DependencyManager::get<PickManager>()->removePick(uid);
+}
+
+QVariantMap PickScriptingInterface::getPickProperties(unsigned int uid) const {
+    return DependencyManager::get<PickManager>()->getPickProperties(uid);
+}
+
+QVariantMap PickScriptingInterface::getPickScriptParameters(unsigned int uid) const {
+    return DependencyManager::get<PickManager>()->getPickScriptParameters(uid);
+}
+
+QVector<unsigned int> PickScriptingInterface::getCreatedPicks() const {
+    return DependencyManager::get<PickManager>()->getCreatedPicks();
 }
 
 QVariantMap PickScriptingInterface::getPrevPickResult(unsigned int uid) {

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -99,7 +99,7 @@ PickFilter getPickFilter(unsigned int filter) {
  * @property {Vec3} [dirOffset] - Synonym for <code>direction</code>.
  * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the 
  *     default <code>direction</code> value.
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties}. A ray pick's type is {@link PickType.Ray}.
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or {@link Picks.getPickScriptParameters}. A ray pick's type is {@link PickType.Ray}.
  * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale (usually an avatar or an entity).
  *     Its value is the original scale of the parent at the moment the pick was created, and is used to scale the pointer which owns this pick, if any.
  */
@@ -170,7 +170,7 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildRayPick(const QVariantMa
  *     means no maximum.
  * @property {Vec3} [tipOffset=0,0.095,0] - The position of the stylus tip relative to the hand position at default avatar 
  *     scale.
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties}. A stylus pick's type is {@link PickType.Stylus}.
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or {@link Picks.getPickScriptParameters}. A stylus pick's type is {@link PickType.Stylus}.
  */
 std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVariantMap& propMap) {
     bilateral::Side side = bilateral::Side::Invalid;
@@ -245,7 +245,7 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVarian
  *     with the avatar or other parent.
  * @property {boolean} [scaleWithAvatar=true] - Synonym for <code>scalewithParent</code>.
  *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties}. A parabola pick's type is {@link PickType.Parabola}.
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or {@link Picks.getPickScriptParameters}. A parabola pick's type is {@link PickType.Parabola}.
  * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale (usually an avatar or an entity).
  *     Its value is the original scale of the parent at the moment the pick was created, and is used to rescale the pick, and/or the pointer which owns this pick, if any.
  */
@@ -344,7 +344,7 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildParabolaPick(const QVari
  *     the collision region. The depth is in world coordinates but scales with the parent if defined.
  * @property {CollisionMask} [collisionGroup=8] - The type of objects the collision region collides as. Objects whose collision
  *     masks overlap with the region's collision group are considered to be colliding with the region.
- * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties}. A collision pick's type is {@link PickType.Collision}.
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties} or {@link Picks.getPickScriptParameters}. A collision pick's type is {@link PickType.Collision}.
  * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale (usually an avatar or an entity).
  *     Its value is the original scale of the parent at the moment the pick was created, and is used to rescale the pick, and/or the pointer which owns this pick, if any.
  */

--- a/interface/src/raypick/PickScriptingInterface.cpp
+++ b/interface/src/raypick/PickScriptingInterface.cpp
@@ -58,7 +58,7 @@ unsigned int PickScriptingInterface::createPick(const PickQuery::PickType type, 
         return PickManager::INVALID_PICK_ID;
     }
 
-    propMap["type"] = (int)type;
+    propMap["pickType"] = (int)type;
 
     pick->setScriptParameters(propMap);
 
@@ -99,7 +99,7 @@ PickFilter getPickFilter(unsigned int filter) {
  * @property {Vec3} [dirOffset] - Synonym for <code>direction</code>.
  * @property {Quat} [orientation] - Alternative property for specifying <code>direction</code>. The value is applied to the 
  *     default <code>direction</code> value.
- * @property {PickType} type - The type of pick when getting these properties from {@link Picks.getPickProperties}. A ray pick's type is {@link PickType.Ray}.
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties}. A ray pick's type is {@link PickType.Ray}.
  * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale (usually an avatar or an entity).
  *     Its value is the original scale of the parent at the moment the pick was created, and is used to scale the pointer which owns this pick, if any.
  */
@@ -170,7 +170,7 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildRayPick(const QVariantMa
  *     means no maximum.
  * @property {Vec3} [tipOffset=0,0.095,0] - The position of the stylus tip relative to the hand position at default avatar 
  *     scale.
- * @property {PickType} type - The type of pick when getting these properties from {@link Picks.getPickProperties}. A stylus pick's type is {@link PickType.Stylus}.
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties}. A stylus pick's type is {@link PickType.Stylus}.
  */
 std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVariantMap& propMap) {
     bilateral::Side side = bilateral::Side::Invalid;
@@ -245,7 +245,7 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildStylusPick(const QVarian
  *     with the avatar or other parent.
  * @property {boolean} [scaleWithAvatar=true] - Synonym for <code>scalewithParent</code>.
  *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
- * @property {PickType} type - The type of pick when getting these properties from {@link Picks.getPickProperties}. A parabola pick's type is {@link PickType.Parabola}.
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties}. A parabola pick's type is {@link PickType.Parabola}.
  * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale (usually an avatar or an entity).
  *     Its value is the original scale of the parent at the moment the pick was created, and is used to rescale the pick, and/or the pointer which owns this pick, if any.
  */
@@ -344,7 +344,7 @@ std::shared_ptr<PickQuery> PickScriptingInterface::buildParabolaPick(const QVari
  *     the collision region. The depth is in world coordinates but scales with the parent if defined.
  * @property {CollisionMask} [collisionGroup=8] - The type of objects the collision region collides as. Objects whose collision
  *     masks overlap with the region's collision group are considered to be colliding with the region.
- * @property {PickType} type - The type of pick when getting these properties from {@link Picks.getPickProperties}. A collision pick's type is {@link PickType.Collision}.
+ * @property {PickType} pickType - The type of pick when getting these properties from {@link Picks.getPickProperties}. A collision pick's type is {@link PickType.Collision}.
  * @property {Vec3} baseScale - Returned from {@link Picks.getPickProperties} when the pick has a parent with varying scale (usually an avatar or an entity).
  *     Its value is the original scale of the parent at the moment the pick was created, and is used to rescale the pick, and/or the pointer which owns this pick, if any.
  */

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -164,10 +164,10 @@ public:
 
     /**jsdoc
      * Gets all picks which currently exist, including disabled picks.
-     * @function Picks.getCreatedPicks
+     * @function Picks.getPicks
      * @returns {number[]} picks - The IDs of the picks.
      */
-    Q_INVOKABLE QVector<unsigned int> getCreatedPicks() const;
+    Q_INVOKABLE QVector<unsigned int> getPicks() const;
 
     /**jsdoc
      * Gets the most recent result from a pick. A pick continues to be updated ready to return a result, as long as it is 

--- a/interface/src/raypick/PickScriptingInterface.h
+++ b/interface/src/raypick/PickScriptingInterface.h
@@ -10,7 +10,6 @@
 
 #include <QtCore/QObject>
 
-#include <RegisteredMetaTypes.h>
 #include <DependencyManager.h>
 #include <PhysicsEngine.h>
 #include <Pick.h>
@@ -98,11 +97,6 @@ class PickScriptingInterface : public QObject, public Dependency {
     SINGLETON_DEPENDENCY
 
 public:
-    unsigned int createRayPick(const QVariant& properties);
-    unsigned int createStylusPick(const QVariant& properties);
-    unsigned int createCollisionPick(const QVariant& properties);
-    unsigned int createParabolaPick(const QVariant& properties);
-
     void registerMetaTypes(QScriptEngine* engine);
 
     /**jsdoc
@@ -135,11 +129,45 @@ public:
     Q_INVOKABLE void disablePick(unsigned int uid);
 
     /**jsdoc
+     * Get the enabled status of a pick. Enabled picks update their pick results.
+     * @function Picks.isPickEnabled
+     * @param {number} id - The ID of the pick.
+     * @returns {boolean} enabled - Whether or not the pick is enabled.
+     */
+    Q_INVOKABLE bool isPickEnabled(unsigned int uid) const;
+
+    /**jsdoc
      * Removes (deletes) a pick.
      * @function Picks.removePick
      * @param {number} id - The ID of the pick.
      */
     Q_INVOKABLE void removePick(unsigned int uid);
+
+    /**jsdoc
+     * Gets the current properties of the pick.
+     * @function Picks.getPickProperties
+     * @param {number} id - The ID of the pick.
+     * @returns {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties} Properties of the pick, per the pick <code>type</code>.
+     */
+    Q_INVOKABLE QVariantMap getPickProperties(unsigned int uid) const;
+
+    /**jsdoc
+    * Gets the parameters that were passed in to {@link Picks.createPick} to create the pick,
+    * if the pick was created through a script.
+    * Note that these properties do not reflect the current state of the pick.
+    * See {@link Picks.getPickProperties}.
+    * @function Picks.getPickScriptParameters
+    * @param {number} id - The ID of the pick.
+    * @returns {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties} User-provided properties, per the pick <code>type</code>.
+    */
+    Q_INVOKABLE QVariantMap getPickScriptParameters(unsigned int uid) const;
+
+    /**jsdoc
+     * Gets all picks which currently exist, including disabled picks.
+     * @function Picks.getCreatedPicks
+     * @returns {number[]} picks - The IDs of the picks.
+     */
+    Q_INVOKABLE QVector<unsigned int> getCreatedPicks() const;
 
     /**jsdoc
      * Gets the most recent result from a pick. A pick continues to be updated ready to return a result, as long as it is 
@@ -419,6 +447,11 @@ public slots:
     static constexpr unsigned int INTERSECTED_HUD() { return IntersectionType::HUD; }
 
 protected:
+    static std::shared_ptr<PickQuery> buildRayPick(const QVariantMap& properties);
+    static std::shared_ptr<PickQuery> buildStylusPick(const QVariantMap& properties);
+    static std::shared_ptr<PickQuery> buildCollisionPick(const QVariantMap& properties);
+    static std::shared_ptr<PickQuery> buildParabolaPick(const QVariantMap& properties);
+
     static void setParentTransform(std::shared_ptr<PickQuery> pick, const QVariantMap& propMap);
 };
 

--- a/interface/src/raypick/PointerScriptingInterface.cpp
+++ b/interface/src/raypick/PointerScriptingInterface.cpp
@@ -60,7 +60,7 @@ unsigned int PointerScriptingInterface::createPointer(const PickQuery::PickType&
         return PointerEvent::INVALID_POINTER_ID;
     }
 
-    propertyMap["type"] = (int)type;
+    propertyMap["pointerType"] = (int)type;
 
     pointer->setScriptParameters(propertyMap);
 
@@ -89,6 +89,7 @@ QVariantMap PointerScriptingInterface::getPointerScriptParameters(unsigned int u
  * @property {Pointers.StylusPointerModel} [model] - Override some or all of the default stylus model properties.
  * @property {boolean} [hover=false] - <code>true</code> if the pointer generates {@link Entities} hover events, 
  *     <code>false</code> if it doesn't.
+ * @property {PickType} pointerType - The type of pointer when getting these properties from {@link Pointers.getPointerProperties}. A stylus pointer's type is {@link PickType.Stylus}.
  * @property {number} [pickID] - Returned from {@link Pointers.getPointerProperties}. The ID of the pick created alongside this pointer.
  * @see {@link Picks.StylusPickProperties} for additional properties from the underlying stylus pick.
  */
@@ -207,6 +208,7 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildStylus(const QVariant& 
  *     <code>false</code> if it doesn't.
  * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger 
  *     events on the entity or overlay currently intersected.
+ * @property {PickType} pointerType - The type of pointer when getting these properties from {@link Pointers.getPointerProperties}. A laser pointer's type is {@link PickType.Ray}.
  * @property {number} [pickID] - Returned from {@link Pointers.getPointerProperties}. The ID of the pick created alongside this pointer.
  * @see {@link Picks.RayPickProperties} for additional properties from the underlying ray pick.
  */
@@ -399,6 +401,7 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildLaserPointer(const QVar
  *     <code>false</code> if it doesn't.
  * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger
  *     events on the entity or overlay currently intersected.
+ * @property {PickType} pointerType - The type of pointer when getting these properties from {@link Pointers.getPointerProperties}. A parabola pointer's type is {@link PickType.Parabola}.
  * @property {number} [pickID] - Returned from {@link Pointers.getPointerProperties}. The ID of the pick created alongside this pointer.
  * @see {@link Picks.ParabolaPickProperties} for additional properties from the underlying parabola pick.
  */

--- a/interface/src/raypick/PointerScriptingInterface.cpp
+++ b/interface/src/raypick/PointerScriptingInterface.cpp
@@ -89,7 +89,7 @@ QVariantMap PointerScriptingInterface::getPointerScriptParameters(unsigned int u
  * @property {Pointers.StylusPointerModel} [model] - Override some or all of the default stylus model properties.
  * @property {boolean} [hover=false] - <code>true</code> if the pointer generates {@link Entities} hover events, 
  *     <code>false</code> if it doesn't.
- * @property {PickType} pointerType - The type of pointer when getting these properties from {@link Pointers.getPointerProperties}. A stylus pointer's type is {@link PickType.Stylus}.
+ * @property {PickType} pointerType - The type of pointer when getting these properties from {@link Pointers.getPointerProperties} or {@link Pointers.getPointerScriptParameters}. A stylus pointer's type is {@link PickType.Stylus}.
  * @property {number} [pickID] - Returned from {@link Pointers.getPointerProperties}. The ID of the pick created alongside this pointer.
  * @see {@link Picks.StylusPickProperties} for additional properties from the underlying stylus pick.
  */
@@ -208,7 +208,7 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildStylus(const QVariant& 
  *     <code>false</code> if it doesn't.
  * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger 
  *     events on the entity or overlay currently intersected.
- * @property {PickType} pointerType - The type of pointer when getting these properties from {@link Pointers.getPointerProperties}. A laser pointer's type is {@link PickType.Ray}.
+ * @property {PickType} pointerType - The type of pointer when getting these properties from {@link Pointers.getPointerProperties} or {@link Pointers.getPointerScriptParameters}. A laser pointer's type is {@link PickType.Ray}.
  * @property {number} [pickID] - Returned from {@link Pointers.getPointerProperties}. The ID of the pick created alongside this pointer.
  * @see {@link Picks.RayPickProperties} for additional properties from the underlying ray pick.
  */
@@ -401,7 +401,7 @@ std::shared_ptr<Pointer> PointerScriptingInterface::buildLaserPointer(const QVar
  *     <code>false</code> if it doesn't.
  * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger
  *     events on the entity or overlay currently intersected.
- * @property {PickType} pointerType - The type of pointer when getting these properties from {@link Pointers.getPointerProperties}. A parabola pointer's type is {@link PickType.Parabola}.
+ * @property {PickType} pointerType - The type of pointer when getting these properties from {@link Pointers.getPointerProperties} or {@link Pointers.getPointerScriptParameters}. A parabola pointer's type is {@link PickType.Parabola}.
  * @property {number} [pickID] - Returned from {@link Pointers.getPointerProperties}. The ID of the pick created alongside this pointer.
  * @see {@link Picks.ParabolaPickProperties} for additional properties from the underlying parabola pick.
  */

--- a/interface/src/raypick/PointerScriptingInterface.cpp
+++ b/interface/src/raypick/PointerScriptingInterface.cpp
@@ -69,8 +69,8 @@ bool PointerScriptingInterface::isPointerEnabled(unsigned int uid) const {
     return DependencyManager::get<PointerManager>()->isPointerEnabled(uid);
 }
 
-QVector<unsigned int> PointerScriptingInterface::getCreatedPointers() const {
-    return DependencyManager::get<PointerManager>()->getCreatedPointers();
+QVector<unsigned int> PointerScriptingInterface::getPointers() const {
+    return DependencyManager::get<PointerManager>()->getPointers();
 }
 
 QVariantMap PointerScriptingInterface::getPointerProperties(unsigned int uid) const {

--- a/interface/src/raypick/PointerScriptingInterface.cpp
+++ b/interface/src/raypick/PointerScriptingInterface.cpp
@@ -13,6 +13,7 @@
 #include <shared/QtHelpers.h>
 
 #include "Application.h"
+#include "PickManager.h"
 #include "LaserPointer.h"
 #include "StylusPointer.h"
 #include "ParabolaPointer.h"
@@ -38,16 +39,46 @@ unsigned int PointerScriptingInterface::createPointer(const PickQuery::PickType&
         return result;
     }
 
+    QVariantMap propertyMap = properties.toMap();
+
+    std::shared_ptr<Pointer> pointer;
     switch (type) {
         case PickQuery::PickType::Ray:
-            return createLaserPointer(properties);
+            pointer = buildLaserPointer(propertyMap);
+            break;
         case PickQuery::PickType::Stylus:
-            return createStylus(properties);
+            pointer = buildStylus(propertyMap);
+            break;
         case PickQuery::PickType::Parabola:
-            return createParabolaPointer(properties);
+            pointer = buildParabolaPointer(propertyMap);
+            break;
         default:
-            return PointerEvent::INVALID_POINTER_ID;
+            break;
     }
+
+    if (!pointer) {
+        return PointerEvent::INVALID_POINTER_ID;
+    }
+
+    propertyMap["type"] = (int)type;
+
+    return DependencyManager::get<PointerManager>()->addPointer(pointer);
+}
+
+bool PointerScriptingInterface::isPointerEnabled(unsigned int uid) const {
+    return DependencyManager::get<PointerManager>()->isPointerEnabled(uid);
+}
+
+QVector<unsigned int> PointerScriptingInterface::getCreatedPointers() const {
+    return DependencyManager::get<PointerManager>()->getCreatedPointers();
+}
+
+QVariantMap PointerScriptingInterface::getPointerProperties(unsigned int uid) const {
+    return DependencyManager::get<PointerManager>()->getPointerProperties(uid);
+}
+
+QVariantMap PointerScriptingInterface::getPointerScriptParameters(unsigned int uid) const {
+    return DependencyManager::get<PointerManager>()->getPointerScriptParameters(uid);
 }
 
 /**jsdoc
@@ -56,6 +87,7 @@ unsigned int PointerScriptingInterface::createPointer(const PickQuery::PickType&
  * @property {Pointers.StylusPointerModel} [model] - Override some or all of the default stylus model properties.
  * @property {boolean} [hover=false] - <code>true</code> if the pointer generates {@link Entities} hover events, 
  *     <code>false</code> if it doesn't.
+ * @property {number} [pickID] - Returned from {@link Pointers.getPointerProperties}. The ID of the pick created alongside this pointer.
  * @see {@link Picks.StylusPickProperties} for additional properties from the underlying stylus pick.
  */
 /**jsdoc
@@ -67,7 +99,7 @@ unsigned int PointerScriptingInterface::createPointer(const PickQuery::PickType&
  *     offset.
  * @property {Quat} [rotationOffset] - The rotation offset of the model from the hand, to override the default rotation offset.
  */
-unsigned int PointerScriptingInterface::createStylus(const QVariant& properties) const {
+std::shared_ptr<Pointer> PointerScriptingInterface::buildStylus(const QVariant& properties) {
     QVariantMap propertyMap = properties.toMap();
 
     bool hover = false;
@@ -100,8 +132,7 @@ unsigned int PointerScriptingInterface::createStylus(const QVariant& properties)
         }
     }
 
-    return DependencyManager::get<PointerManager>()->addPointer(std::make_shared<StylusPointer>(properties, StylusPointer::buildStylus(propertyMap), hover, enabled, modelPositionOffset,
-                                                                                                modelRotationOffset, modelDimensions));
+    return std::make_shared<StylusPointer>(properties, StylusPointer::buildStylus(propertyMap), hover, enabled, modelPositionOffset, modelRotationOffset, modelDimensions);
 }
 
 /**jsdoc
@@ -174,9 +205,10 @@ unsigned int PointerScriptingInterface::createStylus(const QVariant& properties)
  *     <code>false</code> if it doesn't.
  * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger 
  *     events on the entity or overlay currently intersected.
+ * @property {number} [pickID] - Returned from {@link Pointers.getPointerProperties}. The ID of the pick created alongside this pointer.
  * @see {@link Picks.RayPickProperties} for additional properties from the underlying ray pick.
  */
-unsigned int PointerScriptingInterface::createLaserPointer(const QVariant& properties) const {
+std::shared_ptr<Pointer> PointerScriptingInterface::buildLaserPointer(const QVariant& properties) {
     QVariantMap propertyMap = properties.toMap();
 
 #if defined (Q_OS_ANDROID)
@@ -185,7 +217,7 @@ unsigned int PointerScriptingInterface::createLaserPointer(const QVariant& prope
         QString jointName = propertyMap["joint"].toString();
         const QString MOUSE_JOINT = "Mouse";
         if (jointName == MOUSE_JOINT) {
-            return PointerEvent::INVALID_POINTER_ID;
+            return nullptr;
         }
     }
 #endif
@@ -283,9 +315,9 @@ unsigned int PointerScriptingInterface::createLaserPointer(const QVariant& prope
         }
     }
 
-    return DependencyManager::get<PointerManager>()->addPointer(std::make_shared<LaserPointer>(properties, renderStates, defaultRenderStates, hover, triggers,
-                                                                                               faceAvatar, followNormal, followNormalStrength, centerEndY, lockEnd,
-                                                                                               distanceScaleEnd, scaleWithParent, enabled));
+    return std::make_shared<LaserPointer>(properties, renderStates, defaultRenderStates, hover, triggers,
+                                          faceAvatar, followNormal, followNormalStrength, centerEndY, lockEnd,
+                                          distanceScaleEnd, scaleWithParent, enabled);
 }
 
 /**jsdoc
@@ -365,9 +397,10 @@ unsigned int PointerScriptingInterface::createLaserPointer(const QVariant& prope
  *     <code>false</code> if it doesn't.
  * @property {Pointers.Trigger[]} [triggers=[]] - A list of ways that a {@link Controller} action or function should trigger
  *     events on the entity or overlay currently intersected.
+ * @property {number} [pickID] - Returned from {@link Pointers.getPointerProperties}. The ID of the pick created alongside this pointer.
  * @see {@link Picks.ParabolaPickProperties} for additional properties from the underlying parabola pick.
  */
-unsigned int PointerScriptingInterface::createParabolaPointer(const QVariant& properties) const {
+std::shared_ptr<Pointer> PointerScriptingInterface::buildParabolaPointer(const QVariant& properties) {
     QVariantMap propertyMap = properties.toMap();
 
     bool faceAvatar = false;
@@ -463,9 +496,9 @@ unsigned int PointerScriptingInterface::createParabolaPointer(const QVariant& pr
         }
     }
 
-    return DependencyManager::get<PointerManager>()->addPointer(std::make_shared<ParabolaPointer>(properties, renderStates, defaultRenderStates, hover, triggers,
-                                                                                                  faceAvatar, followNormal, followNormalStrength, centerEndY, lockEnd, distanceScaleEnd,
-                                                                                                  scaleWithParent, enabled));
+    return std::make_shared<ParabolaPointer>(properties, renderStates, defaultRenderStates, hover, triggers,
+                                             faceAvatar, followNormal, followNormalStrength, centerEndY, lockEnd, distanceScaleEnd,
+                                             scaleWithParent, enabled);
 }
 
 void PointerScriptingInterface::editRenderState(unsigned int uid, const QString& renderState, const QVariant& properties) const {
@@ -496,8 +529,4 @@ QVariantMap PointerScriptingInterface::getPrevPickResult(unsigned int uid) const
         result = pickResult->toVariantMap();
     }
     return result;
-}
-
-QVariantMap PointerScriptingInterface::getPointerProperties(unsigned int uid) const {
-    return DependencyManager::get<PointerManager>()->getPointerProperties(uid);
 }

--- a/interface/src/raypick/PointerScriptingInterface.cpp
+++ b/interface/src/raypick/PointerScriptingInterface.cpp
@@ -62,6 +62,8 @@ unsigned int PointerScriptingInterface::createPointer(const PickQuery::PickType&
 
     propertyMap["type"] = (int)type;
 
+    pointer->setScriptParameters(propertyMap);
+
     return DependencyManager::get<PointerManager>()->addPointer(pointer);
 }
 

--- a/interface/src/raypick/PointerScriptingInterface.h
+++ b/interface/src/raypick/PointerScriptingInterface.h
@@ -11,6 +11,7 @@
 #include <QtCore/QObject>
 
 #include "DependencyManager.h"
+#include "RegisteredMetaTypes.h"
 #include <PointerManager.h>
 #include <Pick.h>
 
@@ -31,9 +32,6 @@ class PointerScriptingInterface : public QObject, public Dependency {
     SINGLETON_DEPENDENCY
 
 public:
-    unsigned int createLaserPointer(const QVariant& properties) const;
-    unsigned int createStylus(const QVariant& properties) const;
-    unsigned int createParabolaPointer(const QVariant& properties) const;
 
     /**jsdoc
      * Specifies that a {@link Controller} action or function should trigger events on the entity or overlay currently 
@@ -148,11 +146,37 @@ public:
     Q_INVOKABLE void disablePointer(unsigned int uid) const { DependencyManager::get<PointerManager>()->disablePointer(uid); }
 
     /**jsdoc
+     * Gets the enabled status of a pointer. Enabled pointers update their pick results and generate events.
+     * @function Pointers.isPointerEnabled
+     * @param {number} id - The ID of the pointer.
+     * @returns {boolean} enabled - Whether or not the pointer is enabled.
+     */
+    Q_INVOKABLE bool isPointerEnabled(unsigned int uid) const;
+
+    /**jsdoc
      * Removes (deletes) a pointer.
      * @function Pointers.removePointer
      * @param {number} id - The ID of the pointer.
      */
     Q_INVOKABLE void removePointer(unsigned int uid) const { DependencyManager::get<PointerManager>()->removePointer(uid); }
+
+    /**jsdoc
+    * Gets the parameters that were passed in to {@link Picks.createPick} to create the pick,
+    * if the pick was created through a script.
+    * Note that these properties do not reflect the current state of the pick.
+    * See {@link Picks.getPickProperties}.
+    * @function Picks.getPickScriptParameters
+    * @param {number} id - The ID of the pick.
+    * @returns {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties} User-provided properties, per the pick <code>type</code>.
+    */
+    Q_INVOKABLE QVariantMap getPointerScriptParameters(unsigned int uid) const;
+
+    /**jsdoc
+    * Gets all pointers which currently exist, including disabled pointers.
+    * @function Pointers.getCreatedPointers
+    * @returns {number[]} pointers - The IDs of the pointers.
+    */
+    Q_INVOKABLE QVector<unsigned int> getCreatedPointers() const;
 
     /**jsdoc
      * Edits a render state of a {@link Pointers.RayPointerProperties|ray} or 
@@ -448,6 +472,11 @@ public:
      * });
      */
     Q_INVOKABLE QVariantMap getPointerProperties(unsigned int uid) const;
+
+protected:
+    static std::shared_ptr<Pointer> buildLaserPointer(const QVariant& properties);
+    static std::shared_ptr<Pointer> buildStylus(const QVariant& properties);
+    static std::shared_ptr<Pointer> buildParabolaPointer(const QVariant& properties);
 };
 
 #endif // hifi_PointerScriptingInterface_h

--- a/interface/src/raypick/PointerScriptingInterface.h
+++ b/interface/src/raypick/PointerScriptingInterface.h
@@ -161,13 +161,13 @@ public:
     Q_INVOKABLE void removePointer(unsigned int uid) const { DependencyManager::get<PointerManager>()->removePointer(uid); }
 
     /**jsdoc
-    * Gets the parameters that were passed in to {@link Picks.createPick} to create the pick,
-    * if the pick was created through a script.
-    * Note that these properties do not reflect the current state of the pick.
-    * See {@link Picks.getPickProperties}.
-    * @function Picks.getPickScriptParameters
-    * @param {number} id - The ID of the pick.
-    * @returns {Picks.RayPickProperties|Picks.ParabolaPickProperties|Picks.StylusPickProperties|Picks.CollisionPickProperties} User-provided properties, per the pick <code>type</code>.
+    * Gets the parameters that were passed in to {@link Pointers.createPointer} to create the pointer,
+    * if the pointer was created through a script.
+    * Note that these properties do not reflect the current state of the pointer.
+    * See {@link Pointers.getPointerProperties}.
+    * @function Pointers.getPointerScriptParameters
+    * @param {number} id - The ID of the pointer.
+    * @returns {Pointers.RayPointerProperties|Picks.ParabolaPointerProperties|Picks.StylusPointerProperties} User-provided properties, per the pointer <code>type</code>.
     */
     Q_INVOKABLE QVariantMap getPointerScriptParameters(unsigned int uid) const;
 

--- a/interface/src/raypick/PointerScriptingInterface.h
+++ b/interface/src/raypick/PointerScriptingInterface.h
@@ -173,10 +173,10 @@ public:
 
     /**jsdoc
     * Gets all pointers which currently exist, including disabled pointers.
-    * @function Pointers.getCreatedPointers
+    * @function Pointers.getPointers
     * @returns {number[]} pointers - The IDs of the pointers.
     */
-    Q_INVOKABLE QVector<unsigned int> getCreatedPointers() const;
+    Q_INVOKABLE QVector<unsigned int> getPointers() const;
 
     /**jsdoc
      * Edits a render state of a {@link Pointers.RayPointerProperties|ray} or 

--- a/interface/src/raypick/RayPick.h
+++ b/interface/src/raypick/RayPick.h
@@ -88,6 +88,8 @@ public:
         Pick(PickRay(position, direction), filter, maxDistance, enabled) {
     }
 
+    PickType getType() const override { return PickType::Ray; }
+
     PickRay getMathematicalPick() const override;
 
     PickResultPointer getDefaultResult(const QVariantMap& pickVariant) const override { return std::make_shared<RayPickResult>(pickVariant); }

--- a/interface/src/raypick/RayPickScriptingInterface.cpp
+++ b/interface/src/raypick/RayPickScriptingInterface.cpp
@@ -17,7 +17,7 @@
 #include <PickManager.h>
 
 unsigned int RayPickScriptingInterface::createRayPick(const QVariant& properties) {
-    return DependencyManager::get<PickScriptingInterface>()->createRayPick(properties);
+    return DependencyManager::get<PickScriptingInterface>()->createPick(PickQuery::PickType::Ray, properties);
 }
 
 void RayPickScriptingInterface::enableRayPick(unsigned int uid) {

--- a/interface/src/raypick/StylusPick.h
+++ b/interface/src/raypick/StylusPick.h
@@ -72,6 +72,7 @@ class StylusPick : public Pick<StylusTip> {
 public:
     StylusPick(Side side, const PickFilter& filter, float maxDistance, bool enabled, const glm::vec3& tipOffset);
 
+    PickType getType() const override { return PickType::Stylus; }
     StylusTip getMathematicalPick() const override;
     PickResultPointer getDefaultResult(const QVariantMap& pickVariant) const override;
     PickResultPointer getEntityIntersection(const StylusTip& pick) override;

--- a/interface/src/raypick/StylusPointer.cpp
+++ b/interface/src/raypick/StylusPointer.cpp
@@ -43,6 +43,10 @@ StylusPointer::~StylusPointer() {
     }
 }
 
+PickQuery::PickType StylusPointer::getType() const {
+    return PickQuery::PickType::Stylus;
+}
+
 QUuid StylusPointer::buildStylus(const QVariantMap& properties) {
     // FIXME: we have to keep using the Overlays interface here, because existing scripts use overlay properties to define pointers
     QVariantMap propertiesMap;

--- a/interface/src/raypick/StylusPointer.cpp
+++ b/interface/src/raypick/StylusPointer.cpp
@@ -29,7 +29,7 @@ static const QString DEFAULT_STYLUS_MODEL_URL = PathUtils::resourcesUrl() + "/me
 
 StylusPointer::StylusPointer(const QVariant& props, const QUuid& stylus, bool hover, bool enabled,
                              const glm::vec3& modelPositionOffset, const glm::quat& modelRotationOffset, const glm::vec3& modelDimensions) :
-    Pointer(DependencyManager::get<PickScriptingInterface>()->createStylusPick(props), enabled, hover),
+    Pointer(DependencyManager::get<PickScriptingInterface>()->createPick(PickQuery::PickType::Stylus, props), enabled, hover),
     _stylus(stylus),
     _modelPositionOffset(modelPositionOffset),
     _modelDimensions(modelDimensions),
@@ -229,7 +229,7 @@ void StylusPointer::setRenderState(const std::string& state) {
 }
 
 QVariantMap StylusPointer::toVariantMap() const {
-    return QVariantMap();
+    return Parent::toVariantMap();
 }
 
 glm::vec3 StylusPointer::findIntersection(const PickedObject& pickedObject, const glm::vec3& origin, const glm::vec3& direction) {

--- a/interface/src/raypick/StylusPointer.h
+++ b/interface/src/raypick/StylusPointer.h
@@ -23,6 +23,8 @@ public:
                   const glm::vec3& modelPositionOffset, const glm::quat& modelRotationOffset, const glm::vec3& modelDimensions);
     ~StylusPointer();
 
+    PickQuery::PickType getType() const override;
+
     void updateVisuals(const PickResultPointer& pickResult) override;
 
     // Styluses have three render states:

--- a/libraries/avatars-renderer/src/avatars-renderer/AvatarTransformNode.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/AvatarTransformNode.cpp
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 9/5/2018
+//  Created by Sabrina Shanman 2018/09/05
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/libraries/avatars-renderer/src/avatars-renderer/AvatarTransformNode.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/AvatarTransformNode.h
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 9/5/2018
+//  Created by Sabrina Shanman 2018/09/05
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
@@ -297,10 +297,6 @@ MeshPointer GraphicsScriptingInterface::getMeshPointer(scriptable::ScriptableMes
 
 namespace {
     QVector<int> metaTypeIds{
-        qRegisterMetaType<glm::uint32>("uint32"),
-        qRegisterMetaType<glm::uint32>("glm::uint32"),
-        qRegisterMetaType<QVector<glm::uint32>>(),
-        qRegisterMetaType<QVector<glm::uint32>>("QVector<uint32>"),
         qRegisterMetaType<scriptable::ScriptableMeshes>(),
         qRegisterMetaType<scriptable::ScriptableMeshes>("ScriptableMeshes"),
         qRegisterMetaType<scriptable::ScriptableMeshes>("scriptable::ScriptableMeshes"),
@@ -532,7 +528,6 @@ namespace scriptable {
 }
 
 void GraphicsScriptingInterface::registerMetaTypes(QScriptEngine* engine) {
-    qScriptRegisterSequenceMetaType<QVector<glm::uint32>>(engine);
     qScriptRegisterSequenceMetaType<QVector<scriptable::ScriptableMaterialLayer>>(engine);
 
     scriptable::registerQPointerMetaType<scriptable::ScriptableModel>(engine);

--- a/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.h
@@ -19,6 +19,7 @@
 
 #include "ScriptableMesh.h"
 #include <DependencyManager.h>
+#include "RegisteredMetaTypes.h"
 
 
 /**jsdoc
@@ -107,8 +108,6 @@ namespace scriptable {
     QScriptValue scriptableMaterialToScriptValue(QScriptEngine* engine, const scriptable::ScriptableMaterial &material);
 };
 
-Q_DECLARE_METATYPE(glm::uint32)
-Q_DECLARE_METATYPE(QVector<glm::uint32>)
 Q_DECLARE_METATYPE(NestableType)
 
 #endif // hifi_GraphicsScriptingInterface_h

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMesh.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMesh.cpp
@@ -59,8 +59,8 @@ glm::uint32 scriptable::ScriptableMesh::getNumVertices() const {
     return 0;
 }
 
-QVector<unsigned int> scriptable::ScriptableMesh::findNearbyVertexIndices(const glm::vec3& origin, float epsilon) const {
-    QVector<unsigned int> result;
+QVector<glm::uint32> scriptable::ScriptableMesh::findNearbyVertexIndices(const glm::vec3& origin, float epsilon) const {
+    QVector<glm::uint32> result;
     if (!isValid()) {
         return result;
     }
@@ -74,14 +74,14 @@ QVector<unsigned int> scriptable::ScriptableMesh::findNearbyVertexIndices(const 
     return result;
 }
 
-QVector<unsigned int> scriptable::ScriptableMesh::getIndices() const {
+QVector<glm::uint32> scriptable::ScriptableMesh::getIndices() const {
     if (auto mesh = getMeshPointer()) {
 #ifdef SCRIPTABLE_MESH_DEBUG
         qCDebug(graphics_scripting, "getIndices mesh %p", mesh.get());
 #endif
         return buffer_helpers::bufferToVector<glm::uint32>(mesh->getIndexBuffer());
     }
-    return QVector<unsigned int>();
+    return QVector<glm::uint32>();
 }
 
 

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMesh.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMesh.cpp
@@ -59,8 +59,8 @@ glm::uint32 scriptable::ScriptableMesh::getNumVertices() const {
     return 0;
 }
 
-QVector<glm::uint32> scriptable::ScriptableMesh::findNearbyVertexIndices(const glm::vec3& origin, float epsilon) const {
-    QVector<glm::uint32> result;
+QVector<unsigned int> scriptable::ScriptableMesh::findNearbyVertexIndices(const glm::vec3& origin, float epsilon) const {
+    QVector<unsigned int> result;
     if (!isValid()) {
         return result;
     }
@@ -74,14 +74,14 @@ QVector<glm::uint32> scriptable::ScriptableMesh::findNearbyVertexIndices(const g
     return result;
 }
 
-QVector<glm::uint32> scriptable::ScriptableMesh::getIndices() const {
+QVector<unsigned int> scriptable::ScriptableMesh::getIndices() const {
     if (auto mesh = getMeshPointer()) {
 #ifdef SCRIPTABLE_MESH_DEBUG
         qCDebug(graphics_scripting, "getIndices mesh %p", mesh.get());
 #endif
         return buffer_helpers::bufferToVector<glm::uint32>(mesh->getIndexBuffer());
     }
-    return QVector<glm::uint32>();
+    return QVector<unsigned int>();
 }
 
 

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMesh.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMesh.h
@@ -83,9 +83,8 @@ namespace scriptable {
 
     public slots:
         const scriptable::ScriptableModelPointer getParentModel() const { return qobject_cast<scriptable::ScriptableModel*>(model); }
-        // Functions exposed to scripts need to use QVector<unsigned int> instead of QVector<glm::uint32> as a workaround to QScriptEngine meta types
-        QVector<unsigned int> getIndices() const;
-        QVector<unsigned int> findNearbyVertexIndices(const glm::vec3& origin, float epsilon = 1e-6) const;
+        QVector<glm::uint32> getIndices() const;
+        QVector<glm::uint32> findNearbyVertexIndices(const glm::vec3& origin, float epsilon = 1e-6) const;
 
         glm::uint32 addAttribute(const QString& attributeName, const QVariant& defaultValue = QVariant());
         glm::uint32 fillAttribute(const QString& attributeName, const QVariant& value);

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMesh.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMesh.h
@@ -83,8 +83,9 @@ namespace scriptable {
 
     public slots:
         const scriptable::ScriptableModelPointer getParentModel() const { return qobject_cast<scriptable::ScriptableModel*>(model); }
-        QVector<glm::uint32> getIndices() const;
-        QVector<glm::uint32> findNearbyVertexIndices(const glm::vec3& origin, float epsilon = 1e-6) const;
+        // Functions exposed to scripts need to use QVector<unsigned int> instead of QVector<glm::uint32> as a workaround to QScriptEngine meta types
+        QVector<unsigned int> getIndices() const;
+        QVector<unsigned int> findNearbyVertexIndices(const glm::vec3& origin, float epsilon = 1e-6) const;
 
         glm::uint32 addAttribute(const QString& attributeName, const QVariant& defaultValue = QVariant());
         glm::uint32 fillAttribute(const QString& attributeName, const QVariant& value);

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.cpp
@@ -244,8 +244,8 @@ glm::uint32 scriptable::ScriptableMeshPart::fillAttribute(const QString& attribu
     return isValid() ? parentMesh->fillAttribute(attributeName, value) : 0;
 }
 
-QVector<glm::uint32> scriptable::ScriptableMeshPart::findNearbyPartVertexIndices(const glm::vec3& origin, float epsilon) const {
-    QSet<glm::uint32> result;
+QVector<unsigned int> scriptable::ScriptableMeshPart::findNearbyPartVertexIndices(const glm::vec3& origin, float epsilon) const {
+    QSet<unsigned int> result;
     if (!isValid()) {
         return result.toList().toVector();
     }
@@ -328,14 +328,14 @@ scriptable::ScriptableMeshPart::ScriptableMeshPart(scriptable::ScriptableMeshPoi
     setObjectName(QString("%1.part[%2]").arg(parentMesh ? parentMesh->objectName() : "").arg(partIndex));
 }
 
-QVector<glm::uint32> scriptable::ScriptableMeshPart::getIndices() const {
+QVector<unsigned int> scriptable::ScriptableMeshPart::getIndices() const {
     if (auto mesh = getMeshPointer()) {
 #ifdef SCRIPTABLE_MESH_DEBUG
         qCDebug(graphics_scripting, "getIndices mesh %p", mesh.get());
 #endif
         return buffer_helpers::bufferToVector<glm::uint32>(mesh->getIndexBuffer());
     }
-    return QVector<glm::uint32>();
+    return QVector<unsigned int>();
 }
 
 bool scriptable::ScriptableMeshPart::setFirstVertexIndex( glm::uint32 vertexIndex) {
@@ -365,11 +365,11 @@ bool scriptable::ScriptableMeshPart::setLastVertexIndex( glm::uint32 vertexIndex
     return true;
 }
 
-bool scriptable::ScriptableMeshPart::setIndices(const QVector<glm::uint32>& indices) {
+bool scriptable::ScriptableMeshPart::setIndices(const QVector<unsigned int>& indices) {
     if (!isValid()) {
         return false;
     }
-    glm::uint32 len = indices.size();
+    unsigned int len = indices.size();
     if (len != getNumIndices()) {
         context()->throwError(QString("setIndices: currently new indicies must be assign 1:1 across old indicies (indicies.size()=%1, numIndices=%2)")
                               .arg(len).arg(getNumIndices()));
@@ -379,14 +379,14 @@ bool scriptable::ScriptableMeshPart::setIndices(const QVector<glm::uint32>& indi
     auto indexBuffer = mesh->getIndexBuffer();
 
     // first loop to validate all indices are valid
-    for (glm::uint32 i = 0; i < len; i++) {
+    for (unsigned int i = 0; i < len; i++) {
         if (!isValidIndex(indices.at(i))) {
             return false;
         }
     }
     const auto first = getFirstVertexIndex();
     // now actually apply them
-    for (glm::uint32 i = 0; i < len; i++) {
+    for (unsigned int i = 0; i < len; i++) {
         buffer_helpers::setValue(indexBuffer, first + i, indices.at(i));
     }
     return true;
@@ -431,7 +431,7 @@ glm::uint32 scriptable::ScriptableMeshPart::getTopologyLength() const {
     return 0;
 }
 
-QVector<glm::uint32> scriptable::ScriptableMeshPart::getFace(glm::uint32 faceIndex) const {
+QVector<unsigned int> scriptable::ScriptableMeshPart::getFace(unsigned int faceIndex) const {
     switch (getTopology()) {
     case graphics::Mesh::Topology::POINTS:
     case graphics::Mesh::Topology::LINES:
@@ -440,7 +440,7 @@ QVector<glm::uint32> scriptable::ScriptableMeshPart::getFace(glm::uint32 faceInd
         if (faceIndex < getNumFaces()) {
             return getIndices().mid(faceIndex * getTopologyLength(), getTopologyLength());
         }
-    default: return QVector<glm::uint32>();
+    default: return QVector<unsigned int>();
     }
 }
 

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.cpp
@@ -244,8 +244,8 @@ glm::uint32 scriptable::ScriptableMeshPart::fillAttribute(const QString& attribu
     return isValid() ? parentMesh->fillAttribute(attributeName, value) : 0;
 }
 
-QVector<unsigned int> scriptable::ScriptableMeshPart::findNearbyPartVertexIndices(const glm::vec3& origin, float epsilon) const {
-    QSet<unsigned int> result;
+QVector<glm::uint32> scriptable::ScriptableMeshPart::findNearbyPartVertexIndices(const glm::vec3& origin, float epsilon) const {
+    QSet<glm::uint32> result;
     if (!isValid()) {
         return result.toList().toVector();
     }
@@ -328,14 +328,14 @@ scriptable::ScriptableMeshPart::ScriptableMeshPart(scriptable::ScriptableMeshPoi
     setObjectName(QString("%1.part[%2]").arg(parentMesh ? parentMesh->objectName() : "").arg(partIndex));
 }
 
-QVector<unsigned int> scriptable::ScriptableMeshPart::getIndices() const {
+QVector<glm::uint32> scriptable::ScriptableMeshPart::getIndices() const {
     if (auto mesh = getMeshPointer()) {
 #ifdef SCRIPTABLE_MESH_DEBUG
         qCDebug(graphics_scripting, "getIndices mesh %p", mesh.get());
 #endif
         return buffer_helpers::bufferToVector<glm::uint32>(mesh->getIndexBuffer());
     }
-    return QVector<unsigned int>();
+    return QVector<glm::uint32>();
 }
 
 bool scriptable::ScriptableMeshPart::setFirstVertexIndex( glm::uint32 vertexIndex) {
@@ -365,11 +365,11 @@ bool scriptable::ScriptableMeshPart::setLastVertexIndex( glm::uint32 vertexIndex
     return true;
 }
 
-bool scriptable::ScriptableMeshPart::setIndices(const QVector<unsigned int>& indices) {
+bool scriptable::ScriptableMeshPart::setIndices(const QVector<glm::uint32>& indices) {
     if (!isValid()) {
         return false;
     }
-    unsigned int len = indices.size();
+    glm::uint32 len = indices.size();
     if (len != getNumIndices()) {
         context()->throwError(QString("setIndices: currently new indicies must be assign 1:1 across old indicies (indicies.size()=%1, numIndices=%2)")
                               .arg(len).arg(getNumIndices()));
@@ -379,14 +379,14 @@ bool scriptable::ScriptableMeshPart::setIndices(const QVector<unsigned int>& ind
     auto indexBuffer = mesh->getIndexBuffer();
 
     // first loop to validate all indices are valid
-    for (unsigned int i = 0; i < len; i++) {
+    for (glm::uint32 i = 0; i < len; i++) {
         if (!isValidIndex(indices.at(i))) {
             return false;
         }
     }
     const auto first = getFirstVertexIndex();
     // now actually apply them
-    for (unsigned int i = 0; i < len; i++) {
+    for (glm::uint32 i = 0; i < len; i++) {
         buffer_helpers::setValue(indexBuffer, first + i, indices.at(i));
     }
     return true;
@@ -431,7 +431,7 @@ glm::uint32 scriptable::ScriptableMeshPart::getTopologyLength() const {
     return 0;
 }
 
-QVector<unsigned int> scriptable::ScriptableMeshPart::getFace(unsigned int faceIndex) const {
+QVector<glm::uint32> scriptable::ScriptableMeshPart::getFace(glm::uint32 faceIndex) const {
     switch (getTopology()) {
     case graphics::Mesh::Topology::POINTS:
     case graphics::Mesh::Topology::LINES:
@@ -440,7 +440,7 @@ QVector<unsigned int> scriptable::ScriptableMeshPart::getFace(unsigned int faceI
         if (faceIndex < getNumFaces()) {
             return getIndices().mid(faceIndex * getTopologyLength(), getTopologyLength());
         }
-    default: return QVector<unsigned int>();
+    default: return QVector<glm::uint32>();
     }
 }
 

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.h
@@ -55,10 +55,9 @@ namespace scriptable {
         bool isValid() const { auto mesh = getMeshPointer(); return mesh && partIndex < mesh->getNumParts(); }
 
     public slots:
-        // Functions exposed to scripts need to use QVector<unsigned int> instead of QVector<glm::uint32> as a workaround to QScriptEngine meta types
-        QVector<unsigned int> getIndices() const;
-        bool setIndices(const QVector<unsigned int>& indices);
-        QVector<unsigned int> findNearbyPartVertexIndices(const glm::vec3& origin, float epsilon = 1e-6) const;
+        QVector<glm::uint32> getIndices() const;
+        bool setIndices(const QVector<glm::uint32>& indices);
+        QVector<glm::uint32> findNearbyPartVertexIndices(const glm::vec3& origin, float epsilon = 1e-6) const;
         QVariantList queryVertexAttributes(QVariant selector) const;
         QVariantMap getVertexAttributes(glm::uint32 vertexIndex) const;
         bool setVertexAttributes(glm::uint32 vertexIndex, const QVariantMap& attributeValues);
@@ -66,7 +65,7 @@ namespace scriptable {
         QVariant getVertexProperty(glm::uint32 vertexIndex, const QString& attributeName) const;
         bool setVertexProperty(glm::uint32 vertexIndex, const QString& attributeName, const QVariant& attributeValues);
 
-        QVector<unsigned int> getFace(glm::uint32 faceIndex) const;
+        QVector<glm::uint32> getFace(glm::uint32 faceIndex) const;
 
         QVariantMap scaleToFit(float unitScale);
         QVariantMap translate(const glm::vec3& translation);

--- a/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/ScriptableMeshPart.h
@@ -55,9 +55,10 @@ namespace scriptable {
         bool isValid() const { auto mesh = getMeshPointer(); return mesh && partIndex < mesh->getNumParts(); }
 
     public slots:
-        QVector<glm::uint32> getIndices() const;
-        bool setIndices(const QVector<glm::uint32>& indices);
-        QVector<glm::uint32> findNearbyPartVertexIndices(const glm::vec3& origin, float epsilon = 1e-6) const;
+        // Functions exposed to scripts need to use QVector<unsigned int> instead of QVector<glm::uint32> as a workaround to QScriptEngine meta types
+        QVector<unsigned int> getIndices() const;
+        bool setIndices(const QVector<unsigned int>& indices);
+        QVector<unsigned int> findNearbyPartVertexIndices(const glm::vec3& origin, float epsilon = 1e-6) const;
         QVariantList queryVertexAttributes(QVariant selector) const;
         QVariantMap getVertexAttributes(glm::uint32 vertexIndex) const;
         bool setVertexAttributes(glm::uint32 vertexIndex, const QVariantMap& attributeValues);
@@ -65,7 +66,7 @@ namespace scriptable {
         QVariant getVertexProperty(glm::uint32 vertexIndex, const QString& attributeName) const;
         bool setVertexProperty(glm::uint32 vertexIndex, const QString& attributeName, const QVariant& attributeValues);
 
-        QVector<glm::uint32> getFace(glm::uint32 faceIndex) const;
+        QVector<unsigned int> getFace(glm::uint32 faceIndex) const;
 
         QVariantMap scaleToFit(float unitScale);
         QVariantMap translate(const glm::vec3& translation);

--- a/libraries/pointers/src/Pick.cpp
+++ b/libraries/pointers/src/Pick.cpp
@@ -56,6 +56,18 @@ QVector<QUuid> PickQuery::getIgnoreItems() const {
     });
 }
 
+void PickQuery::setScriptParameters(const QVariantMap& parameters) {
+    withWriteLock([&] {
+        _scriptParameters = parameters;
+    });
+}
+
+QVariantMap PickQuery::getScriptParameters() const {
+    return resultWithReadLock<QVariantMap>([&] {
+        return _scriptParameters;
+    });
+}
+
 QVector<QUuid> PickQuery::getIncludeItems() const {
     return resultWithReadLock<QVector<QUuid>>([&] {
         return _includeItems;

--- a/libraries/pointers/src/Pick.cpp
+++ b/libraries/pointers/src/Pick.cpp
@@ -57,15 +57,11 @@ QVector<QUuid> PickQuery::getIgnoreItems() const {
 }
 
 void PickQuery::setScriptParameters(const QVariantMap& parameters) {
-    withWriteLock([&] {
-        _scriptParameters = parameters;
-    });
+    _scriptParameters = parameters;
 }
 
 QVariantMap PickQuery::getScriptParameters() const {
-    return resultWithReadLock<QVariantMap>([&] {
-        return _scriptParameters;
-    });
+    return _scriptParameters;
 }
 
 QVector<QUuid> PickQuery::getIncludeItems() const {

--- a/libraries/pointers/src/Pick.h
+++ b/libraries/pointers/src/Pick.h
@@ -173,7 +173,7 @@ public:
     virtual QVariantMap toVariantMap() const {
         QVariantMap properties;
 
-        properties["type"] = (int)getType();
+        properties["pickType"] = (int)getType();
         properties["enabled"] = isEnabled();
         properties["filter"] = (unsigned int)getFilter()._flags.to_ulong();
         properties["maxDistance"] = getMaxDistance();

--- a/libraries/pointers/src/Pick.h
+++ b/libraries/pointers/src/Pick.h
@@ -117,7 +117,8 @@ public:
         Stylus,
         Parabola,
         Collision,
-        NUM_PICK_TYPES
+        NUM_PICK_TYPES,
+        INVALID_PICK_TYPE = -1
     };
     Q_ENUM(PickType)
 
@@ -134,6 +135,7 @@ public:
     PickFilter getFilter() const;
     float getMaxDistance() const;
     bool isEnabled() const;
+    virtual PickType getType() const = 0;
 
     void setPrecisionPicking(bool precisionPicking);
 
@@ -168,6 +170,27 @@ public:
     void setIgnoreItems(const QVector<QUuid>& items);
     void setIncludeItems(const QVector<QUuid>& items);
 
+    virtual QVariantMap toVariantMap() const {
+        QVariantMap properties;
+
+        properties["type"] = (int)getType();
+        properties["enabled"] = isEnabled();
+        properties["filter"] = (unsigned int)getFilter()._flags.to_ulong();
+        properties["maxDistance"] = getMaxDistance();
+
+        if (parentTransform) {
+            auto transformNodeProperties = parentTransform->toVariantMap();
+            for (auto it = transformNodeProperties.cbegin(); it != transformNodeProperties.cend(); ++it) {
+                properties[it.key()] = it.value();
+            }
+        }
+
+        return properties;
+    }
+
+    void setScriptParameters(const QVariantMap& parameters);
+    QVariantMap getScriptParameters() const;
+
     virtual bool isLeftHand() const { return _jointState == JOINT_STATE_LEFT_HAND; }
     virtual bool isRightHand() const { return _jointState == JOINT_STATE_RIGHT_HAND; }
     virtual bool isMouse() const { return _jointState == JOINT_STATE_MOUSE; }
@@ -187,6 +210,9 @@ private:
     QVector<QUuid> _ignoreItems;
     QVector<QUuid> _includeItems;
 
+    // The parameters used to create this pick when created through a script
+    QVariantMap _scriptParameters;
+
     JointState _jointState { JOINT_STATE_NONE };
 };
 Q_DECLARE_METATYPE(PickQuery::PickType)
@@ -202,6 +228,17 @@ public:
     virtual PickResultPointer getAvatarIntersection(const T& pick) = 0;
     virtual PickResultPointer getHUDIntersection(const T& pick) = 0;
 
+    QVariantMap toVariantMap() const override {
+        QVariantMap properties = PickQuery::toVariantMap();
+
+        const QVariantMap mathPickProperties = _mathPick.toVariantMap();
+        for (auto it = mathPickProperties.cbegin(); it != mathPickProperties.cend(); ++it) {
+            properties[it.key()] = it.value();
+        }
+
+        return properties;
+    }
+    
 protected:
     T _mathPick;
 };

--- a/libraries/pointers/src/PickManager.cpp
+++ b/libraries/pointers/src/PickManager.cpp
@@ -49,6 +49,35 @@ void PickManager::removePick(unsigned int uid) {
     });
 }
 
+QVariantMap PickManager::getPickProperties(unsigned int uid) const {
+    auto pick = findPick(uid);
+    if (pick) {
+        return pick->toVariantMap();
+    }
+    return QVariantMap();
+}
+
+QVariantMap PickManager::getPickScriptParameters(unsigned int uid) const {
+    auto pick = findPick(uid);
+    if (pick) {
+        return pick->getScriptParameters();
+    }
+    return QVariantMap();
+}
+
+QVector<unsigned int> PickManager::getCreatedPicks() const {
+    QVector<unsigned int> picks;
+    withReadLock([&] {
+        for (auto typeIt = _picks.cbegin(); typeIt != _picks.cend(); ++typeIt) {
+            auto& picksForType = typeIt->second;
+            for (auto pickIt = picksForType.cbegin(); pickIt != picksForType.cend(); ++pickIt) {
+                picks.push_back(pickIt->first);
+            }
+        }
+    });
+    return picks;
+}
+
 PickResultPointer PickManager::getPrevPickResult(unsigned int uid) const {
     auto pick = findPick(uid);
     if (pick) {
@@ -69,6 +98,14 @@ void PickManager::disablePick(unsigned int uid) const {
     if (pick) {
         pick->disable();
     }
+}
+
+bool PickManager::isPickEnabled(unsigned int uid) const {
+    auto pick = findPick(uid);
+    if (pick) {
+        return pick->isEnabled();
+    }
+    return false;
 }
 
 void PickManager::setPrecisionPicking(unsigned int uid, bool precisionPicking) const {

--- a/libraries/pointers/src/PickManager.cpp
+++ b/libraries/pointers/src/PickManager.cpp
@@ -65,7 +65,7 @@ QVariantMap PickManager::getPickScriptParameters(unsigned int uid) const {
     return QVariantMap();
 }
 
-QVector<unsigned int> PickManager::getCreatedPicks() const {
+QVector<unsigned int> PickManager::getPicks() const {
     QVector<unsigned int> picks;
     withReadLock([&] {
         for (auto typeIt = _picks.cbegin(); typeIt != _picks.cend(); ++typeIt) {

--- a/libraries/pointers/src/PickManager.h
+++ b/libraries/pointers/src/PickManager.h
@@ -31,8 +31,14 @@ public:
     void removePick(unsigned int uid);
     void enablePick(unsigned int uid) const;
     void disablePick(unsigned int uid) const;
+    bool isPickEnabled(unsigned int uid) const;
+    QVector<unsigned int> getCreatedPicks() const;
 
     PickResultPointer getPrevPickResult(unsigned int uid) const;
+    // The actual current properties of the pick
+    QVariantMap getPickProperties(unsigned int uid) const;
+    // The properties that were passed in to create the pick (may be empty if the pick was created by invoking the constructor)
+    QVariantMap getPickScriptParameters(unsigned int uid) const;
 
     template <typename T>
     std::shared_ptr<T> getPrevPickResultTyped(unsigned int uid) const {

--- a/libraries/pointers/src/PickManager.h
+++ b/libraries/pointers/src/PickManager.h
@@ -32,7 +32,7 @@ public:
     void enablePick(unsigned int uid) const;
     void disablePick(unsigned int uid) const;
     bool isPickEnabled(unsigned int uid) const;
-    QVector<unsigned int> getCreatedPicks() const;
+    QVector<unsigned int> getPicks() const;
 
     PickResultPointer getPrevPickResult(unsigned int uid) const;
     // The actual current properties of the pick

--- a/libraries/pointers/src/PickTransformNode.cpp
+++ b/libraries/pointers/src/PickTransformNode.cpp
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 8/22/2018
+//  Created by Sabrina Shanman 2018/08/22
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/libraries/pointers/src/PickTransformNode.cpp
+++ b/libraries/pointers/src/PickTransformNode.cpp
@@ -24,3 +24,9 @@ Transform PickTransformNode::getTransform() {
 
     return pickManager->getResultTransform(_uid);
 }
+
+QVariantMap PickTransformNode::toVariantMap() const {
+    QVariantMap map;
+    map["parentID"] = _uid;
+    return map;
+}

--- a/libraries/pointers/src/PickTransformNode.h
+++ b/libraries/pointers/src/PickTransformNode.h
@@ -15,6 +15,7 @@ class PickTransformNode : public TransformNode {
 public:
     PickTransformNode(unsigned int uid);
     Transform getTransform() override;
+    QVariantMap toVariantMap() const override;
 
 protected:
     unsigned int _uid;

--- a/libraries/pointers/src/PickTransformNode.h
+++ b/libraries/pointers/src/PickTransformNode.h
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 8/22/2018
+//  Created by Sabrina Shanman 2018/08/22
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/libraries/pointers/src/Pointer.cpp
+++ b/libraries/pointers/src/Pointer.cpp
@@ -47,6 +47,7 @@ PickResultPointer Pointer::getPrevPickResult() {
 QVariantMap Pointer::toVariantMap() const {
     QVariantMap qVariantMap = DependencyManager::get<PickManager>()->getPickProperties(_pickUID);
 
+    qVariantMap["pointerType"] = getType();
     qVariantMap["pickID"] = _pickUID;
     qVariantMap["hover"] = _hover;
 

--- a/libraries/pointers/src/Pointer.cpp
+++ b/libraries/pointers/src/Pointer.cpp
@@ -53,8 +53,12 @@ QVariantMap Pointer::toVariantMap() const {
     return qVariantMap;
 }
 
+void Pointer::setScriptParameters(const QVariantMap& scriptParameters) {
+    _scriptParameters = scriptParameters;
+}
+
 QVariantMap Pointer::getScriptParameters() const {
-    return DependencyManager::get<PickManager>()->getPickScriptParameters(_pickUID);
+    return _scriptParameters;
 }
 
 void Pointer::setPrecisionPicking(bool precisionPicking) {

--- a/libraries/pointers/src/Pointer.cpp
+++ b/libraries/pointers/src/Pointer.cpp
@@ -36,8 +36,25 @@ void Pointer::disable() {
     DependencyManager::get<PickManager>()->disablePick(_pickUID);
 }
 
+bool Pointer::isEnabled() {
+    return _enabled;
+}
+
 PickResultPointer Pointer::getPrevPickResult() {
     return DependencyManager::get<PickManager>()->getPrevPickResult(_pickUID);
+}
+
+QVariantMap Pointer::toVariantMap() const {
+    QVariantMap qVariantMap = DependencyManager::get<PickManager>()->getPickProperties(_pickUID);
+
+    qVariantMap["pickID"] = _pickUID;
+    qVariantMap["hover"] = _hover;
+
+    return qVariantMap;
+}
+
+QVariantMap Pointer::getScriptParameters() const {
+    return DependencyManager::get<PickManager>()->getPickScriptParameters(_pickUID);
 }
 
 void Pointer::setPrecisionPicking(bool precisionPicking) {

--- a/libraries/pointers/src/Pointer.h
+++ b/libraries/pointers/src/Pointer.h
@@ -45,12 +45,14 @@ public:
 
     virtual void enable();
     virtual void disable();
+    virtual bool isEnabled();
     virtual PickResultPointer getPrevPickResult();
 
     virtual void setRenderState(const std::string& state) = 0;
     virtual void editRenderState(const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps) = 0;
     
-    virtual QVariantMap toVariantMap() const = 0;
+    virtual QVariantMap toVariantMap() const;
+    virtual QVariantMap getScriptParameters() const;
 
     virtual void setPrecisionPicking(bool precisionPicking);
     virtual void setIgnoreItems(const QVector<QUuid>& ignoreItems) const;

--- a/libraries/pointers/src/Pointer.h
+++ b/libraries/pointers/src/Pointer.h
@@ -46,6 +46,7 @@ public:
     virtual void enable();
     virtual void disable();
     virtual bool isEnabled();
+    virtual PickQuery::PickType getType() const = 0;
     virtual PickResultPointer getPrevPickResult();
 
     virtual void setRenderState(const std::string& state) = 0;

--- a/libraries/pointers/src/Pointer.h
+++ b/libraries/pointers/src/Pointer.h
@@ -52,6 +52,7 @@ public:
     virtual void editRenderState(const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps) = 0;
     
     virtual QVariantMap toVariantMap() const;
+    virtual void setScriptParameters(const QVariantMap& scriptParameters);
     virtual QVariantMap getScriptParameters() const;
 
     virtual void setPrecisionPicking(bool precisionPicking);
@@ -85,6 +86,9 @@ protected:
     const unsigned int _pickUID;
     bool _enabled;
     bool _hover;
+
+    // The parameters used to create this pointer when created through a script
+    QVariantMap _scriptParameters;
 
     virtual PointerEvent buildPointerEvent(const PickedObject& target, const PickResultPointer& pickResult, const std::string& button = "", bool hover = true) = 0;
 

--- a/libraries/pointers/src/PointerManager.cpp
+++ b/libraries/pointers/src/PointerManager.cpp
@@ -54,6 +54,24 @@ void PointerManager::disablePointer(unsigned int uid) const {
     }
 }
 
+bool PointerManager::isPointerEnabled(unsigned int uid) const {
+    auto pointer = find(uid);
+    if (pointer) {
+        return pointer->isEnabled();
+    }
+    return false;
+}
+
+QVector<unsigned int> PointerManager::getCreatedPointers() const {
+    QVector<unsigned int> pointers;
+    withReadLock([&] {
+        for (auto it = _pointers.cbegin(); it != _pointers.cend(); ++it) {
+            pointers.push_back(it->first);
+        }
+    });
+    return pointers;
+}
+
 void PointerManager::setRenderState(unsigned int uid, const std::string& renderState) const {
     auto pointer = find(uid);
     if (pointer) {
@@ -84,6 +102,14 @@ QVariantMap PointerManager::getPointerProperties(unsigned int uid) const {
     } else {
         return QVariantMap();
     }
+}
+
+QVariantMap PointerManager::getPointerScriptParameters(unsigned int uid) const {
+    auto pointer = find(uid);
+    if (pointer) {
+        return pointer->getScriptParameters();
+    }
+    return QVariantMap();
 }
 
 void PointerManager::update() {

--- a/libraries/pointers/src/PointerManager.cpp
+++ b/libraries/pointers/src/PointerManager.cpp
@@ -62,7 +62,7 @@ bool PointerManager::isPointerEnabled(unsigned int uid) const {
     return false;
 }
 
-QVector<unsigned int> PointerManager::getCreatedPointers() const {
+QVector<unsigned int> PointerManager::getPointers() const {
     QVector<unsigned int> pointers;
     withReadLock([&] {
         for (auto it = _pointers.cbegin(); it != _pointers.cend(); ++it) {

--- a/libraries/pointers/src/PointerManager.h
+++ b/libraries/pointers/src/PointerManager.h
@@ -28,7 +28,7 @@ public:
     void enablePointer(unsigned int uid) const;
     void disablePointer(unsigned int uid) const;
     bool isPointerEnabled(unsigned int uid) const;
-    QVector<unsigned int> getCreatedPointers() const;
+    QVector<unsigned int> getPointers() const;
 
     void setRenderState(unsigned int uid, const std::string& renderState) const;
     void editRenderState(unsigned int uid, const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps) const;

--- a/libraries/pointers/src/PointerManager.h
+++ b/libraries/pointers/src/PointerManager.h
@@ -27,10 +27,17 @@ public:
     void removePointer(unsigned int uid);
     void enablePointer(unsigned int uid) const;
     void disablePointer(unsigned int uid) const;
+    bool isPointerEnabled(unsigned int uid) const;
+    QVector<unsigned int> getCreatedPointers() const;
+
     void setRenderState(unsigned int uid, const std::string& renderState) const;
     void editRenderState(unsigned int uid, const std::string& state, const QVariant& startProps, const QVariant& pathProps, const QVariant& endProps) const;
+
     PickResultPointer getPrevPickResult(unsigned int uid) const;
+    // The actual current properties of the pointer
     QVariantMap getPointerProperties(unsigned int uid) const;
+    // The properties that were passed in to create the pointer (may be empty if the pointer was created by invoking the constructor)
+    QVariantMap getPointerScriptParameters(unsigned int uid) const;
 
     void setPrecisionPicking(unsigned int uid, bool precisionPicking) const;
     void setIgnoreItems(unsigned int uid, const QVector<QUuid>& ignoreEntities) const;

--- a/libraries/shared/src/NestableTransformNode.cpp
+++ b/libraries/shared/src/NestableTransformNode.cpp
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 8/14/2018
+//  Created by Sabrina Shanman 2018/08/14
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/libraries/shared/src/NestableTransformNode.h
+++ b/libraries/shared/src/NestableTransformNode.h
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 8/14/2018
+//  Created by Sabrina Shanman 2018/08/14
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/libraries/shared/src/NestableTransformNode.h
+++ b/libraries/shared/src/NestableTransformNode.h
@@ -49,14 +49,12 @@ public:
 
     QVariantMap toVariantMap() const {
         QVariantMap map;
-    
-        if (!_spatiallyNestable.expired()) {
-            auto nestable = _spatiallyNestable.lock();
-            if (nestable) {
-                map["parentID"] = nestable->getID();
-                map["parentJointIndex"] = _jointIndex;
-                map["baseParentScale"] = vec3toVariant(_baseScale);
-            }
+
+        auto nestable = _spatiallyNestable.lock();
+        if (nestable) {
+            map["parentID"] = nestable->getID();
+            map["parentJointIndex"] = _jointIndex;
+            map["baseParentScale"] = vec3toVariant(_baseScale);
         }
 
         return map;

--- a/libraries/shared/src/NestableTransformNode.h
+++ b/libraries/shared/src/NestableTransformNode.h
@@ -47,7 +47,7 @@ public:
         return jointWorldTransform;
     }
 
-    QVariantMap BaseNestableTransformNode<T>::toVariantMap() const {
+    QVariantMap toVariantMap() const {
         QVariantMap map;
     
         if (!_spatiallyNestable.expired()) {

--- a/libraries/shared/src/NestableTransformNode.h
+++ b/libraries/shared/src/NestableTransformNode.h
@@ -47,7 +47,7 @@ public:
         return jointWorldTransform;
     }
 
-    QVariantMap toVariantMap() const {
+    QVariantMap toVariantMap() const override {
         QVariantMap map;
 
         auto nestable = _spatiallyNestable.lock();

--- a/libraries/shared/src/NestableTransformNode.h
+++ b/libraries/shared/src/NestableTransformNode.h
@@ -12,6 +12,8 @@
 
 #include "SpatiallyNestable.h"
 
+#include "RegisteredMetaTypes.h"
+
 template <typename T>
 class BaseNestableTransformNode : public TransformNode {
 public:
@@ -43,6 +45,21 @@ public:
         jointWorldTransform.setScale(getActualScale(nestable) / _baseScale);
 
         return jointWorldTransform;
+    }
+
+    QVariantMap BaseNestableTransformNode<T>::toVariantMap() const {
+        QVariantMap map;
+    
+        if (!_spatiallyNestable.expired()) {
+            auto nestable = _spatiallyNestable.lock();
+            if (nestable) {
+                map["parentID"] = nestable->getID();
+                map["parentJointIndex"] = _jointIndex;
+                map["baseParentScale"] = vec3toVariant(_baseScale);
+            }
+        }
+
+        return map;
     }
 
     glm::vec3 getActualScale(const std::shared_ptr<T>& nestablePointer) const;

--- a/libraries/shared/src/RegisteredMetaTypes.cpp
+++ b/libraries/shared/src/RegisteredMetaTypes.cpp
@@ -26,6 +26,8 @@
 #include <QtScript/QScriptValueIterator>
 #include <QJsonDocument>
 
+int uint32MetaTypeId = qRegisterMetaType<glm::uint32>("uint32");
+int glmUint32MetaTypeId = qRegisterMetaType<glm::uint32>("glm::uint32");
 int vec2MetaTypeId = qRegisterMetaType<glm::vec2>();
 int u8vec3MetaTypeId = qRegisterMetaType<u8vec3>();
 int vec3MetaTypeId = qRegisterMetaType<glm::vec3>();
@@ -67,6 +69,8 @@ void registerMetaTypes(QScriptEngine* engine) {
     qScriptRegisterMetaType(engine, aaCubeToScriptValue, aaCubeFromScriptValue);
 
     qScriptRegisterMetaType(engine, stencilMaskModeToScriptValue, stencilMaskModeFromScriptValue);
+
+    qScriptRegisterSequenceMetaType<QVector<unsigned int>>(engine);
 }
 
 QScriptValue vec2ToScriptValue(QScriptEngine* engine, const glm::vec2& vec2) {

--- a/libraries/shared/src/RegisteredMetaTypes.cpp
+++ b/libraries/shared/src/RegisteredMetaTypes.cpp
@@ -35,6 +35,7 @@ int vec4MetaTypeId = qRegisterMetaType<glm::vec4>();
 int qVectorVec3MetaTypeId = qRegisterMetaType<QVector<glm::vec3>>();
 int qVectorQuatMetaTypeId = qRegisterMetaType<QVector<glm::quat>>();
 int qVectorBoolMetaTypeId = qRegisterMetaType<QVector<bool>>();
+int qVectorGLMUint32MetaTypeId = qRegisterMetaType<QVector<unsigned int>>("QVector<glm::uint32>");
 int quatMetaTypeId = qRegisterMetaType<glm::quat>();
 int pickRayMetaTypeId = qRegisterMetaType<PickRay>();
 int collisionMetaTypeId = qRegisterMetaType<Collision>();

--- a/libraries/shared/src/RegisteredMetaTypes.h
+++ b/libraries/shared/src/RegisteredMetaTypes.h
@@ -37,6 +37,8 @@ Q_DECLARE_METATYPE(glm::vec4)
 Q_DECLARE_METATYPE(glm::quat)
 Q_DECLARE_METATYPE(glm::mat4)
 Q_DECLARE_METATYPE(QVector<float>)
+Q_DECLARE_METATYPE(unsigned int)
+Q_DECLARE_METATYPE(QVector<unsigned int>)
 Q_DECLARE_METATYPE(AACube)
 Q_DECLARE_METATYPE(std::function<void()>);
 Q_DECLARE_METATYPE(std::function<QVariant()>);

--- a/libraries/shared/src/TransformNode.h
+++ b/libraries/shared/src/TransformNode.h
@@ -1,5 +1,5 @@
 //
-//  Created by Sabrina Shanman 8/14/2018
+//  Created by Sabrina Shanman 2018/08/14
 //  Copyright 2018 High Fidelity, Inc.
 //
 //  Distributed under the Apache License, Version 2.0.

--- a/libraries/shared/src/TransformNode.h
+++ b/libraries/shared/src/TransformNode.h
@@ -8,6 +8,8 @@
 #ifndef hifi_TransformNode_h
 #define hifi_TransformNode_h
 
+#include <QVariant>
+
 #include "Transform.h"
 
 class TransformNode {
@@ -15,6 +17,7 @@ public:
     virtual ~TransformNode() = default;
 
     virtual Transform getTransform() = 0;
+    virtual QVariantMap toVariantMap() const = 0;
 };
 
 #endif // hifi_TransformNode_h


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1059

This PR adds and improves to our pick/pointer debug capabilities, allowing to debug and identify an arbitrary pick or pointer at runtime. The following are now possible for both pointers and picks:

- Get the list of created picks/pointers. To make this possible, it was necessary to change how a couple script types were registered, in order for the Graphics javascript API to continue to function.
- Get the properties that were passed in during creation, to more easily identify where the pick/pointer was created in the code, and see how pick properties were interpreted
- Get the current properties of the pick/pointers