### PR TITLE
BUGZ-1119: workaround for race condition crash in QML rendering

### DIFF
--- a/libraries/qml/src/qml/impl/RenderEventHandler.cpp
+++ b/libraries/qml/src/qml/impl/RenderEventHandler.cpp
@@ -136,7 +136,6 @@ void RenderEventHandler::qmlRender(bool sceneGraphSync) {
 
     resize();
 
-
     if (_currentSize != QSize()) {
         PROFILE_RANGE(render_qml_gl, "render");
         GLuint texture = SharedObject::getTextureCache().acquireTexture(_currentSize);
@@ -148,7 +147,15 @@ void RenderEventHandler::qmlRender(bool sceneGraphSync) {
         } else {
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
             _shared->setRenderTarget(_fbo, _currentSize);
-            _shared->_renderControl->render();
+
+            // workaround for https://highfidelity.atlassian.net/browse/BUGZ-1119
+            {
+                // Serialize QML rendering because of a crash caused by Qt bug 
+                // https://bugreports.qt.io/browse/QTBUG-77469
+                static std::mutex qmlRenderMutex;
+                std::unique_lock<std::mutex> qmlRenderLock{ qmlRenderMutex };
+                _shared->_renderControl->render();
+            }
         }
         _shared->_lastRenderTime = usecTimestampNow();
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);


### PR DESCRIPTION
[BUGZ-1119](https://highfidelity.atlassian.net/browse/BUGZ-1119) and [BUGZ-1140](https://highfidelity.atlassian.net/browse/BUGZ-1140)

Qt contains [a bug](https://bugreports.qt.io/browse/QTBUG-77469) that can cause a crash when more than one thread concurrently attempts to link a `QOpenGLShaderProgram`.  

The client side solution that we can implement is to serialize rendering of QML surfaces (the only place our code indirectly uses `QOpenGLShaderProgram`).