### PR TITLE
BUGZ-1170: improved render bounding box for PolyLines, and use opaque render pipeline when possible

### DIFF
--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -101,7 +101,7 @@ protected:
     virtual void doRender(RenderArgs* args) = 0;
 
     virtual bool isFading() const { return _isFading; }
-    void updateModelTransformAndBound();
+    virtual void updateModelTransformAndBound();
     virtual bool isTransparent() const { return _isFading ? Interpolate::calculateFadeRatio(_fadeStartTime) < 1.0f : false; }
     inline bool isValidRenderItem() const { return _renderItemID != Item::INVALID_ITEM_ID; }
 
@@ -124,7 +124,6 @@ signals:
 protected:
     template<typename T>
     std::shared_ptr<T> asTypedEntity() { return std::static_pointer_cast<T>(_entity); }
-        
 
     static void makeStatusGetters(const EntityItemPointer& entity, Item::Status::Getters& statusGetters);
     const Transform& getModelTransform() const;
@@ -153,7 +152,6 @@ protected:
 
     quint64 _created;
 
-private:
     // The base class relies on comparing the model transform to the entity transform in order 
     // to trigger an update, so the member must not be visible to derived classes as a modifiable
     // transform

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -41,6 +41,20 @@ PolyLineEntityRenderer::PolyLineEntityRenderer(const EntityItemPointer& entity) 
     }
 }
 
+void PolyLineEntityRenderer::updateModelTransformAndBound() {
+    bool success = false;
+    auto newModelTransform = _entity->getTransformToCenter(success);
+    if (success) {
+        _modelTransform = newModelTransform;
+
+        auto lineEntity = std::static_pointer_cast<PolyLineEntityItem>(_entity);
+        AABox bound;
+        lineEntity->computeTightLocalBoundingBox(bound);
+        bound.transform(newModelTransform);
+        _bound = bound;
+    }
+}
+
 void PolyLineEntityRenderer::buildPipelines() {
     // FIXME: opaque pipelines
 

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
@@ -27,8 +27,7 @@ public:
 
     void updateModelTransformAndBound() override;
 
-    // FIXME: shouldn't always be transparent: take into account texture and glow
-    virtual bool isTransparent() const override { return true; }
+    virtual bool isTransparent() const override;
 
 protected:
     virtual bool needsRenderUpdate() const override;

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.h
@@ -25,6 +25,8 @@ class PolyLineEntityRenderer : public TypedEntityRenderer<PolyLineEntityItem> {
 public:
     PolyLineEntityRenderer(const EntityItemPointer& entity);
 
+    void updateModelTransformAndBound() override;
+
     // FIXME: shouldn't always be transparent: take into account texture and glow
     virtual bool isTransparent() const override { return true; }
 

--- a/libraries/entities-renderer/src/entities-renderer/paintStroke.slp
+++ b/libraries/entities-renderer/src/entities-renderer/paintStroke.slp
@@ -1,1 +1,1 @@
-DEFINES forward
+DEFINES translucent:f forward

--- a/libraries/entities-renderer/src/paintStroke.slf
+++ b/libraries/entities-renderer/src/paintStroke.slf
@@ -34,7 +34,11 @@ void main(void) {
     texel.a *= mix(1.0, pow(1.0 - min(1.0, abs(_distanceFromCenter)), 10.0), _polylineData.faceCameraGlow.y);
 
 <@if not HIFI_USE_FORWARD@>
-    packDeferredFragmentTranslucent((2.0 * float(gl_FrontFacing) - 1.0) * _normalWS, texel.a, texel.rgb, DEFAULT_ROUGHNESS);
+    <@if HIFI_USE_TRANSLUCENT@>
+        packDeferredFragmentTranslucent((2.0 * float(gl_FrontFacing) - 1.0) * _normalWS, texel.a, texel.rgb, DEFAULT_ROUGHNESS);
+    <@else@>
+        packDeferredFragmentUnlit((2.0 * float(gl_FrontFacing) - 1.0) * _normalWS, texel.a, texel.rgb);
+    <@endif@>
 <@else@>
     _fragColor0 = texel;
 <@endif@>

--- a/libraries/entities/src/PolyLineEntityItem.h
+++ b/libraries/entities/src/PolyLineEntityItem.h
@@ -15,7 +15,7 @@
 #include "EntityItem.h"
 
 class PolyLineEntityItem : public EntityItem {
- public:
+public:
     static EntityItemPointer factory(const EntityItemID& entityID, const EntityItemProperties& properties);
 
     PolyLineEntityItem(const EntityItemID& entityItemID);
@@ -90,10 +90,12 @@ class PolyLineEntityItem : public EntityItem {
                                                   BoxFace& face, glm::vec3& surfaceNormal,
                                                   QVariantMap& extraInfo, bool precisionPicking) const override { return false; }
 
+    void computeTightLocalBoundingBox(AABox& box) const;
+
     virtual void debugDump() const override;
 private:
-    void computeAndUpdateDimensionsAndPosition();
-    
+    void computeAndUpdateDimensions();
+
  protected:
     glm::u8vec3 _color;
     QVector<glm::vec3> _points;

--- a/libraries/render-utils/src/DeferredBufferWrite.slh
+++ b/libraries/render-utils/src/DeferredBufferWrite.slh
@@ -52,7 +52,8 @@ void packDeferredFragmentLightmap(vec3 normal, float alpha, vec3 albedo, float r
 }
 
 void packDeferredFragmentUnlit(vec3 normal, float alpha, vec3 color) {
-    if (alpha < 1.0) {
+    // to reduce texel flickering for floating point error we discard when alpha is "almost one"
+    if (alpha < 0.999999) {
         discard;
     }
     _fragColor0 = vec4(color, packUnlit());


### PR DESCRIPTION
This PR makes the bounding box of PolyLine render items tighter and more correct than the typical AABox used for the EntityTree spatial sorting.  Also, opaque PolyLine render items now use an opaque render pipeline.

https://highfidelity.atlassian.net/browse/BUGZ-1170