### PR TITLE
(DEV-359) Allow more image names to be used as Nitpick test reference images

### DIFF
--- a/tools/nitpick/src/TestCreator.cpp
+++ b/tools/nitpick/src/TestCreator.cpp
@@ -323,9 +323,11 @@ void TestCreator::startTestsEvaluation(
 
             QString expectedImagePartialSourceDirectory = getExpectedImagePartialSourceDirectory(currentFilename);
 
-            // Images are stored on GitHub as ExpectedImage_ddddd.png
-            // Extract the digits at the end of the filename (excluding the file extension)
-            QString expectedImageFilenameTail = currentFilename.left(currentFilename.length() - 4).right(NUM_DIGITS);
+            // Images are stored on GitHub as ExpectedImage_ddddd.png or ExpectedImage_some_metadata_ddddd.png
+            // Extract the part of the filename after "ExpectedImage_" and excluding the file extension
+            QString expectedImageFilenameTail = currentFilename.left(currentFilename.lastIndexOf("."));
+            int expectedImageStart = expectedImageFilenameTail.lastIndexOf(".") + 1;
+            expectedImageFilenameTail.remove(0, expectedImageStart);
             QString expectedImageStoredFilename = EXPECTED_IMAGE_PREFIX + expectedImageFilenameTail + ".png";
 
             QString imageURLString("https://raw.githubusercontent.com/" + user + "/" + GIT_HUB_REPOSITORY  + "/" + branch + "/" +


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-359

To make it possible to use [per-profile test reference images](https://github.com/highfidelity/hifi_tests/pull/423), this PR changes how the test result image names are parsed.

Before: Images could only be in the format "ExpectedImage_00000.png"
After: Images can also be in the format "ExpectedImage_additional_information_00000.png"