### PR TITLE
RC84: BUGZ-1435: Re-enable head IK when seated on HMD

### DIFF
--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1958,8 +1958,7 @@ void Rig::updateReactions(const ControllerParameters& params) {
 
         bool isSeated = _state == RigRole::Seated;
         bool hipsEnabled = params.primaryControllerFlags[PrimaryControllerType_Hips] & (uint8_t)ControllerFlags::Enabled;
-        bool hipsEstimated = params.primaryControllerFlags[PrimaryControllerType_Hips] & (uint8_t)ControllerFlags::Estimated;
-        bool hmdMode = hipsEnabled && !hipsEstimated;
+        bool hmdMode = hipsEnabled;
 
         if ((reactionPlaying || isSeated) && !hmdMode) {
             // TODO: make this smooth.


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1435
https://highfidelity.atlassian.net/browse/BUGZ-1319
https://highfidelity.atlassian.net/browse/BUGZ-1393
This bug was introduced by #15992
It disables head IK when seated on HMD.
This PR re-enables it.