### PR TITLE
Error handling for Launcher's update

### DIFF
--- a/launchers/darwin/src/updater/main.m
+++ b/launchers/darwin/src/updater/main.m
@@ -21,15 +21,39 @@ int main(int argc, char const* argv[]) {
     for (int index = 0; index < argc; index++) {
         NSLog(@"argv at index %d = %s", index, argv[index]);
     }
+
+    NSError *error = nil;
+
     NSString* oldLauncher = [NSString stringWithUTF8String:argv[1]];
     NSString* newLauncher = [NSString stringWithUTF8String:argv[2]];
     NSURL* destinationUrl = [UpdaterHelper NSStringToNSURL:newLauncher];
     NSFileManager* fileManager = [NSFileManager defaultManager];
-    [fileManager replaceItemAtURL:[UpdaterHelper NSStringToNSURL:oldLauncher] withItemAtURL:[UpdaterHelper NSStringToNSURL:newLauncher] backupItemName:nil options:NSFileManagerItemReplacementUsingNewMetadataOnly resultingItemURL:&destinationUrl error:nil];
+    [fileManager replaceItemAtURL:[UpdaterHelper NSStringToNSURL:oldLauncher]
+                    withItemAtURL:[UpdaterHelper NSStringToNSURL:newLauncher]
+                   backupItemName:nil
+                          options:NSFileManagerItemReplacementUsingNewMetadataOnly
+                 resultingItemURL:&destinationUrl
+                            error:&error];
+    if (error != nil) {
+        NSLog(@"couldn't update launcher: %@", error);
+        return 1;
+    }
+
     NSWorkspace* workspace = [NSWorkspace sharedWorkspace];
     NSURL* applicationURL = [UpdaterHelper NSStringToNSURL: [oldLauncher stringByAppendingString: @"/Contents/MacOS/HQ Launcher"]];
     NSArray* arguments =@[];
     NSLog(@"Launcher agruments: %@", arguments);
-    [workspace launchApplicationAtURL:applicationURL options:NSWorkspaceLaunchNewInstance configuration:[NSDictionary dictionaryWithObject:arguments forKey:NSWorkspaceLaunchConfigurationArguments] error:nil];
+
+    NSDictionary *configuration = [NSDictionary dictionaryWithObject:arguments
+                                                              forKey:NSWorkspaceLaunchConfigurationArguments];
+    [workspace launchApplicationAtURL:applicationURL
+                              options:NSWorkspaceLaunchNewInstance
+                        configuration:configuration
+                                error:&error];
+    if (error != nil) {
+        NSLog(@"couldn't start launcher: %@", error);
+        return 1;
+    }
+
     return 0;
 }


### PR DESCRIPTION
Before this change the update helper app in the Mac version of HQ
Launcher silently ignored errors. This change adds error handling to aid
troubleshooting.