### PR TITLE
BUGZ-1398: Tablet access to local HTML

### DIFF
--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -291,6 +291,10 @@ void OffscreenSurface::setMaxFps(uint8_t maxFps) {
 }
 
 void OffscreenSurface::load(const QUrl& qmlSource, QQuickItem* parent, const QJSValue& callback) {
+    loadFromQml(qmlSource, parent, callback);
+}
+
+void OffscreenSurface::loadFromQml(const QUrl& qmlSource, QQuickItem* parent, const QJSValue& callback) {
     loadInternal(qmlSource, false, parent, [callback](QQmlContext* context, QQuickItem* newItem) {
         QJSValue(callback).call(QJSValueList() << context->engine()->newQObject(newItem));
     });

--- a/libraries/qml/src/qml/OffscreenSurface.h
+++ b/libraries/qml/src/qml/OffscreenSurface.h
@@ -111,6 +111,7 @@ signals:
     void rootItemCreated(QQuickItem* rootContext);
 
 protected:
+    virtual void loadFromQml(const QUrl& qmlSource, QQuickItem* parent, const QJSValue& callback);
     bool eventFilter(QObject* originalDestination, QEvent* event) override;
     bool filterEnabled(QObject* originalDestination, QEvent* event) const;
 

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -38,6 +38,7 @@
 
 #include <QtScriptTools/QScriptEngineDebugger>
 
+#include <shared/LocalFileAccessGate.h>
 #include <shared/QtHelpers.h>
 #include <AudioConstants.h>
 #include <AudioEffectOptions.h>
@@ -1123,6 +1124,12 @@ QScriptValue ScriptEngine::evaluate(const QString& sourceCode, const QString& fi
 }
 
 void ScriptEngine::run() {
+    if (QThread::currentThread() != qApp->thread() && _context == Context::CLIENT_SCRIPT) {
+        // Flag that we're allowed to access local HTML files on UI created from C++ calls on this thread
+        // (because we're a client script)
+        hifi::scripting::setLocalAccessSafeThread(true);
+    }
+
     auto filenameParts = _fileNameString.split("/");
     auto name = filenameParts.size() > 0 ? filenameParts[filenameParts.size() - 1] : "unknown";
     PROFILE_SET_THREAD_NAME("Script: " + name);
@@ -1300,6 +1307,9 @@ void ScriptEngine::run() {
 
     emit finished(_fileNameString, qSharedPointerCast<ScriptEngine>(sharedFromThis()));
 
+    // Don't leave our local-file-access flag laying around, reset it to false when the scriptengine 
+    // thread is finished
+    hifi::scripting::setLocalAccessSafeThread(false);
     _isRunning = false;
     emit runningStateChanged();
     emit doneRunning();

--- a/libraries/shared/src/shared/LocalFileAccessGate.cpp
+++ b/libraries/shared/src/shared/LocalFileAccessGate.cpp
@@ -1,0 +1,21 @@
+//
+//  Created by Bradley Austin Davis on 2019/09/05
+//  Copyright 2013-2019 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "LocalFileAccessGate.h"
+
+#include <QtCore/QThreadStorage>
+
+static QThreadStorage<bool> localAccessSafe;
+
+void hifi::scripting::setLocalAccessSafeThread(bool safe) {
+    localAccessSafe.setLocalData(safe);
+}
+
+bool hifi::scripting::isLocalAccessSafeThread() {
+    return localAccessSafe.hasLocalData() && localAccessSafe.localData();
+}

--- a/libraries/shared/src/shared/LocalFileAccessGate.h
+++ b/libraries/shared/src/shared/LocalFileAccessGate.h
@@ -1,0 +1,21 @@
+//
+//  Created by Bradley Austin Davis on 2019/09/05
+//  Copyright 2013-2019 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#pragma once
+#ifndef hifi_LocalFileAccessGate_h
+#define hifi_LocalFileAccessGate_h
+
+namespace hifi { namespace scripting {
+
+void setLocalAccessSafeThread(bool safe = true);
+
+bool isLocalAccessSafeThread();
+
+}}  // namespace hifi::scripting
+
+#endif

--- a/libraries/ui/src/ui/OffscreenQmlSurface.h
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.h
@@ -37,8 +37,8 @@ public:
     Q_INVOKABLE void lowerKeyboard();
     PointerEvent::EventType choosePointerEventType(QEvent::Type type);
     Q_INVOKABLE unsigned int deviceIdByTouchPoint(qreal x, qreal y);
-    
-    
+   
+
 signals:
     void focusObjectChanged(QObject* newFocus);
     void focusTextChanged(bool focusText);
@@ -61,6 +61,7 @@ public slots:
     void sendToQml(const QVariant& message);
 
 protected:
+    void loadFromQml(const QUrl& qmlSource, QQuickItem* parent, const QJSValue& callback) override;
     void clearFocusItem();
     void setFocusText(bool newFocusText);
     void initializeEngine(QQmlEngine* engine) override;

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -291,6 +291,13 @@ public:
      *     to have it not resizable.
      */
     Q_INVOKABLE void loadQMLSource(const QVariant& path, bool resizable = false);
+
+    /**jsdoc
+     * Internal function, do not call from scripts
+     * @function TabletProxy#loadQMLSourceImpl
+     */
+    Q_INVOKABLE void loadQMLSourceImpl(const QVariant& path, bool resizable, bool localSafeContext);
+
     // FIXME: This currently relies on a script initializing the tablet (hence the bool denoting success);
     //        it should be initialized internally so it cannot fail
 


### PR DESCRIPTION
[BUGZ-1398](https://highfidelity.atlassian.net/browse/BUGZ-1398): A recent change to make access to local HTML files disabled by default caused the tablet version of the Create/Edit script to fail to load.  This change fixes this by using thread-local storage to determine when the calling ScriptEngine / thread for a C++ scripting interface function is allowed to access local HTML files.  This information can be propagated internally as a parameter to the main-thread invocation of a function to ensure that calls that were initiated from client-scripts are properly marked.

The thread-local implementation has been placed in the Shared library because this change involves interaction between the Script-Engine library and the UI library, which don't have a direct dependency relationship and don't have many dependencies in common.

