### PR TITLE
DOC-95: Fix callback functions' display in JSDoc

### DIFF
--- a/tools/jsdoc/hifi-jsdoc-template/tmpl/container.tmpl
+++ b/tools/jsdoc/hifi-jsdoc-template/tmpl/container.tmpl
@@ -239,7 +239,7 @@
             <?js typedefs.forEach(function(e) {
                     if (e.signature) {
                 ?>
-                    <?js= self.partial('members.tmpl', e) ?>
+                    <?js= self.partial('method.tmpl', e) ?>
                 <?js
                     }
                     else {

--- a/tools/jsdoc/hifi-jsdoc-template/tmpl/method.tmpl
+++ b/tools/jsdoc/hifi-jsdoc-template/tmpl/method.tmpl
@@ -13,7 +13,10 @@ var self = this;
                         <?js returns.forEach(function(r) { ?>
                             <?js= self.partial('returns.tmpl', r) ?>
                         <?js });
-                    } ?></span>           
+                    } ?></span>
+                    <?js if (data.kind === 'typedef' && data.type && data.type.names) { ?>
+                        <br />Type: <?js= self.partial('type.tmpl', data.type.names) ?>
+                    <?js } ?>
                 </th>
             </tr>
         </thead>

--- a/tools/jsdoc/hifi-jsdoc-template/tmpl/method.tmpl
+++ b/tools/jsdoc/hifi-jsdoc-template/tmpl/method.tmpl
@@ -66,7 +66,7 @@ var self = this;
     <?js= self.partial('augments.tmpl', data) ?>
 <?js } ?>
 
-<?js if (kind === 'event' && data.type && data.type.names) {?>
+<?js if (data.kind === 'event' && data.type && data.type.names) {?>
     <h5>Type:</h5>
     <ul>
         <li>


### PR DESCRIPTION
The parameters for callback functions such `Entities~getServerScriptStatusCallback(...)` weren't being included in the JSDoc output, but now they are.

Case: https://highfidelity.atlassian.net/browse/DOC-95
