### PR TITLE
Update vcpkg sdl2 port

### DIFF
--- a/cmake/ports/sdl2/CONTROL
+++ b/cmake/ports/sdl2/CONTROL
@@ -1,3 +1,8 @@
 Source: sdl2
-Version: 2.0.8-1
+Version: 2.0.9-4
+Homepage: https://github.com/SDL-Mirror/SDL
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
+
+Feature: vulkan
+Description: Vulkan functionality for SDL
+Build-Depends: vulkan

--- a/cmake/ports/sdl2/CONTROL
+++ b/cmake/ports/sdl2/CONTROL
@@ -1,5 +1,5 @@
 Source: sdl2
-Version: 2.0.9-4
+Version: 2.0.9-5
 Homepage: https://github.com/SDL-Mirror/SDL
 Description: Simple DirectMedia Layer is a cross-platform development library designed to provide low level access to audio, keyboard, mouse, joystick, and graphics hardware via OpenGL and Direct3D.
 

--- a/cmake/ports/sdl2/SDL-2.0.9-bug-4391-fix.patch
+++ b/cmake/ports/sdl2/SDL-2.0.9-bug-4391-fix.patch
@@ -1,0 +1,75 @@
+# HG changeset patch
+# User Sam Lantinga <slouken@libsdl.org>
+# Date 1542691020 28800
+# Node ID 9091b20040cf04cdc348d290ca22373b36364c39
+# Parent  144400e4630d885d2eb0761b7174433b4c0d90bb
+Fixed bug 4391 - hid_enumerate() sometimes causes game to freeze for a few seconds
+
+Daniel Gibson
+
+Even though my game (dhewm3) doesn't use SDL_INIT_JOYSTICK, SDL_PumpEvent() calls SDL_JoystickUpdate() which ends up calling hid_enumerate() every three seconds, and sometimes on my Win7 box hid_enumerate() takes about 5 seconds, which causes the whole game to freeze for that time.
+
+diff -r 144400e4630d -r 9091b20040cf include/SDL_bits.h
+--- a/include/SDL_bits.h	Sun Nov 18 19:28:20 2018 +0300
++++ b/include/SDL_bits.h	Mon Nov 19 21:17:00 2018 -0800
+@@ -101,6 +101,15 @@
+ #endif
+ }
+ 
++SDL_FORCE_INLINE SDL_bool
++SDL_HasExactlyOneBitSet32(Uint32 x)
++{
++    if (x && !(x & (x - 1))) {
++        return SDL_TRUE;
++    }
++    return SDL_FALSE;
++}
++
+ /* Ends C function definitions when using C++ */
+ #ifdef __cplusplus
+ }
+diff -r 144400e4630d -r 9091b20040cf src/SDL.c
+--- a/src/SDL.c	Sun Nov 18 19:28:20 2018 +0300
++++ b/src/SDL.c	Mon Nov 19 21:17:00 2018 -0800
+@@ -348,6 +348,12 @@
+     int num_subsystems = SDL_arraysize(SDL_SubsystemRefCount);
+     Uint32 initialized = 0;
+ 
++    /* Fast path for checking one flag */
++    if (SDL_HasExactlyOneBitSet32(flags)) {
++        int subsystem_index = SDL_MostSignificantBitIndex32(flags);
++        return SDL_SubsystemRefCount[subsystem_index] ? flags : 0;
++    }
++
+     if (!flags) {
+         flags = SDL_INIT_EVERYTHING;
+     }
+diff -r 144400e4630d -r 9091b20040cf src/joystick/SDL_joystick.c
+--- a/src/joystick/SDL_joystick.c	Sun Nov 18 19:28:20 2018 +0300
++++ b/src/joystick/SDL_joystick.c	Mon Nov 19 21:17:00 2018 -0800
+@@ -1016,6 +1016,10 @@
+     int i;
+     SDL_Joystick *joystick;
+ 
++    if (!SDL_WasInit(SDL_INIT_JOYSTICK)) {
++        return;
++    }
++
+     SDL_LockJoysticks();
+ 
+     if (SDL_updating_joystick) {
+diff -r 144400e4630d -r 9091b20040cf src/sensor/SDL_sensor.c
+--- a/src/sensor/SDL_sensor.c	Sun Nov 18 19:28:20 2018 +0300
++++ b/src/sensor/SDL_sensor.c	Mon Nov 19 21:17:00 2018 -0800
+@@ -505,6 +505,10 @@
+     int i;
+     SDL_Sensor *sensor;
+ 
++    if (!SDL_WasInit(SDL_INIT_SENSOR)) {
++        return;
++    }
++
+     SDL_LockSensors();
+ 
+     if (SDL_updating_sensor) {
+

--- a/cmake/ports/sdl2/enable-winrt-cmake.patch
+++ b/cmake/ports/sdl2/enable-winrt-cmake.patch
@@ -1,102 +1,75 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 73d9407..082fbc5 100644
+index 0128c7a..bd534e4 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -3,7 +3,11 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
- endif()
- 
+@@ -5,6 +5,18 @@ endif()
  cmake_minimum_required(VERSION 2.8.11)
--project(SDL2 C)
-+if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-+  project(SDL2 C CXX)
-+else()
-+  project(SDL2 C)
-+endif()
+ project(SDL2 C)
  
++if(WINDOWS_STORE)
++  enable_language(CXX)
++  cmake_minimum_required(VERSION 3.11)
++  add_definitions(-DSDL_BUILDING_WINRT=1 -ZW)
++  link_libraries(
++    -nodefaultlib:vccorlib$<$<CONFIG:Debug>:d>
++    -nodefaultlib:msvcrt$<$<CONFIG:Debug>:d>
++    vccorlib$<$<CONFIG:Debug>:d>.lib
++    msvcrt$<$<CONFIG:Debug>:d>.lib
++  )
++endif()
++
  # !!! FIXME: this should probably do "MACOSX_RPATH ON" as a target property
  # !!! FIXME:  for the SDL2 shared library (so you get an
-@@ -358,7 +362,6 @@ file(GLOB SOURCE_FILES
-   ${SDL2_SOURCE_DIR}/src/timer/*.c
-   ${SDL2_SOURCE_DIR}/src/video/*.c)
- 
--
- if(ASSERTIONS STREQUAL "auto")
-   # Do nada - use optimization settings to determine the assertion level
- elseif(ASSERTIONS STREQUAL "disabled")
-@@ -1132,6 +1135,22 @@ elseif(WINDOWS)
+ # !!! FIXME:  install_name ("soname") of "@rpath/libSDL-whatever.dylib"
+@@ -1166,6 +1178,11 @@ elseif(WINDOWS)
    file(GLOB CORE_SOURCES ${SDL2_SOURCE_DIR}/src/core/windows/*.c)
    set(SOURCE_FILES ${SOURCE_FILES} ${CORE_SOURCES})
  
 +  if(WINDOWS_STORE)
-+    cmake_minimum_required(VERSION 3.0)
-+    add_definitions(-DSDL_BUILDING_WINRT=1 -ZW)
-+    link_libraries(
-+      -nodefaultlib:vccorlib$<$<CONFIG:Debug>:d>
-+      -nodefaultlib:msvcrt$<$<CONFIG:Debug>:d>
-+      vccorlib$<$<CONFIG:Debug>:d>.lib
-+      msvcrt$<$<CONFIG:Debug>:d>.lib
-+    )
-+  endif()
-+
-+  if(WINDOWS_STORE)
 +    file(GLOB WINRT_SOURCE_FILES ${SDL2_SOURCE_DIR}/src/core/winrt/*.c ${SDL2_SOURCE_DIR}/src/core/winrt/*.cpp)
-+    set(SOURCE_FILES ${SOURCE_FILES} ${WINRT_SOURCE_FILES})
++    list(APPEND SOURCE_FILES ${WINRT_SOURCE_FILES})
 +  endif()
 +
    if(MSVC)
      # Prevent codegen that would use the VC runtime libraries.
      set_property(DIRECTORY . APPEND PROPERTY COMPILE_OPTIONS "/GS-")
-@@ -1176,7 +1195,11 @@ elseif(WINDOWS)
-     check_include_file(d3d11_1.h HAVE_D3D11_H)
+@@ -1211,6 +1228,9 @@ elseif(WINDOWS)
      check_include_file(ddraw.h HAVE_DDRAW_H)
      check_include_file(dsound.h HAVE_DSOUND_H)
--    check_include_file(dinput.h HAVE_DINPUT_H)
-+    if(WINDOWS_STORE)
+     check_include_file(dinput.h HAVE_DINPUT_H)
++    if(WINDOWS_STORE OR VCPKG_TARGET_TRIPLET MATCHES "arm-windows")
 +      set(HAVE_DINPUT_H 0)
-+    else()
-+      check_include_file(dinput.h HAVE_DINPUT_H)
 +    endif()
-     check_include_file(xaudio2.h HAVE_XAUDIO2_H)
-     check_include_file(mmdeviceapi.h HAVE_MMDEVICEAPI_H)
-     check_include_file(audioclient.h HAVE_AUDIOCLIENT_H)
-@@ -1193,12 +1216,14 @@ elseif(WINDOWS)
-   endif()
+     check_include_file(dxgi.h HAVE_DXGI_H)
+     if(HAVE_D3D_H OR HAVE_D3D11_H OR HAVE_DDRAW_H OR HAVE_DSOUND_H OR HAVE_DINPUT_H)
+       set(HAVE_DIRECTX TRUE)
+@@ -1229,18 +1249,20 @@ elseif(WINDOWS)
+   check_include_file(endpointvolume.h HAVE_ENDPOINTVOLUME_H)
  
    if(SDL_AUDIO)
--    set(SDL_AUDIO_DRIVER_WINMM 1)
--    file(GLOB WINMM_AUDIO_SOURCES ${SDL2_SOURCE_DIR}/src/audio/winmm/*.c)
--    set(SOURCE_FILES ${SOURCE_FILES} ${WINMM_AUDIO_SOURCES})
--    set(HAVE_SDL_AUDIO TRUE)
 +    if(NOT WINDOWS_STORE)
-+      set(SDL_AUDIO_DRIVER_WINMM 1)
-+      file(GLOB WINMM_AUDIO_SOURCES ${SDL2_SOURCE_DIR}/src/audio/winmm/*.c)
-+      set(SOURCE_FILES ${SOURCE_FILES} ${WINMM_AUDIO_SOURCES})
-+      set(HAVE_SDL_AUDIO TRUE)
+     set(SDL_AUDIO_DRIVER_WINMM 1)
+     file(GLOB WINMM_AUDIO_SOURCES ${SDL2_SOURCE_DIR}/src/audio/winmm/*.c)
+     set(SOURCE_FILES ${SOURCE_FILES} ${WINMM_AUDIO_SOURCES})
 +    endif()
+     set(HAVE_SDL_AUDIO TRUE)
  
 -    if(HAVE_DSOUND_H)
 +    if(HAVE_DSOUND_H AND NOT WINDOWS_STORE)
        set(SDL_AUDIO_DRIVER_DSOUND 1)
        file(GLOB DSOUND_AUDIO_SOURCES ${SDL2_SOURCE_DIR}/src/audio/directsound/*.c)
        set(SOURCE_FILES ${SOURCE_FILES} ${DSOUND_AUDIO_SOURCES})
-@@ -1208,9 +1233,10 @@ elseif(WINDOWS)
-       set(SDL_AUDIO_DRIVER_XAUDIO2 1)
-       file(GLOB XAUDIO2_AUDIO_SOURCES ${SDL2_SOURCE_DIR}/src/audio/xaudio2/*.c)
-       set(SOURCE_FILES ${SOURCE_FILES} ${XAUDIO2_AUDIO_SOURCES})
-+      set(HAVE_SDL_AUDIO TRUE)
      endif()
  
--    if(HAVE_AUDIOCLIENT_H AND HAVE_MMDEVICEAPI_H)
-+    if(HAVE_AUDIOCLIENT_H AND HAVE_MMDEVICEAPI_H AND NOT WINDOWS_STORE)
+-    if(WASAPI AND HAVE_AUDIOCLIENT_H AND HAVE_MMDEVICEAPI_H)
++    if(WASAPI AND HAVE_AUDIOCLIENT_H AND HAVE_MMDEVICEAPI_H AND NOT WINDOWS_STORE)
        set(SDL_AUDIO_DRIVER_WASAPI 1)
        file(GLOB WASAPI_AUDIO_SOURCES ${SDL2_SOURCE_DIR}/src/audio/wasapi/*.c)
        set(SOURCE_FILES ${SOURCE_FILES} ${WASAPI_AUDIO_SOURCES})
-@@ -1222,11 +1248,20 @@ elseif(WINDOWS)
+@@ -1252,11 +1274,20 @@ elseif(WINDOWS)
      if(NOT SDL_LOADSO)
        message_error("SDL_VIDEO requires SDL_LOADSO, which is not enabled")
      endif()
--    set(SDL_VIDEO_DRIVER_WINDOWS 1)
--    file(GLOB WIN_VIDEO_SOURCES ${SDL2_SOURCE_DIR}/src/video/windows/*.c)
 +    if(WINDOWS_STORE)
 +      set(SDL_VIDEO_DRIVER_WINRT 1)
 +      file(GLOB WIN_VIDEO_SOURCES
@@ -105,8 +78,8 @@ index 73d9407..082fbc5 100644
 +        ${SDL2_SOURCE_DIR}/src/render/direct3d11/*.cpp
 +        )
 +    else()
-+      set(SDL_VIDEO_DRIVER_WINDOWS 1)
-+      file(GLOB WIN_VIDEO_SOURCES ${SDL2_SOURCE_DIR}/src/video/windows/*.c)
+     set(SDL_VIDEO_DRIVER_WINDOWS 1)
+     file(GLOB WIN_VIDEO_SOURCES ${SDL2_SOURCE_DIR}/src/video/windows/*.c)
 +    endif()
      set(SOURCE_FILES ${SOURCE_FILES} ${WIN_VIDEO_SOURCES})
  
@@ -115,43 +88,39 @@ index 73d9407..082fbc5 100644
        set(SDL_VIDEO_RENDER_D3D 1)
        set(HAVE_RENDER_D3D TRUE)
      endif()
-@@ -1249,20 +1284,31 @@ elseif(WINDOWS)
+@@ -1279,20 +1310,31 @@ elseif(WINDOWS)
    endif()
  
    if(SDL_POWER)
--    set(SDL_POWER_WINDOWS 1)
--    set(SOURCE_FILES ${SOURCE_FILES} ${SDL2_SOURCE_DIR}/src/power/windows/SDL_syspower.c)
 +    if(WINDOWS_STORE)
 +      set(SDL_POWER_WINRT 1)
 +      set(SOURCE_FILES ${SOURCE_FILES} ${SDL2_SOURCE_DIR}/src/power/winrt/SDL_syspower.cpp)
 +    else()
-+      set(SDL_POWER_WINDOWS 1)
-+      set(SOURCE_FILES ${SOURCE_FILES} ${SDL2_SOURCE_DIR}/src/power/windows/SDL_syspower.c)
+     set(SDL_POWER_WINDOWS 1)
+     set(SOURCE_FILES ${SOURCE_FILES} ${SDL2_SOURCE_DIR}/src/power/windows/SDL_syspower.c)
 +    endif()
      set(HAVE_SDL_POWER TRUE)
    endif()
  
    if(SDL_FILESYSTEM)
      set(SDL_FILESYSTEM_WINDOWS 1)
--    file(GLOB FILESYSTEM_SOURCES ${SDL2_SOURCE_DIR}/src/filesystem/windows/*.c)
 +    if(WINDOWS_STORE)
 +      file(GLOB FILESYSTEM_SOURCES ${SDL2_SOURCE_DIR}/src/filesystem/winrt/*.cpp)
 +    else()
-+      file(GLOB FILESYSTEM_SOURCES ${SDL2_SOURCE_DIR}/src/filesystem/windows/*.c)
+     file(GLOB FILESYSTEM_SOURCES ${SDL2_SOURCE_DIR}/src/filesystem/windows/*.c)
 +    endif()
      set(SOURCE_FILES ${SOURCE_FILES} ${FILESYSTEM_SOURCES})
      set(HAVE_SDL_FILESYSTEM TRUE)
    endif()
  
    # Libraries for Win32 native and MinGW
--  list(APPEND EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid)
 +  if(NOT WINDOWS_STORE)
-+    list(APPEND EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid)
+   list(APPEND EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 shell32)
 +  endif()
  
    # TODO: in configure.in the check for timers is set on
    # cygwin | mingw32* - does this include mingw32CE?
-@@ -1284,7 +1330,7 @@ elseif(WINDOWS)
+@@ -1314,7 +1356,7 @@ elseif(WINDOWS)
    set(SOURCE_FILES ${SOURCE_FILES} ${CORE_SOURCES})
  
    if(SDL_VIDEO)
@@ -160,26 +129,26 @@ index 73d9407..082fbc5 100644
        set(SDL_VIDEO_OPENGL 1)
        set(SDL_VIDEO_OPENGL_WGL 1)
        set(SDL_VIDEO_RENDER_OGL 1)
-@@ -1688,9 +1734,11 @@ endif()
+@@ -1731,12 +1773,14 @@ endif()
  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_CFLAGS}")
  
  # Always build SDLmain
--add_library(SDL2main STATIC ${SDLMAIN_SOURCES})
--target_include_directories(SDL2main PUBLIC $<INSTALL_INTERFACE:include>)
--set(_INSTALL_LIBS "SDL2main")
 +if(NOT WINDOWS_STORE)
-+  add_library(SDL2main STATIC ${SDLMAIN_SOURCES})
-+  target_include_directories(SDL2main PUBLIC $<INSTALL_INTERFACE:include>)
-+  set(_INSTALL_LIBS "SDL2main")
+ add_library(SDL2main STATIC ${SDLMAIN_SOURCES})
+ target_include_directories(SDL2main PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include/SDL2>)
+ set(_INSTALL_LIBS "SDL2main")
+ if (NOT ANDROID)
+   set_target_properties(SDL2main PROPERTIES DEBUG_POSTFIX ${SDL_CMAKE_DEBUG_POSTFIX})
+ endif()
 +endif()
  
  if(SDL_SHARED)
    add_library(SDL2 SHARED ${SOURCE_FILES} ${VERSION_SOURCES})
 diff --git a/include/SDL_config.h.cmake b/include/SDL_config.h.cmake
-index 9b20398..7ae6e35 100644
+index 48dd2d4..0c4fa28 100644
 --- a/include/SDL_config.h.cmake
 +++ b/include/SDL_config.h.cmake
-@@ -298,6 +298,7 @@
+@@ -324,6 +324,7 @@
  #cmakedefine SDL_VIDEO_DRIVER_DIRECTFB_DYNAMIC @SDL_VIDEO_DRIVER_DIRECTFB_DYNAMIC@
  #cmakedefine SDL_VIDEO_DRIVER_DUMMY @SDL_VIDEO_DRIVER_DUMMY@
  #cmakedefine SDL_VIDEO_DRIVER_WINDOWS @SDL_VIDEO_DRIVER_WINDOWS@
@@ -187,7 +156,7 @@ index 9b20398..7ae6e35 100644
  #cmakedefine SDL_VIDEO_DRIVER_WAYLAND @SDL_VIDEO_DRIVER_WAYLAND@
  #cmakedefine SDL_VIDEO_DRIVER_RPI @SDL_VIDEO_DRIVER_RPI@
  #cmakedefine SDL_VIDEO_DRIVER_VIVANTE @SDL_VIDEO_DRIVER_VIVANTE@
-@@ -365,6 +366,7 @@
+@@ -392,6 +393,7 @@
  #cmakedefine SDL_POWER_ANDROID @SDL_POWER_ANDROID@
  #cmakedefine SDL_POWER_LINUX @SDL_POWER_LINUX@
  #cmakedefine SDL_POWER_WINDOWS @SDL_POWER_WINDOWS@
@@ -195,7 +164,7 @@ index 9b20398..7ae6e35 100644
  #cmakedefine SDL_POWER_MACOSX @SDL_POWER_MACOSX@
  #cmakedefine SDL_POWER_HAIKU @SDL_POWER_HAIKU@
  #cmakedefine SDL_POWER_EMSCRIPTEN @SDL_POWER_EMSCRIPTEN@
-@@ -387,7 +389,7 @@
+@@ -414,7 +416,7 @@
  #cmakedefine SDL_LIBSAMPLERATE_DYNAMIC @SDL_LIBSAMPLERATE_DYNAMIC@
  
  /* Platform specific definitions */

--- a/cmake/ports/sdl2/fix-x86-windows.patch
+++ b/cmake/ports/sdl2/fix-x86-windows.patch
@@ -1,0 +1,15 @@
+diff --git a/src/events/SDL_mouse.c b/src/events/SDL_mouse.c
+index ff23c5e..fc90bba 100644
+--- a/src/events/SDL_mouse.c
++++ b/src/events/SDL_mouse.c
+@@ -20,6 +20,10 @@
+ */
+ #include "../SDL_internal.h"
+ 
++#ifdef __WIN32__
++#include "../core/windows/SDL_windows.h"
++#endif
++
+ /* General mouse handling code for SDL */
+ 
+ #include "SDL_assert.h"

--- a/cmake/ports/sdl2/portfile.cmake
+++ b/cmake/ports/sdl2/portfile.cmake
@@ -3,21 +3,24 @@ include(vcpkg_common_functions)
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO SDL-Mirror/SDL
-    REF release-2.0.8
-    SHA512 5922dbeb14bb22991160251664b417d3f846867c18b5ecc1bd19c328ffd69b16252b7d45b9a317bafd1207fdb66d93a022dfb239e02447db9babd941956b6b37
+    REF release-2.0.9
+    SHA512 444c906c0baa720c86ca72d1b4cd66fdf6f516d5d2a9836169081a2997a5aebaaf9caa687ec060fa02292d79cfa4a62442333e00f90a0239edd1601529f6b056
     HEAD_REF master
-)
-
-vcpkg_apply_patches(
-    SOURCE_PATH ${SOURCE_PATH}
     PATCHES
-        ${CMAKE_CURRENT_LIST_DIR}/export-symbols-only-in-shared-build.patch
-        ${CMAKE_CURRENT_LIST_DIR}/enable-winrt-cmake.patch
+        export-symbols-only-in-shared-build.patch
+        fix-x86-windows.patch
+        enable-winrt-cmake.patch
+        SDL-2.0.9-bug-4391-fix.patch # See: https://bugzilla.libsdl.org/show_bug.cgi?id=4391 # Can be removed once SDL 2.0.10 is released
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" SDL_SHARED)
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "static" FORCE_STATIC_VCRT)
+
+set(VULKAN_VIDEO OFF)
+if("vulkan" IN_LIST FEATURES)
+    set(VULKAN_VIDEO ON)
+endif()
 
 vcpkg_configure_cmake(
     SOURCE_PATH ${SOURCE_PATH}
@@ -25,7 +28,7 @@ vcpkg_configure_cmake(
     OPTIONS
         -DSDL_STATIC=${SDL_STATIC}
         -DSDL_SHARED=${SDL_SHARED}
-        -DVIDEO_VULKAN=OFF
+        -DVIDEO_VULKAN=${VULKAN_VIDEO}
         -DFORCE_STATIC_VCRT=${FORCE_STATIC_VCRT}
         -DLIBC=ON
 )
@@ -33,11 +36,11 @@ vcpkg_configure_cmake(
 vcpkg_install_cmake()
 
 if(EXISTS "${CURRENT_PACKAGES_DIR}/cmake")
-    vcpkg_fixup_cmake_targets(CONFIG_PATH "cmake")
+    vcpkg_fixup_cmake_targets(CONFIG_PATH cmake)
 elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/SDL2")
-    vcpkg_fixup_cmake_targets(CONFIG_PATH "lib/cmake/SDL2")
+    vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/SDL2)
 elseif(EXISTS "${CURRENT_PACKAGES_DIR}/SDL2.framework/Resources")
-    vcpkg_fixup_cmake_targets(CONFIG_PATH "SDL2.framework/Resources")
+    vcpkg_fixup_cmake_targets(CONFIG_PATH SDL2.framework/Resources)
 endif()
 
 file(REMOVE_RECURSE
@@ -75,5 +78,6 @@ if(NOT VCPKG_CMAKE_SYSTEM_NAME)
     endforeach()
 endif()
 
-file(INSTALL ${SOURCE_PATH}/COPYING.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/sdl2 RENAME copyright)
+file(COPY ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/sdl2)
+configure_file(${SOURCE_PATH}/COPYING.txt ${CURRENT_PACKAGES_DIR}/share/sdl2/copyright COPYONLY)
 vcpkg_copy_pdbs()

--- a/cmake/ports/sdl2/vcpkg-cmake-wrapper.cmake
+++ b/cmake/ports/sdl2/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,8 @@
+_find_package(${ARGS})
+if(TARGET SDL2::SDL2 AND NOT TARGET SDL2::SDL2-static)
+    add_library( SDL2::SDL2-static INTERFACE IMPORTED)
+    set_target_properties(SDL2::SDL2-static PROPERTIES INTERFACE_LINK_LIBRARIES "SDL2::SDL2")
+elseif(TARGET SDL2::SDL2-static AND NOT TARGET SDL2::SDL2)
+    add_library( SDL2::SDL2 INTERFACE IMPORTED)
+    set_target_properties(SDL2::SDL2 PROPERTIES INTERFACE_LINK_LIBRARIES "SDL2::SDL2-static")
+endif()

--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -148,7 +148,7 @@ endif()
                 print("Cloning vcpkg from github to {}".format(self.path))
                 hifi_utils.executeSubprocess(['git', 'clone', 'https://github.com/microsoft/vcpkg.git', self.path])
                 print("Bootstrapping vcpkg")
-                hifi_utils.executeSubprocess([self.bootstrapCmd], folder=self.path)
+                hifi_utils.executeSubprocess(["{}/{}".format(self.path, self.bootstrapCmd)], folder=self.path)
             else:
                 print("Fetching vcpkg from {} to {}".format(self.vcpkgUrl, self.path))
                 hifi_utils.downloadAndExtract(self.vcpkgUrl, self.path, self.vcpkgHash)

--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -144,7 +144,7 @@ endif()
             downloadVcpkg = True
 
         if downloadVcpkg:
-            if "HIFI_VCPKG_BOOTSTRAP" in os.environ:
+            if True or ("HIFI_VCPKG_BOOTSTRAP" in os.environ):
                 print("Cloning vcpkg from github to {}".format(self.path))
                 hifi_utils.executeSubprocess(['git', 'clone', 'git@github.com:microsoft/vcpkg.git', self.path])
                 print("Bootstrapping vcpkg")

--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -146,7 +146,7 @@ endif()
         if downloadVcpkg:
             if True or ("HIFI_VCPKG_BOOTSTRAP" in os.environ):
                 print("Cloning vcpkg from github to {}".format(self.path))
-                hifi_utils.executeSubprocess(['git', 'clone', 'git@github.com:microsoft/vcpkg.git', self.path])
+                hifi_utils.executeSubprocess(['git', 'clone', 'https://github.com/microsoft/vcpkg.git', self.path])
                 print("Bootstrapping vcpkg")
                 hifi_utils.executeSubprocess([self.bootstrapCmd], folder=self.path)
             else:


### PR DESCRIPTION
The current SDL2 Vcpkg port we use is outdated and won't build with a modern vcpkg version, meaning it's impossible to build on a system using only VS2019.  This PR updated the SDL2 to the most recent vcpkg build, which hopefully work with both VS2017 and our pre-built vcpkg as well as the HEAD version of vcpkg used when using the VS2019 build path.