### PR TITLE
DEV-336: Fixes for avatar-verify failures with rapid avatar selection

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -83,7 +83,7 @@ AvatarMixer::AvatarMixer(ReceivedMessage& message) :
     packetReceiver.registerListener(PacketType::BulkAvatarTraitsAck, this, "queueIncomingPacket");
     packetReceiver.registerListenerForTypes({ PacketType::OctreeStats, PacketType::EntityData, PacketType::EntityErase },
         this, "handleOctreePacket");
-    packetReceiver.registerListener(PacketType::ChallengeOwnership, this, "handleChallengeOwnership");
+    packetReceiver.registerListener(PacketType::ChallengeOwnership, this, "queueIncomingPacket");
 
     packetReceiver.registerListenerForTypes({
         PacketType::ReplicatedAvatarIdentity,
@@ -1141,7 +1141,7 @@ void AvatarMixer::handleChallengeOwnership(QSharedPointer<ReceivedMessage> messa
         auto clientData = static_cast<AvatarMixerClientData*>(senderNode->getLinkedData());
         auto avatar = clientData->getAvatarSharedPointer();
         if (avatar) {
-            avatar->handleChallengeResponse(message.data());
+            //avatar->handleChallengeResponse(message.data());
         }
     }
 }

--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -1136,16 +1136,6 @@ void AvatarMixer::entityChange() {
     _dirtyHeroStatus = true;
 }
 
-void AvatarMixer::handleChallengeOwnership(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
-    if (senderNode->getType() == NodeType::Agent && senderNode->getLinkedData()) {
-        auto clientData = static_cast<AvatarMixerClientData*>(senderNode->getLinkedData());
-        auto avatar = clientData->getAvatarSharedPointer();
-        if (avatar) {
-            //avatar->handleChallengeResponse(message.data());
-        }
-    }
-}
-
 void AvatarMixer::aboutToFinish() {
     DependencyManager::destroy<ResourceManager>();
     DependencyManager::destroy<ResourceCacheSharedItems>();

--- a/assignment-client/src/avatars/AvatarMixer.h
+++ b/assignment-client/src/avatars/AvatarMixer.h
@@ -65,7 +65,6 @@ private slots:
     void domainSettingsRequestComplete();
     void handlePacketVersionMismatch(PacketType type, const HifiSockAddr& senderSockAddr, const QUuid& senderUUID);
     void handleOctreePacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
-    void handleChallengeOwnership(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void start();
 
 private:

--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -75,7 +75,7 @@ int AvatarMixerClientData::processPackets(const SlaveSharedData& slaveSharedData
                 processBulkAvatarTraitsAckMessage(*packet);
                 break;
             case PacketType::ChallengeOwnership:
-                _avatar->handleChallengeResponse(*packet);
+                _avatar->processChallengeResponse(*packet);
                 break;
             default:
                 Q_UNREACHABLE();

--- a/assignment-client/src/avatars/AvatarMixerClientData.cpp
+++ b/assignment-client/src/avatars/AvatarMixerClientData.cpp
@@ -74,6 +74,9 @@ int AvatarMixerClientData::processPackets(const SlaveSharedData& slaveSharedData
             case PacketType::BulkAvatarTraitsAck:
                 processBulkAvatarTraitsAckMessage(*packet);
                 break;
+            case PacketType::ChallengeOwnership:
+                _avatar->handleChallengeResponse(*packet);
+                break;
             default:
                 Q_UNREACHABLE();
         }

--- a/assignment-client/src/avatars/MixerAvatar.cpp
+++ b/assignment-client/src/avatars/MixerAvatar.cpp
@@ -51,7 +51,6 @@ const char* MixerAvatar::stateToName(VerifyState state) {
 }
 
 void MixerAvatar::fetchAvatarFST() {
-    volatile auto enumName = stateToName(_verifyState);
     if (_verifyState >= requestingFST && _verifyState <= challengeClient) {
         qCDebug(avatars) << "WARNING: Avatar verification restarted; old state:" << stateToName(_verifyState);
     }

--- a/assignment-client/src/avatars/MixerAvatar.cpp
+++ b/assignment-client/src/avatars/MixerAvatar.cpp
@@ -329,7 +329,7 @@ void MixerAvatar::sendOwnerChallenge() {
     QMetaObject::invokeMethod(&_challengeTimer, static_cast<void(QTimer::*)()>(&QTimer::start));
 }
 
-void MixerAvatar::handleChallengeResponse(ReceivedMessage& response) {
+void MixerAvatar::processChallengeResponse(ReceivedMessage& response) {
     QByteArray avatarID;
     QMutexLocker certifyLocker(&_avatarCertifyLock);
     QMetaObject::invokeMethod(&_challengeTimer, &QTimer::stop);

--- a/assignment-client/src/avatars/MixerAvatar.h
+++ b/assignment-client/src/avatars/MixerAvatar.h
@@ -9,8 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-// Avatar class for use within the avatar mixer - encapsulates data required only for
-// sorting priorities within the mixer.
+// Avatar class for use within the avatar mixer - includes avatar-verification state.
 
 #ifndef hifi_MixerAvatar_h
 #define hifi_MixerAvatar_h

--- a/assignment-client/src/avatars/MixerAvatar.h
+++ b/assignment-client/src/avatars/MixerAvatar.h
@@ -22,7 +22,8 @@ class ResourceRequest;
 class MixerAvatar : public AvatarData {
     Q_OBJECT
 public:
-    ~MixerAvatar();
+    MixerAvatar();
+
     bool getNeedsHeroCheck() const { return _needsHeroCheck; }
     void setNeedsHeroCheck(bool needsHeroCheck = true) { _needsHeroCheck = needsHeroCheck; }
 
@@ -57,7 +58,7 @@ private:
     QString _dynamicMarketResponse;
     QString _ownerPublicKey;
     QByteArray _challengeNonceHash;
-    QTimer* _challengeTimeout { nullptr };
+    QTimer _challengeTimer;
     bool _needsIdentityUpdate { false };
 
     bool generateFSTHash();

--- a/assignment-client/src/avatars/MixerAvatar.h
+++ b/assignment-client/src/avatars/MixerAvatar.h
@@ -32,7 +32,7 @@ public:
     void setNeedsIdentityUpdate(bool value = true) { _needsIdentityUpdate = value; }
 
     void processCertifyEvents();
-    void handleChallengeResponse(ReceivedMessage& response);
+    void processChallengeResponse(ReceivedMessage& response);
 
     // Avatar certification/verification:
     enum VerifyState {


### PR DESCRIPTION
Jira: https://highfidelity.atlassian.net/browse/DEV-336

1. Handle resetting of the state machine better when a user changes avatar while a verification is in-progress. This is the main part of the Jira.
2. Pass challenge response to slave thread using the same mechanism used for incoming AvatarData packets, etc. This gets rid of one of the intermediate verify states.
3. More rational use of the QTimer used for challenge timeouts - previously it was owned by the slave thread, which is a little fragile in terms of concurrency since a Node is not guaranteed to be processed by the same thread each frame. Now the timer is a component of the avatar class, which is cleaner.
4. Better diagnostics, including making the verify-state enum a Qt registered enum, for which the type had to be made public(?).
5. Miscellaneous clean-up.
