### PR TITLE
BUGZ-984: Wait for client entity-scripts to unload when shutting down

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2761,7 +2761,6 @@ void Application::cleanupBeforeQuit() {
     }
 
     getEntities()->shutdown(); // tell the entities system we're shutting down, so it will stop running scripts
-    getEntities()->clear();
 
     // Clear any queued processing (I/O, FBX/OBJ/Texture parsing)
     QThreadPool::globalInstance()->clear();

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -253,7 +253,7 @@ void EntityTreeRenderer::clear() {
     // unload and stop the engine
     if (_entitiesScriptEngine) {
         // do this here (instead of in deleter) to avoid marshalling unload signals back to this thread
-        _entitiesScriptEngine->unloadAllEntityScripts();
+        _entitiesScriptEngine->unloadAllEntityScripts(true);
         _entitiesScriptEngine->stop();
     }
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -2470,13 +2470,14 @@ QList<EntityItemID> ScriptEngine::getListOfEntityScriptIDs() {
     return _entityScripts.keys();
 }
 
-void ScriptEngine::unloadAllEntityScripts() {
+void ScriptEngine::unloadAllEntityScripts(bool blockingCall) {
     if (QThread::currentThread() != thread()) {
 #ifdef THREAD_DEBUGGING
         qCDebug(scriptengine) << "*** WARNING *** ScriptEngine::unloadAllEntityScripts() called on wrong thread [" << QThread::currentThread() << "], invoking on correct thread [" << thread() << "]";
 #endif
 
-        QMetaObject::invokeMethod(this, "unloadAllEntityScripts");
+        QMetaObject::invokeMethod(this, "unloadAllEntityScripts",
+            blockingCall ? Qt::BlockingQueuedConnection : Qt::QueuedConnection);
         return;
     }
 #ifdef THREAD_DEBUGGING

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -578,9 +578,10 @@ public:
 
     /**jsdoc
      * @function Script.unloadAllEntityScripts
+     * @param {boolean} [blockingCall=false] - Wait for completion if call moved to another thread.
      * @deprecated This function is deprecated and will be removed.
      */
-    Q_INVOKABLE void unloadAllEntityScripts();
+    Q_INVOKABLE void unloadAllEntityScripts(bool blockingCall = false);
 
     /**jsdoc
      * Calls a method in an entity script.


### PR DESCRIPTION
Jira: https://highfidelity.atlassian.net/browse/BUGZ-984

On Interface shutdown,  
1. `Application::cleanupBeforeQuit()` calls `EntityTreeRenderer::shutdown()`, which calls `EntityScriptEngine::unloadAllEntityScripts()` on its (single) script engine.
2. Unloading a script will call the script's `unload` function if it exists. In this case of some audio scripts this may call `ScriptAudioInjector::stop()`.
3. `cleanupBeforeQuit()` then shuts down all script engines.
4. `~Application()` destroys AudioInjectorManager along with all the other singleton classes.

The ordering looks good but a lot of our code uses the `QMetaObject::invokeMethod()` mechanism to move calls to the object's affiliated thread, which for a ScriptEngine is its own thread (also the AudioInjectorManager used by `ScriptAudioInjector::stop()` has its own thread). The invokeMethod call is nonblocking by default which means the actual ordering of events is nondeterministic, and I think in the case of some Macs is leading to the crash with the null AudioInjectorManager.

This PR:
1. Removes a call to `EntityTreeRenderer::clear()` since `EntityTreeRenderer::shutdown()` already calls it.
2. Allows blocking calls to `EntityScriptEngine::unloadAllEntityScripts()`. Any JS calls to`unload` should then be completed after the script engines are shut down. 

