### PR TITLE
Remove unused TabletAddressDialog internal property, fixing BUGZ-1294

### DIFF
--- a/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
+++ b/interface/resources/qml/hifi/tablet/TabletAddressDialog.qml
@@ -225,10 +225,6 @@ StackView {
                     verticalCenter: addressLineContainer.verticalCenter;
                 }
 
-                onFocusChanged: {
-                    addressBarDialog.raised = focus;
-                }
-
                 onTextChanged: {
                     updateLocationText(text.length > 0);
                 }


### PR DESCRIPTION
[BUGZ-1294](https://highfidelity.atlassian.net/browse/BUGZ-1294)

I'm guessing at some point this property was used, but now it's not. It shouldn't be in there, because it's causing the QML to not parse properly.