### PR TITLE
Support updater in Contents/{MacOS,Resources}

### DIFF
--- a/launchers/darwin/CMakeLists.txt
+++ b/launchers/darwin/CMakeLists.txt
@@ -126,7 +126,10 @@ add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
 
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
   COMMAND updater
-  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/updater" "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${APP_NAME}.app/Contents/Resources/")
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/updater" "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${APP_NAME}.app/Contents/MacOS/"
+  # Older versions of Launcher put updater in `/Contents/Resources/updater`.
+  COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${APP_NAME}.app/Contents/Resources" ln -sf ../MacOS/updater updater
+)
 
 install(
   TARGETS HQLauncher

--- a/launchers/darwin/src/Launcher.m
+++ b/launchers/darwin/src/Launcher.m
@@ -383,6 +383,13 @@ static BOOL const DELETE_ZIP_FILES = TRUE;
 
     [self updateLatestBuildInfo];
 
+    NSString *kLauncherUrl = @"LAUNCHER_URL";
+    NSString *envLauncherUrl = [[NSProcessInfo processInfo] environment][kLauncherUrl];
+    if (envLauncherUrl != nil) {
+        NSLog(@"Using launcherUrl from environment: %@ = %@", kLauncherUrl, envLauncherUrl);
+        launcherUrl = envLauncherUrl;
+    }
+
     NSDictionary* launcherArguments = [LauncherCommandlineArgs arguments];
     if (newLauncherAvailable && ![launcherArguments valueForKey: @"--noUpdate"]) {
         [self.downloadLauncher downloadLauncher: launcherUrl];
@@ -460,11 +467,36 @@ static BOOL const DELETE_ZIP_FILES = TRUE;
 
 -(void)runAutoupdater
 {
-    NSTask* task = [[NSTask alloc] init]; 
+    NSException *exception;
+    bool launched = false;
     NSString* newLauncher =  [[[Launcher sharedLauncher] getDownloadPathForContentAndScripts] stringByAppendingPathComponent: @"HQ Launcher.app"];
-    task.launchPath = [newLauncher stringByAppendingString:@"/Contents/Resources/updater"];
-    task.arguments = @[[[NSBundle mainBundle] bundlePath], newLauncher];
-    [task launch];
+
+    // Older versions of Launcher put updater in `/Contents/Resources/updater`.
+    for (NSString *bundlePath in @[@"/Contents/MacOS/updater",
+                                   @"/Contents/Resources/updater",
+                                   ]) {
+        NSTask* task = [[NSTask alloc] init];
+        task.launchPath = [newLauncher stringByAppendingString: bundlePath];
+        task.arguments = @[[[NSBundle mainBundle] bundlePath], newLauncher];
+
+        NSLog(@"launching updater: %@ %@", task.launchPath, task.arguments);
+
+        @try {
+            [task launch];
+        }
+        @catch (NSException *e) {
+            NSLog(@"couldn't launch updater: %@, %@", e.name, e.reason);
+            exception = e;
+            continue;
+        }
+
+        launched = true;
+        break;
+    }
+
+    if (!launched) {
+        @throw exception;
+    }
 
     [NSApp terminate:self];
 }


### PR DESCRIPTION
Codesigning fails when binaries are in the `Resources` directory. This
change moves updater and ensures HQLauncher can handle the updater at
both paths.