### PR TITLE
BUGZ-1394: Fix avatars with rotation offsets

### DIFF
--- a/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
+++ b/libraries/model-baker/src/model-baker/PrepareJointsTask.cpp
@@ -107,7 +107,6 @@ void PrepareJointsTask::run(const baker::BakeContextPointer& context, const Inpu
                     glm::quat rotationOffset = itr.value();
                     jointRotationOffsets.insert(jointIndex, rotationOffset);
                     qCDebug(model_baker) << "Joint Rotation Offset added to Rig._jointRotationOffsets : " << " jointName: " << jointName << " jointIndex: " << jointIndex << " rotation offset: " << rotationOffset;
-                    break;
                 }
             }
         }


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1394

This PR fixes a bug introduced here:
https://github.com/highfidelity/hifi/pull/16065

Caused by exiting prematurely, while reading and applying the rotation offsets, so only the first offset was applied.