### PR TITLE
Avatar sitting bug fixes

### DIFF
--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -3935,6 +3935,19 @@
                                                                                         },
                                                                                         "id": "LANDRUN",
                                                                                         "type": "clip"
+                                                                                    },
+                                                                                    {
+                                                                                        "children": [
+                                                                                        ],
+                                                                                        "data": {
+                                                                                            "endFrame": 105,
+                                                                                            "loopFlag": false,
+                                                                                            "startFrame": 100,
+                                                                                            "timeScale": 1,
+                                                                                            "url": "qrc:///avatar/animations/idle.fbx"
+                                                                                        },
+                                                                                        "id": "seatedToIdle",
+                                                                                        "type": "clip"
                                                                                     }
                                                                                 ],
                                                                                 "data": {
@@ -3951,60 +3964,8 @@
                                                                                             "interpType": "snapshotPrev",
                                                                                             "transitions": [
                                                                                                 {
-                                                                                                    "state": "idle",
-                                                                                                    "var": "isNotMoving"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "WALKFWD",
-                                                                                                    "var": "isMovingForward"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "WALKBWD",
-                                                                                                    "var": "isMovingBackward"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "STRAFERIGHT",
-                                                                                                    "var": "isMovingRight"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "STRAFELEFT",
-                                                                                                    "var": "isMovingLeft"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "turnRight",
-                                                                                                    "var": "isTurningRight"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "turnLeft",
-                                                                                                    "var": "isTurningLeft"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "fly",
-                                                                                                    "var": "isFlying"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "takeoffStand",
-                                                                                                    "var": "isTakeoffStand"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "TAKEOFFRUN",
-                                                                                                    "var": "isTakeoffRun"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "inAirStand",
-                                                                                                    "var": "isInAirStand"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "INAIRRUN",
-                                                                                                    "var": "isInAirRun"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "strafeRightHmd",
-                                                                                                    "var": "isMovingRightHmd"
-                                                                                                },
-                                                                                                {
-                                                                                                    "state": "strafeLeftHmd",
-                                                                                                    "var": "isMovingLeftHmd"
+                                                                                                    "state": "seatedToIdle",
+                                                                                                    "var": "isNotSeated"
                                                                                                 }
                                                                                             ]
                                                                                         },
@@ -4884,6 +4845,18 @@
                                                                                                 {
                                                                                                     "state": "WALKFWD",
                                                                                                     "var": "landRunOnDone"
+                                                                                                }
+                                                                                            ]
+                                                                                        },
+                                                                                        {
+                                                                                            "id": "seatedToIdle",
+                                                                                            "interpDuration": 10,
+                                                                                            "interpTarget": 1,
+                                                                                            "interpType": "snapshotPrev",
+                                                                                            "transitions": [
+                                                                                                {
+                                                                                                    "state": "idle",
+                                                                                                    "var": "seatedToIdleOnDone"
                                                                                                 }
                                                                                             ]
                                                                                         }

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1144,6 +1144,11 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _desiredStateAge = STATE_CHANGE_HYSTERESIS_TIMER;
         }
 
+        // Skip hysterisis timer for sit transitions.
+        if (_desiredState == RigRole::Seated || _state == RigRole::Seated) {
+            _desiredStateAge = STATE_CHANGE_HYSTERESIS_TIMER;
+        }
+
         if ((_desiredStateAge >= STATE_CHANGE_HYSTERESIS_TIMER) && _desiredState != _state) {
             _state = _desiredState;
             _desiredStateAge = 0.0f;
@@ -1223,6 +1228,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isInAirRun", false);
             _animVars.set("isNotInAir", true);
             _animVars.set("isSeated", false);
+            _animVars.set("isNotSeated", true);
 
         } else if (_state == RigRole::Turn) {
             if (turningSpeed > 0.0f) {
@@ -1252,6 +1258,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isInAirRun", false);
             _animVars.set("isNotInAir", true);
             _animVars.set("isSeated", false);
+            _animVars.set("isNotSeated", true);
 
         } else if (_state == RigRole::Idle) {
             // default anim vars to notMoving and notTurning
@@ -1274,6 +1281,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isInAirRun", false);
             _animVars.set("isNotInAir", true);
             _animVars.set("isSeated", false);
+            _animVars.set("isNotSeated", true);
 
         } else if (_state == RigRole::Hover) {
             // flying.
@@ -1296,6 +1304,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isInAirRun", false);
             _animVars.set("isNotInAir", true);
             _animVars.set("isSeated", false);
+            _animVars.set("isNotSeated", true);
 
         } else if (_state == RigRole::Takeoff) {
             // jumping in-air
@@ -1326,6 +1335,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isInAirRun", false);
             _animVars.set("isNotInAir", false);
             _animVars.set("isSeated", false);
+            _animVars.set("isNotSeated", true);
 
         } else if (_state == RigRole::InAir) {
             // jumping in-air
@@ -1345,6 +1355,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isTakeoffRun", false);
             _animVars.set("isNotTakeoff", true);
             _animVars.set("isSeated", false);
+            _animVars.set("isNotSeated", true);
 
             bool inAirRun = forwardSpeed > 0.1f;
             if (inAirRun) {
@@ -1386,6 +1397,7 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
             _animVars.set("isInAirRun", false);
             _animVars.set("isNotInAir", true);
             _animVars.set("isSeated", true);
+            _animVars.set("isNotSeated", false);
         }
 
         t += deltaTime;
@@ -1821,8 +1833,10 @@ void Rig::updateFeet(bool leftFootEnabled, bool rightFootEnabled, bool headEnabl
     int hipsIndex = indexOfJoint("Hips");
     const float KNEE_POLE_VECTOR_BLEND_FACTOR = 0.85f;
 
-    if (headEnabled) {
-        // always do IK if head is enabled
+    bool isSeated = _state == RigRole::Seated;
+
+    if (headEnabled && !isSeated) {
+        // enable leg IK if head is enabled and we arent sitting down.
         _animVars.set("leftFootIKEnabled", true);
         _animVars.set("rightFootIKEnabled", true);
     } else {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -131,7 +131,7 @@ AvatarTransit::Status AvatarTransit::update(float deltaTime, const glm::vec3& av
         } else {
             _lastPosition = avatarPosition;
             _status = Status::ABORT_TRANSIT;
-        }        
+        }
     }
     _lastPosition = avatarPosition;
     _status = updatePosition(deltaTime);
@@ -143,11 +143,18 @@ AvatarTransit::Status AvatarTransit::update(float deltaTime, const glm::vec3& av
     return _status;
 }
 
+void AvatarTransit::slamPosition(const glm::vec3& avatarPosition) {
+    // used to instantly teleport between two points without triggering a change in status.
+    _lastPosition = avatarPosition;
+    _endPosition = avatarPosition;
+}
+
 void AvatarTransit::reset() {
     _lastPosition = _endPosition;
     _currentPosition = _endPosition;
     _isActive = false;
 }
+
 void AvatarTransit::start(float deltaTime, const glm::vec3& startPosition, const glm::vec3& endPosition, const AvatarTransit::TransitConfig& config) {
     _startPosition = startPosition;
     _endPosition = endPosition;
@@ -192,8 +199,8 @@ AvatarTransit::Status AvatarTransit::updatePosition(float deltaTime) {
             status = Status::PRE_TRANSIT;
             if (_currentTime == 0) {
                 status = Status::STARTED;
-            } 
-        } else if (nextTime < _totalTime - _postTransitTime){
+            }
+        } else if (nextTime < _totalTime - _postTransitTime) {
             status = Status::TRANSITING;
             if (_currentTime <= _preTransitTime) {
                 status = Status::START_TRANSIT;
@@ -519,10 +526,10 @@ void Avatar::relayJointDataToChildren() {
  *   <tbody>
  *     <tr><td><code>"avatar" or ""</code></td><td>The rate at which the avatar is updated even if not in view.</td></tr>
  *     <tr><td><code>"avatarInView"</code></td><td>The rate at which the avatar is updated if in view.</td></tr>
- *     <tr><td><code>"skeletonModel"</code></td><td>The rate at which the skeleton model is being updated, even if there are no 
+ *     <tr><td><code>"skeletonModel"</code></td><td>The rate at which the skeleton model is being updated, even if there are no
  *       joint data available.</td></tr>
  *     <tr><td><code>"jointData"</code></td><td>The rate at which joint data are being updated.</td></tr>
- *     <tr><td><code>""</code></td><td>When no rate name is specified, the <code>"avatar"</code> update rate is 
+ *     <tr><td><code>""</code></td><td>When no rate name is specified, the <code>"avatar"</code> update rate is
  *       provided.</td></tr>
  *   </tbody>
  * </table>
@@ -557,6 +564,7 @@ void Avatar::slamPosition(const glm::vec3& newPosition) {
     _positionDeltaAccumulator = glm::vec3(0.0f);
     setWorldVelocity(glm::vec3(0.0f));
     _lastVelocity = glm::vec3(0.0f);
+    _transit.slamPosition(newPosition);
 }
 
 void Avatar::updateAttitude(const glm::quat& orientation) {
@@ -1533,7 +1541,7 @@ void Avatar::setModelURLFinished(bool success) {
             QMetaObject::invokeMethod(_skeletonModel.get(), "setURL",
                 Qt::QueuedConnection, Q_ARG(QUrl, AvatarData::defaultFullAvatarModelUrl()));
         } else {
-            qCWarning(avatars_renderer) << "Avatar model failed to load... attempts:" 
+            qCWarning(avatars_renderer) << "Avatar model failed to load... attempts:"
                 << _skeletonModel->getResourceDownloadAttempts() << "out of:" << MAX_SKELETON_DOWNLOAD_ATTEMPTS;
         }
     }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -93,6 +93,7 @@ public:
 
     AvatarTransit() {};
     Status update(float deltaTime, const glm::vec3& avatarPosition, const TransitConfig& config);
+    void slamPosition(const glm::vec3& avatarPosition);
     Status getStatus() { return _status; }
     bool isActive() { return _isActive; }
     glm::vec3 getCurrentPosition() { return _currentPosition; }


### PR DESCRIPTION
* Added seatedToIdle transition, to make transition quicker to better match the capsule physics.
* Made switching into and out of instantly set animVar for the animation graph, previously it was delayed by 100 ms.
* Created "isNotSeated" anim var for exiting the seated state.
* MyAvatar::beginSit & MyAvatar::endSit no longer calls goToPosition, instead MyAvatar::slamPosition is called.
* MyAvatar::slamPosition will cause the AvatarTransit class to NOT play the teleport anticipation/reaction animation.
  Note: This does not prevent other clients from interpolating the position when entering the seat, but it prevents the teleport reaction animation from playing.
* Disable leg IK in HMD mode while seated.