### PR TITLE
BUGZ-1247: Better handling of other-avatar verify-failed appearance

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerSlave.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlave.cpp
@@ -157,11 +157,6 @@ qint64 AvatarMixerSlave::addChangedTraitsToBulkPacket(AvatarMixerClientData* lis
             ++simpleReceivedIt;
         }
 
-        if (bytesWritten > 0 && sendingAvatar->isCertifyFailed()) {
-            // Resend identity packet if certification failed:
-            sendingAvatar->setNeedsIdentityUpdate();
-        }
-
         // enumerate the received instanced trait versions
         auto instancedReceivedIt = lastReceivedVersions.instancedCBegin();
         while (instancedReceivedIt != lastReceivedVersions.instancedCEnd()) {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1866,6 +1866,9 @@ public:
     // also clears internal reaction triggers
     void updateRigControllerParameters(Rig::ControllerParameters& params);
 
+    // Don't substitute verify-fail:
+    virtual const QUrl& getSkeletonModelURL() const override { return _skeletonModelURL; }
+
 public slots:
 
    /**jsdoc

--- a/interface/src/commerce/Wallet.cpp
+++ b/interface/src/commerce/Wallet.cpp
@@ -830,9 +830,14 @@ void Wallet::handleChallengeOwnershipPacket(QSharedPointer<ReceivedMessage> pack
 }
 
 void Wallet::sendChallengeOwnershipResponses() {
-    if (_pendingChallenges.size() == 0 || getSalt().length() == 0) {
+    if (_pendingChallenges.size() == 0) {
         return;
     }
+    if (getSalt().length() == 0) {
+        qCDebug(commerce) << "Not responding to ownership challenge due to missing Wallet salt";
+        return;
+    }
+
     auto nodeList = DependencyManager::get<NodeList>();
 
     EC_KEY* ec = readKeys(keyFilePath());

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1511,7 +1511,7 @@ void Avatar::setSkeletonModelURL(const QUrl& skeletonModelURL) {
     }
     indicateLoadingStatus(LoadingStatus::LoadModel);
 
-    _skeletonModel->setURL(_skeletonModelURL);
+    _skeletonModel->setURL(getSkeletonModelURL());
 }
 
 void Avatar::setModelURLFinished(bool success) {

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1988,6 +1988,7 @@ void AvatarData::processAvatarIdentity(QDataStream& packetStream, bool& identity
         if (flagValue != _verificationFailed) {
             _verificationFailed = flagValue;
             identityChanged = true;
+            setSkeletonModelURL(_skeletonModelURL);
         }
 
         if (identity.attachmentData != _attachmentData) {
@@ -2016,6 +2017,18 @@ QUrl AvatarData::getWireSafeSkeletonModelURL() const {
         return QUrl();
     }
 }
+
+static const QString VERIFY_FAIL_MODEL { "/meshes/verifyFailed.fst" };
+
+const QUrl& AvatarData::getSkeletonModelURL() const {
+    if (_verificationFailed) {
+        static QUrl VERIFY_FAIL_MODEL_URL = PathUtils::resourcesUrl(VERIFY_FAIL_MODEL);
+        return VERIFY_FAIL_MODEL_URL;
+    } else {
+        return _skeletonModelURL;
+    }
+}
+
 QByteArray AvatarData::packSkeletonData() const {
     // Send an avatar trait packet with the skeleton data before the mesh is loaded
     int avatarDataSize = 0;

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1989,7 +1989,10 @@ void AvatarData::processAvatarIdentity(QDataStream& packetStream, bool& identity
             _verificationFailed = flagValue;
             identityChanged = true;
             setSkeletonModelURL(_skeletonModelURL);
-        }
+            if (_verificationFailed) {
+                qCDebug(avatars) << "Avatar" << getSessionDisplayName() << "marked as VERIFY-FAILED";
+            }
+        };
 
         if (identity.attachmentData != _attachmentData) {
             setAttachmentData(identity.attachmentData);

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1205,7 +1205,7 @@ public:
     QByteArray identityByteArray(bool setIsReplicated = false) const;
 
     QUrl getWireSafeSkeletonModelURL() const;
-    const QUrl& getSkeletonModelURL() const { return _skeletonModelURL; }
+    virtual const QUrl& getSkeletonModelURL() const;
 
     const QString& getDisplayName() const { return _displayName; }
     const QString& getSessionDisplayName() const { return _sessionDisplayName; }

--- a/libraries/avatars/src/AvatarHashMap.cpp
+++ b/libraries/avatars/src/AvatarHashMap.cpp
@@ -330,10 +330,6 @@ void AvatarHashMap::processAvatarIdentityPacket(QSharedPointer<ReceivedMessage> 
             bool displayNameChanged = false;
             // In this case, the "sendingNode" is the Avatar Mixer.
             avatar->processAvatarIdentity(avatarIdentityStream, identityChanged, displayNameChanged);
-            if (avatar->isCertifyFailed() && identityUUID != EMPTY) {
-                qCDebug(avatars) << "Avatar" << avatar->getSessionDisplayName() << "marked as VERIFY-FAILED";
-                avatar->setSkeletonModelURL(PathUtils::resourcesUrl(VERIFY_FAIL_MODEL));
-            }
             _replicas.processAvatarIdentity(identityUUID, message->getMessage(), identityChanged, displayNameChanged);
         }
     }


### PR DESCRIPTION
Jira: https://highfidelity.atlassian.net/browse/BUGZ-1247
(Verify-failed avatar not appearing verify-failed part)

1. Add diagnostic for challenge ignored due to Wallet-salt not initialized.
2. Make verify-failed appearance (for other clients) more fundamental part of
AvatarData.