### PR TITLE
Sit bug fixes

### DIFF
--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -4598,6 +4598,10 @@
                                                                                                 {
                                                                                                     "state": "strafeLeftHmd",
                                                                                                     "var": "isMovingLeftHmd"
+                                                                                                },
+                                                                                                {
+                                                                                                    "state": "idle",
+                                                                                                    "var": "isNotSeated"
                                                                                                 }
                                                                                             ]
                                                                                         },

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2903,6 +2903,9 @@ private:
     int _reactionEnabledRefCounts[NUM_AVATAR_BEGIN_END_REACTIONS] { 0, 0, 0 };
 
     mutable std::mutex _reactionLock;
+
+    // used to prevent character from jumping after endSit is called.
+    bool _endSitKeyPressComplete { false };
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);


### PR DESCRIPTION
* You should not be able to move after being seated, even if you switch seats.
* You should not be able to jump out of the chair by holding the space bar.
* Fixed small issue with the sitting to standing transition being delayed. (causing the user to look
  like there were sitting in mid-air)  This was due to a missing transition in the animation.json

https://highfidelity.atlassian.net/browse/BUGZ-1286
https://highfidelity.atlassian.net/browse/BUGZ-1428