### PR TITLE
DEV-2375: ensure web entities stop playing audio

### DIFF
--- a/interface/resources/qml/Web3DSurface.qml
+++ b/interface/resources/qml/Web3DSurface.qml
@@ -33,6 +33,10 @@ Item {
     property var item: null
 
     function load(url, scriptUrl) {
+        // Ensure we reset any existing item to "about:blank" to ensure web audio stops: DEV-2375
+        if (root.item != null) {
+            root.item.url = "about:blank"
+        }
         QmlSurface.load("./controls/WebView.qml", root, function(newItem) {
             root.item = newItem
             root.item.url = url

--- a/interface/resources/qml/Web3DSurface.qml
+++ b/interface/resources/qml/Web3DSurface.qml
@@ -36,6 +36,8 @@ Item {
         // Ensure we reset any existing item to "about:blank" to ensure web audio stops: DEV-2375
         if (root.item != null) {
             root.item.url = "about:blank"
+            root.item.destroy()
+            root.item = null
         }
         QmlSurface.load("./controls/WebView.qml", root, function(newItem) {
             root.item = newItem


### PR DESCRIPTION
[DEV-2375](https://highfidelity.atlassian.net/browse/DEV-2375):  Stop web entities from playing audio when they're destroyed or when you change domains

[DEV-2083](https://highfidelity.atlassian.net/browse/DEV-2083): Stop web engine processes from sticking around after web entities are destroyed