### PR TITLE
Attempt to fix crash from script running too late

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -423,9 +423,9 @@ void ScriptEngine::waitTillDoneRunning() {
                 qCWarning(scriptengine) << "Script Engine has been running too long, aborting:" << getFilename();
                 abortEvaluation();
             } else {
-                qCWarning(scriptengine) << "Script Engine has been running too long, throwing:" << getFilename();
                 auto context = currentContext();
                 if (context) {
+                    qCWarning(scriptengine) << "Script Engine has been running too long, throwing:" << getFilename();
                     context->throwError("Timed out during shutdown");
                 }
             }
@@ -450,9 +450,9 @@ void ScriptEngine::waitTillDoneRunning() {
                     qCWarning(scriptengine) << "Script Engine has been running too long, aborting:" << getFilename();
                     abortEvaluation();
                 } else {
-                    qCWarning(scriptengine) << "Script Engine has been running too long, throwing:" << getFilename();
                     auto context = currentContext();
                     if (context) {
+                        qCWarning(scriptengine) << "Script Engine has been running too long, throwing:" << getFilename();
                         context->throwError("Timed out during shutdown");
                     }
                 }

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -422,6 +422,12 @@ void ScriptEngine::waitTillDoneRunning() {
             if (isEvaluating()) {
                 qCWarning(scriptengine) << "Script Engine has been running too long, aborting:" << getFilename();
                 abortEvaluation();
+            } else {
+                qCWarning(scriptengine) << "Script Engine has been running too long, throwing:" << getFilename();
+                auto context = currentContext();
+                if (context) {
+                    context->throwError("Timed out during shutdown");
+                }
             }
 
             // Wait for the scripting thread to stop running, as


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1311

This is a speculative fix which makes mac-specific code in ScriptEngine::waitTillDoneRunning more similar to the non-mac equivalent.