### PR TITLE
BUGZ-573: Fix loadOtherBase in tablet.gotoWebScreen() not working

### DIFF
--- a/interface/resources/qml/hifi/tablet/+webengine/BlocksWebView.qml
+++ b/interface/resources/qml/hifi/tablet/+webengine/BlocksWebView.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtWebEngine 1.5
-import "../../controls" as Controls
+import "../../../controls" as Controls
 
 Controls.TabletWebView {
 	profile: WebEngineProfile { httpUserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36"}  

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -279,6 +279,7 @@ public:
      * @param {string} [injectedJavaScriptUrl=""] - The URL of JavaScript to inject into the web page.
      * @param {boolean} [loadOtherBase=false] - If <code>true</code>, the web page or app is displayed in a frame with "back" 
      * and "close" buttons.
+     * <p class="important">Deprecated: This parameter is deprecated and will be removed.</p>
      */
     Q_INVOKABLE void gotoWebScreen(const QString& url);
     Q_INVOKABLE void gotoWebScreen(const QString& url, const QString& injectedJavaScriptUrl, bool loadOtherBase = false);

--- a/unpublishedScripts/marketplace/blocks/blocksApp.js
+++ b/unpublishedScripts/marketplace/blocks/blocksApp.js
@@ -35,7 +35,7 @@
 
 	function onClicked() {
 	    if (!shown) {
-	        tablet.gotoWebScreen(APP_URL, "", true);
+	        tablet.gotoWebScreen(APP_URL, "");
 	    } else {
 	        tablet.gotoHomeScreen();
 	    }


### PR DESCRIPTION
- Fixed the "loadOtherBase" parameter to not display a blank screen.
- Updated the Blocks script to not use this parameter, so that "CLOSE" and "BACK" buttons are not displayed at the top of its screen. (They don't work.)
- Deprecated the "loadOtherBase" parameter in the JSDoc. (Blocks app is only script that uses it.)

Case: https://highfidelity.atlassian.net/browse/BUGZ-573
