### PR TITLE
Fix for avatars that are stuck in idle pose for observers

### DIFF
--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -359,7 +359,7 @@ protected:
             A,
             B
         };
-        NetworkAnimState() : clipNodeEnum(NetworkAnimState::None) {}
+        NetworkAnimState() : clipNodeEnum(NetworkAnimState::None), fps(30.0f), loop(false), firstFrame(0.0f), lastFrame(0.0f), blendTime(FLT_MAX) {}
         NetworkAnimState(ClipNodeEnum clipNodeEnumIn, const QString& urlIn, float fpsIn, bool loopIn, float firstFrameIn, float lastFrameIn) :
             clipNodeEnum(clipNodeEnumIn), url(urlIn), fps(fpsIn), loop(loopIn), firstFrame(firstFrameIn), lastFrame(lastFrameIn) {}
 

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -133,7 +133,21 @@ void Avatar::setShowNamesAboveHeads(bool show) {
     showNamesAboveHeads = show;
 }
 
+static const char* avatarTransitStatusToStringMap[] = {
+    "IDLE",
+    "STARTED",
+    "PRE_TRANSIT",
+    "START_TRANSIT",
+    "TRANSITING",
+    "END_TRANSIT",
+    "POST_TRANSIT",
+    "ENDED",
+    "ABORT_TRANSIT"
+};
+
 AvatarTransit::Status AvatarTransit::update(float deltaTime, const glm::vec3& avatarPosition, const AvatarTransit::TransitConfig& config) {
+    AvatarTransit::Status previousStatus = _status;
+
     float oneFrameDistance = _isActive ? glm::length(avatarPosition - _endPosition) : glm::length(avatarPosition - _lastPosition);
     if (oneFrameDistance > (config._minTriggerDistance * _scale)) {
         if (oneFrameDistance < (config._maxTriggerDistance * _scale)) {
@@ -149,6 +163,10 @@ AvatarTransit::Status AvatarTransit::update(float deltaTime, const glm::vec3& av
     if (_isActive && oneFrameDistance > (config._abortDistance * _scale) && _status == Status::POST_TRANSIT) {
         reset();
         _status = Status::ENDED;
+    }
+
+    if (previousStatus != _status) {
+        qDebug(avatars_renderer) << "AvatarTransit " << avatarTransitStatusToStringMap[(int)previousStatus] << "->" << avatarTransitStatusToStringMap[_status];
     }
     return _status;
 }


### PR DESCRIPTION
The problem can occur because the default constructor for the NetworkAnimState does not initialize the blendTime member. This can cause the avatar to remain stuck in an idle pose for observers when blendTime happens to be randomly initialized to a large negative floating point value. To fix this we explicitly initialize it to FLT_MAX.

Additionally, a debug print has been added to help diagnose this issue if it occurs again.

https://highfidelity.atlassian.net/browse/DEV-1810