### PR TITLE
BUGZ-1325 prevent MyAvatar from pushing through mesh barrier

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -3586,6 +3586,8 @@ void MyAvatar::updateActionMotor(float deltaTime) {
         float speedGrowthTimescale  = 2.0f;
         float speedIncreaseFactor = 1.8f * _walkSpeedScalar;
         motorSpeed *= 1.0f + glm::clamp(deltaTime / speedGrowthTimescale, 0.0f, 1.0f) * speedIncreaseFactor;
+        // use feedback from CharacterController to prevent tunneling under high motorspeed
+        motorSpeed *= _characterController.getCollisionBrakeAttenuationFactor();
         const float maxBoostSpeed = sensorToWorldScale * MAX_BOOST_SPEED;
 
         if (_isPushing) {

--- a/libraries/physics/src/CharacterController.cpp
+++ b/libraries/physics/src/CharacterController.cpp
@@ -189,7 +189,7 @@ void CharacterController::addToWorld() {
     _rigidBody->setCollisionFlags(btCollisionObject::CF_CUSTOM_MATERIAL_CALLBACK);
 
     // enable CCD
-    _rigidBody->setCcdSweptSphereRadius(2.0f * (_radius + _halfHeight));
+    _rigidBody->setCcdSweptSphereRadius(_halfHeight);
     _rigidBody->setCcdMotionThreshold(_radius);
 
     btCollisionShape* shape = _rigidBody->getCollisionShape();
@@ -556,7 +556,7 @@ void CharacterController::setLocalBoundingBox(const glm::vec3& minCorner, const 
 
     if (_rigidBody) {
         // update CCD with new _radius
-        _rigidBody->setCcdSweptSphereRadius(2.0f * (_radius + _halfHeight));
+        _rigidBody->setCcdSweptSphereRadius(_halfHeight);
         _rigidBody->setCcdMotionThreshold(_radius);
     }
 }

--- a/libraries/physics/src/CharacterController.h
+++ b/libraries/physics/src/CharacterController.h
@@ -128,6 +128,7 @@ public:
     void setPhysicsEngine(const PhysicsEnginePointer& engine);
     bool isEnabledAndReady() const { return (bool)_physicsEngine; }
     bool isStuck() const { return _isStuck; }
+    float getCollisionBrakeAttenuationFactor() const;
 
     void setCollisionless(bool collisionless);
 
@@ -221,6 +222,7 @@ protected:
     bool _isPushingUp;
     bool _isStuck { false };
     bool _isSeated { false };
+    float _collisionBrake { 0.0f };
 
     PhysicsEnginePointer _physicsEngine { nullptr };
     btRigidBody* _rigidBody { nullptr };


### PR DESCRIPTION
This PR fixes a problem where MyAvatar and "push" into a mesh wall, ramping up its target velocity, until it manages to tunnel through.

https://highfidelity.atlassian.net/browse/BUGZ-1325

Also included: fix for the problem where the continuous collision detection (CCD) sphere proxy is too big:

https://highfidelity.atlassian.net/browse/BUGZ-1373