### PR TITLE
(BUGZ-1469) Add option in oven to disable geometry quantization for baked models

### DIFF
--- a/libraries/baking/src/ModelBaker.cpp
+++ b/libraries/baking/src/ModelBaker.cpp
@@ -20,6 +20,7 @@
 
 #include <model-baker/Baker.h>
 #include <model-baker/PrepareJointsTask.h>
+#include <model-baker/BuildDracoMeshTask.h>
 
 #include <FBXWriter.h>
 #include <FSTReader.h>
@@ -239,7 +240,9 @@ void ModelBaker::bakeSourceCopy() {
         baker::Baker baker(loadedModel, serializerMapping, _mappingURL);
         auto config = baker.getConfiguration();
         // Enable compressed draco mesh generation
-        config->getJobConfig("BuildDracoMesh")->setEnabled(true);
+        auto buildDracoMeshConfig = (BuildDracoMeshConfig*)config->getJobConfig("BuildDracoMesh");
+        buildDracoMeshConfig->setEnabled(true);
+        buildDracoMeshConfig->setQuantized(_shouldQuantizeGeometry);
         // Do not permit potentially lossy modification of joint data meant for runtime
         ((PrepareJointsConfig*)config->getJobConfig("PrepareJoints"))->passthrough = true;
     

--- a/libraries/baking/src/ModelBaker.h
+++ b/libraries/baking/src/ModelBaker.h
@@ -44,6 +44,7 @@ public:
     void setOutputURLSuffix(const QUrl& urlSuffix);
     void setMappingURL(const QUrl& mappingURL);
     void setMapping(const hifi::VariantHash& mapping);
+    void setShouldQuantizeGeometry(bool shouldQuantizeGeometry) { _shouldQuantizeGeometry = shouldQuantizeGeometry; }
 
     void initializeOutputDirs();
 
@@ -78,6 +79,8 @@ protected:
     QString _originalOutputModelPath;
     QString _outputMappingURL;
     QUrl _bakedModelURL;
+
+    bool _shouldQuantizeGeometry { true };
 
 protected slots:
     void handleModelNetworkReply();

--- a/libraries/baking/src/baking/FSTBaker.cpp
+++ b/libraries/baking/src/baking/FSTBaker.cpp
@@ -84,6 +84,7 @@ void FSTBaker::bakeSourceCopy() {
     _modelBaker->setMapping(_mapping);
     // Hold on to the old url userinfo/query/fragment data so ModelBaker::getFullOutputMappingURL retains that data from the original model URL
     _modelBaker->setOutputURLSuffix(modelURL);
+    _modelBaker->setShouldQuantizeGeometry(_shouldQuantizeGeometry);
 
     connect(_modelBaker.get(), &ModelBaker::aborted, this, &FSTBaker::handleModelBakerAborted);
     connect(_modelBaker.get(), &ModelBaker::finished, this, &FSTBaker::handleModelBakerFinished);

--- a/libraries/model-baker/src/model-baker/BuildDracoMeshTask.cpp
+++ b/libraries/model-baker/src/model-baker/BuildDracoMeshTask.cpp
@@ -208,6 +208,7 @@ std::tuple<std::unique_ptr<draco::Mesh>, bool> createDracoMesh(const hfm::Mesh& 
 void BuildDracoMeshTask::configure(const Config& config) {
     _encodeSpeed = config.encodeSpeed;
     _decodeSpeed = config.decodeSpeed;
+    _quantized = config.quantized;
 }
 
 void BuildDracoMeshTask::run(const baker::BakeContextPointer& context, const Input& input, Output& output) {
@@ -243,9 +244,15 @@ void BuildDracoMeshTask::run(const baker::BakeContextPointer& context, const Inp
         if (dracoMesh) {
             draco::Encoder encoder;
 
-            encoder.SetAttributeQuantization(draco::GeometryAttribute::POSITION, 14);
-            encoder.SetAttributeQuantization(draco::GeometryAttribute::TEX_COORD, 12);
-            encoder.SetAttributeQuantization(draco::GeometryAttribute::NORMAL, 10);
+            if (_quantized) {
+                encoder.SetAttributeQuantization(draco::GeometryAttribute::POSITION, 14);
+                encoder.SetAttributeQuantization(draco::GeometryAttribute::TEX_COORD, 12);
+                encoder.SetAttributeQuantization(draco::GeometryAttribute::NORMAL, 10);
+            } else {
+                encoder.SetAttributeQuantization(draco::GeometryAttribute::POSITION, 0);
+                encoder.SetAttributeQuantization(draco::GeometryAttribute::TEX_COORD, 0);
+                encoder.SetAttributeQuantization(draco::GeometryAttribute::NORMAL, 0);
+            }
             encoder.SetSpeedOptions(_encodeSpeed, _decodeSpeed);
 
             draco::EncoderBuffer buffer;

--- a/libraries/model-baker/src/model-baker/BuildDracoMeshTask.h
+++ b/libraries/model-baker/src/model-baker/BuildDracoMeshTask.h
@@ -21,13 +21,28 @@
 // BuildDracoMeshTask is disabled by default
 class BuildDracoMeshConfig : public baker::JobConfig {
     Q_OBJECT
-    Q_PROPERTY(int encodeSpeed MEMBER encodeSpeed)
-    Q_PROPERTY(int decodeSpeed MEMBER decodeSpeed)
+    Q_PROPERTY(int encodeSpeed READ getEncodeSpeed WRITE setEncodeSpeed NOTIFY dirty())
+    Q_PROPERTY(int decodeSpeed READ getDecodeSpeed WRITE setDecodeSpeed NOTIFY dirty())
+    Q_PROPERTY(bool quantized READ isQuantized WRITE setQuantized NOTIFY dirty())
 public:
     BuildDracoMeshConfig() : baker::JobConfig(false) {}
 
+    int getEncodeSpeed() { return encodeSpeed; }
+    int getDecodeSpeed() { return decodeSpeed; }
+    int isQuantized() { return quantized; }
+
+public slots:
+    void setEncodeSpeed(int value) { encodeSpeed = value; emit dirty(); }
+    void setDecodeSpeed(int value) { decodeSpeed = value; emit dirty(); }
+    void setQuantized(bool enabled) { quantized = enabled; emit dirty(); }
+
+signals:
+    void dirty();
+
+public:
     int encodeSpeed { 0 };
     int decodeSpeed { 5 };
+    bool quantized { true };
 };
 
 class BuildDracoMeshTask {
@@ -43,6 +58,7 @@ public:
 protected:
     int _encodeSpeed { 0 };
     int _decodeSpeed { 5 };
+    bool _quantized { true };
 };
 
 #endif // hifi_BuildDracoMeshTask_h

--- a/tools/oven/src/BakerCLI.cpp
+++ b/tools/oven/src/BakerCLI.cpp
@@ -51,6 +51,10 @@ void BakerCLI::bakeFile(QUrl inputUrl, const QString& outputPath, const QString&
         if (!bakeableModelURL.isEmpty()) {
             _baker = getModelBaker(bakeableModelURL, outputPath);
             if (_baker) {
+                auto modelBaker = dynamic_cast<ModelBaker*>(_baker.get());
+                if (modelBaker) {
+                    modelBaker->setShouldQuantizeGeometry(_shouldQuantizeGeometry);
+                }
                 _baker->moveToThread(Oven::instance().getNextWorkerThread());
             }
         }

--- a/tools/oven/src/BakerCLI.h
+++ b/tools/oven/src/BakerCLI.h
@@ -19,7 +19,8 @@
 #include <memory>
 
 #include "Baker.h"
-#include "OvenCLIApplication.h"
+
+class OvenCLIApplication;
 
 static const int OVEN_STATUS_CODE_SUCCESS { 0 };
 static const int OVEN_STATUS_CODE_FAIL { 1 };
@@ -33,6 +34,8 @@ class BakerCLI : public QObject {
 public:
     BakerCLI(OvenCLIApplication* parent);
 
+    void setShouldQuantizeGeometry(bool shouldQuantizeGeometry) { _shouldQuantizeGeometry = shouldQuantizeGeometry; }
+
 public slots:
     void bakeFile(QUrl inputUrl, const QString& outputPath, const QString& type = QString::null);
 
@@ -41,6 +44,7 @@ private slots:
 
 private:
     QDir _outputPath;
+    bool _shouldQuantizeGeometry { true };
     std::unique_ptr<Baker> _baker;
 };
 

--- a/tools/oven/src/DomainBaker.cpp
+++ b/tools/oven/src/DomainBaker.cpp
@@ -159,6 +159,7 @@ void DomainBaker::addModelBaker(const QString& property, const QString& url, con
                 //       Url suffix is still propagated to the baked URL if the input URL is an FST.
                 //       Url suffix has always been stripped from the URL when loading the original model file to be baked.
                 baker->setOutputURLSuffix(url);
+                baker->setShouldQuantizeGeometry(_shouldQuantizeGeometry);
 
                 // make sure our handler is called when the baker is done
                 connect(baker.data(), &Baker::finished, this, &DomainBaker::handleFinishedModelBaker);

--- a/tools/oven/src/DomainBaker.h
+++ b/tools/oven/src/DomainBaker.h
@@ -33,6 +33,8 @@ public:
                 const QString& baseOutputPath, const QUrl& destinationPath,
                 bool shouldRebakeOriginals);
 
+    void setShouldQuantizeGeometry(bool shouldQuantizeGeometry) { _shouldQuantizeGeometry = shouldQuantizeGeometry; }
+
 signals:
     void allModelsFinished();
     void bakeProgress(int baked, int total);
@@ -75,6 +77,7 @@ private:
     int _completedSubBakes { 0 };
 
     bool _shouldRebakeOriginals { false };
+    bool _shouldQuantizeGeometry { true };
 
     void addModelBaker(const QString& property, const QString& url, const QJsonValueRef& jsonRef);
     void addTextureBaker(const QString& property, const QString& url, image::TextureUsage::Type type, const QJsonValueRef& jsonRef);

--- a/tools/oven/src/OvenCLIApplication.h
+++ b/tools/oven/src/OvenCLIApplication.h
@@ -15,6 +15,7 @@
 #include <QtCore/QCoreApplication>
 
 #include "Oven.h"
+#include "BakerCLI.h"
 
 class OvenCLIApplication : public QCoreApplication, public Oven {
     Q_OBJECT
@@ -25,10 +26,14 @@ public:
 
     static OvenCLIApplication* instance() { return dynamic_cast<OvenCLIApplication*>(QCoreApplication::instance()); }
 
+protected:
+    std::unique_ptr<BakerCLI> _bakerCLI;
+
 private:
     static QUrl _inputUrlParameter;
     static QUrl _outputUrlParameter;
     static QString _typeParameter;
+    static bool _shouldQuantizeGeometry;
 };
 
 #endif // hifi_OvenCLIApplication_h

--- a/tools/oven/src/main.cpp
+++ b/tools/oven/src/main.cpp
@@ -21,7 +21,6 @@ int main (int argc, char** argv) {
     // figure out if we're launching our GUI application or just the simple command line interface
     if (argc > 1) {
         OvenCLIApplication::parseCommandLine(argc, argv);
-
         // init the settings interface so we can save and load settings
         Setting::init();
 

--- a/tools/oven/src/ui/DomainBakeWidget.cpp
+++ b/tools/oven/src/ui/DomainBakeWidget.cpp
@@ -129,6 +129,10 @@ void DomainBakeWidget::setupUI() {
     // setup a checkbox to allow re-baking of original assets
     _rebakeOriginalsCheckBox = new QCheckBox("Re-bake originals");
     gridLayout->addWidget(_rebakeOriginalsCheckBox, rowIndex, 0);
+    // add checkbox to allow disabling quantization during draco compression to reduce z-fighting/texture smearing
+    _quantizeGeometryCheckBox = new QCheckBox("Quantize geometry");
+    _quantizeGeometryCheckBox->setChecked(true);
+    gridLayout->addWidget(_quantizeGeometryCheckBox, rowIndex, 1);
 
     // add a button that will kickoff the bake
     QPushButton* bakeButton = new QPushButton("Bake");
@@ -214,6 +218,7 @@ void DomainBakeWidget::bakeButtonClicked() {
                                 outputDirectory.absolutePath(), _destinationPathLineEdit->text(),
                                 _rebakeOriginalsCheckBox->isChecked())
         };
+        domainBaker->setShouldQuantizeGeometry(_quantizeGeometryCheckBox->isChecked());
 
         // make sure we hear from the baker when it is done
         connect(domainBaker.get(), &DomainBaker::finished, this, &DomainBakeWidget::handleFinishedBaker);

--- a/tools/oven/src/ui/DomainBakeWidget.h
+++ b/tools/oven/src/ui/DomainBakeWidget.h
@@ -46,6 +46,7 @@ private:
     QLineEdit* _outputDirLineEdit;
     QLineEdit* _destinationPathLineEdit;
     QCheckBox* _rebakeOriginalsCheckBox;
+    QCheckBox* _quantizeGeometryCheckBox;
 
     Setting::Handle<QString> _domainNameSetting;
     Setting::Handle<QString> _exportDirectory;

--- a/tools/oven/src/ui/ModelBakeWidget.cpp
+++ b/tools/oven/src/ui/ModelBakeWidget.cpp
@@ -93,6 +93,11 @@ void ModelBakeWidget::setupUI() {
     // start a new row for the next component
     ++rowIndex;
 
+    // add checkbox to allow disabling quantization during draco compression to reduce z-fighting/texture smearing
+    _quantizeGeometryCheckBox = new QCheckBox("Quantize geometry");
+    _quantizeGeometryCheckBox->setChecked(true);
+    gridLayout->addWidget(_quantizeGeometryCheckBox, rowIndex, 0);
+
     // add a button that will kickoff the bake
     QPushButton* bakeButton = new QPushButton("Bake");
     connect(bakeButton, &QPushButton::clicked, this, &ModelBakeWidget::bakeButtonClicked);
@@ -183,6 +188,13 @@ void ModelBakeWidget::bakeButtonClicked() {
             std::unique_ptr<Baker> baker = getModelBaker(bakeableModelURL, outputDirectory.path());
             if (baker) {
                 // everything seems to be in place, kick off a bake for this model now
+
+                {
+                    ModelBaker* modelBaker = dynamic_cast<ModelBaker*>(baker.get());
+                    if (modelBaker) {
+                        modelBaker->setShouldQuantizeGeometry(_quantizeGeometryCheckBox->isChecked());
+                    }
+                }
 
                 // move the baker to the FBX baker thread
                 baker->moveToThread(Oven::instance().getNextWorkerThread());

--- a/tools/oven/src/ui/ModelBakeWidget.h
+++ b/tools/oven/src/ui/ModelBakeWidget.h
@@ -13,6 +13,7 @@
 #define hifi_ModelBakeWidget_h
 
 #include <QtWidgets/QWidget>
+#include <QCheckBox>
 
 #include <SettingHandle.h>
 
@@ -41,6 +42,7 @@ private:
 
     QLineEdit* _modelLineEdit;
     QLineEdit* _outputDirLineEdit;
+    QCheckBox* _quantizeGeometryCheckBox;
 
     Setting::Handle<QString> _exportDirectory;
     Setting::Handle<QString> _modelStartDirectory;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1469

This PR adds the option to disable quantization of geometry in baked models, effectively leaving the geometry at its uncompressed size, while still allowing textures to be baked.