### PR TITLE
BUGZ-1360: Avoid bad normal values leading to black pixels in Forward

### DIFF
--- a/libraries/graphics/src/graphics/MaterialTextures.slh
+++ b/libraries/graphics/src/graphics/MaterialTextures.slh
@@ -111,7 +111,7 @@ vec3 fetchNormalMap(vec2 uv) {
     // unpack normal, swizzle to get into hifi tangent space with Y axis pointing out
     vec2 t = 2.0 * (texture(normalMap, uv, TAA_TEXTURE_LOD_BIAS).rg - vec2(0.5, 0.5));
     vec2 t2 = t*t;
-    return vec3(t.x, sqrt(1.0 - t2.x - t2.y), t.y);
+    return vec3(t.x, sqrt(max(0.0, 1.0 - t2.x - t2.y)), t.y);
 }
 <@endif@>
 


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1360

This PR fixes the black pixels showing up in forward renderer due to the unpacking of normal map texel leading to unormalized normals which breaks the lighting equation as a consequence.
We added a protection on the unpacking equation in the shader to avoid that case and now it s fixed.

This also resolve the problem of these black pixels bleeding through the transparent surfaces  