### PR TITLE
BUGZ-1357: Fix crashes in ScriptDiscoveryService API

### DIFF
--- a/libraries/script-engine/src/ScriptsModel.cpp
+++ b/libraries/script-engine/src/ScriptsModel.cpp
@@ -85,6 +85,9 @@ QModelIndex ScriptsModel::index(int row, int column, const QModelIndex& parent) 
 }
 
 QModelIndex ScriptsModel::parent(const QModelIndex& child) const {
+    if (!child.isValid()) {
+        return QModelIndex();
+    }
     TreeNodeFolder* parent = (static_cast<TreeNodeBase*>(child.internalPointer()))->getParent();
     if (!parent) {
         return QModelIndex();

--- a/libraries/script-engine/src/ScriptsModel.cpp
+++ b/libraries/script-engine/src/ScriptsModel.cpp
@@ -78,7 +78,7 @@ TreeNodeBase* ScriptsModel::getTreeNodeFromIndex(const QModelIndex& index) const
 }
 
 QModelIndex ScriptsModel::index(int row, int column, const QModelIndex& parent) const {
-    if (row < 0 || column < 0) {
+    if (row < 0 || row >= rowCount(parent) || column < 0  || column >= columnCount(parent)) {
         return QModelIndex();
     }
     return createIndex(row, column, getFolderNodes(static_cast<TreeNodeFolder*>(getTreeNodeFromIndex(parent))).at(row));


### PR DESCRIPTION
Fixes:
- Crash in ScriptDiscoveryService.scriptsModel.data(index) if index row is not valid.
- Unexpected data in ScriptDiscoveryService.scriptsModel.data(index) if index column is not valid.
- Crash in ScriptDiscoveryService.scriptsModel.parent(index) is index row or column are not valid.

Case: https://highfidelity.atlassian.net/browse/BUGZ-1357
