### PR TITLE
DEV-2309: Report ESS stats to domain server

### DIFF
--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -556,7 +556,9 @@ void EntityScriptServer::checkAndCallPreload(const EntityItemID& entityID, bool 
 }
 
 void EntityScriptServer::sendStatsPacket() {
-
+    QJsonObject statsObject;
+    // Add ESS-specific ...
+    ThreadedAssignment::addPacketStatsAndSendStatsPacket(statsObject);
 }
 
 void EntityScriptServer::handleOctreePacket(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {


### PR DESCRIPTION
Jira: https://highfidelity.atlassian.net/browse/DEV-2309

The ESS doesn't have its own NodeData-derived class for client-specific data. I've included some generic client stats such as bits-per-second, reliable-packets-per-second, etc., and some overall octree stats such as number of tree nodes.