### PR TITLE
BUGZ-1167: remove unwanted binaries from bad client-only installers

### DIFF
--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -1159,9 +1159,11 @@ Section "-Core installation"
   ; 2016-02-25 - The following delete blocks are temporary and can be removed once users who had the initial installer have updated
   ; 2019-09-10 - (3 and a half years later) Sure they are buddy.  Sure they are.
 
-  ;Delete any server executables that might have been installed by bad versions of the client-only installer
-  Delete "$INSTDIR\assignment-client.exe"
-  Delete "$INSTDIR\domain-server.exe"
+  ;Delete any server executables that might have been installed by bad versions of the client-only installer, but ONLY if we are a client-only installer
+  ${If} "@INSTALLER_TYPE@" == "client_only"
+    Delete "$INSTDIR\assignment-client.exe"
+    Delete "$INSTDIR\domain-server.exe"
+  ${EndIf}
 
   ;Delete any server-console files installed before it was placed in sub-folder
   Delete "$INSTDIR\server-console.exe"

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -1159,11 +1159,11 @@ Section "-Core installation"
   ; 2016-02-25 - The following delete blocks are temporary and can be removed once users who had the initial installer have updated
   ; 2019-09-10 - (3 and a half years later) Sure they are buddy.  Sure they are.
 
-  MessageBox MB_OK|MB_ICONEXCLAMATION "installer type is @INSTALLER_TYPE@"
+  ; MessageBox MB_OK|MB_ICONEXCLAMATION "installer type is @INSTALLER_TYPE@"
 
   ;Delete any server executables that might have been installed by bad versions of the client-only installer, but ONLY if we are a client-only installer
   ${If} "@INSTALLER_TYPE@" == "client_only"
-    MessageBox MB_OK|MB_ICONEXCLAMATION "trying to delete server binaries"
+    ; MessageBox MB_OK|MB_ICONEXCLAMATION "trying to delete server binaries"
     Delete "$INSTDIR\assignment-client.exe"
     Delete "$INSTDIR\domain-server.exe"
   ${EndIf}

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -1159,8 +1159,11 @@ Section "-Core installation"
   ; 2016-02-25 - The following delete blocks are temporary and can be removed once users who had the initial installer have updated
   ; 2019-09-10 - (3 and a half years later) Sure they are buddy.  Sure they are.
 
+  MessageBox MB_OK|MB_ICONEXCLAMATION "installer type is @INSTALLER_TYPE@"
+
   ;Delete any server executables that might have been installed by bad versions of the client-only installer, but ONLY if we are a client-only installer
   ${If} "@INSTALLER_TYPE@" == "client_only"
+    MessageBox MB_OK|MB_ICONEXCLAMATION "trying to delete server binaries"
     Delete "$INSTDIR\assignment-client.exe"
     Delete "$INSTDIR\domain-server.exe"
   ${EndIf}

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -1156,7 +1156,12 @@ FunctionEnd
 
 Section "-Core installation"
 
-  ;The following delete blocks are temporary and can be removed once users who had the initial installer have updated
+  ; 2016-02-25 - The following delete blocks are temporary and can be removed once users who had the initial installer have updated
+  ; 2019-09-10 - (3 and a half years later) Sure they are buddy.  Sure they are.
+
+  ;Delete any server executables that might have been installed by bad versions of the client-only installer
+  Delete "$INSTDIR\assignment-client.exe"
+  Delete "$INSTDIR\domain-server.exe"
 
   ;Delete any server-console files installed before it was placed in sub-folder
   Delete "$INSTDIR\server-console.exe"


### PR DESCRIPTION
[BUGZ-1167](https://highfidelity.atlassian.net/browse/BUGZ-1167)

The behavior of the console app is determined based on the presence or absence of the _server binaries_ (and nothing else).  Although the build system has been fixed to stop including these server binaries in the new builds, the installer doesn't clean them out if they already exist, _even_ when the installer UI is told to clean up old settings and resources.  

This PR will force the installer to delete pre-existing server binaries in the target folder.

# Testing

Verify that the sandbox version of the installer for this PR works and properly installs the binaries.

To test the actual functionality of this PR

* install the client-only version of the PR
* Verify the console is acting in client only mode
* Go into the install folder and copy the `interface.exe` to `assignment-client.exe` and also to `domain-server.exe`
* Quit the console
* Restart the console
* Verify the console is acting in sandbox mode
* Quit the console
* Uninstall the application
* Verify that the copied `assignment-client.exe` and `domain-server.exe` are still present in the folder
* Re-install the client-only version of the PR
* Verify after re-install that the copied `assignment-client.exe` and `domain-server.exe` are **NO LONGER** present in the folder
* Verify the console is acting in client-only mode

