### PR TITLE
Revert "Percent decode URL from Thunder"

### DIFF
--- a/launchers/darwin/src/LatestBuildRequest.m
+++ b/launchers/darwin/src/LatestBuildRequest.m
@@ -59,7 +59,7 @@
         NSString* defaultBuildTag = [json valueForKey:@"default_tag"];
 
         NSString* launcherVersion = [launcherValues valueForKey:@"version"];
-        NSString* launcherUrl = [[[launcherValues valueForKey:@"mac"] valueForKey:@"url"] stringByRemovingPercentEncoding];
+        NSString* launcherUrl = [[launcherValues valueForKey:@"mac"] valueForKey:@"url"];
 
         BOOL appDirectoryExist = [fileManager fileExistsAtPath:[[sharedLauncher getAppPath] stringByAppendingString:@"interface.app"]];
 


### PR DESCRIPTION
This reverts commit 4e6198d784e521de77f7f7afbe928cac84b63e4b.

If Thunder is properly configured this wouldn't be required.