### PR TITLE
BUGZ-491: Fix tablet.loadWebScreenOnTop()

### DIFF
--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -330,7 +330,6 @@ QObject* TabletScriptingInterface::getFlags() {
 //
 
 static const char* TABLET_HOME_SOURCE_URL = "hifi/tablet/TabletHome.qml";
-static const char* WEB_VIEW_SOURCE_URL = "hifi/tablet/TabletWebView.qml";
 static const char* VRMENU_SOURCE_URL = "hifi/tablet/TabletMenu.qml";
 
 class TabletRootWindow : public QmlWindowClass {

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -834,38 +834,6 @@ void TabletProxy::loadWebScreenOnTop(const QVariant& url, const QString& injectJ
     loadHTMLSourceOnTopImpl(url.toString(), injectJavaScriptUrl, false, localSafeContext);
 }
 
-
-
-void TabletProxy::loadHTMLSourceImpl(const QVariant& url, const QString& injectJavaScriptUrl, bool localSafeContext) {
-    if (QThread::currentThread() != thread()) {
-        qCWarning(uiLogging) << __FUNCTION__ << "may not be called directly by scripts";
-        return;
-
-    }
-
-
-    QObject* root = nullptr;
-    if (!_toolbarMode && _qmlTabletRoot) {
-        root = _qmlTabletRoot;
-    } else if (_toolbarMode && _desktopWindow) {
-        root = _desktopWindow->asQuickItem();
-    }
-
-    if (root) {
-        if (localSafeContext) {
-            hifi::scripting::setLocalAccessSafeThread(true);
-        }
-        QMetaObject::invokeMethod(root, "loadQMLOnTop", Q_ARG(const QVariant&, QVariant(WEB_VIEW_SOURCE_URL)));
-        QMetaObject::invokeMethod(root, "setShown", Q_ARG(const QVariant&, QVariant(true)));
-        if (_toolbarMode && _desktopWindow) {
-            QMetaObject::invokeMethod(root, "setResizable", Q_ARG(const QVariant&, QVariant(false)));
-        }
-        QMetaObject::invokeMethod(root, "loadWebOnTop", Q_ARG(const QVariant&, QVariant(url)), Q_ARG(const QVariant&, QVariant(injectJavaScriptUrl)));
-        hifi::scripting::setLocalAccessSafeThread(false);
-    }
-    _state = State::Web;
-}
-
 void TabletProxy::gotoWebScreen(const QString& url, const QString& injectedJavaScriptUrl, bool loadOtherBase) {
     bool localSafeContext = hifi::scripting::isLocalAccessSafeThread();
     if (QThread::currentThread() != thread()) {

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -869,16 +869,14 @@ void TabletProxy::loadHTMLSourceImpl(const QVariant& url, const QString& injectJ
 void TabletProxy::gotoWebScreen(const QString& url, const QString& injectedJavaScriptUrl, bool loadOtherBase) {
     bool localSafeContext = hifi::scripting::isLocalAccessSafeThread();
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "loadHTMLSourceImpl", Q_ARG(QString, url), Q_ARG(QString, injectedJavaScriptUrl), Q_ARG(bool, loadOtherBase), Q_ARG(bool, localSafeContext));
+        QMetaObject::invokeMethod(this, "loadHTMLSourceOnTopImpl", Q_ARG(QString, url), Q_ARG(QString, injectedJavaScriptUrl), Q_ARG(bool, loadOtherBase), Q_ARG(bool, localSafeContext));
         return;
     }
 
-
-    loadHTMLSourceImpl(url, injectedJavaScriptUrl, loadOtherBase, localSafeContext);
+    loadHTMLSourceOnTopImpl(url, injectedJavaScriptUrl, loadOtherBase, localSafeContext);
 }
 
-void TabletProxy::loadHTMLSourceImpl(const QString& url, const QString& injectedJavaScriptUrl, bool loadOtherBase, bool localSafeContext) {
-
+void TabletProxy::loadHTMLSourceOnTopImpl(const QString& url, const QString& injectedJavaScriptUrl, bool loadOtherBase, bool localSafeContext) {
     QObject* root = nullptr;
     if (!_toolbarMode && _qmlTabletRoot) {
         root = _qmlTabletRoot;
@@ -911,7 +909,6 @@ void TabletProxy::loadHTMLSourceImpl(const QString& url, const QString& injected
         _initialWebPathParams.first = injectedJavaScriptUrl;
         _initialWebPathParams.second = loadOtherBase;
         _initialScreen = true;
-
     }
 }
 

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -827,11 +827,11 @@ void TabletProxy::loadWebScreenOnTop(const QVariant& url) {
 void TabletProxy::loadWebScreenOnTop(const QVariant& url, const QString& injectJavaScriptUrl) {
     bool localSafeContext = hifi::scripting::isLocalAccessSafeThread();
     if (QThread::currentThread() != thread()) {
-        QMetaObject::invokeMethod(this, "loadHTMLSourceImpl", Q_ARG(QVariant, url), Q_ARG(QString, injectJavaScriptUrl), Q_ARG(bool, localSafeContext));
+        QMetaObject::invokeMethod(this, "loadHTMLSourceOnTopImpl", Q_ARG(QString, url.toString()), Q_ARG(QString, injectJavaScriptUrl), Q_ARG(bool, false), Q_ARG(bool, localSafeContext));
         return;
     }
 
-    loadHTMLSourceImpl(url, injectJavaScriptUrl, localSafeContext);
+    loadHTMLSourceOnTopImpl(url.toString(), injectJavaScriptUrl, false, localSafeContext);
 }
 
 

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -293,29 +293,38 @@ public:
     Q_INVOKABLE void loadQMLSource(const QVariant& path, bool resizable = false);
 
     /**jsdoc
-     * Internal function, do not call from scripts
      * @function TabletProxy#loadQMLSourceImpl
+     * @deprecated This function is deprecated and will be removed.
      */
+    // Internal function, do not call from scripts.
     Q_INVOKABLE void loadQMLSourceImpl(const QVariant& path, bool resizable, bool localSafeContext);
 
-     /**jsdoc
-     * Internal function, do not call from scripts
+    /**jsdoc
      * @function TabletProxy#loadHTMLSourceImpl
+     * @deprecated This function is deprecated and will be removed.
      */
+    // Internal function, do not call from scripts.
     Q_INVOKABLE void loadHTMLSourceImpl(const QVariant& url, const QString& injectJavaScriptUrl, bool localSafeContext);
 
-     /**jsdoc
-     * Internal function, do not call from scripts
+    /**jsdoc
      * @function TabletProxy#loadHTMLSourceImpl
+     * @deprecated This function is deprecated and will be removed.
      */
+    // Internal function, do not call from scripts.
     Q_INVOKABLE void loadHTMLSourceImpl(const QString& url, const QString& injectedJavaScriptUrl, bool loadOtherBase, bool localSafeContext);
 
-     /**jsdoc
-     * Internal function, do not call from scripts
+    /**jsdoc
      * @function TabletProxy#returnToPreviousAppImpl
+     * @deprecated This function is deprecated and will be removed.
      */
+    // Internal function, do not call from scripts.
     Q_INVOKABLE void returnToPreviousAppImpl(bool localSafeContext);
 
+    /**jsdoc
+     *@function TabletProxy#loadQMLOnTopImpl
+     * @deprecated This function is deprecated and will be removed.
+     */
+    // Internal function, do not call from scripts.
     Q_INVOKABLE void loadQMLOnTopImpl(const QVariant& path, bool localSafeContext);
 
     // FIXME: This currently relies on a script initializing the tablet (hence the bool denoting success);

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -300,13 +300,6 @@ public:
     Q_INVOKABLE void loadQMLSourceImpl(const QVariant& path, bool resizable, bool localSafeContext);
 
     /**jsdoc
-     * @function TabletProxy#loadHTMLSourceImpl
-     * @deprecated This function is deprecated and will be removed.
-     */
-    // Internal function, do not call from scripts.
-    Q_INVOKABLE void loadHTMLSourceImpl(const QVariant& url, const QString& injectJavaScriptUrl, bool localSafeContext);
-
-    /**jsdoc
      * @function TabletProxy#loadHTMLSourceOnTopImpl
      * @deprecated This function is deprecated and will be removed.
      */

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -307,11 +307,11 @@ public:
     Q_INVOKABLE void loadHTMLSourceImpl(const QVariant& url, const QString& injectJavaScriptUrl, bool localSafeContext);
 
     /**jsdoc
-     * @function TabletProxy#loadHTMLSourceImpl
+     * @function TabletProxy#loadHTMLSourceOnTopImpl
      * @deprecated This function is deprecated and will be removed.
      */
     // Internal function, do not call from scripts.
-    Q_INVOKABLE void loadHTMLSourceImpl(const QString& url, const QString& injectedJavaScriptUrl, bool loadOtherBase, bool localSafeContext);
+    Q_INVOKABLE void loadHTMLSourceOnTopImpl(const QString& url, const QString& injectedJavaScriptUrl, bool loadOtherBase, bool localSafeContext);
 
     /**jsdoc
      * @function TabletProxy#returnToPreviousAppImpl

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -273,7 +273,9 @@ public:
     Q_INVOKABLE void gotoHomeScreen();
 
     /**jsdoc
-     * Opens a web page or app on the tablet.
+     * Opens a web app or page in addition to any current app. In tablet mode, the app or page is displayed over the top of the
+     * current app; in toolbar mode, the app is opened in a new window that replaces any current window open. If in tablet
+     * mode, the app or page can be closed using {@link TabletProxy#returnToPreviousApp}.
      * @function TabletProxy#gotoWebScreen
      * @param {string} url - The URL of the web page or app.
      * @param {string} [injectedJavaScriptUrl=""] - The URL of JavaScript to inject into the web page.
@@ -356,8 +358,8 @@ public:
 
     /**jsdoc
      * Opens a web app or page in addition to any current app. In tablet mode, the app or page is displayed over the top of the
-     * current app; in toolbar mode, the app is opened in a new window. If in tablet mode, the app or page can be closed using
-     * {@link TabletProxy#returnToPreviousApp}.
+     * current app; in toolbar mode, the app is opened in a new window that replaces any current window open. If in tablet 
+     * mode, the app or page can be closed using {@link TabletProxy#returnToPreviousApp}.
      * @function TabletProxy#loadWebScreenOnTop
      * @param {string} path - The URL of the web page or HTML app.
      * @param {string} [injectedJavaScriptURL=""] - The URL of JavaScript to inject into the web page.


### PR DESCRIPTION
Compared with the QML functions, tablet.loadQMLSource() and tablet.loadQMLScreenOnTop(), tablet.gotoWebScreen() already implemented expected tablet.loadWebScreenOnTop() behavior.

(There is no tablet.loadWebScreen() function because it hasn't been needed to date.)

Case: https://highfidelity.atlassian.net/browse/BUGZ-491 / https://highfidelity.atlassian.net/browse/DEV-1821
