### PR TITLE
Put flush timer on right thread without parenting

### DIFF
--- a/assignment-client/src/AssignmentClientApp.cpp
+++ b/assignment-client/src/AssignmentClientApp.cpp
@@ -240,7 +240,7 @@ AssignmentClientApp::AssignmentClientApp(int argc, char* argv[]) :
 
     QThread::currentThread()->setObjectName("main thread");
 
-    LogHandler::getInstance().setParent(this);
+    LogHandler::getInstance().moveToThread(thread());
     LogHandler::getInstance().setupRepeatedMessageFlusher();
 
     DependencyManager::registerInheritance<LimitedNodeList, NodeList>();

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -174,7 +174,7 @@ DomainServer::DomainServer(int argc, char* argv[]) :
 
     LogUtils::init();
 
-    LogHandler::getInstance().setParent(this);
+    LogHandler::getInstance().moveToThread(thread());
     LogHandler::getInstance().setupRepeatedMessageFlusher();
 
     qDebug() << "Setting up domain-server";

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1062,7 +1062,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     setProperty(hifi::properties::STEAM, (steamClient && steamClient->isRunning()));
     setProperty(hifi::properties::CRASHED, _previousSessionCrashed);
 
-    LogHandler::getInstance().setParent(this);
+    LogHandler::getInstance().moveToThread(thread());
     LogHandler::getInstance().setupRepeatedMessageFlusher();
 
     {


### PR DESCRIPTION
Related to [JIRA ticket](https://highfidelity.atlassian.net/browse/BUGZ-489)

Parenting is causing a crash on shutdown