### PR TITLE
BUGZ-919: Skybox broken on older AMD drivers

### DIFF
--- a/libraries/gpu-gl-common/src/gpu/gl/GLTexelFormat.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTexelFormat.cpp
@@ -33,8 +33,8 @@ using namespace gpu::gl;
 #define GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT 0x8E8F
 #endif
 
-bool GLTexelFormat::isCompressed() const {
-    switch (internalFormat) {
+bool GLTexelFormat::isCompressed(GLenum format) {
+    switch (format) {
         case GL_COMPRESSED_SRGB_S3TC_DXT1_EXT:
         case GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT:
         case GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT:
@@ -91,6 +91,11 @@ bool GLTexelFormat::isCompressed() const {
             return false;
     }
 }
+
+bool GLTexelFormat::isCompressed() const {
+    return isCompressed(internalFormat);
+}
+
 
 GLenum GLTexelFormat::evalGLTexelFormatInternal(const gpu::Element& dstFormat) {
     GLenum result = GL_RGBA8;

--- a/libraries/gpu-gl-common/src/gpu/gl/GLTexelFormat.h
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTexelFormat.h
@@ -14,12 +14,14 @@ namespace gpu { namespace gl {
 
 class GLTexelFormat {
 public:
-    GLenum internalFormat;
-    GLenum format;
-    GLenum type;
+    GLenum internalFormat{ GL_RGBA8 };
+    GLenum format{ GL_RGBA };
+    GLenum type{ GL_UNSIGNED_BYTE };
 
     GLTexelFormat(GLenum glinternalFormat, GLenum glformat, GLenum gltype) : internalFormat(glinternalFormat), format(glformat), type(gltype) {}
     GLTexelFormat(GLenum glinternalFormat) : internalFormat(glinternalFormat) {}
+
+    static bool isCompressed(GLenum glinternalFormat);
 
     bool isCompressed() const;
 

--- a/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
+++ b/libraries/gpu-gl/src/gpu/gl45/GL45Backend.h
@@ -33,6 +33,7 @@ class GL45Backend : public GLBackend {
     friend class Context;
 
 public:
+    static const GLint RESOURCE_TRANSFER_TEX_UNIT { 32 };
     static GLint MAX_COMBINED_SHADER_STORAGE_BLOCKS;
     static GLint MAX_UNIFORM_LOCATIONS;
 #if GPU_BINDLESS_TEXTURES


### PR DESCRIPTION
[BUGZ-919](https://highfidelity.atlassian.net/browse/BUGZ-919):  Not long ago AMD had broken OpenGL cubemap DSA functions.  As a result, our client used a workaround involving the DSA functions exposed by the original DSA EXT extension that pre-dated the inclusion of DSA functions in 4.5.  

However, a recent AMD driver release both fixed the broken DSA cubemap loading _and_ simultaneously broke the workaround we were using.  This meant that we could no longer use either the strictly new code or the old workaround, since we _MUST_ support both the old and new drivers apparently. 

As such, this PR modifies the cubemap loading code in the GL 4.5 backend to use non-DSA functionality.  Like the GL 4.1 backend it dedicates texture unit 32 to transfer duties and uses the older, but more reliable `glBindTexture` + ` glCompressedTexSubImage2D`/`glTexSubImage2D` functions.  

## Testing

We don't know the exact version where the AMD behavior changed, so it's difficult to specify a specific set of drivers to test on to verify that this logic works on both sides of that version.  However, we should attempt to verify that the new pathway works with both the current AMD and nVidia drivers (on windows... this code change won't affect macs).