### PR TITLE
Fix for Mat4.getForward, getRight and getUp

### DIFF
--- a/libraries/script-engine/src/Mat4.cpp
+++ b/libraries/script-engine/src/Mat4.cpp
@@ -70,15 +70,15 @@ glm::mat4 Mat4::inverse(const glm::mat4& m) const {
 }
 
 glm::vec3 Mat4::getForward(const glm::mat4& m) const {
-    return glm::vec3(-m[0][2], -m[1][2], -m[2][2]);
+    return -glm::vec3(m[2]);
 }
 
 glm::vec3 Mat4::getRight(const glm::mat4& m) const {
-    return glm::vec3(m[0][0], m[1][0], m[2][0]);
+    return glm::vec3(m[0]);
 }
 
 glm::vec3 Mat4::getUp(const glm::mat4& m) const {
-    return glm::vec3(m[0][1], m[1][1], m[2][1]);
+    return glm::vec3(m[1]);
 }
 
 void Mat4::print(const QString& label, const glm::mat4& m, bool transpose) const {

--- a/libraries/script-engine/src/Mat4.cpp
+++ b/libraries/script-engine/src/Mat4.cpp
@@ -70,15 +70,16 @@ glm::mat4 Mat4::inverse(const glm::mat4& m) const {
 }
 
 glm::vec3 Mat4::getForward(const glm::mat4& m) const {
-    return -glm::vec3(m[2]);
+    // -z is forward
+    return -glm::normalize(glm::vec3(m[2]));
 }
 
 glm::vec3 Mat4::getRight(const glm::mat4& m) const {
-    return glm::vec3(m[0]);
+    return glm::normalize(glm::vec3(m[0]));
 }
 
 glm::vec3 Mat4::getUp(const glm::mat4& m) const {
-    return glm::vec3(m[1]);
+    return glm::normalize(glm::vec3(m[1]));
 }
 
 void Mat4::print(const QString& label, const glm::mat4& m, bool transpose) const {


### PR DESCRIPTION
It should match the results from the same methods on the Quat class.

https://highfidelity.atlassian.net/browse/DEV-2310

