### PR TITLE
Additive animation support

### DIFF
--- a/libraries/animation/src/AnimBlendLinear.cpp
+++ b/libraries/animation/src/AnimBlendLinear.cpp
@@ -37,6 +37,19 @@ const AnimPoseVec& AnimBlendLinear::evaluate(const AnimVariantMap& animVars, con
     } else if (_children.size() == 1) {
         _poses = _children[0]->evaluate(animVars, context, dt, triggersOut);
         context.setDebugAlpha(_children[0]->getID(), parentDebugAlpha, _children[0]->getType());
+    } else if (_children.size() == 2 && _blendType != AnimBlendType_Normal) {
+        // special case for additive blending
+        float alpha = glm::clamp(_alpha, 0.0f, 1.0f);
+        const size_t prevPoseIndex = 0;
+        const size_t nextPoseIndex = 1;
+        evaluateAndBlendChildren(animVars, context, triggersOut, alpha, prevPoseIndex, nextPoseIndex, dt);
+
+        // for animation stack debugging
+        float weight2 = alpha;
+        float weight1 = 1.0f - weight2;
+        context.setDebugAlpha(_children[prevPoseIndex]->getID(), weight1 * parentDebugAlpha, _children[prevPoseIndex]->getType());
+        context.setDebugAlpha(_children[nextPoseIndex]->getID(), weight2 * parentDebugAlpha, _children[nextPoseIndex]->getType());
+
     } else {
         float clampedAlpha = glm::clamp(_alpha, 0.0f, (float)(_children.size() - 1));
         size_t prevPoseIndex = glm::floor(clampedAlpha);

--- a/libraries/animation/src/AnimBlendLinear.cpp
+++ b/libraries/animation/src/AnimBlendLinear.cpp
@@ -93,16 +93,14 @@ void AnimBlendLinear::evaluateAndBlendChildren(const AnimVariantMap& animVars, c
                 AnimPoseVec relOffsetPoses;
                 relOffsetPoses.reserve(nextPoses.size());
                 for (size_t i = 0; i < nextPoses.size(); ++i) {
+
                     // copy translation and scale from nextPoses
                     AnimPose pose = nextPoses[i];
 
-                    // AJT: HACK nuke trans
-                    pose.trans() = glm::vec3(0.0f);
-
-                    int parentIndex = _skeleton->getParentIndex(i);
+                    int parentIndex = _skeleton->getParentIndex((int)i);
                     if (parentIndex >= 0) {
                         // but transform nextPoses rot into absPrev parent frame.
-                        pose.rot() = glm::inverse(absPrev[parentIndex].rot()) * nextPoses[i].rot();
+                        pose.rot() = glm::inverse(absPrev[parentIndex].rot()) * pose.rot() * absPrev[parentIndex].rot();
                     }
 
                     relOffsetPoses.push_back(pose);

--- a/libraries/animation/src/AnimBlendLinear.h
+++ b/libraries/animation/src/AnimBlendLinear.h
@@ -27,7 +27,7 @@ class AnimBlendLinear : public AnimNode {
 public:
     friend class AnimTests;
 
-    AnimBlendLinear(const QString& id, float alpha);
+    AnimBlendLinear(const QString& id, float alpha, AnimBlendType blendType);
     virtual ~AnimBlendLinear() override;
 
     virtual const AnimPoseVec& evaluate(const AnimVariantMap& animVars, const AnimContext& context, float dt, AnimVariantMap& triggersOut) override;
@@ -43,6 +43,7 @@ protected:
 
     AnimPoseVec _poses;
 
+    AnimBlendType _blendType;
     float _alpha;
 
     QString _alphaVar;

--- a/libraries/animation/src/AnimBlendLinear.h
+++ b/libraries/animation/src/AnimBlendLinear.h
@@ -43,8 +43,8 @@ protected:
 
     AnimPoseVec _poses;
 
-    AnimBlendType _blendType;
     float _alpha;
+    AnimBlendType _blendType;
 
     QString _alphaVar;
 

--- a/libraries/animation/src/AnimClip.cpp
+++ b/libraries/animation/src/AnimClip.cpp
@@ -16,100 +16,6 @@
 #include "AnimationLogging.h"
 #include "AnimUtil.h"
 
-
-AnimClip::AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag, bool mirrorFlag) :
-    AnimNode(AnimNode::Type::Clip, id),
-    _startFrame(startFrame),
-    _endFrame(endFrame),
-    _timeScale(timeScale),
-    _loopFlag(loopFlag),
-    _mirrorFlag(mirrorFlag),
-    _frame(startFrame)
-{
-    loadURL(url);
-}
-
-AnimClip::~AnimClip() {
-
-}
-
-const AnimPoseVec& AnimClip::evaluate(const AnimVariantMap& animVars, const AnimContext& context, float dt, AnimVariantMap& triggersOut) {
-
-    // lookup parameters from animVars, using current instance variables as defaults.
-    _startFrame = animVars.lookup(_startFrameVar, _startFrame);
-    _endFrame = animVars.lookup(_endFrameVar, _endFrame);
-    _timeScale = animVars.lookup(_timeScaleVar, _timeScale);
-    _loopFlag = animVars.lookup(_loopFlagVar, _loopFlag);
-    _mirrorFlag = animVars.lookup(_mirrorFlagVar, _mirrorFlag);
-    float frame = animVars.lookup(_frameVar, _frame);
-
-    _frame = ::accumulateTime(_startFrame, _endFrame, _timeScale, frame, dt, _loopFlag, _id, triggersOut);
-
-    // poll network anim to see if it's finished loading yet.
-    if (_networkAnim && _networkAnim->isLoaded() && _skeleton) {
-        // loading is complete, copy animation frames from network animation, then throw it away.
-        copyFromNetworkAnim();
-        _networkAnim.reset();
-    }
-
-    if (_anim.size()) {
-
-        // lazy creation of mirrored animation frames.
-        if (_mirrorFlag && _anim.size() != _mirrorAnim.size()) {
-            buildMirrorAnim();
-        }
-
-        int prevIndex = (int)glm::floor(_frame);
-        int nextIndex;
-        if (_loopFlag && _frame >= _endFrame) {
-            nextIndex = (int)glm::ceil(_startFrame);
-        } else {
-            nextIndex = (int)glm::ceil(_frame);
-        }
-
-        // It can be quite possible for the user to set _startFrame and _endFrame to
-        // values before or past valid ranges.  We clamp the frames here.
-        int frameCount = (int)_anim.size();
-        prevIndex = std::min(std::max(0, prevIndex), frameCount - 1);
-        nextIndex = std::min(std::max(0, nextIndex), frameCount - 1);
-
-        const AnimPoseVec& prevFrame = _mirrorFlag ? _mirrorAnim[prevIndex] : _anim[prevIndex];
-        const AnimPoseVec& nextFrame = _mirrorFlag ? _mirrorAnim[nextIndex] : _anim[nextIndex];
-        float alpha = glm::fract(_frame);
-
-        ::blend(_poses.size(), &prevFrame[0], &nextFrame[0], alpha, &_poses[0]);
-    }
-
-    processOutputJoints(triggersOut);
-
-    return _poses;
-}
-
-void AnimClip::loadURL(const QString& url) {
-    auto animCache = DependencyManager::get<AnimationCache>();
-    _networkAnim = animCache->getAnimation(url);
-    _url = url;
-}
-
-void AnimClip::setCurrentFrameInternal(float frame) {
-    // because dt is 0, we should not encounter any triggers
-    const float dt = 0.0f;
-    AnimVariantMap triggers;
-    _frame = ::accumulateTime(_startFrame, _endFrame, _timeScale, frame + _startFrame, dt, _loopFlag, _id, triggers);
-}
-
-static std::vector<int> buildJointIndexMap(const AnimSkeleton& dstSkeleton, const AnimSkeleton& srcSkeleton) {
-    std::vector<int> jointIndexMap;
-    int srcJointCount = srcSkeleton.getNumJoints();
-    jointIndexMap.reserve(srcJointCount);
-    for (int srcJointIndex = 0; srcJointIndex < srcJointCount; srcJointIndex++) {
-        QString srcJointName = srcSkeleton.getJointName(srcJointIndex);
-        int dstJointIndex = dstSkeleton.nameToJointIndex(srcJointName);
-        jointIndexMap.push_back(dstJointIndex);
-    }
-    return jointIndexMap;
-}
-
 #ifdef USE_CUSTOM_ASSERT
 #undef ASSERT
 #define ASSERT(x)                     \
@@ -123,12 +29,44 @@ static std::vector<int> buildJointIndexMap(const AnimSkeleton& dstSkeleton, cons
 #define ASSERT assert
 #endif
 
-void AnimClip::copyFromNetworkAnim() {
-    assert(_networkAnim && _networkAnim->isLoaded() && _skeleton);
-    _anim.clear();
+static std::vector<int> buildJointIndexMap(const AnimSkeleton& dstSkeleton, const AnimSkeleton& srcSkeleton) {
+    std::vector<int> jointIndexMap;
+    int srcJointCount = srcSkeleton.getNumJoints();
+    jointIndexMap.reserve(srcJointCount);
+    for (int srcJointIndex = 0; srcJointIndex < srcJointCount; srcJointIndex++) {
+        QString srcJointName = srcSkeleton.getJointName(srcJointIndex);
+        int dstJointIndex = dstSkeleton.nameToJointIndex(srcJointName);
+        jointIndexMap.push_back(dstJointIndex);
+    }
+    return jointIndexMap;
+}
 
-    auto avatarSkeleton = getSkeleton();
-    const HFMModel& animModel = _networkAnim->getHFMModel();
+static void bakeRelativeAnim(std::vector<AnimPoseVec>& anim, const AnimPoseVec& basePoses) {
+
+    // invert all the basePoses
+    AnimPoseVec invBasePoses = basePoses;
+    for (auto&& invBasePose : invBasePoses) {
+        invBasePose = invBasePose.inverse();
+    }
+
+    // for each frame of the animation
+    for (auto&& animPoses : anim) {
+        ASSERT(animPoses.size() == basePoses.size());
+
+        // for each joint in animPoses
+        for (size_t i = 0; i < animPoses.size(); ++i) {
+
+            // convert this AnimPose into a relative animation.
+            animPoses[i] = animPoses[i] * invBasePoses[i];
+        }
+    }
+}
+
+static std::vector<AnimPoseVec> copyAndRetargetFromNetworkAnim(AnimationPointer networkAnim, AnimSkeleton::ConstPointer avatarSkeleton) {
+    ASSERT(networkAnim && networkAnim->isLoaded() && avatarSkeleton);
+    std::vector<AnimPoseVec> anim;
+
+    const HFMModel& animModel = networkAnim->getHFMModel();
     AnimSkeleton animSkeleton(animModel);
     const int animJointCount = animSkeleton.getNumJoints();
     const int avatarJointCount = avatarSkeleton->getNumJoints();
@@ -137,7 +75,7 @@ void AnimClip::copyFromNetworkAnim() {
     std::vector<int> avatarToAnimJointIndexMap = buildJointIndexMap(animSkeleton, *avatarSkeleton);
 
     const int animFrameCount = animModel.animationFrames.size();
-    _anim.resize(animFrameCount);
+    anim.resize(animFrameCount);
 
     // find the size scale factor for translation in the animation.
     float boneLengthScale = 1.0f;
@@ -223,8 +161,8 @@ void AnimClip::copyFromNetworkAnim() {
         // convert avatar rotations into relative frame
         avatarSkeleton->convertAbsoluteRotationsToRelative(avatarRotations);
 
-        ASSERT(frame >= 0 && frame < (int)_anim.size());
-        _anim[frame].reserve(avatarJointCount);
+        ASSERT(frame >= 0 && frame < (int)anim.size());
+        anim[frame].reserve(avatarJointCount);
         for (int avatarJointIndex = 0; avatarJointIndex < avatarJointCount; avatarJointIndex++) {
             const AnimPose& avatarDefaultPose = avatarSkeleton->getRelativeDefaultPose(avatarJointIndex);
 
@@ -251,14 +189,123 @@ void AnimClip::copyFromNetworkAnim() {
 
             // build the final pose
             ASSERT(avatarJointIndex >= 0 && avatarJointIndex < (int)avatarRotations.size());
-            _anim[frame].push_back(AnimPose(relativeScale, avatarRotations[avatarJointIndex], relativeTranslation));
+            anim[frame].push_back(AnimPose(relativeScale, avatarRotations[avatarJointIndex], relativeTranslation));
         }
     }
 
-    // mirrorAnim will be re-built on demand, if needed.
-    _mirrorAnim.clear();
+    return anim;
+}
 
-    _poses.resize(avatarJointCount);
+AnimClip::AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag, bool mirrorFlag,
+                   bool isRelative, const QString& baseURL, float baseFrame) :
+    AnimNode(AnimNode::Type::Clip, id),
+    _startFrame(startFrame),
+    _endFrame(endFrame),
+    _timeScale(timeScale),
+    _loopFlag(loopFlag),
+    _mirrorFlag(mirrorFlag),
+    _frame(startFrame),
+    _isRelative(isRelative),
+    _baseFrame(baseFrame)
+{
+    loadURL(url);
+
+    if (isRelative) {
+        auto animCache = DependencyManager::get<AnimationCache>();
+        _baseNetworkAnim = animCache->getAnimation(baseURL);
+        _baseURL = baseURL;
+    }
+}
+
+AnimClip::~AnimClip() {
+
+}
+
+const AnimPoseVec& AnimClip::evaluate(const AnimVariantMap& animVars, const AnimContext& context, float dt, AnimVariantMap& triggersOut) {
+
+    // lookup parameters from animVars, using current instance variables as defaults.
+    _startFrame = animVars.lookup(_startFrameVar, _startFrame);
+    _endFrame = animVars.lookup(_endFrameVar, _endFrame);
+    _timeScale = animVars.lookup(_timeScaleVar, _timeScale);
+    _loopFlag = animVars.lookup(_loopFlagVar, _loopFlag);
+    _mirrorFlag = animVars.lookup(_mirrorFlagVar, _mirrorFlag);
+    float frame = animVars.lookup(_frameVar, _frame);
+
+    _frame = ::accumulateTime(_startFrame, _endFrame, _timeScale, frame, dt, _loopFlag, _id, triggersOut);
+
+    // poll network anim to see if it's finished loading yet.
+    if (_isRelative) {
+        if (_networkAnim && _networkAnim->isLoaded() && _skeleton) {
+            // loading is complete, copy & retarget animation.
+            _anim = copyAndRetargetFromNetworkAnim(_networkAnim, _skeleton);
+
+            // we no longer need the actual animation resource anymore.
+            _networkAnim.reset();
+
+            // mirrorAnim will be re-built on demand, if needed.
+            _mirrorAnim.clear();
+
+            _poses.resize(_skeleton->getNumJoints());
+        }
+    } else {
+        if (_networkAnim && _networkAnim->isLoaded() && _baseNetworkAnim && _baseNetworkAnim->isLoaded() && _skeleton) {
+            // loading is complete, copy & retarget animation.
+            _anim = copyAndRetargetFromNetworkAnim(_networkAnim, _skeleton);
+
+            // we no longer need the actual animation resource anymore.
+            _networkAnim.reset();
+
+            // mirrorAnim will be re-built on demand, if needed.
+            _mirrorAnim.clear();
+
+            _poses.resize(_skeleton->getNumJoints());
+
+            // copy & retarget baseAnim!
+            auto baseAnim = copyAndRetargetFromNetworkAnim(_baseNetworkAnim, _skeleton);
+
+            // make _anim relative to the baseAnim reference frame.
+            bakeRelativeAnim(_anim, baseAnim[(int)_baseFrame]);
+        }
+    }
+
+    if (_anim.size()) {
+
+        // lazy creation of mirrored animation frames.
+        if (_mirrorFlag && _anim.size() != _mirrorAnim.size()) {
+            buildMirrorAnim();
+        }
+
+        int prevIndex = (int)glm::floor(_frame);
+        int nextIndex;
+        if (_loopFlag && _frame >= _endFrame) {
+            nextIndex = (int)glm::ceil(_startFrame);
+        } else {
+            nextIndex = (int)glm::ceil(_frame);
+        }
+
+        // It can be quite possible for the user to set _startFrame and _endFrame to
+        // values before or past valid ranges.  We clamp the frames here.
+        int frameCount = (int)_anim.size();
+        prevIndex = std::min(std::max(0, prevIndex), frameCount - 1);
+        nextIndex = std::min(std::max(0, nextIndex), frameCount - 1);
+
+        const AnimPoseVec& prevFrame = _mirrorFlag ? _mirrorAnim[prevIndex] : _anim[prevIndex];
+        const AnimPoseVec& nextFrame = _mirrorFlag ? _mirrorAnim[nextIndex] : _anim[nextIndex];
+        float alpha = glm::fract(_frame);
+
+        ::blend(_poses.size(), &prevFrame[0], &nextFrame[0], alpha, &_poses[0]);
+    }
+
+    processOutputJoints(triggersOut);
+
+    return _poses;
+}
+
+void AnimClip::setCurrentFrameInternal(float frame) {
+    // because dt is 0, we should not encounter any triggers
+    const float dt = 0.0f;
+    AnimVariantMap triggers;
+    _frame = ::accumulateTime(_startFrame, _endFrame, _timeScale, frame + _startFrame, dt, _loopFlag, _id, triggers);
 }
 
 void AnimClip::buildMirrorAnim() {
@@ -274,4 +321,10 @@ void AnimClip::buildMirrorAnim() {
 
 const AnimPoseVec& AnimClip::getPosesInternal() const {
     return _poses;
+}
+
+void AnimClip::loadURL(const QString& url) {
+    auto animCache = DependencyManager::get<AnimationCache>();
+    _networkAnim = animCache->getAnimation(url);
+    _url = url;
 }

--- a/libraries/animation/src/AnimClip.h
+++ b/libraries/animation/src/AnimClip.h
@@ -25,7 +25,8 @@ class AnimClip : public AnimNode {
 public:
     friend class AnimTests;
 
-    AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag, bool mirrorFlag);
+    AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag, bool mirrorFlag,
+             bool isRelative, const QString& baseURL, float baseFrame);
     virtual ~AnimClip() override;
 
     virtual const AnimPoseVec& evaluate(const AnimVariantMap& animVars, const AnimContext& context, float dt, AnimVariantMap& triggersOut) override;
@@ -52,19 +53,20 @@ public:
     void setMirrorFlag(bool mirrorFlag) { _mirrorFlag = mirrorFlag; }
 
     float getFrame() const { return _frame; }
-
     void loadURL(const QString& url);
+
 protected:
 
     virtual void setCurrentFrameInternal(float frame) override;
 
-    void copyFromNetworkAnim();
     void buildMirrorAnim();
 
     // for AnimDebugDraw rendering
     virtual const AnimPoseVec& getPosesInternal() const override;
 
     AnimationPointer _networkAnim;
+    AnimationPointer _baseNetworkAnim;
+
     AnimPoseVec _poses;
 
     // _anim[frame][joint]
@@ -78,6 +80,9 @@ protected:
     bool _loopFlag;
     bool _mirrorFlag;
     float _frame;
+    bool _isRelative;
+    QString _baseURL;
+    float _baseFrame;
 
     QString _startFrameVar;
     QString _endFrameVar;

--- a/libraries/animation/src/AnimClip.h
+++ b/libraries/animation/src/AnimClip.h
@@ -26,7 +26,7 @@ public:
     friend class AnimTests;
 
     AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag, bool mirrorFlag,
-             bool isRelative, const QString& baseURL, float baseFrame);
+             bool relativeFlag, const QString& baseURL, float baseFrame);
     virtual ~AnimClip() override;
 
     virtual const AnimPoseVec& evaluate(const AnimVariantMap& animVars, const AnimContext& context, float dt, AnimVariantMap& triggersOut) override;
@@ -80,7 +80,7 @@ protected:
     bool _loopFlag;
     bool _mirrorFlag;
     float _frame;
-    bool _isRelative;
+    bool _relativeFlag;
     QString _baseURL;
     float _baseFrame;
 

--- a/libraries/animation/src/AnimClip.h
+++ b/libraries/animation/src/AnimClip.h
@@ -26,7 +26,7 @@ public:
     friend class AnimTests;
 
     AnimClip(const QString& id, const QString& url, float startFrame, float endFrame, float timeScale, bool loopFlag, bool mirrorFlag,
-             bool relativeFlag, const QString& baseURL, float baseFrame);
+             AnimBlendType blendType, const QString& baseURL, float baseFrame);
     virtual ~AnimClip() override;
 
     virtual const AnimPoseVec& evaluate(const AnimVariantMap& animVars, const AnimContext& context, float dt, AnimVariantMap& triggersOut) override;
@@ -80,7 +80,7 @@ protected:
     bool _loopFlag;
     bool _mirrorFlag;
     float _frame;
-    bool _relativeFlag;
+    AnimBlendType _blendType;
     QString _baseURL;
     float _baseFrame;
 

--- a/libraries/animation/src/AnimContext.h
+++ b/libraries/animation/src/AnimContext.h
@@ -34,6 +34,13 @@ enum class AnimNodeType {
     NumTypes
 };
 
+enum AnimBlendType {
+    AnimBlendType_Normal,
+    AnimBlendType_AddRelative,
+    AnimBlendType_AddAbsolute,
+    AnimBlendType_NumTypes
+};
+
 class AnimContext {
 public:
     AnimContext() {}

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -374,7 +374,7 @@ static AnimNode::Pointer loadClipNode(const QJsonObject& jsonObj, const QString&
     READ_FLOAT(timeScale, jsonObj, id, jsonUrl, nullptr);
     READ_BOOL(loopFlag, jsonObj, id, jsonUrl, nullptr);
     READ_OPTIONAL_BOOL(mirrorFlag, jsonObj, false);
-    READ_OPTIONAL_BOOL(isRelative, jsonObj, false);
+    READ_OPTIONAL_BOOL(relativeFlag, jsonObj, false);
     READ_OPTIONAL_STRING(baseURL, jsonObj);
     READ_OPTIONAL_FLOAT(baseFrame, jsonObj, 0.0f);
 
@@ -389,7 +389,7 @@ static AnimNode::Pointer loadClipNode(const QJsonObject& jsonObj, const QString&
     auto tempUrl = QUrl(url);
     tempUrl = jsonUrl.resolved(tempUrl);
 
-    auto node = std::make_shared<AnimClip>(id, tempUrl.toString(), startFrame, endFrame, timeScale, loopFlag, mirrorFlag, isRelative, baseURL, baseFrame);
+    auto node = std::make_shared<AnimClip>(id, tempUrl.toString(), startFrame, endFrame, timeScale, loopFlag, mirrorFlag, relativeFlag, baseURL, baseFrame);
 
     if (!startFrameVar.isEmpty()) {
         node->setStartFrameVar(startFrameVar);

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -374,6 +374,9 @@ static AnimNode::Pointer loadClipNode(const QJsonObject& jsonObj, const QString&
     READ_FLOAT(timeScale, jsonObj, id, jsonUrl, nullptr);
     READ_BOOL(loopFlag, jsonObj, id, jsonUrl, nullptr);
     READ_OPTIONAL_BOOL(mirrorFlag, jsonObj, false);
+    READ_OPTIONAL_BOOL(isRelative, jsonObj, false);
+    READ_OPTIONAL_STRING(baseURL, jsonObj);
+    READ_OPTIONAL_FLOAT(baseFrame, jsonObj, 0.0f);
 
     READ_OPTIONAL_STRING(startFrameVar, jsonObj);
     READ_OPTIONAL_STRING(endFrameVar, jsonObj);
@@ -381,11 +384,12 @@ static AnimNode::Pointer loadClipNode(const QJsonObject& jsonObj, const QString&
     READ_OPTIONAL_STRING(loopFlagVar, jsonObj);
     READ_OPTIONAL_STRING(mirrorFlagVar, jsonObj);
 
+
     // animation urls can be relative to the containing url document.
     auto tempUrl = QUrl(url);
     tempUrl = jsonUrl.resolved(tempUrl);
 
-    auto node = std::make_shared<AnimClip>(id, tempUrl.toString(), startFrame, endFrame, timeScale, loopFlag, mirrorFlag);
+    auto node = std::make_shared<AnimClip>(id, tempUrl.toString(), startFrame, endFrame, timeScale, loopFlag, mirrorFlag, isRelative, baseURL, baseFrame);
 
     if (!startFrameVar.isEmpty()) {
         node->setStartFrameVar(startFrameVar);

--- a/libraries/animation/src/AnimNodeLoader.cpp
+++ b/libraries/animation/src/AnimNodeLoader.cpp
@@ -387,7 +387,7 @@ static AnimNode::Pointer loadClipNode(const QJsonObject& jsonObj, const QString&
     READ_FLOAT(timeScale, jsonObj, id, jsonUrl, nullptr);
     READ_BOOL(loopFlag, jsonObj, id, jsonUrl, nullptr);
     READ_OPTIONAL_BOOL(mirrorFlag, jsonObj, false);
-    READ_OPTIONAL_BOOL(relativeFlag, jsonObj, false);
+    READ_OPTIONAL_STRING(blendType, jsonObj);
     READ_OPTIONAL_STRING(baseURL, jsonObj);
     READ_OPTIONAL_FLOAT(baseFrame, jsonObj, 0.0f);
 
@@ -402,7 +402,17 @@ static AnimNode::Pointer loadClipNode(const QJsonObject& jsonObj, const QString&
     auto tempUrl = QUrl(url);
     tempUrl = jsonUrl.resolved(tempUrl);
 
-    auto node = std::make_shared<AnimClip>(id, tempUrl.toString(), startFrame, endFrame, timeScale, loopFlag, mirrorFlag, relativeFlag, baseURL, baseFrame);
+    // AJT:
+    AnimBlendType blendTypeEnum = AnimBlendType_Normal;  // default value
+    if (!blendType.isEmpty()) {
+        blendTypeEnum = stringToAnimBlendType(blendType);
+        if (blendTypeEnum == AnimBlendType_NumTypes) {
+            qCCritical(animation) << "AnimNodeLoader, bad blendType on clip, id = " << id;
+            return nullptr;
+        }
+    }
+
+    auto node = std::make_shared<AnimClip>(id, tempUrl.toString(), startFrame, endFrame, timeScale, loopFlag, mirrorFlag, blendTypeEnum, baseURL, baseFrame);
 
     if (!startFrameVar.isEmpty()) {
         node->setStartFrameVar(startFrameVar);

--- a/libraries/animation/src/AnimUtil.cpp
+++ b/libraries/animation/src/AnimUtil.cpp
@@ -15,7 +15,6 @@
 
 // TODO: use restrict keyword
 // TODO: excellent candidate for simd vectorization.
-
 void blend(size_t numPoses, const AnimPose* a, const AnimPose* b, float alpha, AnimPose* result) {
     for (size_t i = 0; i < numPoses; i++) {
         const AnimPose& aPose = a[i];
@@ -24,6 +23,26 @@ void blend(size_t numPoses, const AnimPose* a, const AnimPose* b, float alpha, A
         result[i].scale() = lerp(aPose.scale(), bPose.scale(), alpha);
         result[i].rot() = safeLerp(aPose.rot(), bPose.rot(), alpha);
         result[i].trans() = lerp(aPose.trans(), bPose.trans(), alpha);
+    }
+}
+
+// additive blend
+void blendAdd(size_t numPoses, const AnimPose* a, const AnimPose* b, float alpha, AnimPose* result) {
+    for (size_t i = 0; i < numPoses; i++) {
+        const AnimPose& aPose = a[i];
+        const AnimPose& bPose = b[i];
+
+        result[i].scale() = lerp(aPose.scale(), bPose.scale(), alpha);
+
+        // adjust sign of bPose.rot() if necessary
+        glm::quat bTemp = bPose.rot();
+        float dot = glm::dot(aPose.rot(), bTemp);
+        if (dot < 0.0f) {
+            bTemp = -bTemp;
+        }
+        result[i].rot() = glm::normalize((alpha * bTemp) * aPose.rot());
+
+        result[i].trans() = aPose.trans() + (alpha * bPose.trans());
     }
 }
 

--- a/libraries/animation/src/AnimUtil.h
+++ b/libraries/animation/src/AnimUtil.h
@@ -16,6 +16,9 @@
 // this is where the magic happens
 void blend(size_t numPoses, const AnimPose* a, const AnimPose* b, float alpha, AnimPose* result);
 
+// additive blending
+void blendAdd(size_t numPoses, const AnimPose* a, const AnimPose* b, float alpha, AnimPose* result);
+
 glm::quat averageQuats(size_t numQuats, const glm::quat* quats);
 
 float accumulateTime(float startFrame, float endFrame, float timeScale, float currentFrame, float dt, bool loopFlag,

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -564,7 +564,7 @@ void Rig::overrideRoleAnimation(const QString& role, const QString& url, float f
             _origRoleAnimations[role] = node;
             const float REFERENCE_FRAMES_PER_SECOND = 30.0f;
             float timeScale = fps / REFERENCE_FRAMES_PER_SECOND;
-            auto clipNode = std::make_shared<AnimClip>(role, url, firstFrame, lastFrame, timeScale, loop, false, false, "", 0.0f);
+            auto clipNode = std::make_shared<AnimClip>(role, url, firstFrame, lastFrame, timeScale, loop, false, AnimBlendType_Normal, "", 0.0f);
             _roleAnimStates[role] = { role, url, fps, loop, firstFrame, lastFrame };
             AnimNode::Pointer parent = node->getParent();
             parent->replaceChild(node, clipNode);

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -564,7 +564,7 @@ void Rig::overrideRoleAnimation(const QString& role, const QString& url, float f
             _origRoleAnimations[role] = node;
             const float REFERENCE_FRAMES_PER_SECOND = 30.0f;
             float timeScale = fps / REFERENCE_FRAMES_PER_SECOND;
-            auto clipNode = std::make_shared<AnimClip>(role, url, firstFrame, lastFrame, timeScale, loop, false);
+            auto clipNode = std::make_shared<AnimClip>(role, url, firstFrame, lastFrame, timeScale, loop, false, false, "", 0.0f);
             _roleAnimStates[role] = { role, url, fps, loop, firstFrame, lastFrame };
             AnimNode::Pointer parent = node->getParent();
             parent->replaceChild(node, clipNode);


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-270

Additive blending is a technique for combining two or more animations together in a seamless way. For example: a looking to the right animation can be combined with a walking animation, resulting in walking while looking to the right.  We support two types of additive blending, relative and absolute.
Which correspond to the local space and mesh space blending supported by the [Unreal engine](https://wiki.unrealengine.com/Additive_Mesh_Space)

Three new fields have been added to AnimClip nodes.
* blendType - (Normal, AddRelative, AddAbsolute)
* baseUrl - An animation that forms the reference frame for the additive animation.
* baseFrame - The specific frame in the base animation to serve as the reference frame.

Also, a new blendType field has been added to AnimBlendLinear nodes.  This can be used to additive blend a regular animation with an offset animation (from a AnimClip node).

This [script](https://gist.githubusercontent.com/hyperlogic/e8857e0d172b29de1622ac56b0a27767/raw/7f5c6201ebefab084af3299e79e72d03057e633a/additive-blend-test.js) can be used to test the additive blending feature. The following keys can be used to test the blending:
* The COMMA and PERIOD keys can be used to ramp on and off the aim offset.
* The SQUARE BRACKET keys can be used to adjust the aim offset to look left and right.
