### PR TITLE
RC84: BUGZ-1416: Always stop challenge timer from the right thread

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -499,6 +499,8 @@ void AvatarMixer::handleAvatarKilled(SharedNodePointer avatarNode) {
            } else {
                _sessionDisplayNames.erase(displayNameIter);
            }
+
+            nodeData->getAvatar().stopChallengeTimer();
         }
 
         std::unique_ptr<NLPacket> killPacket;

--- a/assignment-client/src/avatars/MixerAvatar.cpp
+++ b/assignment-client/src/avatars/MixerAvatar.cpp
@@ -332,7 +332,7 @@ void MixerAvatar::sendOwnerChallenge() {
 void MixerAvatar::processChallengeResponse(ReceivedMessage& response) {
     QByteArray avatarID;
     QMutexLocker certifyLocker(&_avatarCertifyLock);
-    QMetaObject::invokeMethod(&_challengeTimer, &QTimer::stop);
+    stopChallengeTimer();
     if (_verifyState == challengeClient) {
         QByteArray responseData = response.readAll();
         if (responseData.length() < 8) {
@@ -363,5 +363,13 @@ void MixerAvatar::processChallengeResponse(ReceivedMessage& response) {
 
     } else {
         qCDebug(avatars) << "WARNING: Unexpected avatar challenge-response in state" << stateToName(_verifyState);
+    }
+}
+
+void MixerAvatar::stopChallengeTimer() {
+    if (QThread::currentThread() == thread()) {
+        _challengeTimer.stop();
+    } else {
+        QMetaObject::invokeMethod(&_challengeTimer, &QTimer::stop);
     }
 }

--- a/assignment-client/src/avatars/MixerAvatar.h
+++ b/assignment-client/src/avatars/MixerAvatar.h
@@ -34,6 +34,8 @@ public:
     void processCertifyEvents();
     void processChallengeResponse(ReceivedMessage& response);
 
+    void stopChallengeTimer();
+
     // Avatar certification/verification:
     enum VerifyState {
         nonCertified, requestingFST, receivedFST, staticValidation, requestingOwner, ownerResponse,


### PR DESCRIPTION
[JIRA ticket](https://highfidelity.atlassian.net/browse/BUGZ-1416)

Make sure challenge timer is always stopped from the proper thread before the MixerAvatar is destroyed.