### PR TITLE
Revert "BUGZ-1551: Do not download Qt if Qt_CMAKE_PREFIX_PATH is set as an environment variable"

### DIFF
--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -257,27 +257,26 @@ endif()
 
     def installQt(self):
         qt5InstallPath = self.getQt5InstallPath()
-        if os.getenv('QT_CMAKE_PREFIX_PATH') == None:
-            if not os.path.isdir(qt5InstallPath):
-                print ('Downloading Qt from AWS')
-                dest, tail = os.path.split(qt5InstallPath)
+        if not os.path.isdir(qt5InstallPath):
+            print ('Downloading Qt from AWS')
+            dest, tail = os.path.split(qt5InstallPath)
 
-                url = 'NOT DEFINED'
-                if platform.system() == 'Windows':
-                    url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-windows3.tar.gz'
-                elif platform.system() == 'Darwin':
-                    url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-macos3.tar.gz'
-                elif platform.system() == 'Linux':
-                    if platform.linux_distribution()[1][:3] == '16.':
-                        url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-ubuntu-16.04-with-symbols.tar.gz'
-                    elif platform.linux_distribution()[1][:3] == '18.':
-                        url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-ubuntu-18.04.tar.gz'
-                    else:
-                        print('UNKNOWN LINUX VERSION!!!')
+            url = 'NOT DEFINED'
+            if platform.system() == 'Windows':
+                url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-windows3.tar.gz'
+            elif platform.system() == 'Darwin':
+                url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-macos3.tar.gz'
+            elif platform.system() == 'Linux':
+                if platform.linux_distribution()[1][:3] == '16.':
+                    url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-ubuntu-16.04-with-symbols.tar.gz'
+                elif platform.linux_distribution()[1][:3] == '18.':
+                    url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-ubuntu-18.04.tar.gz'
                 else:
-                    print('UNKNOWN OPERATING SYSTEM!!!')
-
-                print('Extracting ' + url + ' to ' + dest)
-                hifi_utils.downloadAndExtract(url, dest)
+                    print('UNKNOWN LINUX VERSION!!!')
             else:
-                print ('Qt has already been downloaded')
+                print('UNKNOWN OPERATING SYSTEM!!!')
+
+            print('Extracting ' + url + ' to ' + dest)
+            hifi_utils.downloadAndExtract(url, dest)
+        else:
+            print ('Qt has already been downloaded')


### PR DESCRIPTION
Reverts highfidelity/hifi#16229

This PR seems to be causing (randomly) broken builds...

According to @jherico's research...

> the QT_CMAKE_PREFIX_PATH env variable doesn't actually override the behavior of our code... so Dante's change probably has no impact if a machine already has the Qt dependency downloaded
however, if a machine doesn't already have it, then this change breaks it because it sees the env variable, refuses to download Qt, and then can't find Qt

But there's also a possible fix on the build systems....

> we can fix this by no longer setting the variable on the build hosts

cc: @joy-highfidelity @MattHardcastle @shanzzam 

We have two choices:
- merge this revert
- change the windows jenkins config to not set the ENV variable