### PR TITLE
Make hfm::Deformer more closely resemble original model data

### DIFF
--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -296,8 +296,8 @@ public:
 // Formerly contained in hfm::Mesh
 class Deformer {
 public:
-    std::vector<uint16_t> indices;
-    std::vector<uint16_t> weights;
+    std::vector<uint32_t> indices;
+    std::vector<float> weights;
 };
 
 class DynamicTransform {


### PR DESCRIPTION
The idea will be to convert the data to `uint16_t` format during `BuildGraphicsMeshTask`, as that is the only place cluster weights are used.