### PR TITLE
RC85-Bugfix for legacy sit scripts

### DIFF
--- a/libraries/animation/src/AnimClip.h
+++ b/libraries/animation/src/AnimClip.h
@@ -55,6 +55,8 @@ public:
     float getFrame() const { return _frame; }
     void loadURL(const QString& url);
 
+    AnimBlendType getBlendType() const { return _blendType; };
+
 protected:
 
     virtual void setCurrentFrameInternal(float frame) override;

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -545,7 +545,8 @@ QStringList Rig::getAnimationRoles() const {
             auto clipNode = std::dynamic_pointer_cast<AnimClip>(node);
             if (clipNode) {
                 // filter out the userAnims, they are for internal use only.
-                if (!clipNode->getID().startsWith("userAnim")) {
+                // also don't return additive blend node clips as valid roles.
+                if (!clipNode->getID().startsWith("userAnim") && clipNode->getBlendType() == AnimBlendType_Normal) {
                     list.append(node->getID());
                 }
             }


### PR DESCRIPTION
Don't return additive clip nodes as valid "roles" for users to override.

(cherry picked from commit 14e59626750cd1c79379b4d7d6e987a66aac9c2f)

https://highfidelity.atlassian.net/browse/DEV-2434