### PR TITLE
BUGZ-1553: Reset look at params when the avatar's location is set

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -4144,6 +4144,7 @@ void MyAvatar::goToLocation(const glm::vec3& newPosition,
         _goToOrientation = quatOrientation;
     }
 
+    resetLookAtRotation(_goToPosition, _goToOrientation);
     emit transformChanged();
 }
 
@@ -5996,6 +5997,7 @@ bool MyAvatar::pinJoint(int index, const glm::vec3& position, const glm::quat& o
     }
 
     slamPosition(position);
+    resetLookAtRotation(position, orientation);
     setWorldOrientation(orientation);
 
     auto it = std::find(_pinnedJoints.begin(), _pinnedJoints.end(), index);
@@ -6660,6 +6662,15 @@ void MyAvatar::resetHeadLookAt() {
         _skeletonModel->getRig().setDirectionalBlending(HEAD_BLENDING_NAME, glm::vec3(),
             HEAD_ALPHA_NAME, HEAD_ALPHA_BLENDING);
     }
+}
+
+void MyAvatar::resetLookAtRotation(const glm::vec3& avatarPosition, const glm::quat& avatarOrientation) {
+    // Align the look at values to the given avatar orientation
+    float yaw = safeEulerAngles(avatarOrientation).y;
+    _lookAtYaw = glm::angleAxis(yaw, avatarOrientation * Vectors::UP);
+    _lookAtPitch = Quaternions::IDENTITY;
+    _lookAtCameraTarget =  avatarPosition + avatarOrientation * Vectors::FRONT;
+    resetHeadLookAt();
 }
 
 void MyAvatar::updateHeadLookAt(float deltaTime) {    

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2654,11 +2654,6 @@ private:
     bool _scriptControlsHeadLookAt { false };
     float _scriptHeadControlTimer { 0.0f };
 
-    // LookAt camera data
-    float _selfieTriggerAngle { 55.0f };
-    float _frontLookAtSpeed { 0.15f };
-    float _backLookAtSpeed { 0.25f };
-
     Setting::Handle<float> _realWorldFieldOfView;
     Setting::Handle<bool> _useAdvancedMovementControls;
     Setting::Handle<bool> _showPlayArea;
@@ -2685,6 +2680,7 @@ private:
     void initFlowFromFST();
     void updateHeadLookAt(float deltaTime);
     void resetHeadLookAt();
+    void resetLookAtRotation(const glm::vec3& avatarPosition, const glm::quat& avatarOrientation);
 
     // Avatar Preferences
     QUrl _fullAvatarURLFromPreferences;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/BUGZ-1553

This PR resets the look at parameters that configure the new camera modes (look at and selfie), when the location of the avatar is set after entering a new domain or sitting.
Also, some unused code added here: https://github.com/highfidelity/hifi/pull/16144 has been cleaned up 


 