### PR TITLE
BUGZ-1097: Fix invalid rendering of splash frame on AMD based macs

### DIFF
--- a/interface/src/graphics/GraphicsEngine.cpp
+++ b/interface/src/graphics/GraphicsEngine.cpp
@@ -258,6 +258,7 @@ void GraphicsEngine::render_performFrame() {
             batch.setFramebuffer(finalFramebuffer);
             batch.enableSkybox(true);
             batch.enableStereo(isStereo);
+            batch.clearDepthStencilFramebuffer(1.0, 0);
             batch.setViewportTransform({ 0, 0, finalFramebuffer->getSize() });
             _splashScreen->render(batch, viewFrustum, renderArgs._renderMethod == RenderArgs::RenderMethod::FORWARD);
         });


### PR DESCRIPTION
[BUGZ-1097](https://highfidelity.atlassian.net/browse/BUGZ-1097):  On AMD based Mac systems the splash screen (which is a very simple procedural shader) is rendering with strange blue stripes.  After some work grabbing the frame and serializing it and examining the custom shader used to render I began to suspect that this bug was triggered by another recent change to the default output framebuffer which added a depth-stencil buffer to it in all cases.  Since we weren't performing any clears of the stencil framebuffer, technically it could contain any set of stencil values at all, although on most systems it appears to end up being initially set to 0, on AMD based macs, it appears to have some strange pattern in it.  This pattern was producing the alternating blue/black line output because the procedural skybox pipeline uses a non-trivial stencil test.  

Simply adding a call to `clearDepthStencilFramebuffer` in the splash screen batch appears to resolve the issue.