### PR TITLE
BUGZ-1435: Re-enable head IK when seated on HMD

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -6257,7 +6257,6 @@ void MyAvatar::beginSit(const glm::vec3& position, const glm::quat& rotation) {
 
     _characterController.setSeated(true);
     setCollisionsEnabled(false);
-    setHMDLeanRecenterEnabled(false);
     // Disable movement
     setSitDriveKeysStatus(false);
     centerBody();
@@ -6276,7 +6275,6 @@ void MyAvatar::endSit(const glm::vec3& position, const glm::quat& rotation) {
         clearPinOnJoint(getJointIndex("Hips"));
         _characterController.setSeated(false);
         setCollisionsEnabled(true);
-        setHMDLeanRecenterEnabled(true);
         centerBody();
         slamPosition(position);
         setWorldOrientation(rotation);

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -6257,6 +6257,7 @@ void MyAvatar::beginSit(const glm::vec3& position, const glm::quat& rotation) {
 
     _characterController.setSeated(true);
     setCollisionsEnabled(false);
+    setHMDLeanRecenterEnabled(false);
     // Disable movement
     setSitDriveKeysStatus(false);
     centerBody();
@@ -6275,6 +6276,7 @@ void MyAvatar::endSit(const glm::vec3& position, const glm::quat& rotation) {
         clearPinOnJoint(getJointIndex("Hips"));
         _characterController.setSeated(false);
         setCollisionsEnabled(true);
+        setHMDLeanRecenterEnabled(true);
         centerBody();
         slamPosition(position);
         setWorldOrientation(rotation);

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1958,8 +1958,7 @@ void Rig::updateReactions(const ControllerParameters& params) {
 
         bool isSeated = _state == RigRole::Seated;
         bool hipsEnabled = params.primaryControllerFlags[PrimaryControllerType_Hips] & (uint8_t)ControllerFlags::Enabled;
-        bool hipsEstimated = params.primaryControllerFlags[PrimaryControllerType_Hips] & (uint8_t)ControllerFlags::Estimated;
-        bool hmdMode = hipsEnabled && !hipsEstimated;
+        bool hmdMode = hipsEnabled;
 
         if ((reactionPlaying || isSeated) && !hmdMode) {
             // TODO: make this smooth.


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1435
https://highfidelity.atlassian.net/browse/BUGZ-1319
https://highfidelity.atlassian.net/browse/BUGZ-1393
This bug was introduced by https://github.com/highfidelity/hifi/pull/15992
It disables head IK when seated on HMD.
This PR re-enables it.