### PR TITLE
BUGZ-1385: allow entity-script-server to move entities kinematically

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -17,7 +17,6 @@
 #include <QJsonDocument>
 
 #include <EntityTree.h>
-#include <SimpleEntitySimulation.h>
 #include <ResourceCache.h>
 #include <ScriptCache.h>
 #include <EntityEditFilters.h>
@@ -36,7 +35,7 @@ const char* LOCAL_MODELS_PERSIST_FILE = "resources/models.svo";
 
 EntityServer::EntityServer(ReceivedMessage& message) :
     OctreeServer(message),
-    _entitySimulation(NULL),
+    _entitySimulation(nullptr),
     _dynamicDomainVerificationTimer(this)
 {
     DependencyManager::set<ResourceManager>();

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -16,9 +16,11 @@
 
 #include <memory>
 
-#include "EntityItem.h"
+#include <EntityItem.h>
+#include <EntityTree.h>
+#include <SimpleEntitySimulation.h>
+
 #include "EntityServerConsts.h"
-#include "EntityTree.h"
 
 /// Handles assignments of type EntityServer - sending entities to various clients.
 
@@ -26,9 +28,6 @@ struct ViewerSendingStats {
     quint64 lastSent;
     quint64 lastEdited;
 };
-
-class SimpleEntitySimulation;
-using SimpleEntitySimulationPointer = std::shared_ptr<SimpleEntitySimulation>;
 
 class EntityServer : public OctreeServer, public NewlyCreatedEntityHook {
     Q_OBJECT

--- a/assignment-client/src/scripts/EntityScriptServer.h
+++ b/assignment-client/src/scripts/EntityScriptServer.h
@@ -21,6 +21,7 @@
 #include <EntityEditPacketSender.h>
 #include <plugins/CodecPlugin.h>
 #include <ScriptEngine.h>
+#include <SimpleEntitySimulation.h>
 #include <ThreadedAssignment.h>
 #include "../entities/EntityTreeHeadlessViewer.h"
 
@@ -75,6 +76,7 @@ private:
 
     static int _entitiesScriptEngineCount;
     ScriptEnginePointer _entitiesScriptEngine;
+    SimpleEntitySimulationPointer _entitySimulation;
     EntityEditPacketSender _entityEditSender;
     EntityTreeHeadlessViewer _entityViewer;
 

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -512,13 +512,13 @@ void OtherAvatar::handleChangedAvatarEntityData() {
                 entity->setParentID(NULL_ID);
                 entity->setParentID(oldParentID);
 
-                if (entity->stillHasMyGrabAction()) {
+                if (entity->stillHasMyGrab()) {
                     // For this case: we want to ignore transform+velocities coming from authoritative OtherAvatar
                     // because the MyAvatar is grabbing and we expect the local grab state
                     // to have enough information to prevent simulation drift.
                     //
                     // Clever readers might realize this could cause problems.  For example,
-                    // if an ignored OtherAvagtar were to simultanously grab the object then there would be
+                    // if an ignored OtherAvatar were to simultanously grab the object then there would be
                     // a noticeable discrepancy between participants in the distributed physics simulation,
                     // however the difference would be stable and would not drift.
                     properties.clearTransformOrVelocityChanges();

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -569,7 +569,7 @@ public:
     static void setPrimaryViewFrustumPositionOperator(std::function<glm::vec3()> getPrimaryViewFrustumPositionOperator) { _getPrimaryViewFrustumPositionOperator = getPrimaryViewFrustumPositionOperator; }
     static glm::vec3 getPrimaryViewFrustumPosition() { return _getPrimaryViewFrustumPositionOperator(); }
 
-    bool stillHasMyGrabAction() const;
+    bool stillHasMyGrab() const;
 
     bool needsRenderUpdate() const { return resultWithReadLock<bool>([&] { return _needsRenderUpdate; }); }
     void setNeedsRenderUpdate(bool needsRenderUpdate) { withWriteLock([&] { _needsRenderUpdate = needsRenderUpdate; }); }
@@ -585,7 +585,7 @@ protected:
     void setSimulated(bool simulated) { _simulated = simulated; }
 
     const QByteArray getDynamicDataInternal() const;
-    bool stillHasGrabAction() const;
+    bool stillHasGrab() const;
     void setDynamicDataInternal(QByteArray dynamicData);
 
     virtual void dimensionsChanged() override;

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -2246,8 +2246,8 @@ void EntityTree::preUpdate() {
 void EntityTree::update(bool simulate) {
     PROFILE_RANGE(simulation_physics, "UpdateTree");
     PerformanceTimer perfTimer("updateTree");
-    withWriteLock([&] {
-        if (simulate && _simulation) {
+    if (simulate && _simulation) {
+        withWriteLock([&] {
             _simulation->updateEntities();
             {
                 PROFILE_RANGE(simulation_physics, "Deletes");
@@ -2265,8 +2265,8 @@ void EntityTree::update(bool simulate) {
                     deleteEntities(idsToDelete, true);
                 }
             }
-        }
-    });
+        });
+    }
 }
 
 quint64 EntityTree::getAdjustedConsiderSince(quint64 sinceTime) {

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -274,6 +274,7 @@ enum class EntityVersion : PacketVersion {
     TextUnlit,
     ShadowBiasAndDistance,
     TextEntityFonts,
+    ScriptServerKinematicMotion
 
     // Add new versions above here
     NUM_PACKET_TYPE,

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -274,7 +274,7 @@ enum class EntityVersion : PacketVersion {
     TextUnlit,
     ShadowBiasAndDistance,
     TextEntityFonts,
-    ScriptServerKinematicMotion
+    ScriptServerKinematicMotion,
 
     // Add new versions above here
     NUM_PACKET_TYPE,

--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -740,7 +740,8 @@ bool EntityMotionState::shouldSendBid() const {
         && (_region == workload::Region::R1)
         && _ownershipState != EntityMotionState::OwnershipState::Unownable
         && glm::max(glm::max(VOLUNTEER_SIMULATION_PRIORITY, _bumpedPriority), _entity->getScriptSimulationPriority()) >= _entity->getSimulationPriority()
-        && !_entity->getLocked();
+        && !_entity->getLocked()
+        && (!_body->isStaticOrKinematicObject() || _entity->stillHasMyGrab());
 }
 
 void EntityMotionState::setRigidBody(btRigidBody* body) {


### PR DESCRIPTION
This PR gives the entity-script-server an `EntitySimulation` and changes the interface-client rules for distributed simulation ownership to allow the entity-script-server to move entities around in a kinematic way.

https://highfidelity.atlassian.net/browse/BUGZ-1385