### PR TITLE
DEV-2223: Add shutdown annotations for crash reporting

### DIFF
--- a/assignment-client/src/AssignmentClient.cpp
+++ b/assignment-client/src/AssignmentClient.cpp
@@ -22,6 +22,7 @@
 #include <AccountManager.h>
 #include <AddressManager.h>
 #include <Assignment.h>
+#include <CrashAnnotations.h>
 #include <LogHandler.h>
 #include <LogUtils.h>
 #include <LimitedNodeList.h>
@@ -144,6 +145,7 @@ AssignmentClient::~AssignmentClient() {
 }
 
 void AssignmentClient::aboutToQuit() {
+    crash::annotations::setShutdownState(true);
     stopAssignmentClient();
 }
 
@@ -173,6 +175,7 @@ void AssignmentClient::sendStatusPacketToACM() {
 
 void AssignmentClient::sendAssignmentRequest() {
     if (!_currentAssignment && !_isAssigned) {
+        crash::annotations::setShutdownState(false);
 
         auto nodeList = DependencyManager::get<NodeList>();
 
@@ -289,6 +292,8 @@ void AssignmentClient::handleAuthenticationRequest() {
 }
 
 void AssignmentClient::assignmentCompleted() {
+    crash::annotations::setShutdownState(true);
+    
     // we expect that to be here the previous assignment has completely cleaned up
     assert(_currentAssignment.isNull());
 

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -186,6 +186,7 @@ DomainServer::DomainServer(int argc, char* argv[]) :
     qDebug() << "[VERSION] BUILD_GLOBAL_SERVICES:" << BuildInfo::BUILD_GLOBAL_SERVICES;
     qDebug() << "[VERSION] We will be using this name to find ICE servers:" << _iceServerAddr;
 
+    connect(this, &QCoreApplication::aboutToQuit, this, &DomainServer::aboutToQuit);
 
     // make sure we have a fresh AccountManager instance
     // (need this since domain-server can restart itself and maintain static variables)

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -32,6 +32,7 @@
 #include <AccountManager.h>
 #include <AssetClient.h>
 #include <BuildInfo.h>
+#include <CrashAnnotations.h>
 #include <DependencyManager.h>
 #include <HifiConfigVariantMap.h>
 #include <HTTPConnection.h>
@@ -430,6 +431,10 @@ DomainServer::~DomainServer() {
 
     // destroy the LimitedNodeList before the DomainServer QCoreApplication is down
     DependencyManager::destroy<LimitedNodeList>();
+}
+
+void DomainServer::aboutToQuit() {
+    crash::annotations::setShutdownState(true);
 }
 
 void DomainServer::queuedQuit(QString quitMessage, int exitCode) {

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -136,6 +136,8 @@ private slots:
     void tokenGrantFinished();
     void profileRequestFinished();
 
+    void aboutToQuit();
+
 signals:
     void iceServerChanged();
     void userConnected();

--- a/domain-server/src/main.cpp
+++ b/domain-server/src/main.cpp
@@ -15,9 +15,10 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
+#include <BuildInfo.h>
+#include <CrashAnnotations.h>
 #include <LogHandler.h>
 #include <SharedUtil.h>
-#include <BuildInfo.h>
 
 #include "DomainServer.h"
 
@@ -32,6 +33,7 @@ int main(int argc, char* argv[]) {
 
     // use a do-while to handle domain-server restart
     do {
+        crash::annotations::setShutdownState(false);
         DomainServer domainServer(argc, argv);
         currentExitCode = domainServer.exec();
     } while (currentExitCode == DomainServer::EXIT_CODE_REBOOT);
@@ -39,4 +41,3 @@ int main(int argc, char* argv[]) {
     qInfo() << "Quitting.";
     return currentExitCode;
 }
-

--- a/libraries/shared/src/CrashAnnotations.cpp
+++ b/libraries/shared/src/CrashAnnotations.cpp
@@ -1,0 +1,27 @@
+//
+//  CrashAnnotations.cpp
+//  libraries/shared/src
+//
+//  Created by Clement Brisset on 9/26/19.
+//  Copyright 2019 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "SharedUtil.h"
+
+// Global variables specifically tuned to work with ptrace module for crash collection
+// Do not move/rename unless you update the ptrace module with it.
+bool crash_annotation_isShuttingDown = false;
+
+namespace crash {
+namespace annotations {
+
+void setShutdownState(bool isShuttingDown) {
+    crash_annotation_isShuttingDown = isShuttingDown;
+}
+
+
+};
+};

--- a/libraries/shared/src/CrashAnnotations.h
+++ b/libraries/shared/src/CrashAnnotations.h
@@ -1,0 +1,23 @@
+//
+//  CrashAnnotations.h
+//  libraries/shared/src
+//
+//  Created by Clement Brisset on 9/26/19.
+//  Copyright 2019 High Fidelity, Inc.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef hifi_CrashAnnotations_h
+#define hifi_CrashAnnotations_h
+
+namespace crash {
+namespace annotations {
+
+void setShutdownState(bool isShuttingDown);
+
+};
+};
+
+#endif // hifi_CrashAnnotations_h


### PR DESCRIPTION
[JIRA ticket](https://highfidelity.atlassian.net/browse/DEV-2223)

Sets up a specific global variable that gets picked by the crash reporting system.
See [this PR](https://github.com/highfidelity/hifi-ci/pull/1506) for more info