### PR TITLE
(BUGZ-1112) Make 20:20 vision equal seeing 1m cube from 400 meters away

### DIFF
--- a/interface/resources/qml/hifi/dialogs/TabletLODTools.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletLODTools.qml
@@ -27,11 +27,8 @@ Rectangle {
 
     HifiConstants { id: hifi }
 
-    readonly property real treeScale: 32768; // ~20 miles.. This is the number of meters of the 0.0 to 1.0 voxel universe
-    readonly property real halfTreeScale: treeScale / 2;
-
-    // This controls the LOD. Larger number will make smaller voxels visible at greater distance.
-    readonly property real defaultOctreeSizeScale: treeScale * 400.0
+    // This controls the LOD. Larger number will make smaller objects visible at greater distance.
+    readonly property real defaultMaxVisibilityDistance: 400.0
 
     Column {
         anchors.margins: 10
@@ -89,10 +86,10 @@ Rectangle {
             anchors.right: parent.right
             minimumValue: 5
             maximumValue: 2000
-            value: LODManager.getOctreeSizeScale() / treeScale
+            value: defaultMaxVisibilityDistance
             tickmarksEnabled: false
             onValueChanged: {
-                LODManager.setOctreeSizeScale(value * treeScale);
+                LODManager.setVisibilityDistanceForUnitElement(value);
                 whatYouCanSeeLabel.text = LODManager.getLODFeedbackText()
             }
         }
@@ -106,7 +103,7 @@ Rectangle {
             colorScheme: root.colorScheme
             height: 30
             onClicked: {
-                slider.value = defaultOctreeSizeScale/treeScale
+                slider.value = defaultMaxVisibilityDistance
                 adjustCheckbox.checked = false
                 LODManager.setAutomaticLODAdjust(adjustCheckbox.checked);
             }

--- a/interface/resources/qml/hifi/dialogs/TabletLODTools.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletLODTools.qml
@@ -31,9 +31,10 @@ Rectangle {
     readonly property real defaultMaxVisibilityDistance: 400.0
     readonly property real unitElementMaxExtent: Math.sqrt(3.0) * 0.5
     
-    function lodAngleDegToVisibilityDistance(var lodAngleDeg) {
-        var lodAngleRadians = lodAngleDeg * Math.PI / 180.0;
-        return unitElementMaxExtent / tan(lodAngleRadians);
+    function visibilityDistanceToLODAngleDeg(visibilityDistance) {
+        var lodHalfAngle = Math.atan(unitElementMaxExtent / visibilityDistance);
+        var lodAngle = lodHalfAngle * 2.0;
+        return lodAngle * 180.0 / Math.PI;
     }
 
     Column {
@@ -74,7 +75,7 @@ Rectangle {
                 id: adjustCheckbox
                 boxSize: 20
                 anchors.verticalCenter: parent.verticalCenter
-                onCheckedChanged: LODManager.setAutomaticLODAdjust(!checked);
+                onCheckedChanged: LODManager.setAutomaticLODAdjust(!adjustCheckbox.checked);
             }
         }
 
@@ -95,7 +96,7 @@ Rectangle {
             value: defaultMaxVisibilityDistance
             tickmarksEnabled: false
             onValueChanged: {
-                LODManager.setLODAngleDeg(lodAngleDegToVisibilityDistance(value));
+                LODManager.lodAngleDeg = visibilityDistanceToLODAngleDeg(slider.value);
                 whatYouCanSeeLabel.text = LODManager.getLODFeedbackText()
             }
         }

--- a/interface/resources/qml/hifi/dialogs/TabletLODTools.qml
+++ b/interface/resources/qml/hifi/dialogs/TabletLODTools.qml
@@ -29,6 +29,12 @@ Rectangle {
 
     // This controls the LOD. Larger number will make smaller objects visible at greater distance.
     readonly property real defaultMaxVisibilityDistance: 400.0
+    readonly property real unitElementMaxExtent: Math.sqrt(3.0) * 0.5
+    
+    function lodAngleDegToVisibilityDistance(var lodAngleDeg) {
+        var lodAngleRadians = lodAngleDeg * Math.PI / 180.0;
+        return unitElementMaxExtent / tan(lodAngleRadians);
+    }
 
     Column {
         anchors.margins: 10
@@ -89,7 +95,7 @@ Rectangle {
             value: defaultMaxVisibilityDistance
             tickmarksEnabled: false
             onValueChanged: {
-                LODManager.setVisibilityDistanceForUnitElement(value);
+                LODManager.setLODAngleDeg(lodAngleDegToVisibilityDistance(value));
                 whatYouCanSeeLabel.text = LODManager.getLODFeedbackText()
             }
         }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6818,7 +6818,7 @@ void Application::updateRenderArgs(float deltaTime) {
                 _viewFrustum.calculate();
             }
             appRenderArgs._renderArgs = RenderArgs(_graphicsEngine.getGPUContext(), lodManager->getVisibilityDistance(),
-                lodManager->getBoundaryLevelAdjust(), lodManager->getLODAngleHalfTan(), RenderArgs::DEFAULT_RENDER_MODE,
+                lodManager->getBoundaryLevelAdjust(), lodManager->getLODHalfAngleTan(), RenderArgs::DEFAULT_RENDER_MODE,
                 RenderArgs::MONO, RenderArgs::DEFERRED, RenderArgs::RENDER_DEBUG_NONE);
             appRenderArgs._renderArgs._scene = getMain3DScene();
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -6817,7 +6817,7 @@ void Application::updateRenderArgs(float deltaTime) {
                 _viewFrustum.setProjection(adjustedProjection);
                 _viewFrustum.calculate();
             }
-            appRenderArgs._renderArgs = RenderArgs(_graphicsEngine.getGPUContext(), lodManager->getOctreeSizeScale(),
+            appRenderArgs._renderArgs = RenderArgs(_graphicsEngine.getGPUContext(), lodManager->getVisibilityDistance(),
                 lodManager->getBoundaryLevelAdjust(), lodManager->getLODAngleHalfTan(), RenderArgs::DEFAULT_RENDER_MODE,
                 RenderArgs::MONO, RenderArgs::DEFERRED, RenderArgs::RENDER_DEBUG_NONE);
             appRenderArgs._renderArgs._scene = getMain3DScene();

--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -175,6 +175,7 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
 
 float LODManager::getLODAngleHalfTan() const {
     return getPerspectiveAccuracyAngleTan(_octreeSizeScale, _boundaryLevelAdjust);
+
 }
 float LODManager::getLODAngle() const {
     return 2.0f * atanf(getLODAngleHalfTan());
@@ -184,9 +185,9 @@ float LODManager::getLODAngleDeg() const {
 }
 
 void LODManager::setLODAngleDeg(float lodAngle) {
-    auto newSolidAngle = std::max(0.5f, std::min(lodAngle, 90.f));
-    auto halTan = glm::tan(glm::radians(newSolidAngle * 0.5f));
-    auto octreeSizeScale = TREE_SCALE * OCTREE_TO_MESH_RATIO / halTan;
+    auto newSolidAngle = std::max(0.001f, std::min(lodAngle, 90.f));
+    auto halfTan = glm::tan(glm::radians(newSolidAngle * 0.5f));
+    auto octreeSizeScale = /*TREE_SCALE *  OCTREE_TO_MESH_RATIO */ (sqrtf(3.0f) * 0.5f) / halfTan;
     setOctreeSizeScale(octreeSizeScale);
 }
 
@@ -294,7 +295,8 @@ QString LODManager::getLODFeedbackText() {
     }
     // distance feedback
     float octreeSizeScale = getOctreeSizeScale();
-    float relativeToDefault = octreeSizeScale / DEFAULT_OCTREE_SIZE_SCALE;
+ //   float relativeToDefault = octreeSizeScale / DEFAULT_OCTREE_SIZE_SCALE;
+    float relativeToDefault = octreeSizeScale / MAX_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT;
     int relativeToTwentyTwenty = 20 / relativeToDefault;
 
     QString result;

--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -92,8 +92,7 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
         return;
     }
 
-    // Previous values for output
-    float oldVisibilityDistance = getVisibilityDistance();
+    // Previous value for output
     float oldLODAngle = getLODAngleDeg();
 
     // Target fps is slightly overshooted by 5hz
@@ -174,7 +173,6 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
 
 float LODManager::getLODHalfAngleTan() const {
     return tan(_lodHalfAngle);
-
 }
 float LODManager::getLODAngle() const {
     return 2.0f * _lodHalfAngle;
@@ -196,10 +194,9 @@ void LODManager::setVisibilityDistance(float distance) {
 }
 
 void LODManager::setLODAngleDeg(float lodAngle) {
-    auto newSolidAngle = std::max(0.001f, std::min(lodAngle, 90.f));
-    auto halfTan = glm::tan(glm::radians(newSolidAngle * 0.5f));
-    auto visibilityDistance = UNIT_ELEMENT_MAX_EXTENT / halfTan;
-    setVisibilityDistance(visibilityDistance);
+    auto newLODAngleDeg = std::max(0.001f, std::min(lodAngle, 90.f));
+    auto newLODHalfAngle = glm::radians(newLODAngleDeg * 0.5);
+    _lodHalfAngle = newLODHalfAngle;
 }
 
 void LODManager::setSmoothScale(float t) {

--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -311,7 +311,9 @@ QString LODManager::getLODFeedbackText() {
     int relativeToTwentyTwenty = 20 / relativeToDefault;
 
     QString result;
-    if (relativeToDefault > 1.01f) {
+    if (relativeToTwentyTwenty < 1) {
+        result = QString("%2 times further than average vision%3").arg(relativeToDefault, 0, 'f', 3).arg(granularityFeedback);
+    } else if (relativeToDefault > 1.01f) {
         result = QString("20:%1 or %2 times further than average vision%3").arg(relativeToTwentyTwenty).arg(relativeToDefault, 0, 'f', 2).arg(granularityFeedback);
     } else if (relativeToDefault > 0.99f) {
         result = QString("20:20 or the default distance for average vision%1").arg(granularityFeedback);

--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -173,12 +173,12 @@ void LODManager::autoAdjustLOD(float realTimeDelta) {
     }
 }
 
-float LODManager::getLODAngleHalfTan() const {
-    return getPerspectiveAccuracyAngleTan(_visibilityDistance, _boundaryLevelAdjust);
+float LODManager::getLODHalfAngleTan() const {
+    return getPerspectiveAccuracyHalfAngleTan(_visibilityDistance, _boundaryLevelAdjust);
 
 }
 float LODManager::getLODAngle() const {
-    return 2.0f * atanf(getLODAngleHalfTan());
+    return 2.0f * atanf(getLODHalfAngleTan());
 }
 float LODManager::getLODAngleDeg() const {
     return glm::degrees(getLODAngle());

--- a/interface/src/LODManager.cpp
+++ b/interface/src/LODManager.cpp
@@ -195,7 +195,7 @@ void LODManager::setVisibilityDistance(float distance) {
 
 void LODManager::setLODAngleDeg(float lodAngle) {
     auto newLODAngleDeg = std::max(0.001f, std::min(lodAngle, 90.f));
-    auto newLODHalfAngle = glm::radians(newLODAngleDeg * 0.5);
+    auto newLODHalfAngle = glm::radians(newLODAngleDeg * 0.5f);
     _lodHalfAngle = newLODHalfAngle;
 }
 

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -59,6 +59,7 @@ class LODManager : public QObject, public Dependency {
 
         Q_PROPERTY(float lodQualityLevel READ getLODQualityLevel WRITE setLODQualityLevel NOTIFY lodQualityLevelChanged)
 
+        // Deprecated
         Q_PROPERTY(bool automaticLODAdjust READ getAutomaticLODAdjust WRITE setAutomaticLODAdjust NOTIFY autoLODChanged)
 
         Q_PROPERTY(float presentTime READ getPresentTime)
@@ -138,24 +139,28 @@ public:
     /**jsdoc
      * @function LODManager.setOctreeSizeScale
      * @param {number} sizeScale
+     * @deprecated This function is deprecated and will be removed. Use the {@link LODManager.lodAngleDeg} property instead.
      */
     Q_INVOKABLE void setOctreeSizeScale(float sizeScale);
 
     /**jsdoc
      * @function LODManager.getOctreeSizeScale
      * @returns {number}
+     * @deprecated This function is deprecated and will be removed. Use the {@link LODManager.lodAngleDeg} property instead.
      */
     Q_INVOKABLE float getOctreeSizeScale() const;
 
     /**jsdoc
      * @function LODManager.setBoundaryLevelAdjust
      * @param {number} boundaryLevelAdjust
+     * @deprecated This function is deprecated and will be removed.
      */
     Q_INVOKABLE void setBoundaryLevelAdjust(int boundaryLevelAdjust);
 
     /**jsdoc
      * @function LODManager.getBoundaryLevelAdjust
      * @returns {number}
+     * @deprecated This function is deprecated and will be removed.
      */
     Q_INVOKABLE int getBoundaryLevelAdjust() const { return _boundaryLevelAdjust; }
 

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -17,6 +17,7 @@
 #include <DependencyManager.h>
 #include <NumericalConstants.h>
 #include <OctreeConstants.h>
+#include <OctreeUtils.h>
 #include <PIDController.h>
 #include <SimpleMovingAverage.h>
 #include <render/Args.h>
@@ -261,7 +262,7 @@ private:
     float _desktopTargetFPS { LOD_OFFSET_FPS + LOD_DEFAULT_QUALITY_LEVEL * LOD_MAX_LIKELY_DESKTOP_FPS };
     float _hmdTargetFPS { LOD_OFFSET_FPS + LOD_DEFAULT_QUALITY_LEVEL * LOD_MAX_LIKELY_HMD_FPS };
 
-    float _visibilityDistance = DEFAULT_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT;
+    float _lodHalfAngle = getHalfAngleFromVisibilityDistance(DEFAULT_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT);
     int _boundaryLevelAdjust = 0;
 
     glm::vec4 _pidCoefs{ 1.0f, 0.0f, 0.0f, 1.0f }; // Kp, Ki, Kd, Kv

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -201,7 +201,7 @@ public:
 
     float getLODAngleDeg() const;
     void setLODAngleDeg(float lodAngle);
-    float getLODAngleHalfTan() const;
+    float getLODHalfAngleTan() const;
     float getLODAngle() const;
     float getVisibilityDistance() const;
     void setVisibilityDistance(float distance);

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -145,7 +145,7 @@ public:
      * @function LODManager.getOctreeSizeScale
      * @returns {number}
      */
-    Q_INVOKABLE float getOctreeSizeScale() const { return _octreeSizeScale; }
+    Q_INVOKABLE float getOctreeSizeScale() const;
 
     /**jsdoc
      * @function LODManager.setBoundaryLevelAdjust
@@ -198,6 +198,8 @@ public:
     void setLODAngleDeg(float lodAngle);
     float getLODAngleHalfTan() const;
     float getLODAngle() const;
+    float getVisibilityDistance() const;
+    void setVisibilityDistance(float distance);
 
     float getPidKp() const;
     float getPidKi() const;
@@ -254,7 +256,7 @@ private:
     float _desktopTargetFPS { LOD_OFFSET_FPS + LOD_DEFAULT_QUALITY_LEVEL * LOD_MAX_LIKELY_DESKTOP_FPS };
     float _hmdTargetFPS { LOD_OFFSET_FPS + LOD_DEFAULT_QUALITY_LEVEL * LOD_MAX_LIKELY_HMD_FPS };
 
-    float _octreeSizeScale = DEFAULT_OCTREE_SIZE_SCALE;
+    float _visibilityDistance = DEFAULT_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT;
     int _boundaryLevelAdjust = 0;
 
     glm::vec4 _pidCoefs{ 1.0f, 0.0f, 0.0f, 1.0f }; // Kp, Ki, Kd, Kv

--- a/interface/src/LODManager.h
+++ b/interface/src/LODManager.h
@@ -60,7 +60,6 @@ class LODManager : public QObject, public Dependency {
 
         Q_PROPERTY(float lodQualityLevel READ getLODQualityLevel WRITE setLODQualityLevel NOTIFY lodQualityLevelChanged)
 
-        // Deprecated
         Q_PROPERTY(bool automaticLODAdjust READ getAutomaticLODAdjust WRITE setAutomaticLODAdjust NOTIFY autoLODChanged)
 
         Q_PROPERTY(float presentTime READ getPresentTime)

--- a/interface/src/ui/LodToolsDialog.cpp
+++ b/interface/src/ui/LodToolsDialog.cpp
@@ -64,7 +64,7 @@ LodToolsDialog::LodToolsDialog(QWidget* parent) :
     _lodSize->setTickPosition(QSlider::TicksBelow);
     _lodSize->setFixedWidth(SLIDER_WIDTH);
     _lodSize->setPageStep(PAGE_STEP_LOD_SIZE);
-    int sliderValue = lodManager->getOctreeSizeScale() / TREE_SCALE;
+    int sliderValue = lodManager->getVisibilityDistance();
     _lodSize->setValue(sliderValue);
     form->addRow("Level of Detail:", _lodSize);
     connect(_lodSize,SIGNAL(valueChanged(int)),this,SLOT(sizeScaleValueChanged(int)));
@@ -81,7 +81,7 @@ LodToolsDialog::LodToolsDialog(QWidget* parent) :
 
 void LodToolsDialog::reloadSliders() {
     auto lodManager = DependencyManager::get<LODManager>();
-    _lodSize->setValue(lodManager->getOctreeSizeScale() / TREE_SCALE);
+    _lodSize->setValue(lodManager->getVisibilityDistance());
     _feedback->setText(lodManager->getLODFeedbackText());
 }
 
@@ -93,15 +93,14 @@ void LodToolsDialog::updateAutomaticLODAdjust() {
 
 void LodToolsDialog::sizeScaleValueChanged(int value) {
     auto lodManager = DependencyManager::get<LODManager>();
-    float realValue = value /** TREE_SCALE*/;
-    lodManager->setOctreeSizeScale(realValue);
+    lodManager->setVisibilityDistance(value);
     
     _feedback->setText(lodManager->getLODFeedbackText());
 }
 
 void LodToolsDialog::resetClicked(bool checked) {
 
-    int sliderValue = DEFAULT_OCTREE_SIZE_SCALE / TREE_SCALE;
+    int sliderValue = DEFAULT_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT;
     _lodSize->setValue(sliderValue);
     _manualLODAdjust->setChecked(false);
     
@@ -124,8 +123,8 @@ void LodToolsDialog::closeEvent(QCloseEvent* event) {
     lodManager->setAutomaticLODAdjust(true); 
 
     // if the user adjusted the LOD above "normal" then always revert back to default
-    if (lodManager->getOctreeSizeScale() > DEFAULT_OCTREE_SIZE_SCALE) {
-        lodManager->setOctreeSizeScale(DEFAULT_OCTREE_SIZE_SCALE);
+    if (lodManager->getVisibilityDistance() > DEFAULT_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT) {
+        lodManager->setVisibilityDistance(DEFAULT_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT);
     }
 #endif
 }

--- a/interface/src/ui/LodToolsDialog.cpp
+++ b/interface/src/ui/LodToolsDialog.cpp
@@ -93,7 +93,7 @@ void LodToolsDialog::updateAutomaticLODAdjust() {
 
 void LodToolsDialog::sizeScaleValueChanged(int value) {
     auto lodManager = DependencyManager::get<LODManager>();
-    float realValue = value * TREE_SCALE;
+    float realValue = value /** TREE_SCALE*/;
     lodManager->setOctreeSizeScale(realValue);
     
     _feedback->setText(lodManager->getLODFeedbackText());

--- a/libraries/octree/src/OctreeConstants.h
+++ b/libraries/octree/src/OctreeConstants.h
@@ -21,8 +21,9 @@ const int TREE_SCALE = 32768; // ~20 miles.. This is the number of meters of the
 const int HALF_TREE_SCALE = TREE_SCALE / 2;
 
 // This controls the LOD. Larger number will make smaller voxels visible at greater distance.
-const float MAX_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT = 400.0f; // max distance where a 1x1x1 cube is visible for 20:20 vision
-const float DEFAULT_OCTREE_SIZE_SCALE = TREE_SCALE * MAX_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT;
+const float DEFAULT_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT = 400.0f; // max distance where a 1x1x1 cube is visible for 20:20 vision
+const float UNIT_ELEMENT_MAX_EXTENT = sqrt(3.0f) / 2.0f; // A unit cube tilted on its edge will have its edge jutting out sqrt(3)/2 units from the center
+const float DEFAULT_OCTREE_SIZE_SCALE = TREE_SCALE * DEFAULT_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT;
 
 // Since entities like models live inside of octree cells, and they themselves can have very small mesh parts,
 // we want to have some constant that controls have big a mesh part must be to render even if the octree cell itself

--- a/libraries/octree/src/OctreeConstants.h
+++ b/libraries/octree/src/OctreeConstants.h
@@ -22,7 +22,7 @@ const int HALF_TREE_SCALE = TREE_SCALE / 2;
 
 // This controls the LOD. Larger number will make smaller voxels visible at greater distance.
 const float DEFAULT_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT = 400.0f; // max distance where a 1x1x1 cube is visible for 20:20 vision
-const float UNIT_ELEMENT_MAX_EXTENT = sqrt(3.0f) / 2.0f; // A unit cube tilted on its edge will have its edge jutting out sqrt(3)/2 units from the center
+const float UNIT_ELEMENT_MAX_EXTENT = sqrtf(3.0f) / 2.0f; // A unit cube tilted on its edge will have its edge jutting out sqrt(3)/2 units from the center
 const float DEFAULT_OCTREE_SIZE_SCALE = TREE_SCALE * DEFAULT_VISIBILITY_DISTANCE_FOR_UNIT_ELEMENT;
 
 // Since entities like models live inside of octree cells, and they themselves can have very small mesh parts,

--- a/libraries/octree/src/OctreeUtils.cpp
+++ b/libraries/octree/src/OctreeUtils.cpp
@@ -18,17 +18,17 @@
 #include <AABox.h>
 #include <AACube.h>
 
-float boundaryDistanceForRenderLevel(unsigned int renderLevel, float voxelSizeScale) {
-    return voxelSizeScale / powf(2.0f, renderLevel);
+float boundaryDistanceForRenderLevel(unsigned int renderLevel, float visibilityDistance) {
+    return visibilityDistance / powf(2.0f, renderLevel);
 }
 
-float getPerspectiveAccuracyAngleTan(float visibilityDistance, int boundaryLevelAdjust) {
+float getPerspectiveAccuracyHalfAngleTan(float visibilityDistance, int boundaryLevelAdjust) {
     float visibleDistanceAtMaxScale = boundaryDistanceForRenderLevel(boundaryLevelAdjust, visibilityDistance);
-    return UNIT_ELEMENT_MAX_EXTENT / visibleDistanceAtMaxScale; // TODO: consider renaming this function to half tangent because we're taking into account a factor of 1/2
+    return UNIT_ELEMENT_MAX_EXTENT / visibleDistanceAtMaxScale;
 }
 
-float getPerspectiveAccuracyAngle(float visibilityDistance, int boundaryLevelAdjust) {
-    return atan(getPerspectiveAccuracyAngleTan(visibilityDistance, boundaryLevelAdjust));
+float getPerspectiveAccuracyHalfAngle(float visibilityDistance, int boundaryLevelAdjust) {
+    return atan(getPerspectiveAccuracyHalfAngleTan(visibilityDistance, boundaryLevelAdjust));
 }
 
 float getOrthographicAccuracySize(float visibilityDistance, int boundaryLevelAdjust) {

--- a/libraries/octree/src/OctreeUtils.cpp
+++ b/libraries/octree/src/OctreeUtils.cpp
@@ -31,6 +31,15 @@ float getPerspectiveAccuracyHalfAngle(float visibilityDistance, int boundaryLeve
     return atan(getPerspectiveAccuracyHalfAngleTan(visibilityDistance, boundaryLevelAdjust));
 }
 
+float getVisibilityDistanceFromHalfAngle(float halfAngle) {
+    float halfAngleTan = tan(halfAngle);
+    return UNIT_ELEMENT_MAX_EXTENT / halfAngleTan;
+}
+
+float getHalfAngleFromVisibilityDistance(float visibilityDistance) {
+    return UNIT_ELEMENT_MAX_EXTENT / visibilityDistance;
+}
+
 float getOrthographicAccuracySize(float visibilityDistance, int boundaryLevelAdjust) {
     // Smallest visible element is 1cm
     const float smallestSize = 0.01f;

--- a/libraries/octree/src/OctreeUtils.cpp
+++ b/libraries/octree/src/OctreeUtils.cpp
@@ -65,8 +65,8 @@ float boundaryDistanceForRenderLevel(unsigned int renderLevel, float voxelSizeSc
 }
 
 float getPerspectiveAccuracyAngleTan(float octreeSizeScale, int boundaryLevelAdjust) {
-    const float maxScale = (float)TREE_SCALE;
-    float visibleDistanceAtMaxScale = boundaryDistanceForRenderLevel(boundaryLevelAdjust, octreeSizeScale) / OCTREE_TO_MESH_RATIO;
+    const float maxScale = sqrtf(3.0f) * 0.5f; //(float)TREE_SCALE;
+    float visibleDistanceAtMaxScale = boundaryDistanceForRenderLevel(boundaryLevelAdjust, octreeSizeScale) /* / OCTREE_TO_MESH_RATIO*/;
     return (maxScale / visibleDistanceAtMaxScale);
 }
 

--- a/libraries/octree/src/OctreeUtils.cpp
+++ b/libraries/octree/src/OctreeUtils.cpp
@@ -37,7 +37,8 @@ float getVisibilityDistanceFromHalfAngle(float halfAngle) {
 }
 
 float getHalfAngleFromVisibilityDistance(float visibilityDistance) {
-    return UNIT_ELEMENT_MAX_EXTENT / visibilityDistance;
+    float halfAngleTan = UNIT_ELEMENT_MAX_EXTENT / visibilityDistance;
+    return atan(halfAngleTan);
 }
 
 float getOrthographicAccuracySize(float visibilityDistance, int boundaryLevelAdjust) {

--- a/libraries/octree/src/OctreeUtils.h
+++ b/libraries/octree/src/OctreeUtils.h
@@ -20,10 +20,10 @@ class AABox;
 class AACube;
 class QJsonDocument;
 
-float boundaryDistanceForRenderLevel(unsigned int renderLevel, float voxelSizeScale);
+float boundaryDistanceForRenderLevel(unsigned int renderLevel, float visibilityDistance);
 
-float getPerspectiveAccuracyAngleTan(float visibilityDistance, int boundaryLevelAdjust);
-float getPerspectiveAccuracyAngle(float visibilityDistance, int boundaryLevelAdjust);
+float getPerspectiveAccuracyHalfAngleTan(float visibilityDistance, int boundaryLevelAdjust);
+float getPerspectiveAccuracyHalfAngle(float visibilityDistance, int boundaryLevelAdjust);
 float getOrthographicAccuracySize(float visibilityDistance, int boundaryLevelAdjust);
 
 // MIN_ELEMENT_ANGULAR_DIAMETER = angular diameter of 1x1x1m cube at 400m = sqrt(3) / 400 = 0.0043301 radians ~= 0.25 degrees

--- a/libraries/octree/src/OctreeUtils.h
+++ b/libraries/octree/src/OctreeUtils.h
@@ -20,18 +20,11 @@ class AABox;
 class AACube;
 class QJsonDocument;
 
-/// renderAccuracy represents a floating point "visibility" of an object based on it's view from the camera. At a simple
-/// level it returns 0.0f for things that are so small for the current settings that they could not be visible.
-float calculateRenderAccuracy(const glm::vec3& position,
-        const AABox& bounds,
-        float octreeSizeScale = DEFAULT_OCTREE_SIZE_SCALE,
-        int boundaryLevelAdjust = 0);
-
 float boundaryDistanceForRenderLevel(unsigned int renderLevel, float voxelSizeScale);
 
-float getPerspectiveAccuracyAngleTan(float octreeSizeScale, int boundaryLevelAdjust);
-float getPerspectiveAccuracyAngle(float octreeSizeScale, int boundaryLevelAdjust);
-float getOrthographicAccuracySize(float octreeSizeScale, int boundaryLevelAdjust);
+float getPerspectiveAccuracyAngleTan(float visibilityDistance, int boundaryLevelAdjust);
+float getPerspectiveAccuracyAngle(float visibilityDistance, int boundaryLevelAdjust);
+float getOrthographicAccuracySize(float visibilityDistance, int boundaryLevelAdjust);
 
 // MIN_ELEMENT_ANGULAR_DIAMETER = angular diameter of 1x1x1m cube at 400m = sqrt(3) / 400 = 0.0043301 radians ~= 0.25 degrees
 const float MIN_ELEMENT_ANGULAR_DIAMETER = 0.0043301f; // radians

--- a/libraries/octree/src/OctreeUtils.h
+++ b/libraries/octree/src/OctreeUtils.h
@@ -24,6 +24,8 @@ float boundaryDistanceForRenderLevel(unsigned int renderLevel, float visibilityD
 
 float getPerspectiveAccuracyHalfAngleTan(float visibilityDistance, int boundaryLevelAdjust);
 float getPerspectiveAccuracyHalfAngle(float visibilityDistance, int boundaryLevelAdjust);
+float getVisibilityDistanceFromHalfAngle(float halfAngle);
+float getHalfAngleFromVisibilityDistance(float visibilityDistance);
 float getOrthographicAccuracySize(float visibilityDistance, int boundaryLevelAdjust);
 
 // MIN_ELEMENT_ANGULAR_DIAMETER = angular diameter of 1x1x1m cube at 400m = sqrt(3) / 400 = 0.0043301 radians ~= 0.25 degrees

--- a/libraries/render/src/render/DrawSceneOctree.cpp
+++ b/libraries/render/src/render/DrawSceneOctree.cpp
@@ -120,7 +120,7 @@ void DrawSceneOctree::run(const RenderContextPointer& renderContext, const ItemS
 
         // Draw the LOD Reticle
         {
-            float angle = glm::degrees(getPerspectiveAccuracyAngle(args->_sizeScale, args->_boundaryLevelAdjust));
+            float angle = glm::degrees(getPerspectiveAccuracyHalfAngle(args->_sizeScale, args->_boundaryLevelAdjust));
             Transform crosshairModel;
             crosshairModel.setTranslation(glm::vec3(0.0, 0.0, -1000.0));
             crosshairModel.setScale(1000.0f * tanf(glm::radians(angle))); // Scaling at the actual tan of the lod angle => Multiplied by TWO

--- a/scripts/developer/utilities/render/lod.qml
+++ b/scripts/developer/utilities/render/lod.qml
@@ -80,7 +80,7 @@ Item {
             valueVar: LODManager["lodAngleDeg"]
             valueVarSetter: (function (v) { LODManager["lodAngleDeg"] = v })
             max: 90.0
-            min: 0.5
+            min: 0.01
             integral: false
 
             anchors.left: parent.left
@@ -239,6 +239,7 @@ Item {
             object: LODManager
             valueScale: 1.0
             valueUnit: "deg"
+            valueNumDigits: 2
             plots: [
                 {
                     prop: "lodAngleDeg",

--- a/scripts/simplifiedUI/ui/simplifiedUI.js
+++ b/scripts/simplifiedUI/ui/simplifiedUI.js
@@ -533,7 +533,7 @@ function maybeUpdateOutputDeviceMutedOverlay() {
 var oldAutomaticLODAdjust;
 var oldLODAngleDeg;
 var SIMPLIFIED_UI_AUTO_LOD_ADJUST = false;
-var SIMPLIFIED_UI_LOD_ANGLE_DEG = 0.5;
+var SIMPLIFIED_UI_LOD_ANGLE_DEG = 0.248;
 function modifyLODSettings() {
     oldAutomaticLODAdjust = LODManager.automaticLODAdjust;
     oldLODAngleDeg = LODManager.lodAngleDeg;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1112

This PR fixes incorrect default LOD and incorrect debug display values for current LOD. It also changes the internal representation of LOD in LODManager to be the half angular resolution, deprecates some LODManager script properties associated with the old representation, and does a bit of cleanup.