### PR TITLE
BUGZ-1234: Mitigate the effect of audio noise on talking animations

### DIFF
--- a/interface/src/avatar/MySkeletonModel.cpp
+++ b/interface/src/avatar/MySkeletonModel.cpp
@@ -313,8 +313,8 @@ void MySkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
     if (spine2Joint >= 0) {
         params.spine2ShapeInfo = hfmModel.joints[spine2Joint].shapeInfo;
     }
-
-    params.isTalking = head->getTimeWithoutTalking() <= 1.5f;
+    const float TALKING_TIME_THRESHOLD = 0.75f;
+    params.isTalking = head->getTimeWithoutTalking() <= TALKING_TIME_THRESHOLD;
 
     myAvatar->updateRigControllerParameters(params);
 

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -2117,7 +2117,7 @@ void Rig::updateFromControllerParameters(const ControllerParameters& params, flo
     _previousIsTalking = params.isTalking;
 
     const float TOTAL_EASE_IN_TIME = 0.75f;
-    const float TOTAL_EASE_OUT_TIME = 1.5f;
+    const float TOTAL_EASE_OUT_TIME = 0.75f;
     if (params.isTalking) {
         if (_talkIdleInterpTime < 1.0f) {
             _talkIdleInterpTime += dt / TOTAL_EASE_IN_TIME;

--- a/libraries/avatars-renderer/src/avatars-renderer/Head.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Head.cpp
@@ -49,7 +49,7 @@ void Head::simulate(float deltaTime) {
 
     // Update audio trailing average for rendering facial animations
     const float AUDIO_AVERAGING_SECS = 0.05f;
-    const float AUDIO_LONG_TERM_AVERAGING_SECS = 30.0f;
+    const float AUDIO_LONG_TERM_AVERAGING_SECS = 15.0f;
     _averageLoudness = glm::mix(_averageLoudness, audioLoudness, glm::min(deltaTime / AUDIO_AVERAGING_SECS, 1.0f));
 
     if (_longTermAverageLoudness == -1.0f) {
@@ -84,7 +84,7 @@ void Head::simulate(float deltaTime) {
     if (getHasProceduralBlinkFaceMovement()) {
         // Detect transition from talking to not; force blink after that and a delay
         bool forceBlink = false;
-        const float TALKING_LOUDNESS = 100.0f;
+        const float TALKING_LOUDNESS = 150.0f;
         const float BLINK_AFTER_TALKING = 0.25f;
         _timeWithoutTalking += deltaTime;
         if ((_averageLoudness - _longTermAverageLoudness) > TALKING_LOUDNESS) {
@@ -176,7 +176,7 @@ void Head::simulate(float deltaTime) {
 }
 
 void Head::calculateMouthShapes(float deltaTime) {
-    const float JAW_OPEN_SCALE = 0.015f;
+    const float JAW_OPEN_SCALE = 0.25f;
     const float JAW_OPEN_RATE = 0.9f;
     const float JAW_CLOSE_RATE = 0.90f;
     const float TIMESTEP_CONSTANT = 0.0032f;
@@ -192,7 +192,9 @@ void Head::calculateMouthShapes(float deltaTime) {
     float deltaTimeRatio = deltaTime / (1.0f / NORMAL_HZ);
 
     // From the change in loudness, decide how much to open or close the jaw
-    float audioDelta = sqrtf(glm::max(_averageLoudness - _longTermAverageLoudness, 0.0f)) * JAW_OPEN_SCALE;
+    float MAX_DELTA_LOUDNESS = 300.0f;
+    float deltaLoudness = glm::max(glm::min(_averageLoudness - _longTermAverageLoudness, MAX_DELTA_LOUDNESS), 0.0f) / MAX_DELTA_LOUDNESS;
+    float audioDelta = powf(deltaLoudness, 2.0f) * JAW_OPEN_SCALE;
     if (audioDelta > _audioJawOpen) {
         _audioJawOpen += (audioDelta - _audioJawOpen) * JAW_OPEN_RATE * deltaTimeRatio;
     } else {

--- a/libraries/avatars-renderer/src/avatars-renderer/Head.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Head.cpp
@@ -176,7 +176,7 @@ void Head::simulate(float deltaTime) {
 }
 
 void Head::calculateMouthShapes(float deltaTime) {
-    const float JAW_OPEN_SCALE = 0.25f;
+    const float JAW_OPEN_SCALE = 0.35f;
     const float JAW_OPEN_RATE = 0.9f;
     const float JAW_CLOSE_RATE = 0.90f;
     const float TIMESTEP_CONSTANT = 0.0032f;
@@ -188,11 +188,11 @@ void Head::calculateMouthShapes(float deltaTime) {
     const float FUNNEL_SPEED = 2.335f;
     const float STOP_GAIN = 5.0f;
     const float NORMAL_HZ = 60.0f; // the update rate the constant values were tuned for
+    const float MAX_DELTA_LOUDNESS = 100.0f;
 
     float deltaTimeRatio = deltaTime / (1.0f / NORMAL_HZ);
 
     // From the change in loudness, decide how much to open or close the jaw
-    float MAX_DELTA_LOUDNESS = 300.0f;
     float deltaLoudness = glm::max(glm::min(_averageLoudness - _longTermAverageLoudness, MAX_DELTA_LOUDNESS), 0.0f) / MAX_DELTA_LOUDNESS;
     float audioDelta = powf(deltaLoudness, 2.0f) * JAW_OPEN_SCALE;
     if (audioDelta > _audioJawOpen) {


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1234
https://highfidelity.atlassian.net/browse/BUGZ-1361

Sometimes the sound that is received when others are talking can leak into the user mic and trigger the body and mouth talking animations.
This PR tries to mitigate that effect by:
- Reducing the time for the adjustment of the long term average calculation. In situations with noisy sound cards or faulty mics the long term average will adjust faster.
- Reducing the ease-out response time that ends the talking animation. 
- Augmenting the threshold that trigger the talking flag.
- Unsetting the talking flag sooner.
- Changing the mouth's blendshape computation. Small changes in loudness will not result in visible mouth movement now. 