### PR TITLE
BUGZ-1265: Don't allow reactions refcount go bellow 0

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -5863,7 +5863,11 @@ bool MyAvatar::endReaction(QString reactionName) {
     int reactionIndex = beginEndReactionNameToIndex(reactionName);
     if (reactionIndex >= 0 && reactionIndex < (int)NUM_AVATAR_BEGIN_END_REACTIONS) {
         std::lock_guard<std::mutex> guard(_reactionLock);
-        _reactionEnabledRefCounts[reactionIndex]--;
+        if (_reactionEnabledRefCounts[reactionIndex] > 0) {
+            _reactionEnabledRefCounts[reactionIndex]--;
+        } else {
+            _reactionEnabledRefCounts[reactionIndex] = 0;
+        }
         return true;
     }
     return false;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -5865,10 +5865,11 @@ bool MyAvatar::endReaction(QString reactionName) {
         std::lock_guard<std::mutex> guard(_reactionLock);
         if (_reactionEnabledRefCounts[reactionIndex] > 0) {
             _reactionEnabledRefCounts[reactionIndex]--;
+            return true;
         } else {
             _reactionEnabledRefCounts[reactionIndex] = 0;
+            return false;
         }
-        return true;
     }
     return false;
 }


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1265
https://highfidelity.atlassian.net/browse/DEV-405

This PR maintains the reaction `refcount >= 0` so when MyAvatar.endReaction is called with a valid string and there's not reaction triggered previously `MyAvatar.endReaction` returns false.