### PR TITLE
BUGZ-1239: Delete reply after the callback is executed

### DIFF
--- a/libraries/script-engine/src/XMLHttpRequestClass.cpp
+++ b/libraries/script-engine/src/XMLHttpRequestClass.cpp
@@ -218,12 +218,12 @@ void XMLHttpRequestClass::requestFinished() {
         }
     }
 
+    setReadyState(DONE);
+    emit requestComplete();
+
     disconnectFromReply(_reply);
     _reply->deleteLater();
     _reply = nullptr;
-
-    setReadyState(DONE);
-    emit requestComplete();
 }
 
 void XMLHttpRequestClass::abortRequest() {


### PR DESCRIPTION
[JIRA Ticket](https://highfidelity.atlassian.net/browse/BUGZ-1239)

Some getters rely on the reply.
If those getters are called in the callback function, they return erroneous informations.