### PR TITLE
DEV-263: HQ Launcher/Interface (Mac) - appear to consolidate apps

### DIFF
--- a/launchers/darwin/CMakeLists.txt
+++ b/launchers/darwin/CMakeLists.txt
@@ -43,6 +43,8 @@ set(src_files
   src/LaunchInterface.h
   src/CustomUI.h
   src/CustomUI.m
+  src/NSTask+NSTaskExecveAdditions.h
+  src/NSTask+NSTaskExecveAdditions.m
   src/main.mm
   nib/Window.xib
   nib/SplashScreen.xib

--- a/launchers/darwin/src/NSTask+NSTaskExecveAdditions.h
+++ b/launchers/darwin/src/NSTask+NSTaskExecveAdditions.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSTask (NSTaskExecveAdditions)
+- (void) replaceThisProcess;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/launchers/darwin/src/NSTask+NSTaskExecveAdditions.m
+++ b/launchers/darwin/src/NSTask+NSTaskExecveAdditions.m
@@ -1,0 +1,73 @@
+#import "NSTask+NSTaskExecveAdditions.h"
+
+#import <libgen.h>
+
+char **
+toCArray(NSArray<NSString *> *array)
+{
+    // Add one to count to accommodate the NULL that terminates the array.
+    char **cArray = (char **) calloc([array count] + 1, sizeof(char *));
+    if (cArray == NULL) {
+        NSException *exception = [NSException
+                                  exceptionWithName:@"MemoryException"
+                                  reason:@"malloc failed"
+                                  userInfo:nil];
+        @throw exception;
+    }
+    char *str;
+    for (int i = 0; i < [array count]; i++) {
+        str = (char *) [array[i] UTF8String];
+        if (str == NULL) {
+            NSException *exception = [NSException
+                                      exceptionWithName:@"NULLStringException"
+                                      reason:@"UTF8String was NULL"
+                                      userInfo:nil];
+            @throw exception;
+        }
+        if (asprintf(&cArray[i], "%s", str) == -1) {
+            for (int j = 0; j < i; j++) {
+                free(cArray[j]);
+            }
+            free(cArray);
+            NSException *exception = [NSException
+                                      exceptionWithName:@"MemoryException"
+                                      reason:@"malloc failed"
+                                      userInfo:nil];
+            @throw exception;
+        }
+    }
+    return cArray;
+}
+
+@implementation NSTask (NSTaskExecveAdditions)
+
+- (void) replaceThisProcess {
+    char **args = toCArray([@[[self launchPath]] arrayByAddingObjectsFromArray:[self arguments]]);
+
+    NSMutableArray *env = [[NSMutableArray alloc] init];
+    NSDictionary* environvment = [[NSProcessInfo processInfo] environment];
+    for (NSString* key in environvment) {
+        NSString* environmentVariable = [[key stringByAppendingString:@"="] stringByAppendingString:environvment[key]];
+        [env addObject:environmentVariable];
+    }
+
+    char** envp = toCArray(env);
+    // `execve` replaces the current process with `path`.
+    // It will only return if it fails to replace the current process.
+    chdir(dirname(args[0]));
+    execve(args[0], (char * const *)args, envp);
+
+    // If we're here `execve` failed. :(
+    for (int i = 0; i < [[self arguments] count]; i++) {
+        free((void *) args[i]);
+    }
+    free((void *) args);
+
+    NSException *exception = [NSException
+                              exceptionWithName:@"ExecveException"
+                              reason:[NSString stringWithFormat:@"couldn't execve: %s", strerror(errno)]
+                              userInfo:nil];
+    @throw exception;
+}
+
+@end


### PR DESCRIPTION
Before this change the mac HQ Launcher used `NSTask` to start Interface, then it closed itself down. This implementation meant the HQ Launcher's icon was opened and then closed in the dock before Interface's icon took its place.
This change modifies the previously described behavior to have the dock icon for HQ Launcher continue to represent Interface once it's closed. It does this by using `execve` rather than `NSTask`'s default launching behavior to start Interface.
Jira: <https://highfidelity.atlassian.net/browse/DEV-263>