### PR TITLE
Fix BUGZ-1197 (and others): Ensure enterEntity is emitted when avatar is inside entity and script is reloaded

### DIFF
--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -1027,6 +1027,10 @@ void EntityTreeRenderer::addingEntity(const EntityItemID& entityID) {
 
 void EntityTreeRenderer::entityScriptChanging(const EntityItemID& entityID, bool reload) {
     checkAndCallPreload(entityID, reload, true);
+    // Force "re-checking" entities so that the logic inside `checkEnterLeaveEntities()` is run.
+    // This will ensure that the `enterEntity()` signal is emitted on clients whose avatars
+    // are inside an entity when the script is reloaded.
+    forceRecheckEntities();
 }
 
 void EntityTreeRenderer::checkAndCallPreload(const EntityItemID& entityID, bool reload, bool unloadFirst) {


### PR DESCRIPTION
[BUGZ-1197](https://highfidelity.atlassian.net/browse/BUGZ-1197)