### PR TITLE
(DEV-591) Change BuildGraphicsMeshTask to use new deformers

### DIFF
--- a/libraries/fbx/src/FBXSerializer.cpp
+++ b/libraries/fbx/src/FBXSerializer.cpp
@@ -1480,7 +1480,7 @@ HFMModel* FBXSerializer::extractHFMModel(const hifi::VariantHash& mapping, const
                 // of skinning information in FBX
                 QString jointID = _connectionChildMap.value(clusterID);
                 hfmCluster.jointIndex = modelIDs.indexOf(jointID);
-                if (hfmCluster.jointIndex == -1) {
+                if (hfmCluster.jointIndex == hfm::Cluster::INVALID_JOINT_INDEX) {
                     qCDebug(modelformat) << "Joint not in model list: " << jointID;
                     hfmCluster.jointIndex = 0;
                 }
@@ -1514,7 +1514,7 @@ HFMModel* FBXSerializer::extractHFMModel(const hifi::VariantHash& mapping, const
         {
             HFMCluster cluster;
             cluster.jointIndex = modelIDs.indexOf(modelID);
-            if (cluster.jointIndex == -1) {
+            if (cluster.jointIndex == hfm::Cluster::INVALID_JOINT_INDEX) {
                 qCDebug(modelformat) << "Model not in model list: " << modelID;
                 cluster.jointIndex = 0;
             }

--- a/libraries/hfm/src/hfm/HFM.cpp
+++ b/libraries/hfm/src/hfm/HFM.cpp
@@ -175,7 +175,7 @@ void HFMModel::computeKdops() {
 
         // NOTE: points are in joint-frame
         ShapeVertices& points = shapeVertices.at(i);
-        glm::quat rotOffset = jointRotationOffsets.contains(i) ? glm::inverse(jointRotationOffsets[i]) : quat();
+        glm::quat rotOffset = jointRotationOffsets.contains((int)i) ? glm::inverse(jointRotationOffsets[(int)i]) : quat();
         if (points.size() > 0) {
             // compute average point
             glm::vec3 avgPoint = glm::vec3(0.0f);

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -66,6 +66,8 @@ static const int DRACO_ATTRIBUTE_ORIGINAL_INDEX = DRACO_BEGIN_CUSTOM_HIFI_ATTRIB
 // High Fidelity Model namespace
 namespace hfm {
 
+static const uint32_t UNDEFINED_KEY = (uint32_t)-1;
+
 /// A single blendshape.
 class Blendshape {
 public:
@@ -301,7 +303,7 @@ public:
 
 class DynamicTransform {
 public:
-    std::vector<uint32_t> deformers;
+    std::vector<uint16_t> deformers;
     std::vector<Cluster> clusters; // affect the deformer of the same index
     std::vector<uint32_t> blendshapes;
     // There are also the meshExtents and modelTransform, which for now are left in hfm::Mesh
@@ -310,8 +312,6 @@ public:
 // The lightweight model part description.
 class Shape {
 public:
-    const static uint32_t UNDEFINED_KEY { (uint32_t)-1 };
-
     uint32_t mesh { UNDEFINED_KEY };
     uint32_t meshPart { UNDEFINED_KEY };
     uint32_t material { UNDEFINED_KEY };

--- a/libraries/hfm/src/hfm/HFM.h
+++ b/libraries/hfm/src/hfm/HFM.h
@@ -124,7 +124,8 @@ public:
 /// A single binding to a joint.
 class Cluster {
 public:
-    uint32_t jointIndex;
+    static const uint32_t INVALID_JOINT_INDEX { (uint32_t)-1 };
+    uint32_t jointIndex { INVALID_JOINT_INDEX };
     glm::mat4 inverseBindMatrix;
     Transform inverseBindTransform;
 };

--- a/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.cpp
+++ b/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.cpp
@@ -172,7 +172,7 @@ void buildGraphicsMesh(const hfm::Mesh& hfmMesh, graphics::MeshPointer& graphics
     ReweightedDeformers reweightedDeformers = getReweightedDeformers(hfmMesh.vertices.size(), dynamicTransform, meshDeformers, NUM_CLUSTERS_PER_VERT);
     // Cluster indices and weights must be the same sizes
     if (reweightedDeformers.trimmedToMatch) {
-        HIFI_FCDEBUG_ID(model_baker(), repeatMessageID, "BuildGraphicsMeshTask -- The number of indices and weights for a blendshape had different sizes and have been trimmed to match");
+        HIFI_FCDEBUG_ID(model_baker(), repeatMessageID, "BuildGraphicsMeshTask -- The number of indices and weights for a deformer had different sizes and have been trimmed to match");
     }
     // Record cluster sizes
     const int numVertClusters = reweightedDeformers.indices.size() / NUM_CLUSTERS_PER_VERT;

--- a/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.cpp
+++ b/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.cpp
@@ -45,7 +45,6 @@ ReweightedDeformers getReweightedDeformers(size_t numMeshVertices, const hfm::Dy
     weightAccumulators.resize(numClusterIndices, 0.0f);
     for (uint16_t i = 0; i < (uint16_t)deformers.size(); ++i) {
         const hfm::Deformer& deformer = *deformers[i];
-        const hfm::Cluster& cluster = dynamicTransform->clusters[i];
 
         if (deformer.indices.size() != deformer.weights.size()) {
             reweightedDeformers.trimmedToMatch = true;

--- a/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.cpp
+++ b/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.cpp
@@ -38,12 +38,12 @@ ReweightedDeformers getReweightedDeformers(size_t numMeshVertices, const hfm::Dy
     size_t numClusterIndices = numMeshVertices * weightsPerVertex;
     ReweightedDeformers reweightedDeformers;
     // TODO: Consider having a rootCluster property in the DynamicTransform rather than appending the root to the end of the cluster list.
-    reweightedDeformers.indices.resize(numClusterIndices, deformers.size() - 1);
+    reweightedDeformers.indices.resize(numClusterIndices, (uint16_t)(deformers.size() - 1));
     reweightedDeformers.weights.resize(numClusterIndices, 0);
 
     std::vector<float> weightAccumulators;
     weightAccumulators.resize(numClusterIndices, 0.0f);
-    for (size_t i = 0; i < deformers.size(); ++i) {
+    for (uint16_t i = 0; i < (uint16_t)deformers.size(); ++i) {
         const hfm::Deformer& deformer = *deformers[i];
         const hfm::Cluster& cluster = dynamicTransform->clusters[i];
 
@@ -175,19 +175,19 @@ void buildGraphicsMesh(const hfm::Mesh& hfmMesh, graphics::MeshPointer& graphics
         HIFI_FCDEBUG_ID(model_baker(), repeatMessageID, "BuildGraphicsMeshTask -- The number of indices and weights for a deformer had different sizes and have been trimmed to match");
     }
     // Record cluster sizes
-    const int numVertClusters = reweightedDeformers.indices.size() / NUM_CLUSTERS_PER_VERT;
-    const int clusterIndicesSize = numVertClusters * clusterIndiceElement.getSize();
-    const int clusterWeightsSize = numVertClusters * clusterWeightElement.getSize();
+    const size_t numVertClusters = reweightedDeformers.indices.size() / NUM_CLUSTERS_PER_VERT;
+    const size_t clusterIndicesSize = numVertClusters * clusterIndiceElement.getSize();
+    const size_t clusterWeightsSize = numVertClusters * clusterWeightElement.getSize();
 
     // Decide on where to put what seequencially in a big buffer:
-    const int positionsOffset = 0;
-    const int normalsAndTangentsOffset = positionsOffset + positionsSize;
-    const int colorsOffset = normalsAndTangentsOffset + normalsAndTangentsSize;
-    const int texCoordsOffset = colorsOffset + colorsSize;
-    const int texCoords1Offset = texCoordsOffset + texCoordsSize;
-    const int clusterIndicesOffset = texCoords1Offset + texCoords1Size;
-    const int clusterWeightsOffset = clusterIndicesOffset + clusterIndicesSize;
-    const int totalVertsSize = clusterWeightsOffset + clusterWeightsSize;
+    const size_t positionsOffset = 0;
+    const size_t normalsAndTangentsOffset = positionsOffset + positionsSize;
+    const size_t colorsOffset = normalsAndTangentsOffset + normalsAndTangentsSize;
+    const size_t texCoordsOffset = colorsOffset + colorsSize;
+    const size_t texCoords1Offset = texCoordsOffset + texCoordsSize;
+    const size_t clusterIndicesOffset = texCoords1Offset + texCoords1Size;
+    const size_t clusterWeightsOffset = clusterIndicesOffset + clusterIndicesSize;
+    const size_t totalVertsSize = clusterWeightsOffset + clusterWeightsSize;
 
     // Copy all vertex data in a single buffer
     auto vertBuffer = std::make_shared<gpu::Buffer>();
@@ -266,7 +266,7 @@ void buildGraphicsMesh(const hfm::Mesh& hfmMesh, graphics::MeshPointer& graphics
     if (clusterIndicesSize > 0) {
         if (meshDeformers.size() < UINT8_MAX) {
             // yay! we can fit the clusterIndices within 8-bits
-            int32_t numIndices = reweightedDeformers.indices.size();
+            int32_t numIndices = (int32_t)reweightedDeformers.indices.size();
             std::vector<uint8_t> packedDeformerIndices;
             packedDeformerIndices.resize(numIndices);
             for (int32_t i = 0; i < numIndices; ++i) {
@@ -289,7 +289,7 @@ void buildGraphicsMesh(const hfm::Mesh& hfmMesh, graphics::MeshPointer& graphics
     auto vertexBufferStream = std::make_shared<gpu::BufferStream>();
 
     gpu::BufferPointer attribBuffer;
-    int totalAttribBufferSize = totalVertsSize;
+    size_t totalAttribBufferSize = totalVertsSize;
     gpu::uint8 posChannel = 0;
     gpu::uint8 tangentChannel = posChannel;
     gpu::uint8 attribChannel = posChannel;
@@ -465,9 +465,9 @@ void BuildGraphicsMeshTask::run(const baker::BakeContextPointer& context, const 
     const auto& deformers = input.get7();
 
     // Currently, there is only (at most) one dynamicTransform per mesh
-    // An undefined shape.dynamicTransform has the value hfm::Shape::UNDEFINED_KEY
+    // An undefined shape.dynamicTransform has the value hfm::UNDEFINED_KEY
     std::vector<uint32_t> dynamicTransformPerMesh;
-    dynamicTransformPerMesh.resize(meshes.size(), hfm::Shape::UNDEFINED_KEY);
+    dynamicTransformPerMesh.resize(meshes.size(), hfm::UNDEFINED_KEY);
     for (const auto& shape : shapes) {
         uint32_t dynamicTransformIndex = shape.dynamicTransform;
         dynamicTransformPerMesh[shape.mesh] = dynamicTransformIndex;
@@ -483,7 +483,7 @@ void BuildGraphicsMeshTask::run(const baker::BakeContextPointer& context, const 
         auto dynamicTransformIndex = dynamicTransformPerMesh[i];
         const hfm::DynamicTransform* dynamicTransform = nullptr;
         std::vector<const hfm::Deformer*> meshDeformers;
-        if (dynamicTransformIndex != hfm::Shape::UNDEFINED_KEY) {
+        if (dynamicTransformIndex != hfm::UNDEFINED_KEY) {
             dynamicTransform = &dynamicTransforms[dynamicTransformIndex];
             for (const auto& deformerIndex : dynamicTransform->deformers) {
                 const auto& deformer = deformers[deformerIndex];

--- a/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.h
+++ b/libraries/model-baker/src/model-baker/BuildGraphicsMeshTask.h
@@ -20,7 +20,7 @@
 
 class BuildGraphicsMeshTask {
 public:
-    using Input = baker::VaryingSet5<std::vector<hfm::Mesh>, hifi::URL, baker::MeshIndicesToModelNames, baker::NormalsPerMesh, baker::TangentsPerMesh>;
+    using Input = baker::VaryingSet8<std::vector<hfm::Mesh>, hifi::URL, baker::MeshIndicesToModelNames, baker::NormalsPerMesh, baker::TangentsPerMesh, std::vector<hfm::Shape>, std::vector<hfm::DynamicTransform>, std::vector<hfm::Deformer>>;
     using Output = std::vector<graphics::MeshPointer>;
     using JobModel = baker::Job::ModelIO<BuildGraphicsMeshTask, Input, Output>;
 


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-591

Another step in the project to introduce hfm::Shape to enable instancing, this PR adds blendshape weight consolidation to the hfm preparation task so it doesn't have to be changed individually in both the FBXSerializer and the GLTFSerializer.