### PR TITLE
BUGZ-1187: Allow developers to bootstrap vcpkg via the traditional method

### DIFF
--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -5,7 +5,7 @@ If you are upgrading from previous versions, do a clean uninstall of those versi
 
 Note: The prerequisites will require about 10 GB of space on your drive. You will also need a system with at least 8GB of main memory.
 
-### Step 1. Visual Studio & Python
+### Step 1. Visual Studio & Python 3.x
 
 If you don’t have Community or Professional edition of Visual Studio, download [Visual Studio Community 2019](https://visualstudio.microsoft.com/vs/). If you have Visual Studio 2017, you are not required to download Visual Studio 2019.
 
@@ -21,7 +21,7 @@ When selecting components, check "Desktop development with C++". On the right on
 * MSVC v141 - VS 2017 C++ x64/x86 build tools
 * MSVC v140 - VS 2015 C++ build tools (v14.00)
 
-If you do not already have a Python development environment installed, also check "Python Development" in this screen.
+If you do not already have a Python 3.x development environment installed, also check "Python Development" in this screen.
 
 If you already have Visual Studio installed and need to add Python, open the "Add or remove programs" control panel and find the "Microsoft Visual Studio Installer".  Select it and click "Modify".  In the installer, select "Modify" again, then check "Python Development" and allow the installer to apply the changes.
 
@@ -31,9 +31,10 @@ If you do not wish to use the Python installation bundled with Visual Studio, yo
 
 ### Step 2. Installing CMake
 
-Download and install the latest version of CMake 3.14.
+Download and install the latest version of CMake 3.15. 
+ * Note that earlier versions of CMake will work, but there is a specific bug related to the interaction of Visual Studio 2019 and CMake versions prior to 3.15 that will cause Visual Studio to rebuild far more than it needs to on every build
 
-Download the file named win64-x64 Installer from the [CMake Website](https://cmake.org/download/). You can access the installer on this [3.14 Version page](https://cmake.org/files/v3.14/). During installation, make sure to check "Add CMake to system PATH for all users" when prompted.
+Download the file named win64-x64 Installer from the [CMake Website](https://cmake.org/download/). You can access the installer on this [3.15 Version page](https://cmake.org/files/v3.15/). During installation, make sure to check "Add CMake to system PATH for all users" when prompted.
 
 ### Step 3. Create VCPKG environment variable
 In the next step, you will use CMake to build High Fidelity. By default, the CMake process builds dependency files in Windows' `%TEMP%` directory, which is periodically cleared by the operating system. To prevent you from having to re-build the dependencies in the event that Windows clears that directory, we recommend that you create a `HIFI_VCPKG_BASE` environment variable linked to a directory somewhere on your machine. That directory will contain all dependency files until you manually remove them.
@@ -42,8 +43,17 @@ To create this variable:
 * Naviagte to 'Edit the System Environment Variables' Through the start menu.
 * Click on 'Environment Variables'
 * Select 'New' 
-* Set "Variable name" to HIFI_VCPKG_BASE
+* Set "Variable name" to `HIFI_VCPKG_BASE`
 * Set "Variable value" to any directory that you have control over.
+
+Additionally, if you have Visual Studio 2019 installed and _only_ Visual Studio 2019 (i.e. you do not have Visual Studio 2017 installed) you must add an additional environment variable `HIFI_VCPKG_BOOTSTRAP` that will fix a bug in our `vcpkg` pre-build step.
+
+To create this variable:
+* Naviagte to 'Edit the System Environment Variables' Through the start menu.
+* Click on 'Environment Variables'
+* Select 'New' 
+* Set "Variable name" to `HIFI_VCPKG_BOOTSTRAP`
+* Set "Variable value" to `1`
 
 ### Step 4. Running CMake to Generate Build Files
 

--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -71,16 +71,19 @@ endif()
 
         if 'Windows' == system:
             self.exe = os.path.join(self.path, 'vcpkg.exe')
+            self.bootstrapCmd = 'bootstrap-vcpkg.bat'
             self.vcpkgUrl = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/vcpkg-win32.tar.gz?versionId=YZYkDejDRk7L_hrK_WVFthWvisAhbDzZ'
             self.vcpkgHash = '3e0ff829a74956491d57666109b3e6b5ce4ed0735c24093884317102387b2cb1b2cd1ff38af9ed9173501f6e32ffa05cc6fe6d470b77a71ca1ffc3e0aa46ab9e'
             self.hostTriplet = 'x64-windows'
         elif 'Darwin' == system:
             self.exe = os.path.join(self.path, 'vcpkg')
+            self.bootstrapCmd = 'bootstrap-vcpkg.sh'
             self.vcpkgUrl = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/vcpkg-osx.tar.gz?versionId=_fhqSxjfrtDJBvEsQ8L_ODcdUjlpX9cc'
             self.vcpkgHash = '519d666d02ef22b87c793f016ca412e70f92e1d55953c8f9bd4ee40f6d9f78c1df01a6ee293907718f3bbf24075cc35492fb216326dfc50712a95858e9cbcb4d'
             self.hostTriplet = 'x64-osx'
         else:
             self.exe = os.path.join(self.path, 'vcpkg')
+            self.bootstrapCmd = 'bootstrap-vcpkg.sh'
             self.vcpkgUrl = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/vcpkg-linux.tar.gz?versionId=97Nazh24etEVKWz33XwgLY0bvxEfZgMU'
             self.vcpkgHash = '6a1ce47ef6621e699a4627e8821ad32528c82fce62a6939d35b205da2d299aaa405b5f392df4a9e5343dd6a296516e341105fbb2dd8b48864781d129d7fba10d'
             self.hostTriplet = 'x64-linux'
@@ -141,8 +144,14 @@ endif()
             downloadVcpkg = True
 
         if downloadVcpkg:
-            print("Fetching vcpkg from {} to {}".format(self.vcpkgUrl, self.path))
-            hifi_utils.downloadAndExtract(self.vcpkgUrl, self.path, self.vcpkgHash)
+            if "HIFI_VCPKG_BOOTSTRAP" in os.environ:
+                print("Cloning vcpkg from github to {}".format(self.path))
+                hifi_utils.executeSubprocess(['git', 'clone', 'git@github.com:microsoft/vcpkg.git', self.path])
+                print("Bootstrapping vcpkg")
+                hifi_utils.executeSubprocess([self.bootstrapCmd], folder=self.path)
+            else:
+                print("Fetching vcpkg from {} to {}".format(self.vcpkgUrl, self.path))
+                hifi_utils.downloadAndExtract(self.vcpkgUrl, self.path, self.vcpkgHash)
 
         print("Replacing port files")
         portsPath = os.path.join(self.path, 'ports')


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1187 This PR supports an alternative method of acquiring the vcpkg binary for developers.  By setting the environment variable `HIFI_VCPKG_BOOTSTRAP` to some value, the client will clone the vcpkg repository and bootstrap it, rather than downloading the pre-built binary.  

This enables developers who have VS 2019 (and _only_ VS 2019) to build, because the current pre-built binary predates the release of VS 2019.

