### PR TITLE
Fix webrtc link errors in debug builds

### DIFF
--- a/cmake/macros/TargetWebRTC.cmake
+++ b/cmake/macros/TargetWebRTC.cmake
@@ -15,9 +15,11 @@ macro(TARGET_WEBRTC)
         # select_library_configurations(WEBRTC)
     else()
         set(WEBRTC_INCLUDE_DIRS "${VCPKG_INSTALL_ROOT}/include/webrtc")
-        find_library(WEBRTC_LIBRARY NAMES webrtc PATHS ${VCPKG_INSTALL_ROOT}/lib/ NO_DEFAULT_PATH)
         target_include_directories(${TARGET_NAME} SYSTEM PUBLIC ${WEBRTC_INCLUDE_DIRS})
-        target_link_libraries(${TARGET_NAME} ${WEBRTC_LIBRARY})
+        find_library(WEBRTC_LIBRARY_RELEASE webrtc PATHS ${VCPKG_INSTALL_ROOT}/lib NO_DEFAULT_PATH)
+        find_library(WEBRTC_LIBRARY_DEBUG webrtc PATHS ${VCPKG_INSTALL_ROOT}/debug/lib NO_DEFAULT_PATH)
+        select_library_configurations(WEBRTC)
+        target_link_libraries(${TARGET_NAME} ${WEBRTC_LIBRARIES})
     endif()
 
 


### PR DESCRIPTION
@amerhifi  reported that debug builds fail with link errors such as 

    LNK2038    mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '0' doesn't match value '2' in mocs_compilation.obj

Investigating the `target_webrtc` macro it appeared to be using the same lib file for both debug and release builds, triggering this error.  This PR modifies the macro to use logic similar to the `target_nvtt` macro to allow CMake to generate different link targets depending on the build type.
