### PR TITLE
DEV-1811: apply deletion rules to linked entities

### DIFF
--- a/interface/src/InterfaceParentFinder.cpp
+++ b/interface/src/InterfaceParentFinder.cpp
@@ -45,10 +45,6 @@ SpatiallyNestableWeakPointer InterfaceParentFinder::find(QUuid parentID, bool& s
         success = true;
         return parent;
     }
-    if (parentID == AVATAR_SELF_ID) {
-        success = true;
-        return avatarManager->getMyAvatar();
-    }
 
     success = false;
     return parent;

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -549,28 +549,6 @@ void AvatarManager::removeDeadAvatarEntities(const SetOfEntities& deadEntities) 
     }
 }
 
-/* ADEBUG: I don't think the code below is necessary because any dead entities will have already been removed from tree and simulation
-        if (entityTree && entity->isMyAvatarEntity()) {
-            entityTree->withWriteLock([&] {
-                // We only need to delete the direct children (rather than the descendants) because
-                // when the child is deleted, it will take care of its own children.  If the child
-                // is also an avatar-entity, we'll end up back here.  If it's not, the entity-server
-                // will take care of it in the usual way.
-                entity->forEachChild([&](SpatiallyNestablePointer child) {
-                    EntityItemPointer childEntity = std::dynamic_pointer_cast<EntityItem>(child);
-                    if (childEntity) {
-                        entityTree->deleteEntity(childEntity->getID(), true, true);
-                        if (avatar) {
-                            avatar->clearAvatarEntity(childEntity->getID(), REQUIRES_REMOVAL_FROM_TREE);
-                        }
-                    }
-                });
-            });
-        }
-    }
-}
-*/
-
 void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar, KillAvatarReason removalReason) {
     auto avatar = std::static_pointer_cast<OtherAvatar>(removedAvatar);
     AvatarHashMap::handleRemovedAvatar(avatar, removalReason);

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -543,10 +543,13 @@ void AvatarManager::removeDeadAvatarEntities(const SetOfEntities& deadEntities) 
     for (auto entity : deadEntities) {
         QUuid entityOwnerID = entity->getOwningAvatarID();
         AvatarSharedPointer avatar = getAvatarBySessionID(entityOwnerID);
-        const bool REQUIRES_REMOVAL_FROM_TREE = false;
         if (avatar) {
-            avatar->clearAvatarEntity(entity->getID(), REQUIRES_REMOVAL_FROM_TREE);
+            avatar->clearAvatarEntity(entity->getID());
         }
+    }
+}
+
+/* ADEBUG: I don't think the code below is necessary because any dead entities will have already been removed from tree and simulation
         if (entityTree && entity->isMyAvatarEntity()) {
             entityTree->withWriteLock([&] {
                 // We only need to delete the direct children (rather than the descendants) because
@@ -566,6 +569,7 @@ void AvatarManager::removeDeadAvatarEntities(const SetOfEntities& deadEntities) 
         }
     }
 }
+*/
 
 void AvatarManager::handleRemovedAvatar(const AvatarSharedPointer& removedAvatar, KillAvatarReason removalReason) {
     auto avatar = std::static_pointer_cast<OtherAvatar>(removedAvatar);

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -558,10 +558,16 @@ void OtherAvatar::handleChangedAvatarEntityData() {
             _avatarEntitiesLock.withReadLock([&] {
                 packedAvatarEntityData = _packedAvatarEntityData;
             });
+            QSet<EntityItemID> idsToDelete;
             foreach (auto entityID, recentlyRemovedAvatarEntities) {
                 if (!packedAvatarEntityData.contains(entityID)) {
-                    entityTree->deleteEntity(entityID, true, true);
+                    idsToDelete.insert(entityID);
                 }
+            }
+            if (!idsToDelete.empty()) {
+                bool force = true;
+                bool ignoreWarnings = true;
+                entityTree->deleteEntitiesByID(idsToDelete, force, ignoreWarnings);
             }
 
             // TODO: move this outside of tree lock

--- a/interface/src/ui/AvatarCertifyBanner.cpp
+++ b/interface/src/ui/AvatarCertifyBanner.cpp
@@ -62,16 +62,7 @@ void AvatarCertifyBanner::show(const QUuid& avatarID) {
 
 void AvatarCertifyBanner::clear() {
     if (_active) {
-        auto entityTreeRenderer = DependencyManager::get<EntityTreeRenderer>();
-        EntityTreePointer entityTree = entityTreeRenderer->getTree();
-        if (!entityTree) {
-            return;
-        }
-
-        entityTree->withWriteLock([&] {
-            entityTree->deleteEntity(_bannerID);
-        });
-
+        DependencyManager::get<EntityTreeRenderer>()->deleteEntity(_bannerID);
         _active = false;
     }
 }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -357,11 +357,13 @@ void Avatar::removeAvatarEntitiesFromTree() {
         _avatarEntitiesLock.withReadLock([&] {
             avatarEntityIDs = _packedAvatarEntityData.keys();
         });
-        entityTree->withWriteLock([&] {
-            for (const auto& entityID : avatarEntityIDs) {
-                entityTree->deleteEntity(entityID, true, true);
-            }
-        });
+        QSet<EntityItemID> ids;
+        foreach (auto id, avatarEntityIDs) {
+            ids.insert(id);
+        }
+        bool force = true;
+        bool ignoreWarnings = true;
+        entityTree->deleteEntitiesByID(ids, force, ignoreWarnings); // locks tree
     }
 }
 

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -2985,15 +2985,12 @@ void AvatarData::updateAvatarEntity(const QUuid& entityID, const QByteArray& ent
 }
 
 void AvatarData::clearAvatarEntity(const QUuid& entityID, bool requiresRemovalFromTree) {
-
+    // NOTE: requiresRemovalFromTree is unused
     bool removedEntity = false;
-
     _avatarEntitiesLock.withWriteLock([this, &removedEntity, &entityID] {
         removedEntity = _packedAvatarEntityData.remove(entityID);
     });
-
     insertRemovedEntityID(entityID);
-
     if (removedEntity && _clientTraitsHandler) {
         // we have a client traits handler, so we need to mark this removed instance trait as deleted
         // so that changes are sent next frame

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1158,7 +1158,7 @@ public:
     /**jsdoc
      * @function Avatar.clearAvatarEntity
      * @param {Uuid} entityID - The entity ID.
-     * @param {boolean} [requiresRemovalFromTree=true] - Requires removal from tree.
+     * @param {boolean} [requiresRemovalFromTree=true] - unused
      * @deprecated This function is deprecated and will be removed.
      */
     Q_INVOKABLE virtual void clearAvatarEntity(const QUuid& entityID, bool requiresRemovalFromTree = true);

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -221,7 +221,7 @@ void EntityTreeRenderer::stopDomainAndNonOwnedEntities() {
             EntityItemPointer entityItem = getTree()->findEntityByEntityItemID(entityID);
 
             if (entityItem && !entityItem->getScript().isEmpty()) {
-                if (!(entityItem->isLocalEntity() || (entityItem->isAvatarEntity() && entityItem->getOwningAvatarID() == getTree()->getMyAvatarSessionUUID()))) {
+                if (!(entityItem->isLocalEntity() || entityItem->isMyAvatarEntity())) {
                     if (_currentEntitiesInside.contains(entityID)) {
                         _entitiesScriptEngine->callEntityScriptMethod(entityID, "leaveEntity");
                     }
@@ -235,7 +235,6 @@ void EntityTreeRenderer::stopDomainAndNonOwnedEntities() {
 void EntityTreeRenderer::clearDomainAndNonOwnedEntities() {
     stopDomainAndNonOwnedEntities();
 
-    auto sessionUUID = getTree()->getMyAvatarSessionUUID();
     std::unordered_map<EntityItemID, EntityRendererPointer> savedEntities;
     std::unordered_set<EntityRendererPointer> savedRenderables;
     // remove all entities from the scene
@@ -244,7 +243,7 @@ void EntityTreeRenderer::clearDomainAndNonOwnedEntities() {
         for (const auto& entry :  _entitiesInScene) {
             const auto& renderer = entry.second;
             const EntityItemPointer& entityItem = renderer->getEntity();
-            if (!(entityItem->isLocalEntity() || (entityItem->isAvatarEntity() && entityItem->getOwningAvatarID() == sessionUUID))) {
+            if (!(entityItem->isLocalEntity() || entityItem->isMyAvatarEntity())) {
                 fadeOutRenderable(renderer);
             } else {
                 savedEntities[entry.first] = entry.second;
@@ -256,6 +255,7 @@ void EntityTreeRenderer::clearDomainAndNonOwnedEntities() {
     _renderablesToUpdate = savedRenderables;
     _entitiesInScene = savedEntities;
 
+    auto sessionUUID = getTree()->getMyAvatarSessionUUID();
     if (_layeredZones.clearDomainAndNonOwnedZones(sessionUUID)) {
         applyLayeredZones();
     }
@@ -678,7 +678,7 @@ void EntityTreeRenderer::leaveDomainAndNonOwnedEntities() {
         QSet<EntityItemID> currentEntitiesInsideToSave;
         foreach (const EntityItemID& entityID, _currentEntitiesInside) {
             EntityItemPointer entityItem = getTree()->findEntityByEntityItemID(entityID);
-            if (!(entityItem->isLocalEntity() || (entityItem->isAvatarEntity() && entityItem->getOwningAvatarID() == getTree()->getMyAvatarSessionUUID()))) {
+            if (!(entityItem->isLocalEntity() || entityItem->isMyAvatarEntity())) {
                 emit leaveEntity(entityID);
                 if (_entitiesScriptEngine) {
                     _entitiesScriptEngine->callEntityScriptMethod(entityID, "leaveEntity");
@@ -1216,7 +1216,7 @@ bool EntityTreeRenderer::LayeredZones::clearDomainAndNonOwnedZones(const QUuid& 
     auto it = begin();
     while (it != end()) {
         auto zone = it->zone.lock();
-        if (!zone || !(zone->isLocalEntity() || (zone->isAvatarEntity() && zone->getOwningAvatarID() == sessionUUID))) {
+        if (!zone || !(zone->isLocalEntity() || zone->isMyAvatarEntity())) {
             zonesChanged = true;
             it = erase(it);
         } else {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -1357,6 +1357,10 @@ EntityItemPointer EntityTreeRenderer::getEntity(const EntityItemID& id) {
     return result;
 }
 
+void EntityTreeRenderer::deleteEntity(const EntityItemID& id) const {
+    DependencyManager::get<EntityScriptingInterface>()->deleteEntity(id);
+}
+
 void EntityTreeRenderer::onEntityChanged(const EntityItemID& id) {
     _changedEntitiesGuard.withWriteLock([&] {
         _changedEntities.insert(id);

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -118,6 +118,7 @@ public:
     void setProxyWindow(const EntityItemID& id, QWindow* proxyWindow);
     void setCollisionSound(const EntityItemID& id, const SharedSoundPointer& sound);
     EntityItemPointer getEntity(const EntityItemID& id);
+    void deleteEntity(const EntityItemID& id) const;
     void onEntityChanged(const EntityItemID& id);
 
     // Access the workload Space

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -43,6 +43,7 @@ const Transform& EntityRenderer::getModelTransform() const {
 
 void EntityRenderer::makeStatusGetters(const EntityItemPointer& entity, Item::Status::Getters& statusGetters) {
     auto nodeList = DependencyManager::get<NodeList>();
+    // DANGER: nodeList->getSessionUUID() will return null id when not connected to domain.
     const QUuid& myNodeID = nodeList->getSessionUUID();
 
     statusGetters.push_back([entity]() -> render::Item::Status::Value {
@@ -103,9 +104,9 @@ void EntityRenderer::makeStatusGetters(const EntityItemPointer& entity, Item::St
             (unsigned char)render::Item::Status::Icon::HAS_ACTIONS);
     });
 
-    statusGetters.push_back([entity, myNodeID] () -> render::Item::Status::Value {
+    statusGetters.push_back([entity] () -> render::Item::Status::Value {
         if (entity->isAvatarEntity()) {
-            if (entity->getOwningAvatarID() == myNodeID) {
+            if (entity->isMyAvatarEntity()) {
                 return render::Item::Status::Value(1.0f, render::Item::Status::Value::GREEN,
                     (unsigned char)render::Item::Status::Icon::ENTITY_HOST_TYPE);
             } else {

--- a/libraries/entities/src/DeleteEntityOperator.cpp
+++ b/libraries/entities/src/DeleteEntityOperator.cpp
@@ -53,6 +53,14 @@ void DeleteEntityOperator::addEntityIDToDeleteList(const EntityItemID& searchEnt
     }
 }
 
+void DeleteEntityOperator::addEntityToDeleteList(const EntityItemPointer& entity) {
+    EntityToDeleteDetails details;
+    details.entity = entity;
+    details.containingElement = entity->getElement();
+    details.cube = details.containingElement->getAACube();
+    _entitiesToDelete << details;
+    _lookingCount++;
+}
 
 // does this entity tree element contain the old entity
 bool DeleteEntityOperator::subTreeContainsSomeEntitiesToDelete(const OctreeElementPointer& element) {

--- a/libraries/entities/src/DeleteEntityOperator.cpp
+++ b/libraries/entities/src/DeleteEntityOperator.cpp
@@ -54,6 +54,7 @@ void DeleteEntityOperator::addEntityIDToDeleteList(const EntityItemID& searchEnt
 }
 
 void DeleteEntityOperator::addEntityToDeleteList(const EntityItemPointer& entity) {
+    assert(entity && entity->getElement());
     EntityToDeleteDetails details;
     details.entity = entity;
     details.containingElement = entity->getElement();

--- a/libraries/entities/src/DeleteEntityOperator.h
+++ b/libraries/entities/src/DeleteEntityOperator.h
@@ -42,6 +42,7 @@ public:
     ~DeleteEntityOperator();
 
     void addEntityIDToDeleteList(const EntityItemID& searchEntityID);
+    void addEntityToDeleteList(const EntityItemPointer& entity);
     virtual bool preRecursion(const OctreeElementPointer& element) override;
     virtual bool postRecursion(const OctreeElementPointer& element) override;
 

--- a/libraries/entities/src/EntityEditFilters.cpp
+++ b/libraries/entities/src/EntityEditFilters.cpp
@@ -43,7 +43,7 @@ QList<EntityItemID> EntityEditFilters::getZonesByPosition(glm::vec3& position) {
 }
 
 bool EntityEditFilters::filter(glm::vec3& position, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut,
-        bool& wasChanged, EntityTree::FilterType filterType, EntityItemID& itemID, EntityItemPointer& existingEntity) {
+        bool& wasChanged, EntityTree::FilterType filterType, EntityItemID& itemID, const EntityItemPointer& existingEntity) {
     
     // get the ids of all the zones (plus the global entity edit filter) that the position
     // lies within

--- a/libraries/entities/src/EntityEditFilters.h
+++ b/libraries/entities/src/EntityEditFilters.h
@@ -55,7 +55,7 @@ public:
     void removeFilter(EntityItemID entityID);
 
     bool filter(glm::vec3& position, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, 
-                EntityTree::FilterType filterType, EntityItemID& entityID, EntityItemPointer& existingEntity);
+                EntityTree::FilterType filterType, EntityItemID& entityID, const EntityItemPointer& existingEntity);
 
 signals:
     void filterAdded(EntityItemID id, bool success);

--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -73,8 +73,12 @@ void EntityEditPacketSender::queueEditEntityMessage(PacketType type,
     if (properties.getEntityHostType() == entity::HostType::AVATAR) {
         if (!_myAvatar) {
             qCWarning(entities) << "Suppressing entity edit message: cannot send avatar entity edit with no myAvatar";
-        } else if (properties.getOwningAvatarID() == _myAvatar->getID()) {
-            // this is an avatar-based entity --> update our avatar-data rather than sending to the entity-server
+        } else if (properties.getOwningAvatarID() == _myAvatar->getID() || properties.getOwningAvatarID() == AVATAR_SELF_ID) {
+            // this is a local avatar-entity --> update our avatar-data rather than sending to the entity-server
+            // Note: we store AVATAR_SELF_ID in EntityItem::_owningAvatarID and we usually
+            // store the actual sessionUUID in EntityItemProperties::_owningAvatarID.
+            // However at this context we check for both cases just in case.  Really we just want to know
+            // where to route the data: entity-server or avatar-mixer.
             queueEditAvatarEntityMessage(entityTree, entityItemID);
         } else {
             qCWarning(entities) << "Suppressing entity edit message: cannot send avatar entity edit for another avatar";

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -18,6 +18,7 @@
 #include <glm/glm.hpp>
 
 #include <QtGui/QWindow>
+#include <QSet>
 
 #include <Octree.h> // for EncodeBitstreamParams class
 #include <OctreeElement.h> // for OctreeElement::AppendState
@@ -49,6 +50,7 @@ typedef std::shared_ptr<EntityTree> EntityTreePointer;
 typedef std::shared_ptr<EntityDynamicInterface> EntityDynamicPointer;
 typedef std::shared_ptr<EntityTreeElement> EntityTreeElementPointer;
 using EntityTreeElementExtraEncodeDataPointer = std::shared_ptr<EntityTreeElementExtraEncodeData>;
+using SetOfEntities = QSet<EntityItemPointer>;
 
 #define DONT_ALLOW_INSTANTIATION virtual void pureVirtualFunctionPlaceHolder() = 0;
 #define ALLOW_INSTANTIATION virtual void pureVirtualFunctionPlaceHolder() override { };
@@ -540,6 +542,8 @@ public:
 
     static QString _marketplacePublicKey;
     static void retrieveMarketplacePublicKey();
+
+    void collectChildrenForDelete(SetOfEntities& entitiesToDelete, SetOfEntities& domainEntities, const QUuid& sessionID) const;
 
     float getBoundingRadius() const { return _boundingRadius; }
     void setSpaceIndex(int32_t index);

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -514,7 +514,8 @@ public:
 
     // if this entity is an avatar entity, which avatar is it associated with?
     QUuid getOwningAvatarID() const { return _owningAvatarID; }
-    virtual void setOwningAvatarID(const QUuid& owningAvatarID) { _owningAvatarID = owningAvatarID; }
+    QUuid getOwningAvatarIDForProperties() const;
+    void setOwningAvatarID(const QUuid& owningAvatarID);
 
     virtual bool wantsHandControllerPointerEvents() const { return false; }
     virtual bool wantsKeyboardFocus() const { return false; }

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -3936,7 +3936,7 @@ bool EntityItemProperties::decodeCloneEntityMessage(const QByteArray& buffer, in
     processedBytes = 0;
 
     if (NUM_BYTES_RFC4122_UUID * 2 > packetLength) {
-        qCDebug(entities) << "EntityItemProperties::processEraseMessageDetails().... bailing because not enough bytes in buffer";
+        qCDebug(entities) << "EntityItemProperties::decodeCloneEntityMessage().... bailing because not enough bytes in buffer";
         return false; // bail to prevent buffer overflow
     }
 

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -21,6 +21,7 @@ void EntitySimulation::setEntityTree(EntityTreePointer tree) {
     if (_entityTree && _entityTree != tree) {
         _entitiesToSort.clear();
         _simpleKinematicEntities.clear();
+        _changedEntities.clear();
         _entitiesToUpdate.clear();
         _mortalEntities.clear();
         _nextExpiry = std::numeric_limits<uint64_t>::max();
@@ -29,15 +30,14 @@ void EntitySimulation::setEntityTree(EntityTreePointer tree) {
 }
 
 void EntitySimulation::updateEntities() {
+    PerformanceTimer perfTimer("EntitySimulation::updateEntities");
     QMutexLocker lock(&_mutex);
     uint64_t now = usecTimestampNow();
-    PerformanceTimer perfTimer("EntitySimulation::updateEntities");
 
     // these methods may accumulate entries in _entitiesToBeDeleted
     expireMortalEntities(now);
     callUpdateOnEntitiesThatNeedIt(now);
     moveSimpleKinematics(now);
-    updateEntitiesInternal(now);
     sortEntitiesThatMoved();
 }
 
@@ -220,14 +220,12 @@ void EntitySimulation::clearEntities() {
     QMutexLocker lock(&_mutex);
     _entitiesToSort.clear();
     _simpleKinematicEntities.clear();
+    _changedEntities.clear();
+    _allEntities.clear();
+    _deadEntities.clear();
     _entitiesToUpdate.clear();
     _mortalEntities.clear();
     _nextExpiry = std::numeric_limits<uint64_t>::max();
-
-    clearEntitiesInternal();
-
-    _allEntities.clear();
-    _deadEntities.clear();
 }
 
 void EntitySimulation::moveSimpleKinematics(uint64_t now) {

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -62,7 +62,6 @@ void EntitySimulation::prepareEntityForDelete(EntityItemPointer entity) {
     assert(entity->isDead());
     if (entity->isSimulated()) {
         QMutexLocker lock(&_mutex);
-        entity->clearActions(getThisPointer());
         removeEntityInternal(entity);
         if (entity->getElement()) {
             _deadEntities.insert(entity);
@@ -152,7 +151,6 @@ void EntitySimulation::sortEntitiesThatMoved() {
 void EntitySimulation::addEntity(EntityItemPointer entity) {
     QMutexLocker lock(&_mutex);
     assert(entity);
-    entity->deserializeActions();
     if (entity->isMortal()) {
         _mortalEntities.insert(entity);
         uint64_t expiry = entity->getExpiry();

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -19,11 +19,11 @@
 
 void EntitySimulation::setEntityTree(EntityTreePointer tree) {
     if (_entityTree && _entityTree != tree) {
-        _mortalEntities.clear();
-        _nextExpiry = std::numeric_limits<uint64_t>::max();
-        _entitiesToUpdate.clear();
         _entitiesToSort.clear();
         _simpleKinematicEntities.clear();
+        _entitiesToUpdate.clear();
+        _mortalEntities.clear();
+        _nextExpiry = std::numeric_limits<uint64_t>::max();
     }
     _entityTree = tree;
 }
@@ -49,11 +49,11 @@ void EntitySimulation::takeDeadEntities(SetOfEntities& entitiesToDelete) {
 
 void EntitySimulation::removeEntityFromInternalLists(EntityItemPointer entity) {
     // remove from all internal lists except _deadEntities
-    _mortalEntities.remove(entity);
-    _entitiesToUpdate.remove(entity);
     _entitiesToSort.remove(entity);
     _simpleKinematicEntities.remove(entity);
     _allEntities.remove(entity);
+    _entitiesToUpdate.remove(entity);
+    _mortalEntities.remove(entity);
     entity->setSimulated(false);
 }
 
@@ -218,11 +218,11 @@ void EntitySimulation::processChangedEntity(const EntityItemPointer& entity) {
 
 void EntitySimulation::clearEntities() {
     QMutexLocker lock(&_mutex);
-    _mortalEntities.clear();
-    _nextExpiry = std::numeric_limits<uint64_t>::max();
-    _entitiesToUpdate.clear();
     _entitiesToSort.clear();
     _simpleKinematicEntities.clear();
+    _entitiesToUpdate.clear();
+    _mortalEntities.clear();
+    _nextExpiry = std::numeric_limits<uint64_t>::max();
 
     clearEntitiesInternal();
 

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -260,26 +260,3 @@ void EntitySimulation::moveSimpleKinematics(uint64_t now) {
         }
     }
 }
-
-void EntitySimulation::addDynamic(EntityDynamicPointer dynamic) {
-    QMutexLocker lock(&_dynamicsMutex);
-    _dynamicsToAdd += dynamic;
-}
-
-void EntitySimulation::removeDynamic(const QUuid dynamicID) {
-    QMutexLocker lock(&_dynamicsMutex);
-    _dynamicsToRemove += dynamicID;
-}
-
-void EntitySimulation::removeDynamics(QList<QUuid> dynamicIDsToRemove) {
-    QMutexLocker lock(&_dynamicsMutex);
-    foreach(QUuid uuid, dynamicIDsToRemove) {
-        _dynamicsToRemove.insert(uuid);
-    }
-}
-
-void EntitySimulation::applyDynamicChanges() {
-    QMutexLocker lock(&_dynamicsMutex);
-    _dynamicsToAdd.clear();
-    _dynamicsToRemove.clear();
-}

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -21,7 +21,6 @@
 
 #include <PerfStat.h>
 
-#include "EntityDynamicInterface.h"
 #include "EntityItem.h"
 #include "EntityTree.h"
 
@@ -59,10 +58,10 @@ public:
 
     void updateEntities();
 
-    virtual void addDynamic(EntityDynamicPointer dynamic);
-    virtual void removeDynamic(const QUuid dynamicID);
-    virtual void removeDynamics(QList<QUuid> dynamicIDsToRemove);
-    virtual void applyDynamicChanges();
+    // FIXME: remove these
+    virtual void addDynamic(EntityDynamicPointer dynamic) {}
+    virtual void removeDynamic(const QUuid dynamicID) {}
+    virtual void applyDynamicChanges() {};
 
     /// \param entity pointer to EntityItem to be added
     /// \sideeffect sets relevant backpointers in entity, but maybe later when appropriate data structures are locked
@@ -102,9 +101,6 @@ protected:
 
     SetOfEntities _entitiesToSort; // entities moved by simulation (and might need resort in EntityTree)
     SetOfEntities _simpleKinematicEntities; // entities undergoing non-colliding kinematic motion
-    QList<EntityDynamicPointer> _dynamicsToAdd;
-    QSet<QUuid> _dynamicsToRemove;
-    QMutex _dynamicsMutex { QMutex::Recursive };
 
 protected:
     SetOfEntities _deadEntities; // dead entities that might still be in the _entityTree

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -115,10 +115,9 @@ private:
     // An entity may be in more than one list.
     std::unordered_set<EntityItemPointer> _changedEntities; // all changes this frame
     SetOfEntities _allEntities; // tracks all entities added the simulation
+    SetOfEntities _entitiesToUpdate; // entities that need to call EntityItem::update()
     SetOfEntities _mortalEntities; // entities that have an expiry
     uint64_t _nextExpiry;
-
-    SetOfEntities _entitiesToUpdate; // entities that need to call EntityItem::update()
 };
 
 #endif // hifi_EntitySimulation_h

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -46,8 +46,8 @@ const int DIRTY_SIMULATION_FLAGS =
 
 class EntitySimulation : public QObject, public std::enable_shared_from_this<EntitySimulation> {
 public:
-    EntitySimulation() : _mutex(QMutex::Recursive), _entityTree(NULL), _nextExpiry(std::numeric_limits<uint64_t>::max()) { }
-    virtual ~EntitySimulation() { setEntityTree(NULL); }
+    EntitySimulation() : _mutex(QMutex::Recursive), _nextExpiry(std::numeric_limits<uint64_t>::max()), _entityTree(nullptr) { }
+    virtual ~EntitySimulation() { setEntityTree(nullptr); }
 
     inline EntitySimulationPointer getThisPointer() const {
         return std::const_pointer_cast<EntitySimulation>(shared_from_this());
@@ -56,7 +56,7 @@ public:
     /// \param tree pointer to EntityTree which is stored internally
     void setEntityTree(EntityTreePointer tree);
 
-    void updateEntities();
+    virtual void updateEntities();
 
     // FIXME: remove these
     virtual void addDynamic(EntityDynamicPointer dynamic) {}
@@ -71,7 +71,7 @@ public:
     /// call this whenever an entity was changed from some EXTERNAL event (NOT by the EntitySimulation itself)
     void changeEntity(EntityItemPointer entity);
 
-    void clearEntities();
+    virtual void clearEntities();
 
     void moveSimpleKinematics(uint64_t now);
 
@@ -79,19 +79,14 @@ public:
 
     virtual void takeDeadEntities(SetOfEntities& entitiesToDelete);
 
-    /// \param entity pointer to EntityItem that needs to be put on the entitiesToDelete list and removed from others.
     virtual void prepareEntityForDelete(EntityItemPointer entity);
 
     void processChangedEntities();
 
 protected:
-    // These pure virtual methods are protected because they are not to be called will-nilly. The base class
-    // calls them in the right places.
-    virtual void updateEntitiesInternal(uint64_t now) = 0;
     virtual void addEntityToInternalLists(EntityItemPointer entity);
     virtual void removeEntityFromInternalLists(EntityItemPointer entity);
     virtual void processChangedEntity(const EntityItemPointer& entity);
-    virtual void clearEntitiesInternal() = 0;
 
     void expireMortalEntities(uint64_t now);
     void callUpdateOnEntitiesThatNeedIt(uint64_t now);
@@ -101,15 +96,10 @@ protected:
 
     SetOfEntities _entitiesToSort; // entities moved by simulation (and might need resort in EntityTree)
     SetOfEntities _simpleKinematicEntities; // entities undergoing non-colliding kinematic motion
-
-protected:
     SetOfEntities _deadEntities; // dead entities that might still be in the _entityTree
 
 private:
     void moveSimpleKinematics();
-
-    // back pointer to EntityTree structure
-    EntityTreePointer _entityTree;
 
     // We maintain multiple lists, each for its distinct purpose.
     // An entity may be in more than one list.
@@ -118,6 +108,9 @@ private:
     SetOfEntities _entitiesToUpdate; // entities that need to call EntityItem::update()
     SetOfEntities _mortalEntities; // entities that have an expiry
     uint64_t _nextExpiry;
+
+    // back pointer to EntityTree structure
+    EntityTreePointer _entityTree;
 };
 
 #endif // hifi_EntitySimulation_h

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -88,8 +88,8 @@ protected:
     // These pure virtual methods are protected because they are not to be called will-nilly. The base class
     // calls them in the right places.
     virtual void updateEntitiesInternal(uint64_t now) = 0;
-    virtual void addEntityInternal(EntityItemPointer entity) = 0;
-    virtual void removeEntityInternal(EntityItemPointer entity);
+    virtual void addEntityToInternalLists(EntityItemPointer entity);
+    virtual void removeEntityFromInternalLists(EntityItemPointer entity);
     virtual void processChangedEntity(const EntityItemPointer& entity);
     virtual void clearEntitiesInternal() = 0;
 

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -94,7 +94,7 @@ protected:
 
     SetOfEntities _entitiesToSort; // entities moved by simulation (and might need resort in EntityTree)
     SetOfEntities _simpleKinematicEntities; // entities undergoing non-colliding kinematic motion
-    SetOfEntities _deadEntities; // dead entities that might still be in the _entityTree
+    SetOfEntities _deadEntitiesToRemoveFromTree;
 
 private:
     void moveSimpleKinematics();

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -16,7 +16,6 @@
 #include <unordered_set>
 
 #include <QtCore/QObject>
-#include <QSet>
 #include <QVector>
 
 #include <PerfStat.h>
@@ -25,7 +24,6 @@
 #include "EntityTree.h"
 
 using EntitySimulationPointer = std::shared_ptr<EntitySimulation>;
-using SetOfEntities = QSet<EntityItemPointer>;
 using VectorOfEntities = QVector<EntityItemPointer>;
 
 // the EntitySimulation needs to know when these things change on an entity,
@@ -77,16 +75,16 @@ public:
 
     EntityTreePointer getEntityTree() { return _entityTree; }
 
-    virtual void takeDeadEntities(SetOfEntities& entitiesToDelete);
-
     virtual void prepareEntityForDelete(EntityItemPointer entity);
 
     void processChangedEntities();
+    virtual void queueEraseDomainEntities(const SetOfEntities& domainEntities) const { }
 
 protected:
     virtual void addEntityToInternalLists(EntityItemPointer entity);
     virtual void removeEntityFromInternalLists(EntityItemPointer entity);
     virtual void processChangedEntity(const EntityItemPointer& entity);
+    virtual void processDeadEntities();
 
     void expireMortalEntities(uint64_t now);
     void callUpdateOnEntitiesThatNeedIt(uint64_t now);

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -99,7 +99,7 @@ void EntityTree::eraseDomainAndNonOwnedEntities() {
                 element->cleanupDomainAndNonOwnedEntities();
             }
 
-            if (entity->isLocalEntity() || (entity->isAvatarEntity() && entity->getOwningAvatarID() == getMyAvatarSessionUUID())) {
+            if (entity->isLocalEntity() || entity->isMyAvatarEntity()) {
                 savedEntities[entity->getEntityItemID()] = entity;
             } else {
                 int32_t spaceIndex = entity->getSpaceIndex();
@@ -121,7 +121,7 @@ void EntityTree::eraseDomainAndNonOwnedEntities() {
 
         foreach (EntityItemWeakPointer entityItem, _needsParentFixup) {
             auto entity = entityItem.lock();
-            if (entity && (entity->isLocalEntity() || (entity->isAvatarEntity() && entity->getOwningAvatarID() == getMyAvatarSessionUUID()))) {
+            if (entity && (entity->isLocalEntity() || entity->isMyAvatarEntity())) {
                 needParentFixup.push_back(entityItem);
             }
         }
@@ -688,6 +688,7 @@ void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool i
     // NOTE: callers must lock the tree before using this method
     DeleteEntityOperator theOperator(getThisPointer());
     foreach(const EntityItemID& entityID, entityIDs) {
+        // ANDREW TODO: rejigger this logic to FIRST get entity THEN get element
         EntityTreeElementPointer containingElement = getContainingElement(entityID);
         if (!containingElement) {
             if (!ignoreWarnings) {

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -98,14 +98,15 @@ void EntityTree::eraseDomainAndNonOwnedEntities() {
             if (element) {
                 element->cleanupDomainAndNonOwnedEntities();
             }
-
-            if (entity->isLocalEntity() || entity->isMyAvatarEntity()) {
-                savedEntities[entity->getEntityItemID()] = entity;
-            } else {
-                int32_t spaceIndex = entity->getSpaceIndex();
-                if (spaceIndex != -1) {
-                    // stale spaceIndices will be freed later
-                    _staleProxies.push_back(spaceIndex);
+            if (!getIsServer()) {
+                if (entity->isLocalEntity() || entity->isMyAvatarEntity()) {
+                    savedEntities[entity->getEntityItemID()] = entity;
+                } else {
+                    int32_t spaceIndex = entity->getSpaceIndex();
+                    if (spaceIndex != -1) {
+                        // stale spaceIndices will be freed later
+                        _staleProxies.push_back(spaceIndex);
+                    }
                 }
             }
         }
@@ -144,10 +145,12 @@ void EntityTree::eraseAllOctreeElements(bool createNewRoot) {
             if (element) {
                 element->cleanupEntities();
             }
-            int32_t spaceIndex = entity->getSpaceIndex();
-            if (spaceIndex != -1) {
-                // assume stale spaceIndices will be freed later
-                _staleProxies.push_back(spaceIndex);
+            if (!getIsServer()) {
+                int32_t spaceIndex = entity->getSpaceIndex();
+                if (spaceIndex != -1) {
+                    // assume stale spaceIndices will be freed later
+                    _staleProxies.push_back(spaceIndex);
+                }
             }
         }
     });
@@ -605,61 +608,21 @@ void EntityTree::setSimulation(EntitySimulationPointer simulation) {
 }
 
 void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ignoreWarnings) {
-    EntityTreeElementPointer containingElement = getContainingElement(entityID);
-    if (!containingElement) {
-        if (!ignoreWarnings) {
-            qCWarning(entities) << "EntityTree::deleteEntity() on non-existent entityID=" << entityID;
-        }
-        return;
-    }
-
-    EntityItemPointer existingEntity = containingElement->getEntityWithEntityItemID(entityID);
-    if (!existingEntity) {
-        if (!ignoreWarnings) {
-            qCWarning(entities) << "EntityTree::deleteEntity() on non-existant entity item with entityID=" << entityID;
-        }
-        return;
-    }
-
-    if (existingEntity->getLocked() && !force) {
-        if (!ignoreWarnings) {
-            qCDebug(entities) << "ERROR! EntityTree::deleteEntity() trying to delete locked entity. entityID=" << entityID;
-        }
-        return;
-    }
-
-    cleanupCloneIDs(entityID);
-    unhookChildAvatar(entityID);
-    emit deletingEntity(entityID);
-    emit deletingEntityPointer(existingEntity.get());
-
-    // NOTE: callers must lock the tree before using this method
-    DeleteEntityOperator theOperator(getThisPointer(), entityID);
-
-    existingEntity->forEachDescendant([&](SpatiallyNestablePointer descendant) {
-        auto descendantID = descendant->getID();
-        theOperator.addEntityIDToDeleteList(descendantID);
-        emit deletingEntity(descendantID);
-        EntityItemPointer descendantEntity = std::dynamic_pointer_cast<EntityItem>(descendant);
-        if (descendantEntity) {
-            emit deletingEntityPointer(descendantEntity.get());
-        }
-    });
-
-    recurseTreeWithOperator(&theOperator);
-    processRemovedEntities(theOperator);
-    _isDirty = true;
+    // NOTE: can be called without lock because deleteEntitiesByID() will lock
+    QSet<EntityItemID> ids;
+    ids << entityID;
+    deleteEntitiesByID(ids, force, ignoreWarnings);
 }
 
 void EntityTree::unhookChildAvatar(const EntityItemID entityID) {
-
-    EntityItemPointer entity = findEntityByEntityItemID(entityID);
-
-    entity->forEachDescendant([&](SpatiallyNestablePointer child) {
-        if (child->getNestableType() == NestableType::Avatar) {
-            child->setParentID(nullptr);
-        }
-    });
+    if (!getIsServer()) {
+        EntityItemPointer entity = findEntityByEntityItemID(entityID);
+        entity->forEachDescendant([&](SpatiallyNestablePointer child) {
+            if (child->getNestableType() == NestableType::Avatar) {
+                child->setParentID(nullptr);
+            }
+        });
+    }
 }
 
 void EntityTree::cleanupCloneIDs(const EntityItemID& entityID) {
@@ -684,40 +647,98 @@ void EntityTree::cleanupCloneIDs(const EntityItemID& entityID) {
     }
 }
 
-void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool ignoreWarnings) {
-    // NOTE: callers must lock the tree before using this method
+void EntityTree::recursivelyFilterAndCollectForDelete(const EntityItemPointer& entity, SetOfEntities& entitiesToDelete, bool force) const {
+    // tree must be read-locked before calling this method
+    //TODO: assert(treeIsLocked);
+    assert(entity);
+    if (entity->getElement() && (entitiesToDelete.find(entity) == entitiesToDelete.end())) {
+        // filter
+        bool allowed = force;
+        if (!allowed) {
+            bool wasChanged = false;
+            auto startFilter = usecTimestampNow();
+            EntityItemProperties dummyProperties;
+            allowed = force || filterProperties(entity, dummyProperties, dummyProperties, wasChanged, FilterType::Delete);
+            auto endFilter = usecTimestampNow();
+            _totalFilterTime += endFilter - startFilter;
+        }
+        if (allowed) {
+            entitiesToDelete.insert(entity);
+            for (SpatiallyNestablePointer child : entity->getChildren()) {
+                if (child && child->getNestableType() == NestableType::Entity) {
+                    EntityItemPointer childEntity = std::static_pointer_cast<EntityItem>(child);
+                    recursivelyFilterAndCollectForDelete(childEntity, entitiesToDelete, force);
+                }
+            }
+        }
+    }
+}
+
+void EntityTree::deleteEntitiesByID(const QSet<EntityItemID>& ids, bool force, bool ignoreWarnings) {
+    // this method has two paths:
+    // (a) entity-server: applies delete filter
+    // (b) interface-client: deletes local- and my-avatar-entities immediately, submits domainEntity deletes to the entity-server
+    if (getIsServer()) {
+        withWriteLock([&] {
+            SetOfEntities entitiesToDelete;
+            for (auto id : ids) {
+                EntityItemPointer entity;
+                {
+                    QReadLocker locker(&_entityMapLock);
+                    entity = _entityMap.value(id);
+                }
+                if (entity) {
+                    recursivelyFilterAndCollectForDelete(entity, entitiesToDelete, force);
+                }
+            }
+            if (!entitiesToDelete.empty()) {
+                deleteEntitiesByPointer(entitiesToDelete);
+            }
+        });
+    } else {
+        SetOfEntities entitiesToDelete;
+        SetOfEntities domainEntities;
+        QUuid sessionID = DependencyManager::get<NodeList>()->getSessionUUID();
+        withWriteLock([&] {
+            for (auto id : ids) {
+                EntityItemPointer entity;
+                {
+                    QReadLocker locker(&_entityMapLock);
+                    entity = _entityMap.value(id);
+                }
+                if (entity) {
+                    if (entity->isDomainEntity()) {
+                        domainEntities.insert(entity);
+                    } else if (entity->isLocalEntity() || entity->isMyAvatarEntity()) {
+                        entitiesToDelete.insert(entity);
+                        entity->collectChildrenForDelete(entitiesToDelete, domainEntities, sessionID);
+                    }
+                }
+            }
+            if (!entitiesToDelete.empty()) {
+                deleteEntitiesByPointer(entitiesToDelete);
+            }
+        });
+        if (!domainEntities.empty() && _simulation) {
+            // interface-client can't delete domainEntities outright, they must roundtrip through the entity-server
+            _simulation->queueEraseDomainEntities(domainEntities);
+        }
+    }
+}
+
+void EntityTree::deleteEntitiesByPointer(const SetOfEntities& entities) {
+    // tree must be write-locked before calling this method
+    //TODO: assert(treeIsLocked);
+    // NOTE: there is no entity validation (i.e. is entity in tree?) nor snarfing of children beyond this point.
+    // Get those done BEFORE calling this method.
+    for (auto entity : entities) {
+        cleanupCloneIDs(entity->getID());
+    }
     DeleteEntityOperator theOperator(getThisPointer());
-    foreach(const EntityItemID& entityID, entityIDs) {
-        // ANDREW TODO: rejigger this logic to FIRST get entity THEN get element
-        EntityTreeElementPointer containingElement = getContainingElement(entityID);
-        if (!containingElement) {
-            if (!ignoreWarnings) {
-                qCWarning(entities) << "EntityTree::deleteEntities() on non-existent entityID=" << entityID;
-            }
-            continue;
-        }
-
-        EntityItemPointer existingEntity = containingElement->getEntityWithEntityItemID(entityID);
-        if (!existingEntity) {
-            if (!ignoreWarnings) {
-                qCWarning(entities) << "EntityTree::deleteEntities() on non-existent entity item with entityID=" << entityID;
-            }
-            continue;
-        }
-
-        if (existingEntity->getLocked() && !force) {
-            if (!ignoreWarnings) {
-                qCDebug(entities) << "ERROR! EntityTree::deleteEntities() trying to delete locked entity. entityID=" << entityID;
-            }
-            continue;
-        }
-
-        // tell our delete operator about this entityID
-        cleanupCloneIDs(entityID);
-        unhookChildAvatar(entityID);
-        theOperator.addEntityIDToDeleteList(entityID);
-        emit deletingEntity(entityID);
-        emit deletingEntityPointer(existingEntity.get());
+    for (auto entity : entities) {
+        theOperator.addEntityToDeleteList(entity);
+        emit deletingEntity(entity->getID());
+        emit deletingEntityPointer(entity.get());
     }
 
     if (!theOperator.getEntities().empty()) {
@@ -728,23 +749,11 @@ void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool i
 }
 
 void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator) {
+    // NOTE: assume tree already write-locked because this method only called in deleteEntitiesByPointer()
     quint64 deletedAt = usecTimestampNow();
     const RemovedEntities& entities = theOperator.getEntities();
     foreach(const EntityToDeleteDetails& details, entities) {
         EntityItemPointer theEntity = details.entity;
-
-        if (getIsServer()) {
-            QSet<EntityItemID> childrenIDs;
-            theEntity->forEachChild([&](SpatiallyNestablePointer child) {
-                if (child->getNestableType() == NestableType::Entity) {
-                    childrenIDs += child->getID();
-                }
-            });
-            deleteEntities(childrenIDs, true, true);
-        }
-
-        theEntity->die();
-
         if (getIsServer()) {
             removeCertifiedEntityOnServer(theEntity);
 
@@ -752,18 +761,23 @@ void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator)
             QWriteLocker recentlyDeletedEntitiesLocker(&_recentlyDeletedEntitiesLock);
             _recentlyDeletedEntityItemIDs.insert(deletedAt, theEntity->getEntityItemID());
         } else {
+            theEntity->forEachDescendant([&](SpatiallyNestablePointer child) {
+                if (child->getNestableType() == NestableType::Avatar) {
+                    child->setParentID(nullptr);
+                }
+            });
+
             // on the client side, we also remember that we deleted this entity, we don't care about the time
             trackDeletedEntity(theEntity->getEntityItemID());
-        }
 
+            int32_t spaceIndex = theEntity->getSpaceIndex();
+            if (spaceIndex != -1) {
+                // stale spaceIndices will be freed later
+                _staleProxies.push_back(spaceIndex);
+            }
+        }
         if (theEntity->isSimulated()) {
             _simulation->prepareEntityForDelete(theEntity);
-        }
-
-        int32_t spaceIndex = theEntity->getSpaceIndex();
-        if (spaceIndex != -1) {
-            // stale spaceIndices will be freed later
-            _staleProxies.push_back(spaceIndex);
         }
     }
 }
@@ -1370,7 +1384,7 @@ void EntityTree::fixupTerseEditLogging(EntityItemProperties& properties, QList<Q
 }
 
 
-bool EntityTree::filterProperties(EntityItemPointer& existingEntity, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, FilterType filterType) {
+bool EntityTree::filterProperties(const EntityItemPointer& existingEntity, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, FilterType filterType) const {
     bool accepted = true;
     auto entityEditFilters = DependencyManager::get<EntityEditFilters>();
     if (entityEditFilters) {
@@ -1750,9 +1764,9 @@ void EntityTree::processChallengeOwnershipPacket(ReceivedMessage& message, const
     }
 }
 
+// NOTE: Caller must lock the tree before calling this.
 int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned char* editData, int maxLength,
                                      const SharedNodePointer& senderNode) {
-
     if (!getIsServer()) {
         qCWarning(entities) << "EntityTree::processEditPacketData() should only be called on a server tree.";
         return 0;
@@ -2218,7 +2232,9 @@ void EntityTree::fixupNeedsParentFixups() {
 
 void EntityTree::deleteDescendantsOfAvatar(QUuid avatarID) {
     if (_childrenOfAvatars.contains(avatarID)) {
-        deleteEntities(_childrenOfAvatars[avatarID]);
+        bool force = true;
+        bool ignoreWarnings = true;
+        deleteEntitiesByID(_childrenOfAvatars[avatarID], force, ignoreWarnings);
         _childrenOfAvatars.remove(avatarID);
     }
 }
@@ -2250,22 +2266,6 @@ void EntityTree::update(bool simulate) {
     if (simulate && _simulation) {
         withWriteLock([&] {
             _simulation->updateEntities();
-            {
-                PROFILE_RANGE(simulation_physics, "Deletes");
-                SetOfEntities deadEntities;
-                _simulation->takeDeadEntities(deadEntities);
-                if (!deadEntities.empty()) {
-                    // translate into list of ID's
-                    QSet<EntityItemID> idsToDelete;
-
-                    for (auto entity : deadEntities) {
-                        idsToDelete.insert(entity->getEntityItemID());
-                    }
-
-                    // delete these things the roundabout way
-                    deleteEntities(idsToDelete, true);
-                }
-            }
         });
     }
 }
@@ -2354,12 +2354,17 @@ bool EntityTree::shouldEraseEntity(EntityItemID entityID, const SharedNodePointe
     return allowed;
 }
 
-
-// TODO: consider consolidating processEraseMessageDetails() and processEraseMessage()
 int EntityTree::processEraseMessage(ReceivedMessage& message, const SharedNodePointer& sourceNode) {
+    // NOTE: this is only called by the interface-client on receipt of deleteEntity message from entity-server.
+    // Which means this is a state synchronization message from the the entity-server.  It is saying
+    // "The following domain-entities have already been deleted". While need to perform sanity checking
+    // (e.g. verify these are domain entities) permissions need NOT checked for the domain-entities.
+    assert(!getIsServer());
+    // TODO: remove this stuff out of EntityTree:: and into interface-client code.
     #ifdef EXTRA_ERASE_DEBUGGING
         qCDebug(entities) << "EntityTree::processEraseMessage()";
     #endif
+    SetOfEntities consequentialDomainEntities;
     withWriteLock([&] {
         message.seek(sizeof(OCTREE_PACKET_FLAGS) + sizeof(OCTREE_PACKET_SEQUENCE) + sizeof(OCTREE_PACKET_SENT_TIME));
 
@@ -2367,10 +2372,9 @@ int EntityTree::processEraseMessage(ReceivedMessage& message, const SharedNodePo
         message.readPrimitive(&numberOfIDs);
 
         if (numberOfIDs > 0) {
-            QSet<EntityItemID> entityItemIDsToDelete;
+            QSet<EntityItemID> idsToDelete;
 
             for (size_t i = 0; i < numberOfIDs; i++) {
-
                 if (NUM_BYTES_RFC4122_UUID > message.getBytesLeftToRead()) {
                     qCDebug(entities) << "EntityTree::processEraseMessage().... bailing because not enough bytes in buffer";
                     break; // bail to prevent buffer overflow
@@ -2382,64 +2386,85 @@ int EntityTree::processEraseMessage(ReceivedMessage& message, const SharedNodePo
                 #endif
 
                 EntityItemID entityItemID(entityID);
+                idsToDelete << entityItemID;
+            }
 
-                if (shouldEraseEntity(entityID, sourceNode)) {
-                    entityItemIDsToDelete << entityItemID;
-                    cleanupCloneIDs(entityItemID);
+            // domain-entity deletion can trigger deletion of other entities the entity-server doesn't know about
+            // so we must recurse down the children and collect consequential deletes however
+            // we must first identify all domain-entities in idsToDelete so as to not overstep entity-server's authority
+            SetOfEntities domainEntities;
+            for (auto id : idsToDelete) {
+                EntityItemPointer entity = _entityMap.value(id);
+                if (entity && entity->isDomainEntity()) {
+                    domainEntities.insert(entity);
                 }
             }
-            deleteEntities(entityItemIDsToDelete, true, true);
+            // now we recurse domain-entities children and snarf consequential entities
+            auto nodeList = DependencyManager::get<NodeList>();
+            QUuid sessionID = nodeList->getSessionUUID();
+            // NOTE: normally a null sessionID would be bad, as that would cause the collectDhildrenForDelete() method below
+            // to snarf domain entities for which the interface-client is not authorized to delete without explicit instructions
+            // from the entity-server, however it is ok here because that would mean:
+            // (a) interface-client is not connected to a domain which means...
+            // (b) we should never get here (since this would correspond to a message from the entity-server) but...
+            // (c) who cares? When not connected to a domain the interface-client can do whatever it wants.
+            SetOfEntities entitiesToDelete;
+            for (auto entity : domainEntities) {
+                entitiesToDelete.insert(entity);
+                entity->collectChildrenForDelete(entitiesToDelete, consequentialDomainEntities, sessionID);
+            }
+
+            if (!entitiesToDelete.empty()) {
+                deleteEntitiesByPointer(entitiesToDelete);
+            }
         }
     });
+    if (!consequentialDomainEntities.empty() && _simulation) {
+        _simulation->queueEraseDomainEntities(consequentialDomainEntities);
+    }
     return message.getPosition();
 }
 
 // This version skips over the header
-// NOTE: Caller must lock the tree before calling this.
-// TODO: consider consolidating processEraseMessageDetails() and processEraseMessage()
+// NOTE: Caller must write-lock the tree before calling this.
 int EntityTree::processEraseMessageDetails(const QByteArray& dataByteArray, const SharedNodePointer& sourceNode) {
+    //TODO: assert(treeIsLocked);
+    assert(getIsServer());
     #ifdef EXTRA_ERASE_DEBUGGING
         qCDebug(entities) << "EntityTree::processEraseMessageDetails()";
     #endif
-    const unsigned char* packetData = (const unsigned char*)dataByteArray.constData();
-    const unsigned char* dataAt = packetData;
     size_t packetLength = dataByteArray.size();
     size_t processedBytes = 0;
 
     uint16_t numberOfIds = 0; // placeholder for now
-    memcpy(&numberOfIds, dataAt, sizeof(numberOfIds));
-    dataAt += sizeof(numberOfIds);
+    memcpy(&numberOfIds, dataByteArray.constData(), sizeof(numberOfIds));
     processedBytes += sizeof(numberOfIds);
 
     if (numberOfIds > 0) {
-        QSet<EntityItemID> entityItemIDsToDelete;
+        QSet<EntityItemID> ids;
 
+        // extract ids from packet
         for (size_t i = 0; i < numberOfIds; i++) {
-
-
             if (processedBytes + NUM_BYTES_RFC4122_UUID > packetLength) {
                 qCDebug(entities) << "EntityTree::processEraseMessageDetails().... bailing because not enough bytes in buffer";
                 break; // bail to prevent buffer overflow
             }
 
             QByteArray encodedID = dataByteArray.mid((int)processedBytes, NUM_BYTES_RFC4122_UUID);
-            QUuid entityID = QUuid::fromRfc4122(encodedID);
-            dataAt += encodedID.size();
+            QUuid id = QUuid::fromRfc4122(encodedID);
             processedBytes += encodedID.size();
 
             #ifdef EXTRA_ERASE_DEBUGGING
-                qCDebug(entities) << "    ---- EntityTree::processEraseMessageDetails() contains id:" << entityID;
+                qCDebug(entities) << "    ---- EntityTree::processEraseMessageDetails() contains id:" << id;
             #endif
 
-            EntityItemID entityItemID(entityID);
-
-            if (shouldEraseEntity(entityID, sourceNode)) {
-                entityItemIDsToDelete << entityItemID;
-                cleanupCloneIDs(entityItemID);
-            }
-
+            EntityItemID entityID(id);
+            ids << entityID;
         }
-        deleteEntities(entityItemIDsToDelete, true, true);
+
+        bool force = sourceNode->isAllowedEditor();
+        bool ignoreWarnings = true;
+        deleteEntitiesByID(ids, force, ignoreWarnings);
     }
     return (int)processedBytes;
 }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -736,9 +736,11 @@ void EntityTree::deleteEntitiesByPointer(const SetOfEntities& entities) {
     }
     DeleteEntityOperator theOperator(getThisPointer());
     for (auto entity : entities) {
-        theOperator.addEntityToDeleteList(entity);
-        emit deletingEntity(entity->getID());
-        emit deletingEntityPointer(entity.get());
+        if (entity->getElement()) {
+            theOperator.addEntityToDeleteList(entity);
+            emit deletingEntity(entity->getID());
+            emit deletingEntityPointer(entity.get());
+        }
     }
 
     if (!theOperator.getEntities().empty()) {

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -126,7 +126,9 @@ public:
     void unhookChildAvatar(const EntityItemID entityID);
     void cleanupCloneIDs(const EntityItemID& entityID);
     void deleteEntity(const EntityItemID& entityID, bool force = false, bool ignoreWarnings = true);
-    void deleteEntities(QSet<EntityItemID> entityIDs, bool force = false, bool ignoreWarnings = true);
+
+    void deleteEntitiesByID(const QSet<EntityItemID>& entityIDs, bool force = false, bool ignoreWarnings = true);
+    void deleteEntitiesByPointer(const SetOfEntities& entities);
 
     EntityItemPointer findEntityByID(const QUuid& id) const;
     EntityItemPointer findEntityByEntityItemID(const EntityItemID& entityID) const;
@@ -291,6 +293,7 @@ signals:
 
 protected:
 
+    void recursivelyFilterAndCollectForDelete(const EntityItemPointer& entity, SetOfEntities& entitiesToDelete, bool force) const;
     void processRemovedEntities(const DeleteEntityOperator& theOperator);
     bool updateEntity(EntityItemPointer entity, const EntityItemProperties& properties,
             const SharedNodePointer& senderNode = SharedNodePointer(nullptr));
@@ -339,12 +342,12 @@ protected:
     int _totalEditMessages = 0;
     int _totalUpdates = 0;
     int _totalCreates = 0;
-    quint64 _totalDecodeTime = 0;
-    quint64 _totalLookupTime = 0;
-    quint64 _totalUpdateTime = 0;
-    quint64 _totalCreateTime = 0;
-    quint64 _totalLoggingTime = 0;
-    quint64 _totalFilterTime = 0;
+    mutable quint64 _totalDecodeTime = 0;
+    mutable quint64 _totalLookupTime = 0;
+    mutable quint64 _totalUpdateTime = 0;
+    mutable quint64 _totalCreateTime = 0;
+    mutable quint64 _totalLoggingTime = 0;
+    mutable quint64 _totalFilterTime = 0;
 
     // these performance statistics are only used in the client
     void resetClientEditStats();
@@ -364,7 +367,7 @@ protected:
 
     float _maxTmpEntityLifetime { DEFAULT_MAX_TMP_ENTITY_LIFETIME };
 
-    bool filterProperties(EntityItemPointer& existingEntity, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, FilterType filterType);
+    bool filterProperties(const EntityItemPointer& existingEntity, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, FilterType filterType) const;
     bool _hasEntityEditFilter{ false };
     QStringList _entityScriptSourceWhitelist;
 

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -705,7 +705,7 @@ void EntityTreeElement::cleanupDomainAndNonOwnedEntities() {
     withWriteLock([&] {
         EntityItems savedEntities;
         foreach(EntityItemPointer entity, _entityItems) {
-            if (!(entity->isLocalEntity() || (entity->isAvatarEntity() && entity->getOwningAvatarID() == getTree()->getMyAvatarSessionUUID()))) {
+            if (!(entity->isLocalEntity() || entity->isMyAvatarEntity())) {
                 entity->preDelete();
                 entity->_element = NULL;
             } else {

--- a/libraries/entities/src/SimpleEntitySimulation.cpp
+++ b/libraries/entities/src/SimpleEntitySimulation.cpp
@@ -47,7 +47,10 @@ void SimpleEntitySimulation::clearOwnership(const QUuid& ownerID) {
     }
 }
 
-void SimpleEntitySimulation::updateEntitiesInternal(uint64_t now) {
+void SimpleEntitySimulation::updateEntities() {
+    EntitySimulation::updateEntities();
+    QMutexLocker lock(&_mutex);
+    uint64_t now = usecTimestampNow();
     expireStaleOwnerships(now);
     stopOwnerlessEntities(now);
 }
@@ -134,10 +137,11 @@ void SimpleEntitySimulation::processChangedEntity(const EntityItemPointer& entit
     entity->clearDirtyFlags();
 }
 
-void SimpleEntitySimulation::clearEntitiesInternal() {
+void SimpleEntitySimulation::clearEntities() {
     QMutexLocker lock(&_mutex);
     _entitiesWithSimulationOwner.clear();
     _entitiesThatNeedSimulationOwner.clear();
+    EntitySimulation::clearEntities();
 }
 
 void SimpleEntitySimulation::sortEntitiesThatMoved() {

--- a/libraries/entities/src/SimpleEntitySimulation.cpp
+++ b/libraries/entities/src/SimpleEntitySimulation.cpp
@@ -52,9 +52,9 @@ void SimpleEntitySimulation::updateEntitiesInternal(uint64_t now) {
     stopOwnerlessEntities(now);
 }
 
-void SimpleEntitySimulation::addEntityInternal(EntityItemPointer entity) {
+void SimpleEntitySimulation::addEntityToInternalLists(EntityItemPointer entity) {
+    EntitySimulation::addEntityToInternalLists(entity);
     if (entity->getSimulatorID().isNull()) {
-        QMutexLocker lock(&_mutex);
         if (entity->getDynamic()) {
             // we don't allow dynamic objects to move without an owner so nothing to do here
         } else if (entity->isMovingRelativeToParent()) {
@@ -65,7 +65,6 @@ void SimpleEntitySimulation::addEntityInternal(EntityItemPointer entity) {
             }
         }
     } else {
-        QMutexLocker lock(&_mutex);
         _entitiesWithSimulationOwner.insert(entity);
         _nextStaleOwnershipExpiry = glm::min(_nextStaleOwnershipExpiry, entity->getSimulationOwnershipExpiry());
 
@@ -79,10 +78,10 @@ void SimpleEntitySimulation::addEntityInternal(EntityItemPointer entity) {
     }
 }
 
-void SimpleEntitySimulation::removeEntityInternal(EntityItemPointer entity) {
-    EntitySimulation::removeEntityInternal(entity);
+void SimpleEntitySimulation::removeEntityFromInternalLists(EntityItemPointer entity) {
     _entitiesWithSimulationOwner.remove(entity);
     _entitiesThatNeedSimulationOwner.remove(entity);
+    EntitySimulation::removeEntityFromInternalLists(entity);
 }
 
 void SimpleEntitySimulation::processChangedEntity(const EntityItemPointer& entity) {

--- a/libraries/entities/src/SimpleEntitySimulation.h
+++ b/libraries/entities/src/SimpleEntitySimulation.h
@@ -23,16 +23,16 @@ using SimpleEntitySimulationPointer = std::shared_ptr<SimpleEntitySimulation>;
 class SimpleEntitySimulation : public EntitySimulation {
 public:
     SimpleEntitySimulation() : EntitySimulation() { }
-    ~SimpleEntitySimulation() { clearEntitiesInternal(); }
+    ~SimpleEntitySimulation() { clearEntities(); }
 
     void clearOwnership(const QUuid& ownerID);
+    void clearEntities() override;
+    void updateEntities() override;
 
 protected:
-    void updateEntitiesInternal(uint64_t now) override;
     void addEntityToInternalLists(EntityItemPointer entity) override;
     void removeEntityFromInternalLists(EntityItemPointer entity) override;
     void processChangedEntity(const EntityItemPointer& entity) override;
-    void clearEntitiesInternal() override;
 
     void sortEntitiesThatMoved() override;
 

--- a/libraries/entities/src/SimpleEntitySimulation.h
+++ b/libraries/entities/src/SimpleEntitySimulation.h
@@ -29,8 +29,8 @@ public:
 
 protected:
     void updateEntitiesInternal(uint64_t now) override;
-    void addEntityInternal(EntityItemPointer entity) override;
-    void removeEntityInternal(EntityItemPointer entity) override;
+    void addEntityToInternalLists(EntityItemPointer entity) override;
+    void removeEntityFromInternalLists(EntityItemPointer entity) override;
     void processChangedEntity(const EntityItemPointer& entity) override;
     void clearEntitiesInternal() override;
 

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -107,7 +107,7 @@ protected:
     uint64_t getNextBidExpiry() const { return _nextBidExpiry; }
     void initForBid();
     void initForOwned();
-    void clearOwnershipState() { _ownershipState = OwnershipState::NotLocallyOwned; }
+    void clearOwnershipState();
     void updateServerPhysicsVariables();
     bool remoteSimulationOutOfSync(uint32_t simulationStep);
 

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -658,15 +658,6 @@ void PhysicalEntitySimulation::removeDynamic(const QUuid dynamicID) {
     _dynamicsToRemove += dynamicID;
 }
 
-/*
-void PhysicalEntitySimulation::removeDynamics(QList<QUuid> dynamicIDsToRemove) {
-    QMutexLocker lock(&_dynamicsMutex);
-    foreach(QUuid uuid, dynamicIDsToRemove) {
-        _dynamicsToRemove.insert(uuid);
-    }
-}
-*/
-
 void PhysicalEntitySimulation::applyDynamicChanges() {
     QList<EntityDynamicPointer> dynamicsFailedToAdd;
     if (_physicsEngine) {

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -69,7 +69,7 @@ void PhysicalEntitySimulation::removeEntityFromInternalLists(EntityItemPointer e
         _entitiesToRemoveFromPhysics.insert(entity);
     }
     if (entity->isDead() && entity->getElement()) {
-        _deadEntities.insert(entity);
+        _deadEntitiesToRemoveFromTree.insert(entity);
     }
     if (entity->isAvatarEntity()) {
         _deadAvatarEntities.insert(entity);
@@ -171,7 +171,7 @@ void PhysicalEntitySimulation::processChangedEntity(const EntityItemPointer& ent
 }
 
 void PhysicalEntitySimulation::processDeadEntities() {
-    if (_deadEntities.empty()) {
+    if (_deadEntitiesToRemoveFromTree.empty()) {
         return;
     }
     PROFILE_RANGE(simulation_physics, "Deletes");
@@ -179,7 +179,7 @@ void PhysicalEntitySimulation::processDeadEntities() {
     SetOfEntities domainEntities;
     QUuid sessionID = Physics::getSessionUUID();
     QMutexLocker lock(&_mutex);
-    for (auto entity : _deadEntities) {
+    for (auto entity : _deadEntitiesToRemoveFromTree) {
         EntityMotionState* motionState = static_cast<EntityMotionState*>(entity->getPhysicsInfo());
         if (motionState) {
             _entitiesToRemoveFromPhysics.insert(entity);
@@ -191,7 +191,7 @@ void PhysicalEntitySimulation::processDeadEntities() {
             entity->collectChildrenForDelete(entitiesToDeleteImmediately, domainEntities, sessionID);
         }
     }
-    _deadEntities.clear();
+    _deadEntitiesToRemoveFromTree.clear();
 
     // interface-client can't delete domainEntities outright, they must roundtrip through the entity-server
     for (auto entity : domainEntities) {

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -40,10 +40,6 @@ void PhysicalEntitySimulation::init(
 }
 
 // begin EntitySimulation overrides
-void PhysicalEntitySimulation::updateEntitiesInternal(uint64_t now) {
-    // Do nothing here because the "internal" update the PhysicsEngine::stepSimulation() which is done elsewhere.
-}
-
 void PhysicalEntitySimulation::addEntityToInternalLists(EntityItemPointer entity) {
     EntitySimulation::addEntityToInternalLists(entity);
     entity->deserializeActions(); // TODO: do this elsewhere
@@ -186,11 +182,12 @@ void PhysicalEntitySimulation::processChangedEntity(const EntityItemPointer& ent
     }
 }
 
-void PhysicalEntitySimulation::clearEntitiesInternal() {
+void PhysicalEntitySimulation::clearEntities() {
     // TODO: we should probably wait to lock the _physicsEngine so we don't mess up data structures
     // while it is in the middle of a simulation step.  As it is, we're probably in shutdown mode
     // anyway, so maybe the simulation was already properly shutdown?  Cross our fingers...
 
+    QMutexLocker lock(&_mutex);
     // remove the objects (aka MotionStates) from physics
     _physicsEngine->removeSetOfObjects(_physicalObjects);
 
@@ -212,6 +209,8 @@ void PhysicalEntitySimulation::clearEntitiesInternal() {
     _entitiesToAddToPhysics.clear();
     _incomingChanges.clear();
     _entitiesToDeleteLater.clear();
+
+    EntitySimulation::clearEntities();
 }
 
 // virtual

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -48,6 +48,7 @@ void PhysicalEntitySimulation::addEntityInternal(EntityItemPointer entity) {
     QMutexLocker lock(&_mutex);
     assert(entity);
     assert(!entity->isDead());
+    entity->deserializeActions();
     uint8_t region = _space->getRegion(entity->getSpaceIndex());
     bool maybeShouldBePhysical = (region < workload::Region::R3 || region == workload::Region::UNKNOWN) && entity->shouldBePhysical();
     bool canBeKinematic = region <= workload::Region::R3;

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -648,9 +648,24 @@ void PhysicalEntitySimulation::addDynamic(EntityDynamicPointer dynamic) {
                     "dynamic that was already in _physicsEngine";
             }
         }
-        EntitySimulation::addDynamic(dynamic);
+        QMutexLocker lock(&_dynamicsMutex);
+        _dynamicsToAdd += dynamic;
     }
 }
+
+void PhysicalEntitySimulation::removeDynamic(const QUuid dynamicID) {
+    QMutexLocker lock(&_dynamicsMutex);
+    _dynamicsToRemove += dynamicID;
+}
+
+/*
+void PhysicalEntitySimulation::removeDynamics(QList<QUuid> dynamicIDsToRemove) {
+    QMutexLocker lock(&_dynamicsMutex);
+    foreach(QUuid uuid, dynamicIDsToRemove) {
+        _dynamicsToRemove.insert(uuid);
+    }
+}
+*/
 
 void PhysicalEntitySimulation::applyDynamicChanges() {
     QList<EntityDynamicPointer> dynamicsFailedToAdd;
@@ -666,8 +681,8 @@ void PhysicalEntitySimulation::applyDynamicChanges() {
                 }
             }
         }
-        // applyDynamicChanges will clear _dynamicsToRemove and _dynamicsToAdd
-        EntitySimulation::applyDynamicChanges();
+        _dynamicsToAdd.clear();
+        _dynamicsToRemove.clear();
     }
 
     // put back the ones that couldn't yet be added

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -66,16 +66,16 @@ public:
     virtual void takeDeadEntities(SetOfEntities& deadEntities) override;
     void takeDeadAvatarEntities(SetOfEntities& deadEntities);
 
+    virtual void clearEntities() override;
+
 signals:
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 
 protected: // only called by EntitySimulation
     // overrides for EntitySimulation
-    virtual void updateEntitiesInternal(uint64_t now) override;
     virtual void addEntityToInternalLists(EntityItemPointer entity) override;
     virtual void removeEntityFromInternalLists(EntityItemPointer entity) override;
     void processChangedEntity(const EntityItemPointer& entity) override;
-    virtual void clearEntitiesInternal() override;
 
     void removeOwnershipData(EntityMotionState* motionState);
     void clearOwnershipData();

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -124,7 +124,7 @@ private:
 
     VectorOfEntityMotionStates _owned;
     VectorOfEntityMotionStates _bids;
-    SetOfEntities _deadAvatarEntities;
+    SetOfEntities _deadAvatarEntities; // to remove from Avatar's lists
     std::vector<EntityItemPointer> _entitiesToDeleteLater;
 
     QList<EntityDynamicPointer> _dynamicsToAdd;

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -61,7 +61,6 @@ public:
 
     void addDynamic(EntityDynamicPointer dynamic) override;
     void removeDynamic(const QUuid dynamicID) override;
-    //void removeDynamics(QList<QUuid> dynamicIDsToRemove);
     void applyDynamicChanges() override;
 
     virtual void takeDeadEntities(SetOfEntities& deadEntities) override;

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -19,6 +19,7 @@
 #include <btBulletDynamicsCommon.h>
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 
+#include <EntityDynamicInterface.h>
 #include <EntityItem.h>
 #include <EntitySimulation.h>
 #include <workload/Space.h>
@@ -58,8 +59,10 @@ public:
     void init(EntityTreePointer tree, PhysicsEnginePointer engine, EntityEditPacketSender* packetSender);
     void setWorkloadSpace(const workload::SpacePointer space) { _space = space; }
 
-    virtual void addDynamic(EntityDynamicPointer dynamic) override;
-    virtual void applyDynamicChanges() override;
+    void addDynamic(EntityDynamicPointer dynamic) override;
+    void removeDynamic(const QUuid dynamicID) override;
+    //void removeDynamics(QList<QUuid> dynamicIDsToRemove);
+    void applyDynamicChanges() override;
 
     virtual void takeDeadEntities(SetOfEntities& deadEntities) override;
     void takeDeadAvatarEntities(SetOfEntities& deadEntities);
@@ -123,6 +126,11 @@ private:
     VectorOfEntityMotionStates _bids;
     SetOfEntities _deadAvatarEntities;
     std::vector<EntityItemPointer> _entitiesToDeleteLater;
+
+    QList<EntityDynamicPointer> _dynamicsToAdd;
+    QSet<QUuid> _dynamicsToRemove;
+    QMutex _dynamicsMutex { QMutex::Recursive };
+
     workload::SpacePointer _space;
     uint64_t _nextBidExpiry;
     uint32_t _lastStepSendPackets { 0 };

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -72,8 +72,8 @@ signals:
 protected: // only called by EntitySimulation
     // overrides for EntitySimulation
     virtual void updateEntitiesInternal(uint64_t now) override;
-    virtual void addEntityInternal(EntityItemPointer entity) override;
-    virtual void removeEntityInternal(EntityItemPointer entity) override;
+    virtual void addEntityToInternalLists(EntityItemPointer entity) override;
+    virtual void removeEntityFromInternalLists(EntityItemPointer entity) override;
     void processChangedEntity(const EntityItemPointer& entity) override;
     virtual void clearEntitiesInternal() override;
 

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -63,19 +63,20 @@ public:
     void removeDynamic(const QUuid dynamicID) override;
     void applyDynamicChanges() override;
 
-    virtual void takeDeadEntities(SetOfEntities& deadEntities) override;
     void takeDeadAvatarEntities(SetOfEntities& deadEntities);
 
     virtual void clearEntities() override;
+    void queueEraseDomainEntities(const SetOfEntities& domainEntities) const override;
 
 signals:
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 
 protected: // only called by EntitySimulation
     // overrides for EntitySimulation
-    virtual void addEntityToInternalLists(EntityItemPointer entity) override;
-    virtual void removeEntityFromInternalLists(EntityItemPointer entity) override;
+    void addEntityToInternalLists(EntityItemPointer entity) override;
+    void removeEntityFromInternalLists(EntityItemPointer entity) override;
     void processChangedEntity(const EntityItemPointer& entity) override;
+    void processDeadEntities() override;
 
     void removeOwnershipData(EntityMotionState* motionState);
     void clearOwnershipData();

--- a/libraries/shared/src/PhysicsHelpers.cpp
+++ b/libraries/shared/src/PhysicsHelpers.cpp
@@ -10,10 +10,12 @@
 //
 
 #include "PhysicsHelpers.h"
-#include "NumericalConstants.h"
+
 #include <QUuid>
 
+#include "NumericalConstants.h"
 #include "PhysicsCollisionGroups.h"
+#include "SharedUtil.h"
 
 // This chunk of code was copied from Bullet-2.82, so we include the Bullet license here:
 /*
@@ -91,7 +93,7 @@ int32_t Physics::getDefaultCollisionMask(int32_t group) {
 QUuid _sessionID;
 
 void Physics::setSessionUUID(const QUuid& sessionID) {
-    _sessionID = sessionID;
+    _sessionID = sessionID.isNull() ? AVATAR_SELF_ID : sessionID;
 }
 
 const QUuid& Physics::getSessionUUID() {

--- a/libraries/shared/src/SpatialParentFinder.h
+++ b/libraries/shared/src/SpatialParentFinder.h
@@ -21,7 +21,7 @@ using SpatiallyNestableWeakPointer = std::weak_ptr<SpatiallyNestable>;
 using SpatiallyNestablePointer = std::shared_ptr<SpatiallyNestable>;
 class SpatialParentTree {
 public:
-    virtual SpatiallyNestablePointer findByID(const QUuid& id) const { return nullptr; }
+    virtual SpatiallyNestablePointer findByID(const QUuid& id) const = 0;
 };
 class SpatialParentFinder : public Dependency {
 

--- a/tests/octree/src/ModelTests.cpp
+++ b/tests/octree/src/ModelTests.cpp
@@ -363,7 +363,8 @@ void EntityTests::entityTreeTests(bool verbose) {
             }
 
             quint64 startDelete = usecTimestampNow();
-            tree.deleteEntity(entityID);
+            bool force = true;
+            tree.deleteEntity(entityID, force);
             quint64 endDelete = usecTimestampNow();
             totalElapsedDelete += (endDelete - startDelete);
 
@@ -446,7 +447,9 @@ void EntityTests::entityTreeTests(bool verbose) {
             }
 
             quint64 startDelete = usecTimestampNow();
-            tree.deleteEntities(entitiesToDelete);
+            bool force = true;
+            bool ignoreWarnings = true;
+            tree.deleteEntitiesByID(entitiesToDelete, force, ignoreWarnings);
             quint64 endDelete = usecTimestampNow();
             totalElapsedDelete += (endDelete - startDelete);
 


### PR DESCRIPTION
This PR is progress toward "more correct" deletion rules on chains of linked entities.  In short: children of entities being deleted should always also be deleted... except in cases where they shouldn't (e.g. where the deleter doesn't have the authority to delete).  The internal ticket is DEV-1811:

https://highfidelity.atlassian.net/browse/DEV-1811