### PR TITLE
BUGZ-1510: don't forget to cleanup expired mortal entities

### DIFF
--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -75,7 +75,8 @@ void PhysicalEntitySimulation::removeEntityInternal(EntityItemPointer entity) {
         if (motionState) {
             removeOwnershipData(motionState);
             _entitiesToRemoveFromPhysics.insert(entity);
-        } else if (entity->isDead() && entity->getElement()) {
+        }
+        if (entity->isDead() && entity->getElement()) {
             _deadEntities.insert(entity);
         }
     }


### PR DESCRIPTION
This PR fixes a bug where entities with finite lifetime would not necessarily be removed from the entity-tree:

https://highfidelity.atlassian.net/browse/BUGZ-1510