### PR TITLE
BUGZ-1363: crash when checking for web content restrictions

### DIFF
--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -136,10 +136,8 @@ void QmlWindowClass::initQml(QVariantMap properties) {
 #if !defined(Q_OS_ANDROID)
         // If the restricted flag is on, override the FileTypeProfile and HFWebEngineProfile objects in the 
         // QML surface root context with local ones
-        qDebug() << "Context initialization lambda";
+        ContextAwareProfile::restrictContext(context, _restricted);
         if (_restricted) {
-            qDebug() << "Restricting web content";
-            ContextAwareProfile::restrictContext(context);
             FileTypeProfile::registerWithContext(context);
             HFWebEngineProfile::registerWithContext(context);
         }

--- a/libraries/ui/src/ui/types/ContextAwareProfile.cpp
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.cpp
@@ -21,7 +21,7 @@
 static const QString RESTRICTED_FLAG_PROPERTY = "RestrictFileAccess";
 
 ContextAwareProfile::ContextAwareProfile(QQmlContext* context) :
-    QQuickWebEngineProfile(context), _context(context) { 
+    ContextAwareProfileParent(context), _context(context) { 
     assert(context);
 }
 

--- a/libraries/ui/src/ui/types/ContextAwareProfile.cpp
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.cpp
@@ -10,19 +10,20 @@
 //
 
 #include "ContextAwareProfile.h"
-#if !defined(Q_OS_ANDROID)
 
+#include <cassert>
 #include <QtCore/QThread>
 #include <QtQml/QQmlContext>
 
 #include <shared/QtHelpers.h>
 #include <SharedUtil.h>
 
-
 static const QString RESTRICTED_FLAG_PROPERTY = "RestrictFileAccess";
 
 ContextAwareProfile::ContextAwareProfile(QQmlContext* context) :
-    QQuickWebEngineProfile(context), _context(context) { }
+    QQuickWebEngineProfile(context), _context(context) { 
+    assert(context);
+}
 
 
 void ContextAwareProfile::restrictContext(QQmlContext* context, bool restrict) {
@@ -40,12 +41,9 @@ bool ContextAwareProfile::isRestrictedInternal() {
 
 bool ContextAwareProfile::isRestricted() {
     auto now = usecTimestampNow();
-    auto cacheAge = now - _lastCacheCheck;
-    if (cacheAge > MAX_CACHE_AGE) {
+    if (now > _cacheExpiry) {
         _cachedValue = isRestrictedInternal();
-        _lastCacheCheck = now;
+        _cacheExpiry = now + MAX_CACHE_AGE;
     }
     return _cachedValue;
 }
-
-#endif

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -20,16 +20,16 @@
 class QQmlContext;
 
 class ContextAwareProfile : public QQuickWebEngineProfile {
+    Q_OBJECT
 public:
-    static void restrictContext(QQmlContext* context);
-    static bool isRestricted(QQmlContext* context);
-    QQmlContext* getContext() const { return _context; }
+    static void restrictContext(QQmlContext* context, bool restrict = true);
+    Q_INVOKABLE bool isRestricted();
 protected:
 
     class RequestInterceptor : public QWebEngineUrlRequestInterceptor {
     public:
         RequestInterceptor(ContextAwareProfile* parent) : QWebEngineUrlRequestInterceptor(parent), _profile(parent) {}
-        QQmlContext* getContext() const { return _profile->getContext(); }
+        bool isRestricted() { return _profile->isRestricted(); }
     protected:
         ContextAwareProfile* _profile;
     };

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -16,11 +16,21 @@
 #if !defined(Q_OS_ANDROID)
 #include <QtWebEngine/QQuickWebEngineProfile>
 #include <QtWebEngineCore/QWebEngineUrlRequestInterceptor>
+
+using ContextAwareProfileParent = QQuickWebEngineProfile;
+using RequestInterceptorParent = QWebEngineUrlRequestInterceptor;
+#else
+#include <QtCore/QObject>
+
+using ContextAwareProfileParent = QObject;
+using RequestInterceptorParent = QObject;
+#endif
+
 #include <NumericalConstants.h>
 
 class QQmlContext;
 
-class ContextAwareProfile : public QQuickWebEngineProfile {
+class ContextAwareProfile : public ContextAwareProfileParent {
     Q_OBJECT
 public:
     static void restrictContext(QQmlContext* context, bool restrict = true);
@@ -28,9 +38,9 @@ public:
     Q_INVOKABLE bool isRestrictedInternal();
 protected:
 
-    class RequestInterceptor : public QWebEngineUrlRequestInterceptor {
+    class RequestInterceptor : public RequestInterceptorParent {
     public:
-        RequestInterceptor(ContextAwareProfile* parent) : QWebEngineUrlRequestInterceptor(parent), _profile(parent) {}
+        RequestInterceptor(ContextAwareProfile* parent) : RequestInterceptorParent(parent), _profile(parent) { }
         bool isRestricted() { return _profile->isRestricted(); }
     protected:
         ContextAwareProfile* _profile;
@@ -39,9 +49,8 @@ protected:
     ContextAwareProfile(QQmlContext* parent);
     QQmlContext* _context{ nullptr };
     bool _cachedValue{ false };
-    quint64 _lastCacheCheck{ 0 };
-    static const quint64 MAX_CACHE_AGE = MSECS_PER_SECOND;
+    quint64 _cacheExpiry{ 0 };
+    constexpr static quint64 MAX_CACHE_AGE = MSECS_PER_SECOND;
 };
-#endif
 
 #endif // hifi_FileTypeProfile_h

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -16,6 +16,7 @@
 #if !defined(Q_OS_ANDROID)
 #include <QtWebEngine/QQuickWebEngineProfile>
 #include <QtWebEngineCore/QWebEngineUrlRequestInterceptor>
+#include <NumericalConstants.h>
 
 class QQmlContext;
 
@@ -23,7 +24,8 @@ class ContextAwareProfile : public QQuickWebEngineProfile {
     Q_OBJECT
 public:
     static void restrictContext(QQmlContext* context, bool restrict = true);
-    Q_INVOKABLE bool isRestricted();
+    bool isRestricted();
+    Q_INVOKABLE bool isRestrictedInternal();
 protected:
 
     class RequestInterceptor : public QWebEngineUrlRequestInterceptor {
@@ -35,7 +37,10 @@ protected:
     };
 
     ContextAwareProfile(QQmlContext* parent);
-    QQmlContext* _context;
+    QQmlContext* _context{ nullptr };
+    bool _cachedValue{ false };
+    quint64 _lastCacheCheck{ 0 };
+    static const quint64 MAX_CACHE_AGE = MSECS_PER_SECOND;
 };
 #endif
 

--- a/libraries/ui/src/ui/types/FileTypeProfile.cpp
+++ b/libraries/ui/src/ui/types/FileTypeProfile.cpp
@@ -29,8 +29,8 @@ FileTypeProfile::FileTypeProfile(QQmlContext* parent) :
 }
 
 void FileTypeProfile::RequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo& info) {
-    RequestFilters::interceptHFWebEngineRequest(info, getContext());
-    RequestFilters::interceptFileType(info, getContext());
+    RequestFilters::interceptHFWebEngineRequest(info, isRestricted());
+    RequestFilters::interceptFileType(info);
 }
 
 void FileTypeProfile::registerWithContext(QQmlContext* context) {

--- a/libraries/ui/src/ui/types/HFWebEngineProfile.cpp
+++ b/libraries/ui/src/ui/types/HFWebEngineProfile.cpp
@@ -28,7 +28,7 @@ HFWebEngineProfile::HFWebEngineProfile(QQmlContext* parent) : Parent(parent)
 }
 
 void HFWebEngineProfile::RequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo& info) {
-    RequestFilters::interceptHFWebEngineRequest(info, getContext());
+    RequestFilters::interceptHFWebEngineRequest(info, isRestricted());
 }
 
 void HFWebEngineProfile::registerWithContext(QQmlContext* context) {

--- a/libraries/ui/src/ui/types/RequestFilters.cpp
+++ b/libraries/ui/src/ui/types/RequestFilters.cpp
@@ -63,8 +63,8 @@ namespace {
      }
 }
 
-void RequestFilters::interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info, QQmlContext* context) {
-    if (ContextAwareProfile::isRestricted(context) && blockLocalFiles(info)) {
+void RequestFilters::interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info, bool restricted) {
+    if (restricted && blockLocalFiles(info)) {
         return;
     }
 
@@ -90,7 +90,7 @@ void RequestFilters::interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info,
     info.setHttpHeader(USER_AGENT.toLocal8Bit(), tokenString.toLocal8Bit());
 }
 
-void RequestFilters::interceptFileType(QWebEngineUrlRequestInfo& info, QQmlContext* context) {
+void RequestFilters::interceptFileType(QWebEngineUrlRequestInfo& info) {
     QString filename = info.requestUrl().fileName();
     if (isScript(filename) || isJSON(filename)) {
         static const QString CONTENT_HEADER = "Accept";

--- a/libraries/ui/src/ui/types/RequestFilters.h
+++ b/libraries/ui/src/ui/types/RequestFilters.h
@@ -24,8 +24,8 @@ class QQmlContext;
 
 class RequestFilters : public QObject {
 public:
-    static void interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info, QQmlContext* context);
-    static void interceptFileType(QWebEngineUrlRequestInfo& info, QQmlContext* context);
+    static void interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info, bool restricted);
+    static void interceptFileType(QWebEngineUrlRequestInfo& info);
 };
 #endif
 


### PR DESCRIPTION
[BUGZ-1363](https://highfidelity.atlassian.net/browse/BUGZ-1363)

The existing codebase needs to ensure that server scripts can't access local files via web content.  The existing mechanism assumes that the check that we do in `ContextAwareProfile::isRestricted`, executed as part of a `QWebEngineUrlRequestInterceptor` callback,  will be done on the main thread, but this appears to be incorrect.  Instead it's happening on another thread, which is handling the network request.  This makes the existing useage of `QQmlContext::contextProperty` unsafe, because it can manipulate internal data structures and is not thread safe.  

The solution is to use a mechanism to ensure that the contextProperty call is left to the main thread.  However, because we don't want every last network request to block the main thread, I've added caching of the value of up to 1 second, so that in theory most requests should hit the cached value instead.  

Note this does not fix [BUGZ-1365](https://highfidelity.atlassian.net/browse/BUGZ-1365), a related bug which points out that we don't have the protection against local file access in our InteractiveWindow class.  