### PR TITLE
BUGZ-1171: Fix audio output not working

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -628,7 +628,9 @@ bool adjustedFormatForAudioDevice(const QAudioDeviceInfo& audioDevice,
 #if defined(Q_OS_WIN)
     if (IsWindows8OrGreater()) {
         // On Windows using WASAPI shared-mode, returns the internal mix format
-        return nativeFormatForAudioDevice(audioDevice, adjustedAudioFormat);
+        if (nativeFormatForAudioDevice(audioDevice, adjustedAudioFormat)) {
+            return true;
+        }
     }   // else enumerate formats
 #endif
     


### PR DESCRIPTION
nativeFormatForAudioDevice() doesn't handle QAudioFormat(48000Hz, 16bit, channelCount=8, sampleType=SignedInt, byteOrder=LittleEndian, codec="audio/pcm"), for example.

Case: https://highfidelity.atlassian.net/browse/BUGZ-1171

