### PR TITLE
Fix additive blending on avatars with non identity scale.

### DIFF
--- a/libraries/animation/src/AnimUtil.cpp
+++ b/libraries/animation/src/AnimUtil.cpp
@@ -54,12 +54,14 @@ void blend4(size_t numPoses, const AnimPose* a, const AnimPose* b, const AnimPos
 // additive blend
 void blendAdd(size_t numPoses, const AnimPose* a, const AnimPose* b, float alpha, AnimPose* result) {
 
-    const glm::quat identity = glm::quat();
+    const glm::vec3 IDENTITY_SCALE = glm::vec3(1.0f);
+    const glm::quat IDENTITY_ROT = glm::quat();
+
     for (size_t i = 0; i < numPoses; i++) {
         const AnimPose& aPose = a[i];
         const AnimPose& bPose = b[i];
 
-        result[i].scale() = lerp(aPose.scale(), bPose.scale(), alpha);
+        result[i].scale() = aPose.scale() * lerp(IDENTITY_SCALE, bPose.scale(), alpha);
 
         // ensure that delta has the same "polarity" as the identity quat.
         // we don't need to do a full dot product, just sign of w is sufficient.
@@ -67,7 +69,7 @@ void blendAdd(size_t numPoses, const AnimPose* a, const AnimPose* b, float alpha
         if (delta.w < 0.0f) {
             delta = -delta;
         }
-        delta = glm::lerp(identity, delta, alpha);
+        delta = glm::lerp(IDENTITY_ROT, delta, alpha);
         result[i].rot() = glm::normalize(aPose.rot() * delta);
         result[i].trans() = aPose.trans() + (alpha * bPose.trans());
     }


### PR DESCRIPTION
Some avatars that have non 1.0 scale values were incorrectly being scaled during additive blends, this fixes that.

https://highfidelity.atlassian.net/browse/BUGZ-1418