### PR TITLE
BUGZ-1487: bug fix for inability to pick entities after unowned kinematic motion - 0.84 version

### DIFF
--- a/libraries/physics/src/EntityMotionState.cpp
+++ b/libraries/physics/src/EntityMotionState.cpp
@@ -122,6 +122,12 @@ void EntityMotionState::handleDeactivation() {
         _body->setWorldTransform(worldTrans);
         // no need to update velocities... should already be zero
     }
+    if (!isLocallyOwned()) {
+        // HACK: To allow the ESS to move entities around in a kinematic way we had to remove the requirement that
+        // every moving+simulated entity has an authoritative simulation owner.  As a result, we cannot rely
+        // on a simulation owner to update the QueryAACube on the entity-server.
+        _entity->updateQueryAACube();
+    }
 }
 
 // virtual

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -528,6 +528,8 @@ void PhysicalEntitySimulation::handleChangedMotionStates(const VectorOfMotionSta
                     addOwnership(entityState);
                 } else if (entityState->shouldSendBid()) {
                     addOwnershipBid(entityState);
+                } else {
+                    entityState->getEntity()->updateQueryAACube();
                 }
             }
         }


### PR DESCRIPTION
To allow the ESS to move objects kinematically (PR-16146) we had to remove the requirement for interface-client-owned kinematic motion. That change continues to deliver collateral damage. This PR tries to fix the latest variety: an un-owned kinematic entity's QueryAACube is sometimes incorrect enough to confound selection/grabbing... because it used to be the duty of the simulation owner to supply it and all the non-owners expected it to be supplied by the owner.

In fact, this is a theoretical fix as I was unable to reproduce the bug.

https://highfidelity.atlassian.net/browse/BUGZ-1487