### PR TITLE
BUGZ-1274: Use UTC with QDateTime rather than local time in AccountManager

### DIFF
--- a/libraries/networking/src/AccountManager.cpp
+++ b/libraries/networking/src/AccountManager.cpp
@@ -498,7 +498,8 @@ bool AccountManager::checkAndSignalForAccessToken() {
 
 bool AccountManager::needsToRefreshToken() {
     if (!_accountInfo.getAccessToken().token.isEmpty() && _accountInfo.getAccessToken().expiryTimestamp > 0) {
-        qlonglong expireThreshold = QDateTime::currentDateTime().addSecs(1 * 60 * 60).toMSecsSinceEpoch();
+        static constexpr int MIN_REMAINING_MS = 1 * SECS_PER_HOUR * MSECS_PER_SECOND;  // 1 h
+        auto expireThreshold = QDateTime::currentDateTimeUtc().addMSecs(MIN_REMAINING_MS).toMSecsSinceEpoch();
         return _accountInfo.getAccessToken().expiryTimestamp < expireThreshold;
     } else {
         return false;


### PR DESCRIPTION
Jira: https://highfidelity.atlassian.net/browse/BUGZ-1274

QDateTime's handling of local-timezone values is insane! Just calling addSecs() requires multiple conversions between local time-since-epoch and UTC time-since-epoch, each one going via broken-out (year, month, etc) forms. This simple change is much more efficient, and avoids calling `tzset()` (see ticket).