### PR TITLE
DNM: Vive quick calibration feedback

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1123,6 +1123,10 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     _controllerScriptingInterface = dynamic_cast<ControllerScriptingInterface*>(controllerScriptingInterface);
     connect(PluginManager::getInstance().data(), &PluginManager::inputDeviceRunningChanged,
         controllerScriptingInterface, &controller::ScriptingInterface::updateRunningInputDevices);
+    connect(PluginManager::getInstance().data(), &PluginManager::inputDeviceCalibrated,
+        controllerScriptingInterface, &controller::ScriptingInterface::inputDeviceCalibrated);
+    connect(PluginManager::getInstance().data(), &PluginManager::inputDeviceUncalibrated,
+        controllerScriptingInterface, &controller::ScriptingInterface::inputDeviceUncalibrated);
 
     EntityTree::setEntityClicksCapturedOperator([this] {
         return _controllerScriptingInterface->areEntityClicksCaptured();

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -619,6 +619,26 @@ namespace controller {
          */
         void inputDeviceRunningChanged(QString deviceName, bool isRunning);
 
+        /**jsdoc
+         * Triggered when an input device is calibrated.
+         * @function Controller.inputDeviceCalibrated
+         * @param {string} deviceName - The name of the device.
+         * @param {boolean} fromUI - <code>true</code> if the calibration was initiated from the UI, <code>false</code> if it
+         *     wasn't.
+         * @param {boolean} success - <code>true</code> if the calibration succeeded, <code>false</code> if it didn't.
+         * @returns {Signal}
+         */
+        void inputDeviceCalibrated(QString deviceName, bool fromUI, bool success);
+
+        /**jsdoc
+         * Triggered when an input device is uncalibrated.
+         * @function Controller.inputDeviceCalibrated
+         * @param {string} deviceName - The name of the device.
+         * @param {boolean} fromUI - <code>true</code> if the uncalibration was initiated from the UI, <code>false</code> if it
+         *     wasn't.
+         * @returns {Signal}
+         */
+        void inputDeviceUncalibrated(QString deviceName, bool fromUI);
 
     private:
         // Update the exposed variant maps reporting active hardware

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -620,7 +620,8 @@ namespace controller {
         void inputDeviceRunningChanged(QString deviceName, bool isRunning);
 
         /**jsdoc
-         * Triggered when an input device is calibrated.
+         * Triggered when an input device is calibrated. If the calibration didn't succeed, the device is left in an 
+         * uncalibrated state.
          * @function Controller.inputDeviceCalibrated
          * @param {string} deviceName - The name of the device.
          * @param {boolean} fromUI - <code>true</code> if the calibration was initiated from the UI, <code>false</code> if it

--- a/libraries/plugins/src/plugins/InputPlugin.h
+++ b/libraries/plugins/src/plugins/InputPlugin.h
@@ -18,6 +18,8 @@ namespace controller {
 }
 
 class InputPlugin : public Plugin {
+    Q_OBJECT
+
 public:
     virtual void pluginFocusOutEvent() = 0;
     virtual void pluginUpdate(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) = 0;
@@ -34,4 +36,8 @@ public:
     virtual bool configurable() { return false; }
     virtual bool isHandController() const { return false; }
     virtual bool isHeadController() const { return false; }
+
+signals:
+    void deviceCalibrated(const QString& deviceName, bool fromUI, bool success);
+    void deviceUncalibrated(const QString& deviceName, bool fromUI);
 };

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -283,6 +283,13 @@ const InputPluginList& PluginManager::getInputPlugins() {
             connect(plugin.get(), &Plugin::deviceStatusChanged, this, [&](const QString& deviceName, bool isRunning) {
                 emit inputDeviceRunningChanged(deviceName, isRunning, getRunningInputDeviceNames());
             }, Qt::QueuedConnection);
+            connect(plugin.get(), &InputPlugin::deviceCalibrated, this, [&](const QString& deviceName, bool fromUI,
+                bool success) {
+                emit inputDeviceCalibrated(deviceName, fromUI, success);
+            }, Qt::QueuedConnection);
+            connect(plugin.get(), &InputPlugin::deviceUncalibrated, this, [&](const QString& deviceName, bool fromUI) {
+                emit inputDeviceUncalibrated(deviceName, fromUI);
+            }, Qt::QueuedConnection);
             plugin->setContainer(_container);
             plugin->init();
         }

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -52,7 +52,9 @@ public:
 
 signals:
     void inputDeviceRunningChanged(const QString& pluginName, bool isRunning, const QStringList& runningDevices);
-    
+    void inputDeviceCalibrated(const QString& deviceName, bool fromUI, bool success);
+    void inputDeviceUncalibrated(const QString& deviceName, bool fromUI);
+
 private:
     PluginManager() = default;
 

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -984,12 +984,12 @@ void ViveControllerManager::InputDevice::printDeviceTrackingResultChange(uint32_
 }
 
 bool ViveControllerManager::InputDevice::checkForCalibrationEvent() {
-    auto& endOfMap = _buttonPressedMap.end();
-    auto& leftTrigger = _buttonPressedMap.find(controller::LT);
-    auto& rightTrigger = _buttonPressedMap.find(controller::RT);
-    auto& leftAppButton = _buttonPressedMap.find(LEFT_APP_MENU);
-    auto& rightAppButton = _buttonPressedMap.find(RIGHT_APP_MENU);
-    return ((leftTrigger != endOfMap && leftAppButton != endOfMap) && (rightTrigger != endOfMap && rightAppButton != endOfMap));
+
+    using namespace controller;
+
+    auto& leftGrip = _axisStateMap[LEFT_GRIP];
+    auto& rightGrip = _axisStateMap[RIGHT_GRIP];
+    return leftGrip.value >= 1.0f && rightGrip.value >= 1.0f;
 }
 
 // These functions do translation from the Steam IDs to the standard controller IDs

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -413,8 +413,6 @@ void ViveControllerManager::InputDevice::calibrateFromHandController(const contr
             _triggersPressedHandled = true;
             calibrateOrUncalibrate(inputCalibrationData);
         }
-
-        emit _parent.deviceCalibrated(_name, false, _calibrated);
     } else {
         _triggersPressedHandled = false;
         _timeTilCalibrationSet = false;
@@ -427,13 +425,9 @@ void ViveControllerManager::InputDevice::calibrateFromUI(const controller::Input
         calibrate(inputCalibrationData);
 
         emit _parent.deviceCalibrated(_name, true, _calibrated);
-        if (!_calibrated) {
-            emit _parent.deviceUncalibrated(_name, true);
-        }
 
         emitCalibrationStatus();
         _calibrate = false;
-
     }
 }
 
@@ -612,9 +606,6 @@ void ViveControllerManager::InputDevice::calibrateOrUncalibrate(const controller
         calibrate(inputCalibration);
 
         emit _parent.deviceCalibrated(_name, false, _calibrated);
-        if (!_calibrated) {
-            emit _parent.deviceUncalibrated(_name, false);
-        }
 
         if (_calibrated) {
             sendUserActivityData("mocap_button_success");

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -70,7 +70,7 @@ public:
 private:
     class InputDevice : public controller::InputDevice {
     public:
-        InputDevice(vr::IVRSystem*& system);
+        ViveControllerManager::InputDevice(ViveControllerManager& parent, vr::IVRSystem*& system);
         bool isHeadControllerMounted() const { return _overrideHead; }
 
     private:
@@ -209,6 +209,7 @@ private:
         std::map<uint32_t, uint64_t> _simDataRunningOkTimestampMap;
 
         QString configToString(Config config);
+        ViveControllerManager& _parent;
         friend class ViveControllerManager;
     };
 
@@ -227,7 +228,7 @@ private:
     int _rightHandRenderID { 0 };
 
     vr::IVRSystem* _system { nullptr };
-    std::shared_ptr<InputDevice> _inputDevice { std::make_shared<InputDevice>(_system) };
+    std::shared_ptr<ViveControllerManager::InputDevice> _inputDevice { std::make_shared<InputDevice>(*this, _system) };
 
     static const char* NAME;
 };


### PR DESCRIPTION
Trials the following improvements:
- Initiate Vive quick calibration with both grips pressed instead of both triggers plus both menu buttons, so that tablet doesn't open and avatar doesn't jump.
- Add API signals for input device calibration and uncalibration events.
- Display quick calibration and uncalibration feedback in a heads-up display.
