### PR TITLE
BUGZ-1365: prevent server scripts from accessing local files in HTML controls

### DIFF
--- a/interface/resources/qml/hifi/tablet/DynamicWebview.qml
+++ b/interface/resources/qml/hifi/tablet/DynamicWebview.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.0
+import "../../controls" as Controls
+
+Controls.WebView {
+    id: root
+    function fromScript(message) {
+        root.url = message.url;
+    }
+}
+
+

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -7507,7 +7507,11 @@ void Application::registerScriptEngineWithApplicationServices(const ScriptEngine
     if (clientScript) {
         scriptEngine->registerGlobalObject("Desktop", DependencyManager::get<DesktopScriptingInterface>().data());
     } else {
-        scriptEngine->registerGlobalObject("Desktop", new DesktopScriptingInterface(scriptEngine.get(), true));
+        auto desktopScriptingInterface = new DesktopScriptingInterface(nullptr, true);
+        scriptEngine->registerGlobalObject("Desktop", desktopScriptingInterface);
+        if (QThread::currentThread() != thread()) {
+            desktopScriptingInterface->moveToThread(thread());
+        }
     }
 #endif
 

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -252,7 +252,7 @@ public:
     NodeToOctreeSceneStats* getOcteeSceneStats() { return &_octreeServerSceneStats; }
 
     virtual controller::ScriptingInterface* getControllerScriptingInterface() { return _controllerScriptingInterface; }
-    virtual void registerScriptEngineWithApplicationServices(ScriptEnginePointer scriptEngine) override;
+    virtual void registerScriptEngineWithApplicationServices(const ScriptEnginePointer& scriptEngine) override;
 
     virtual void copyCurrentViewFrustum(ViewFrustum& viewOut) const override { copyDisplayViewFrustum(viewOut); }
     virtual QThread* getMainThread() override { return thread(); }

--- a/interface/src/scripting/DesktopScriptingInterface.cpp
+++ b/interface/src/scripting/DesktopScriptingInterface.cpp
@@ -52,6 +52,9 @@ static const QVariantMap DOCK_AREA {
     { "RIGHT", DockArea::RIGHT }
 };
 
+DesktopScriptingInterface::DesktopScriptingInterface(QObject* parent, bool restricted) 
+    : QObject(parent), _restricted(restricted) { }
+
 int DesktopScriptingInterface::getWidth() {
     QSize size = qApp->getWindow()->windowHandle()->screen()->virtualSize();
     return size.width();
@@ -128,7 +131,7 @@ InteractiveWindowPointer DesktopScriptingInterface::createWindow(const QString& 
         return nullptr;
     }
 
-    return new InteractiveWindow(sourceUrl, properties);
+    return new InteractiveWindow(sourceUrl, properties, _restricted);
 }
 
 InteractiveWindowPointer DesktopScriptingInterface::createWindowOnThread(const QString& sourceUrl, const QVariantMap& properties, QThread* targetThread) {
@@ -139,7 +142,7 @@ InteractiveWindowPointer DesktopScriptingInterface::createWindowOnThread(const Q
     if (!urlValidator(sourceUrl)) {
         return nullptr;
     }
-    InteractiveWindowPointer window = new InteractiveWindow(sourceUrl, properties);
+    InteractiveWindowPointer window = new InteractiveWindow(sourceUrl, properties, _restricted);
     window->moveToThread(targetThread);
     return window;
 }

--- a/interface/src/scripting/DesktopScriptingInterface.h
+++ b/interface/src/scripting/DesktopScriptingInterface.h
@@ -54,6 +54,8 @@ class DesktopScriptingInterface : public QObject, public Dependency {
     Q_PROPERTY(int CLOSE_BUTTON_HIDES READ flagCloseButtonHides CONSTANT FINAL)
 
 public:
+    DesktopScriptingInterface(QObject* parent= nullptr, bool restricted = false);
+
     /**jsdoc
      * Sets the opacity of the HUD surface.
      * @function Desktop.setHUDAlpha
@@ -106,6 +108,7 @@ private:
     static QVariantMap getDockArea();
 
     Q_INVOKABLE static QVariantMap getPresentationMode();
+    const bool _restricted;
 };
 
 

--- a/interface/src/ui/InteractiveWindow.cpp
+++ b/interface/src/ui/InteractiveWindow.cpp
@@ -19,6 +19,8 @@
 #include <QQuickView>
 
 #include <ui/types/ContextAwareProfile.h>
+#include <ui/types/HFWebEngineProfile.h>
+#include <ui/types/FileTypeProfile.h>
 #include <DependencyManager.h>
 #include <DockWidget.h>
 #include <RegisteredMetaTypes.h>
@@ -135,7 +137,7 @@ void InteractiveWindow::emitMainWindowResizeEvent() {
  *     Set at window creation. Possible flag values are provided as {@link Desktop|Desktop.ALWAYS_ON_TOP} and {@link Desktop|Desktop.CLOSE_BUTTON_HIDES}.
  *     Additional flag values can be found on Qt's website at https://doc.qt.io/qt-5/qt.html#WindowType-enum.
  */
-InteractiveWindow::InteractiveWindow(const QString& sourceUrl, const QVariantMap& properties) {
+InteractiveWindow::InteractiveWindow(const QString& sourceUrl, const QVariantMap& properties, bool restricted) {
     InteractiveWindowPresentationMode presentationMode = InteractiveWindowPresentationMode::Native;
 
     if (properties.contains(PRESENTATION_MODE_PROPERTY)) {
@@ -230,11 +232,10 @@ InteractiveWindow::InteractiveWindow(const QString& sourceUrl, const QVariantMap
         mainWindow->addDockWidget(dockArea, _dockWidget.get());
     } else {
         auto contextInitLambda = [&](QQmlContext* context) {
-#if !defined(Q_OS_ANDROID)
-            // If the restricted flag is on, override the FileTypeProfile and HFWebEngineProfile objects in the 
-            // QML surface root context with local ones
-            ContextAwareProfile::restrictContext(context, false);
-#endif
+            // If the restricted flag is on, the web content will not be able to access local files
+            ContextAwareProfile::restrictContext(context, restricted);
+            FileTypeProfile::registerWithContext(context);
+            HFWebEngineProfile::registerWithContext(context);
         };
 
         auto objectInitLambda = [&](QQmlContext* context, QObject* object) {

--- a/interface/src/ui/InteractiveWindow.cpp
+++ b/interface/src/ui/InteractiveWindow.cpp
@@ -234,8 +234,10 @@ InteractiveWindow::InteractiveWindow(const QString& sourceUrl, const QVariantMap
         auto contextInitLambda = [&](QQmlContext* context) {
             // If the restricted flag is on, the web content will not be able to access local files
             ContextAwareProfile::restrictContext(context, restricted);
+#if !defined(Q_OS_ANDROID)
             FileTypeProfile::registerWithContext(context);
             HFWebEngineProfile::registerWithContext(context);
+#endif
         };
 
         auto objectInitLambda = [&](QQmlContext* context, QObject* object) {

--- a/interface/src/ui/InteractiveWindow.h
+++ b/interface/src/ui/InteractiveWindow.h
@@ -126,7 +126,7 @@ class InteractiveWindow : public QObject {
     Q_PROPERTY(int presentationMode READ getPresentationMode WRITE setPresentationMode)
 
 public:
-    InteractiveWindow(const QString& sourceUrl, const QVariantMap& properties);
+    InteractiveWindow(const QString& sourceUrl, const QVariantMap& properties, bool restricted);
     ~InteractiveWindow();
 
 private:

--- a/libraries/script-engine/src/AbstractScriptingServicesInterface.h
+++ b/libraries/script-engine/src/AbstractScriptingServicesInterface.h
@@ -18,7 +18,7 @@
 class AbstractScriptingServicesInterface {
 public:
     /// Registers application specific services with a script engine.
-    virtual void registerScriptEngineWithApplicationServices(ScriptEnginePointer scriptEngine) = 0;
+    virtual void registerScriptEngineWithApplicationServices(const ScriptEnginePointer& scriptEngine) = 0;
 };
 
 

--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -137,10 +137,8 @@ void QmlWindowClass::initQml(QVariantMap properties) {
         // If the restricted flag is on, override the FileTypeProfile and HFWebEngineProfile objects in the 
         // QML surface root context with local ones
         ContextAwareProfile::restrictContext(context, _restricted);
-        if (_restricted) {
-            FileTypeProfile::registerWithContext(context);
-            HFWebEngineProfile::registerWithContext(context);
-        }
+        FileTypeProfile::registerWithContext(context);
+        HFWebEngineProfile::registerWithContext(context);
 #endif
     };
 

--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -136,10 +136,8 @@ void QmlWindowClass::initQml(QVariantMap properties) {
 #if !defined(Q_OS_ANDROID)
         // If the restricted flag is on, override the FileTypeProfile and HFWebEngineProfile objects in the 
         // QML surface root context with local ones
-        qDebug() << "Context initialization lambda";
+        ContextAwareProfile::restrictContext(context, _restricted);
         if (_restricted) {
-            qDebug() << "Restricting web content";
-            ContextAwareProfile::restrictContext(context);
             FileTypeProfile::registerWithContext(context);
             HFWebEngineProfile::registerWithContext(context);
         }

--- a/libraries/ui/src/ui/types/ContextAwareProfile.cpp
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.cpp
@@ -21,7 +21,7 @@
 static const QString RESTRICTED_FLAG_PROPERTY = "RestrictFileAccess";
 
 ContextAwareProfile::ContextAwareProfile(QQmlContext* context) :
-    QQuickWebEngineProfile(context), _context(context) { 
+    ContextAwareProfileParent(context), _context(context) { 
     assert(context);
 }
 

--- a/libraries/ui/src/ui/types/ContextAwareProfile.cpp
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.cpp
@@ -36,7 +36,15 @@ bool ContextAwareProfile::isRestrictedInternal() {
         BLOCKING_INVOKE_METHOD(this, "isRestrictedInternal", Q_RETURN_ARG(bool, restrictedResult));
         return restrictedResult;
     }
-    return _context->contextProperty(RESTRICTED_FLAG_PROPERTY).toBool();
+
+    QVariant variant = _context->contextProperty(RESTRICTED_FLAG_PROPERTY);
+    if (variant.isValid()) {
+        return variant.toBool();
+    }
+
+    // BUGZ-1365 - we MUST defalut to restricted mode in the absence of a flag, or it's too easy for someone to make 
+    // a new mechanism for loading web content that fails to restrict access to local files
+    return true;
 }
 
 bool ContextAwareProfile::isRestricted() {

--- a/libraries/ui/src/ui/types/ContextAwareProfile.cpp
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.cpp
@@ -10,19 +10,20 @@
 //
 
 #include "ContextAwareProfile.h"
-#if !defined(Q_OS_ANDROID)
 
+#include <cassert>
 #include <QtCore/QThread>
 #include <QtQml/QQmlContext>
 
 #include <shared/QtHelpers.h>
 #include <SharedUtil.h>
 
-
 static const QString RESTRICTED_FLAG_PROPERTY = "RestrictFileAccess";
 
 ContextAwareProfile::ContextAwareProfile(QQmlContext* context) :
-    QQuickWebEngineProfile(context), _context(context) { }
+    QQuickWebEngineProfile(context), _context(context) { 
+    assert(context);
+}
 
 
 void ContextAwareProfile::restrictContext(QQmlContext* context, bool restrict) {
@@ -40,12 +41,9 @@ bool ContextAwareProfile::isRestrictedInternal() {
 
 bool ContextAwareProfile::isRestricted() {
     auto now = usecTimestampNow();
-    auto cacheAge = now - _lastCacheCheck;
-    if (cacheAge > MAX_CACHE_AGE) {
+    if (now > _cacheExpiry) {
         _cachedValue = isRestrictedInternal();
-        _lastCacheCheck = now;
+        _cacheExpiry = now + MAX_CACHE_AGE;
     }
     return _cachedValue;
 }
-
-#endif

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -20,16 +20,16 @@
 class QQmlContext;
 
 class ContextAwareProfile : public QQuickWebEngineProfile {
+    Q_OBJECT
 public:
-    static void restrictContext(QQmlContext* context);
-    static bool isRestricted(QQmlContext* context);
-    QQmlContext* getContext() const { return _context; }
+    static void restrictContext(QQmlContext* context, bool restrict = true);
+    Q_INVOKABLE bool isRestricted();
 protected:
 
     class RequestInterceptor : public QWebEngineUrlRequestInterceptor {
     public:
         RequestInterceptor(ContextAwareProfile* parent) : QWebEngineUrlRequestInterceptor(parent), _profile(parent) {}
-        QQmlContext* getContext() const { return _profile->getContext(); }
+        bool isRestricted() { return _profile->isRestricted(); }
     protected:
         ContextAwareProfile* _profile;
     };

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -16,11 +16,21 @@
 #if !defined(Q_OS_ANDROID)
 #include <QtWebEngine/QQuickWebEngineProfile>
 #include <QtWebEngineCore/QWebEngineUrlRequestInterceptor>
+
+using ContextAwareProfileParent = QQuickWebEngineProfile;
+using RequestInterceptorParent = QWebEngineUrlRequestInterceptor;
+#else
+#include <QtCore/QObject>
+
+using ContextAwareProfileParent = QObject;
+using RequestInterceptorParent = QObject;
+#endif
+
 #include <NumericalConstants.h>
 
 class QQmlContext;
 
-class ContextAwareProfile : public QQuickWebEngineProfile {
+class ContextAwareProfile : public ContextAwareProfileParent {
     Q_OBJECT
 public:
     static void restrictContext(QQmlContext* context, bool restrict = true);
@@ -28,9 +38,9 @@ public:
     Q_INVOKABLE bool isRestrictedInternal();
 protected:
 
-    class RequestInterceptor : public QWebEngineUrlRequestInterceptor {
+    class RequestInterceptor : public RequestInterceptorParent {
     public:
-        RequestInterceptor(ContextAwareProfile* parent) : QWebEngineUrlRequestInterceptor(parent), _profile(parent) {}
+        RequestInterceptor(ContextAwareProfile* parent) : RequestInterceptorParent(parent), _profile(parent) { }
         bool isRestricted() { return _profile->isRestricted(); }
     protected:
         ContextAwareProfile* _profile;
@@ -39,9 +49,8 @@ protected:
     ContextAwareProfile(QQmlContext* parent);
     QQmlContext* _context{ nullptr };
     bool _cachedValue{ false };
-    quint64 _lastCacheCheck{ 0 };
-    static const quint64 MAX_CACHE_AGE = MSECS_PER_SECOND;
+    quint64 _cacheExpiry{ 0 };
+    constexpr static quint64 MAX_CACHE_AGE = MSECS_PER_SECOND;
 };
-#endif
 
 #endif // hifi_FileTypeProfile_h

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -16,6 +16,7 @@
 #if !defined(Q_OS_ANDROID)
 #include <QtWebEngine/QQuickWebEngineProfile>
 #include <QtWebEngineCore/QWebEngineUrlRequestInterceptor>
+#include <NumericalConstants.h>
 
 class QQmlContext;
 
@@ -23,7 +24,8 @@ class ContextAwareProfile : public QQuickWebEngineProfile {
     Q_OBJECT
 public:
     static void restrictContext(QQmlContext* context, bool restrict = true);
-    Q_INVOKABLE bool isRestricted();
+    bool isRestricted();
+    Q_INVOKABLE bool isRestrictedInternal();
 protected:
 
     class RequestInterceptor : public QWebEngineUrlRequestInterceptor {
@@ -35,7 +37,10 @@ protected:
     };
 
     ContextAwareProfile(QQmlContext* parent);
-    QQmlContext* _context;
+    QQmlContext* _context{ nullptr };
+    bool _cachedValue{ false };
+    quint64 _lastCacheCheck{ 0 };
+    static const quint64 MAX_CACHE_AGE = MSECS_PER_SECOND;
 };
 #endif
 

--- a/libraries/ui/src/ui/types/FileTypeProfile.cpp
+++ b/libraries/ui/src/ui/types/FileTypeProfile.cpp
@@ -29,8 +29,8 @@ FileTypeProfile::FileTypeProfile(QQmlContext* parent) :
 }
 
 void FileTypeProfile::RequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo& info) {
-    RequestFilters::interceptHFWebEngineRequest(info, getContext());
-    RequestFilters::interceptFileType(info, getContext());
+    RequestFilters::interceptHFWebEngineRequest(info, isRestricted());
+    RequestFilters::interceptFileType(info);
 }
 
 void FileTypeProfile::registerWithContext(QQmlContext* context) {

--- a/libraries/ui/src/ui/types/HFWebEngineProfile.cpp
+++ b/libraries/ui/src/ui/types/HFWebEngineProfile.cpp
@@ -28,7 +28,7 @@ HFWebEngineProfile::HFWebEngineProfile(QQmlContext* parent) : Parent(parent)
 }
 
 void HFWebEngineProfile::RequestInterceptor::interceptRequest(QWebEngineUrlRequestInfo& info) {
-    RequestFilters::interceptHFWebEngineRequest(info, getContext());
+    RequestFilters::interceptHFWebEngineRequest(info, isRestricted());
 }
 
 void HFWebEngineProfile::registerWithContext(QQmlContext* context) {

--- a/libraries/ui/src/ui/types/RequestFilters.cpp
+++ b/libraries/ui/src/ui/types/RequestFilters.cpp
@@ -63,8 +63,8 @@ namespace {
      }
 }
 
-void RequestFilters::interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info, QQmlContext* context) {
-    if (ContextAwareProfile::isRestricted(context) && blockLocalFiles(info)) {
+void RequestFilters::interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info, bool restricted) {
+    if (restricted && blockLocalFiles(info)) {
         return;
     }
 
@@ -90,7 +90,7 @@ void RequestFilters::interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info,
     info.setHttpHeader(USER_AGENT.toLocal8Bit(), tokenString.toLocal8Bit());
 }
 
-void RequestFilters::interceptFileType(QWebEngineUrlRequestInfo& info, QQmlContext* context) {
+void RequestFilters::interceptFileType(QWebEngineUrlRequestInfo& info) {
     QString filename = info.requestUrl().fileName();
     if (isScript(filename) || isJSON(filename)) {
         static const QString CONTENT_HEADER = "Accept";

--- a/libraries/ui/src/ui/types/RequestFilters.h
+++ b/libraries/ui/src/ui/types/RequestFilters.h
@@ -24,8 +24,8 @@ class QQmlContext;
 
 class RequestFilters : public QObject {
 public:
-    static void interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info, QQmlContext* context);
-    static void interceptFileType(QWebEngineUrlRequestInfo& info, QQmlContext* context);
+    static void interceptHFWebEngineRequest(QWebEngineUrlRequestInfo& info, bool restricted);
+    static void interceptFileType(QWebEngineUrlRequestInfo& info);
 };
 #endif
 

--- a/scripts/developer/tests/ui/testLocalFileAccess.js
+++ b/scripts/developer/tests/ui/testLocalFileAccess.js
@@ -1,0 +1,55 @@
+"use strict";
+
+//  Created by Bradley Austin Davis on 2019/08/29
+//  Copyright 2013-2019 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+/* eslint indent: ["error", 4, { "outerIIFEBody": 0 }] */
+
+(function() { // BEGIN LOCAL_SCOPE
+
+    
+var QML_URL = "qrc:/qml/hifi/tablet/DynamicWebview.qml"
+var LOCAL_FILE_URL = "file:///C:/test-file.html"
+
+var TABLET_BUTTON_NAME = "SCRIPT";
+var ICONS = {
+    icon: "icons/tablet-icons/menu-i.svg",
+    activeIcon: "icons/tablet-icons/meni-a.svg"
+};
+
+
+var tablet = Tablet.getTablet("com.highfidelity.interface.tablet.system");
+var button = tablet.addButton({
+    icon: ICONS.icon,
+    activeIcon: ICONS.activeIcon,
+    text: TABLET_BUTTON_NAME,
+    sortOrder: 1
+});
+
+function onClicked() {
+    var window = Desktop.createWindow(QML_URL, {
+        title: "Local file access test",
+        additionalFlags: Desktop.ALWAYS_ON_TOP,
+        presentationMode: Desktop.PresentationMode.NATIVE,
+        size: { x: 640, y: 480 },
+        visible: true,
+        position: { x: 100, y: 100 },
+    });
+    window.sendToQml({ url: LOCAL_FILE_URL });
+}
+
+button.clicked.connect(onClicked);
+
+Script.scriptEnding.connect(function () {
+    button.clicked.disconnect(onClicked);
+    tablet.removeButton(button);
+});
+
+}()); // END LOCAL_SCOPE
+
+
+

--- a/scripts/developer/tests/ui/testLocalFileAccessServer.js
+++ b/scripts/developer/tests/ui/testLocalFileAccessServer.js
@@ -1,0 +1,30 @@
+"use strict";
+
+//  Created by Bradley Austin Davis on 2019/08/29
+//  Copyright 2013-2019 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+(function () {
+    var QML_URL = "qrc:/qml/hifi/tablet/DynamicWebview.qml"
+    var LOCAL_FILE_URL = "file:///C:/test-file.html"
+
+    var _this = this;
+    _this.preload = function (pEntityID) {
+        var window = Desktop.createWindow(QML_URL, {
+            title: "Local file access test",
+            additionalFlags: Desktop.ALWAYS_ON_TOP,
+            presentationMode: Desktop.PresentationMode.NATIVE,
+            size: { x: 640, y: 480 },
+            visible: true,
+            position: { x: 100, y: 100 },
+        });
+        window.sendToQml({ url: LOCAL_FILE_URL });
+    };
+
+    _this.unload = function () {
+        console.log("QQQ on preload");
+    };
+});


### PR DESCRIPTION
[BUGZ-1365](https://highfidelity.atlassian.net/browse/BUGZ-1365): InteractiveWindow doesn't have the restriction against loading local HTML files....

About a year ago we added logic so that if a _server script_ opened a QML window that in turn loaded an HTML control, that control could not access local content.  However, around the same time, we created the new `InteractiveWindow` class, which is accessed through the `Desktop.createWindow` method.  This new class did not have the same restrictions, so if a server script called `Desktop.createWindow` and was able to load an HTML control, that control would have access to the local file system.

I changed the default behavior for such restrictions.  The `ContentAwareProfile::isRestricted` method now returns true if no property has explicitly been set on a given context or one of it's parents.  We now explicitly set the restricted flag to true on the root context of the desktop, so by default, windows can't access the local filesystem.  

Additionally, the `Desktop` scripting interface provided to scripts is now set differently depending on whether something is a client or server script.  non-client scripts will be restricted explicitly, and client scripts will be unrestricted explicitly.  

## Testing

* Create a file at `C:/test-file.html` that contains something... it doesn't really have to be HTML, just any text will do.
* Open the scripts dialog (CTRL-J)
* Click _From URL_ and paste the URL `https://s3.amazonaws.com/DreamingContent/tests/ui/testLocalFileAccess.js`
* A new button should appear on your toolbar saying _Script_
* Click the button, and it should open a new desktop window that displays the contents of the file you created
* Close the window and unload the script
* Using the Create script, create a new shape object.  Edit it's properties
* In the _script_ field for the cube, paste the URL `https://s3.amazonaws.com/DreamingContent/tests/ui/testLocalFileAccessServer.js`
* Click on any different field so that the changes are applied
* A new window should immediately pop up saying "is blocked"

In existing master builds, the behavior should be the same, except at the last step, you will either see a crash, or no window pop-up.  

Note... if the master build crashes when setting the script URL, you may need to run the PR build again to remove the script field entry, or you will simply continue to crash every time you enter the domain where you did the test until the cube is deleted or fixed.  
