### PR TITLE
DEV-417: Add User-Agent string to macOS Launcher

### DIFF
--- a/launchers/darwin/CMakeLists.txt
+++ b/launchers/darwin/CMakeLists.txt
@@ -89,8 +89,14 @@ if ("${LAUNCHER_HMAC_SECRET}" STREQUAL "")
     message(FATAL_ERROR "LAUNCHER_HMAC_SECRET is not set")
 endif()
 
+# Development environments don't set BUILD_VERSION. Let 0 mean a development version.
+if(NOT BUILD_VERSION)
+    set(BUILD_VERSION 0)
+endif()
+
 target_compile_definitions(${PROJECT_NAME} PRIVATE LAUNCHER_HMAC_SECRET="${LAUNCHER_HMAC_SECRET}")
 target_compile_definitions(${PROJECT_NAME} PRIVATE LAUNCHER_BUILD_VERSION="${BUILD_VERSION}")
+target_compile_definitions(${PROJECT_NAME} PRIVATE USER_AGENT_STRING="HQLauncher/${BUILD_VERSION}")
 
 file(GLOB NIB_FILES "nib/*.xib")
 

--- a/launchers/darwin/src/CredentialsRequest.m
+++ b/launchers/darwin/src/CredentialsRequest.m
@@ -22,6 +22,7 @@
     NSMutableURLRequest *request = [NSMutableURLRequest new];
     [request setURL:[NSURL URLWithString:@"https://metaverse.highfidelity.com/oauth/token"]];
     [request setHTTPMethod:@"POST"];
+    [request setValue:@USER_AGENT_STRING forHTTPHeaderField:@"User-Agent"];
     [request setValue:postLength forHTTPHeaderField:@"Content-Length"];
     [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
     [request setHTTPBody:postData];

--- a/launchers/darwin/src/DownloadDomainContent.m
+++ b/launchers/darwin/src/DownloadDomainContent.m
@@ -12,9 +12,10 @@
 {
     self.progressPercentage = 0.0;
     self.taskProgressPercentage = 0.0;
-    NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:domainContentUrl]
-                                             cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                         timeoutInterval:60.0];
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:domainContentUrl]
+                                                           cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                       timeoutInterval:60.0];
+    [request setValue:@USER_AGENT_STRING forHTTPHeaderField:@"User-Agent"];
 
     NSURLSessionConfiguration *defaultConfigObject = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSURLSession *defaultSession = [NSURLSession sessionWithConfiguration: defaultConfigObject delegate: self delegateQueue: [NSOperationQueue mainQueue]];

--- a/launchers/darwin/src/DownloadInterface.m
+++ b/launchers/darwin/src/DownloadInterface.m
@@ -8,9 +8,10 @@
 {
     self.progressPercentage = 0.0;
     self.taskProgressPercentage = 0.0;
-    NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:downloadUrl]
-                                             cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                         timeoutInterval:60.0];
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:downloadUrl]
+                                                           cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                       timeoutInterval:60.0];
+    [request setValue:@USER_AGENT_STRING forHTTPHeaderField:@"User-Agent"];
 
     NSURLSessionConfiguration *defaultConfigObject = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSURLSession *defaultSession = [NSURLSession sessionWithConfiguration: defaultConfigObject delegate: self delegateQueue: [NSOperationQueue mainQueue]];

--- a/launchers/darwin/src/DownloadLauncher.m
+++ b/launchers/darwin/src/DownloadLauncher.m
@@ -5,9 +5,10 @@
 @implementation DownloadLauncher
 
 - (void) downloadLauncher:(NSString*)launcherUrl {
-    NSURLRequest* request = [NSURLRequest requestWithURL:[NSURL URLWithString:launcherUrl]
-                                             cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                         timeoutInterval:60.0];
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:launcherUrl]
+                                                           cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                       timeoutInterval:60.0];
+    [request setValue:@USER_AGENT_STRING forHTTPHeaderField:@"User-Agent"];
 
     NSURLSessionConfiguration *defaultConfigObject = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSURLSession *defaultSession = [NSURLSession sessionWithConfiguration: defaultConfigObject delegate: self delegateQueue: [NSOperationQueue mainQueue]];

--- a/launchers/darwin/src/DownloadScripts.m
+++ b/launchers/darwin/src/DownloadScripts.m
@@ -5,9 +5,11 @@
 
 - (void) downloadScripts:(NSString*) scriptsUrl
 {
-    /*NSURLRequest* theRequest = [NSURLRequest requestWithURL:[NSURL URLWithString:scriptsUrl]
+    /*NSMutableURLRequest* theRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:scriptsUrl]
                                                 cachePolicy:NSURLRequestUseProtocolCachePolicy
                                             timeoutInterval:6000.0];
+     [theRequest setValue:@USER_AGENT_STRING forHTTPHeaderField:@"User-Agent"];
+
     NSURLDownload  *theDownload = [[NSURLDownload alloc] initWithRequest:theRequest delegate:self];
     
     if (!theDownload) {

--- a/launchers/darwin/src/LatestBuildRequest.m
+++ b/launchers/darwin/src/LatestBuildRequest.m
@@ -27,6 +27,7 @@
     NSMutableURLRequest* request = [NSMutableURLRequest new];
     [request setURL:[NSURL URLWithString:@"https://thunder.highfidelity.com/builds/api/tags/latest?format=json"]];
     [request setHTTPMethod:@"GET"];
+    [request setValue:@USER_AGENT_STRING forHTTPHeaderField:@"User-Agent"];
     [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
 
     // We're using an ephermeral session here to ensure the tags api response is never cached.

--- a/launchers/darwin/src/OrganizationRequest.m
+++ b/launchers/darwin/src/OrganizationRequest.m
@@ -32,6 +32,7 @@ static NSString* const organizationURL = @"https://orgs.highfidelity.com/organiz
     NSMutableURLRequest *request = [NSMutableURLRequest new];
     [request setURL:[NSURL URLWithString:[organizationURL stringByAppendingString:jsonFile]]];
     [request setHTTPMethod:@"GET"];
+    [request setValue:@USER_AGENT_STRING forHTTPHeaderField:@"User-Agent"];
     [request setValue:@"" forHTTPHeaderField:@"Content-Type"];
 
     NSURLSession * session = [NSURLSession sessionWithConfiguration:NSURLSessionConfiguration.ephemeralSessionConfiguration delegate: self delegateQueue: [NSOperationQueue mainQueue]];


### PR DESCRIPTION
Before this change, the mac HQ launcher didn't set a User-Agent string.
This change adds a User-Agent header – HQLauncher/$version – to each
HTTP request the mac launcher makes.

The approach I took was to add the User-Agent header to each HTTP
request. There is room for improvement. Most of the session
initialization could be rolled up into a helper class that sets the
User-Agent headers and other configuration parameters. Making that
change would be too much overhead for this quick task.

Jira: https://highfidelity.atlassian.net/browse/DEV-417