### PR TITLE
DEV-1898: Make Assets.initializeCache() script i/f blocking

### DIFF
--- a/libraries/script-engine/src/AssetScriptingInterface.cpp
+++ b/libraries/script-engine/src/AssetScriptingInterface.cpp
@@ -38,6 +38,25 @@ AssetScriptingInterface::AssetScriptingInterface(QObject* parent) : BaseAssetScr
 
 #define JS_VERIFY(cond, error) { if (!this->jsVerify(cond, error)) { return; } }
 
+bool AssetScriptingInterface::initializeCache() {
+    if (!Parent::initializeCache()) {
+        if (assetClient()) {
+            std::promise<bool> cacheStatusResult;
+            Promise assetClientPromise(makePromise(__func__));
+            assetClientPromise->moveToThread(qApp->thread());  // To ensure the finally() is processed.
+
+            assetClient()->cacheInfoRequestAsync(assetClientPromise);
+            assetClientPromise->finally([&](QString, QVariantMap result)
+                { cacheStatusResult.set_value(!result.isEmpty()); });
+            return cacheStatusResult.get_future().get();
+        } else {
+            return false;
+        }
+    } else {
+        return true;
+    }
+}
+
 void AssetScriptingInterface::uploadData(QString data, QScriptValue callback) {
     auto handler = jsBindCallback(thisObject(), callback);
     QByteArray dataByteArray = data.toUtf8();

--- a/libraries/script-engine/src/AssetScriptingInterface.cpp
+++ b/libraries/script-engine/src/AssetScriptingInterface.cpp
@@ -29,6 +29,8 @@
 #include <shared/QtHelpers.h>
 #include <Gzip.h>
 
+#include <future>
+
 using Promise = MiniPromise::Promise;
 
 AssetScriptingInterface::AssetScriptingInterface(QObject* parent) : BaseAssetScriptingInterface(parent) {

--- a/libraries/script-engine/src/AssetScriptingInterface.h
+++ b/libraries/script-engine/src/AssetScriptingInterface.h
@@ -356,7 +356,7 @@ public:
      * @function Assets.initializeCache
      * @returns {boolean} <code>true</code> if the cache is initialized, <code>false</code> if it isn't.
      */
-    Q_INVOKABLE bool initializeCache() { return Parent::initializeCache(); }
+    Q_INVOKABLE bool initializeCache();
     
     /**jsdoc
      * Checks whether the script can write to the cache.


### PR DESCRIPTION
Jira: https://highfidelity.atlassian.net/browse/DEV-1898

Assets.initializeCache() typically returns false when first called as it sets up the initialization asynchronously. This PR causes the script to be blocked until completion.
 