### PR TITLE
BUGZ-1316: Fix crashes in Assets API

### DIFF
--- a/libraries/script-engine/src/AssetScriptingInterface.cpp
+++ b/libraries/script-engine/src/AssetScriptingInterface.cpp
@@ -127,6 +127,9 @@ void AssetScriptingInterface::setBakingEnabled(QString path, bool enabled, QScri
     auto setBakingEnabledRequest = DependencyManager::get<AssetClient>()->createSetBakingEnabledRequest({ path }, enabled);
 
     Promise deferred = jsPromiseReady(makePromise(__FUNCTION__), thisObject(), callback);
+    if (!deferred) {
+        return;
+    }
 
     connect(setBakingEnabledRequest, &SetBakingEnabledRequest::finished, setBakingEnabledRequest, [deferred](SetBakingEnabledRequest* request) {
         Q_ASSERT(QThread::currentThread() == request->thread());

--- a/libraries/script-engine/src/AssetScriptingInterface.cpp
+++ b/libraries/script-engine/src/AssetScriptingInterface.cpp
@@ -249,8 +249,11 @@ void AssetScriptingInterface::getAsset(QScriptValue options, QScriptValue scope,
               QString("Invalid responseType: '%1' (expected: %2)").arg(responseType).arg(RESPONSE_TYPES.join(" | ")));
 
     Promise fetched = jsPromiseReady(makePromise("fetched"), scope, callback);
-    Promise mapped = makePromise("mapped");
+    if (!fetched) {
+        return;
+    }
 
+    Promise mapped = makePromise("mapped");
     mapped->fail(fetched);
     mapped->then([=](QVariantMap result) {
         QString hash = result.value("hash").toString();


### PR DESCRIPTION
Fixed:
- Crash if callback undefined in Assets.getAsset().
- Crash if callback undefined in Assets.setBakingEnabled().

Case: https://highfidelity.atlassian.net/browse/BUGZ-1316
