### PR TITLE
BUGZ-1543: Suppress repeated socket logging

### DIFF
--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -239,7 +239,7 @@ qint64 Socket::writeDatagram(const QByteArray& datagram, const HifiSockAddr& soc
     int pending = _udpSocket.bytesToWrite();
     if (bytesWritten < 0 || pending) {
         int wsaError = 0;
-        static std::atomic<int> previousWsaError = 0;
+        static std::atomic<int> previousWsaError (0);
 #ifdef WIN32
         wsaError = WSAGetLastError();
 #endif
@@ -534,7 +534,7 @@ std::vector<HifiSockAddr> Socket::getConnectionSockAddrs() {
 
 void Socket::handleSocketError(QAbstractSocket::SocketError socketError) {
     int wsaError = 0;
-    static std::atomic<int> previousWsaError = 0;
+    static std::atomic<int> previousWsaError(0);
 #ifdef WIN32
     wsaError = WSAGetLastError();
 #endif

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -239,11 +239,21 @@ qint64 Socket::writeDatagram(const QByteArray& datagram, const HifiSockAddr& soc
     int pending = _udpSocket.bytesToWrite();
     if (bytesWritten < 0 || pending) {
         int wsaError = 0;
+        static std::atomic<int> previousWsaError = 0;
 #ifdef WIN32
         wsaError = WSAGetLastError();
 #endif
-        qCDebug(networking) << "udt::writeDatagram (" << _udpSocket.state() << sockAddr << ") error - " << wsaError << _udpSocket.error() << "(" << _udpSocket.errorString() << ")"
+        QString errorString;
+        QDebug(&errorString) << "udt::writeDatagram (" << _udpSocket.state() << sockAddr << ") error - "
+            << wsaError << _udpSocket.error() << "(" << _udpSocket.errorString() << ")"
             << (pending ? "pending bytes:" : "pending:") << pending;
+
+        if (previousWsaError.exchange(wsaError) != wsaError) {
+            qCDebug(networking).noquote() << errorString;
+        } else {
+            HIFI_FCDEBUG(networking(), errorString.toLatin1().constData());
+        }
+
 #ifdef DEBUG_EVENT_QUEUE
         int nodeListQueueSize = ::hifi::qt::getEventQueueSize(thread());
         qCDebug(networking) << "Networking queue size - " << nodeListQueueSize << "writing datagram to" << sockAddr;
@@ -525,12 +535,22 @@ std::vector<HifiSockAddr> Socket::getConnectionSockAddrs() {
 
 void Socket::handleSocketError(QAbstractSocket::SocketError socketError) {
     int wsaError = 0;
+    static std::atomic<int> previousWsaError = 0;
 #ifdef WIN32
     wsaError = WSAGetLastError();
 #endif
     int pending = _udpSocket.bytesToWrite();
-    qCDebug(networking) << "udt::Socket (" << _udpSocket.state() << ") error - " << wsaError << socketError << "(" << _udpSocket.errorString() << ")"
-        << (pending ? "pending bytes:" : "pending:") << pending;
+    QString errorString;
+    QDebug(&errorString) << "udt::Socket (" << _udpSocket.state() << ") error - " << wsaError << socketError <<
+        "(" << _udpSocket.errorString() << ")" << (pending ? "pending bytes:" : "pending:")
+        << pending;
+
+    if (previousWsaError.exchange(wsaError) != wsaError) {
+        qCDebug(networking).noquote() << errorString;
+    } else {
+        HIFI_FCDEBUG(networking(), errorString.toLatin1().constData());
+    }
+
 #ifdef DEBUG_EVENT_QUEUE
     int nodeListQueueSize = ::hifi::qt::getEventQueueSize(thread());
     qCDebug(networking) << "Networking queue size - " << nodeListQueueSize;

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -250,14 +250,13 @@ qint64 Socket::writeDatagram(const QByteArray& datagram, const HifiSockAddr& soc
 
         if (previousWsaError.exchange(wsaError) != wsaError) {
             qCDebug(networking).noquote() << errorString;
+#ifdef DEBUG_EVENT_QUEUE
+            int nodeListQueueSize = ::hifi::qt::getEventQueueSize(thread());
+            qCDebug(networking) << "Networking queue size - " << nodeListQueueSize << "writing datagram to" << sockAddr;
+#endif  // DEBUG_EVENT_QUEUE
         } else {
             HIFI_FCDEBUG(networking(), errorString.toLatin1().constData());
         }
-
-#ifdef DEBUG_EVENT_QUEUE
-        int nodeListQueueSize = ::hifi::qt::getEventQueueSize(thread());
-        qCDebug(networking) << "Networking queue size - " << nodeListQueueSize << "writing datagram to" << sockAddr;
-#endif // DEBUG_EVENT_QUEUE    
     }
 
     return bytesWritten;
@@ -547,14 +546,13 @@ void Socket::handleSocketError(QAbstractSocket::SocketError socketError) {
 
     if (previousWsaError.exchange(wsaError) != wsaError) {
         qCDebug(networking).noquote() << errorString;
+#ifdef DEBUG_EVENT_QUEUE
+        int nodeListQueueSize = ::hifi::qt::getEventQueueSize(thread());
+        qCDebug(networking) << "Networking queue size - " << nodeListQueueSize;
+#endif  // DEBUG_EVENT_QUEUE
     } else {
         HIFI_FCDEBUG(networking(), errorString.toLatin1().constData());
     }
-
-#ifdef DEBUG_EVENT_QUEUE
-    int nodeListQueueSize = ::hifi::qt::getEventQueueSize(thread());
-    qCDebug(networking) << "Networking queue size - " << nodeListQueueSize;
-#endif // DEBUG_EVENT_QUEUE
 }
 
 void Socket::handleStateChanged(QAbstractSocket::SocketState socketState) {


### PR DESCRIPTION
Jira: https://highfidelity.atlassian.net/browse/BUGZ-1543

Use the logging accumulation functionality to avoid error logging on every sent packet; instead printing a count every 5 s.