### PR TITLE
BUGZ-1184: Fix create duplication key conflicting with camera orbit

### DIFF
--- a/scripts/system/libraries/entityCameraTool.js
+++ b/scripts/system/libraries/entityCameraTool.js
@@ -355,7 +355,7 @@ CameraManager = function() {
             return;
         }
 
-        if (event.isRightButton || (event.isLeftButton && event.isControl && !event.isShifted)) {
+        if (event.isRightButton || (event.isLeftButton && event.isAlt && !event.isShifted)) {
             that.mode = MODE_ORBIT;
         } else if (event.isMiddleButton || (event.isLeftButton && event.isControl && event.isShifted)) {
             that.mode = MODE_PAN;


### PR DESCRIPTION
This will adjust LeftClick orbit to work with Alt instead of Ctrl. This will remove the conflict with LeftClick+Ctrl to duplicate.