### PR TITLE
BUGZ-1386: Update simplifiedStatusIndicator to use domainID as org name instead of location.hostname

### DIFF
--- a/scripts/simplifiedUI/ui/simplifiedStatusIndicator/simplifiedStatusIndicator.js
+++ b/scripts/simplifiedUI/ui/simplifiedStatusIndicator/simplifiedStatusIndicator.js
@@ -64,7 +64,9 @@ function simplifiedStatusIndicator(properties) {
         
         queryParamString += "&displayName=" + displayNameToSend;
         queryParamString += "&status=" + currentStatus;
-        queryParamString += "&organization=" + location.hostname;
+        var domainID = location.domainID;
+        domainID = domainID.substring(1, domainID.length - 1);
+        queryParamString += "&organization=" + domainID;
 
         var uri = REQUEST_URL + "?" + queryParamString;
 


### PR DESCRIPTION
[BUGZ-1386](https://highfidelity.atlassian.net/browse/BUGZ-1386)