### PR TITLE
DEV-2316: Fix camera position in first person

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -3618,7 +3618,7 @@ void Application::updateCamera(RenderArgs& renderArgs, float deltaTime) {
             _myCamera.setPosition(extractTranslation(camMat));
             _myCamera.setOrientation(glmExtractRotation(camMat));
         } else {
-            _myCamera.setPosition(myAvatar->getLookAtPivotPoint());
+            _myCamera.setPosition(myAvatar->getCameraEyesPosition(deltaTime));
             _myCamera.setOrientation(myAvatar->getLookAtRotation());
         }
     } else if (mode == CAMERA_MODE_THIRD_PERSON || mode == CAMERA_MODE_LOOK_AT || mode == CAMERA_MODE_SELFIE) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -6812,6 +6812,53 @@ glm::vec3 MyAvatar::getLookAtPivotPoint() {
     return yAxisEyePosition;
 }
 
+glm::vec3 MyAvatar::getCameraEyesPosition(float deltaTime) {
+    glm::vec3 defaultEyesPosition = getLookAtPivotPoint();
+    if (isFlying()) {
+        return defaultEyesPosition;
+    }
+    glm::vec3 avatarFrontVector = getWorldOrientation() * Vectors::FRONT;
+    glm::vec3 avatarUpVector = getWorldOrientation() * Vectors::UP;
+    // Compute the offset between the default and real eye positions.
+    glm::vec3 defaultEyesToEyesVector = getHead()->getEyePosition() - defaultEyesPosition;
+    float FRONT_OFFSET_IDLE_MULTIPLIER = 2.0f;
+    float FRONT_OFFSET_JUMP_MULTIPLIER = 1.5f;
+    float frontOffset = FRONT_OFFSET_IDLE_MULTIPLIER * glm::length(defaultEyesPosition - getDefaultEyePosition());
+    
+    // Looking down will aproximate move the camera forward to meet the real eye position
+    float mixAlpha = glm::dot(_lookAtPitch * Vectors::FRONT, -avatarUpVector);
+    
+    // When jumping the camera should follow the real eye on the Y coordenate
+    float upOffset = 0.0f;
+    if (isJumping() || _characterController.getState() == CharacterController::State::Takeoff) {
+        upOffset = glm::dot(defaultEyesToEyesVector, avatarUpVector);
+        
+        frontOffset = glm::dot(defaultEyesToEyesVector, avatarFrontVector) * FRONT_OFFSET_JUMP_MULTIPLIER;
+        mixAlpha = 1.0f;
+    } else {
+        // Limit the range effect from 45 to 90 degrees
+        const float HEAD_OFFSET_DOT_THRESHOLD = 0.7f; // 45 degrees aprox
+        mixAlpha = mixAlpha < HEAD_OFFSET_DOT_THRESHOLD ? 0.0f : (mixAlpha - HEAD_OFFSET_DOT_THRESHOLD) /
+                                                                 (1.0f - HEAD_OFFSET_DOT_THRESHOLD);
+    }
+    const float FPS = 60.0f;
+    float timeScale = deltaTime * FPS;
+    frontOffset = frontOffset < 0.0f ? 0.0f : mixAlpha * frontOffset;
+    glm::vec3 cameraOffset = upOffset * Vectors::UP + frontOffset * Vectors::FRONT;
+    const float TAU = 0.1f;
+    _cameraEyesOffset = _cameraEyesOffset + (cameraOffset - _cameraEyesOffset) * TAU * timeScale;
+    glm::vec3 estimatedCameraPosition = defaultEyesPosition + getWorldOrientation() * _cameraEyesOffset;
+    return estimatedCameraPosition;
+}
+
+bool MyAvatar::isJumping() {
+    if (_skeletonModel->isLoaded()) {
+        return (_skeletonModel->getRig().getState() == Rig::RigRole::InAir || 
+                _skeletonModel->getRig().getState() == Rig::RigRole::Takeoff) && !isFlying();
+    }
+    return false;
+}
+
 bool MyAvatar::setPointAt(const glm::vec3& pointAtTarget) {
     if (QThread::currentThread() != thread()) {
         bool result = false;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -6846,17 +6846,14 @@ glm::vec3 MyAvatar::getCameraEyesPosition(float deltaTime) {
     frontOffset = frontOffset < 0.0f ? 0.0f : mixAlpha * frontOffset;
     glm::vec3 cameraOffset = upOffset * Vectors::UP + frontOffset * Vectors::FRONT;
     const float TAU = 0.1f;
-    _cameraEyesOffset = _cameraEyesOffset + (cameraOffset - _cameraEyesOffset) * TAU * timeScale;
+    _cameraEyesOffset = _cameraEyesOffset + (cameraOffset - _cameraEyesOffset) * min(1.0f, TAU * timeScale);
     glm::vec3 estimatedCameraPosition = defaultEyesPosition + getWorldOrientation() * _cameraEyesOffset;
     return estimatedCameraPosition;
 }
 
 bool MyAvatar::isJumping() {
-    if (_skeletonModel->isLoaded()) {
-        return (_skeletonModel->getRig().getState() == Rig::RigRole::InAir || 
-                _skeletonModel->getRig().getState() == Rig::RigRole::Takeoff) && !isFlying();
-    }
-    return false;
+    return (_characterController.getState() == CharacterController::State::InAir ||
+            _characterController.getState() == CharacterController::State::Takeoff) && !isFlying();
 }
 
 bool MyAvatar::setPointAt(const glm::vec3& pointAtTarget) {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1919,6 +1919,8 @@ public:
 
     bool getIsJointOverridden(int jointIndex) const;
     glm::vec3 getLookAtPivotPoint();
+    glm::vec3 getCameraEyesPosition(float deltaTime);
+    bool isJumping();
 
 public slots:
 
@@ -2973,6 +2975,8 @@ private:
 
     // used to prevent character from jumping after endSit is called.
     bool _endSitKeyPressComplete { false };
+
+    glm::vec3 _cameraEyesOffset;
 };
 
 QScriptValue audioListenModeToScriptValue(QScriptEngine* engine, const AudioListenerMode& audioListenerMode);

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -115,16 +115,6 @@ public:
         Seated
     };
 
-    enum class RigRole {
-        Idle = 0,
-        Turn,
-        Move,
-        Hover,
-        Takeoff,
-        InAir,
-        Seated
-    };
-
     Rig();
     virtual ~Rig();
 
@@ -267,7 +257,6 @@ public:
     bool getFlowActive() const;
     bool getNetworkGraphActive() const;
     void setDirectionalBlending(const QString& targetName, const glm::vec3& blendingTarget, const QString& alphaName, float alpha);
-    const RigRole getState() const { return _state; }
 
 signals:
     void onLoadComplete();
@@ -349,6 +338,16 @@ protected:
     std::unique_ptr<AnimNodeLoader> _networkLoader;
     AnimVariantMap _animVars;
     AnimVariantMap _networkVars;
+
+    enum class RigRole {
+        Idle = 0,
+        Turn,
+        Move,
+        Hover,
+        Takeoff,
+        InAir,
+        Seated
+    };
 
     RigRole _state { RigRole::Idle };
     RigRole _desiredState { RigRole::Idle };

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -348,7 +348,6 @@ protected:
         InAir,
         Seated
     };
-
     RigRole _state { RigRole::Idle };
     RigRole _desiredState { RigRole::Idle };
     float _desiredStateAge { 0.0f };

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -115,6 +115,16 @@ public:
         Seated
     };
 
+    enum class RigRole {
+        Idle = 0,
+        Turn,
+        Move,
+        Hover,
+        Takeoff,
+        InAir,
+        Seated
+    };
+
     Rig();
     virtual ~Rig();
 
@@ -257,6 +267,7 @@ public:
     bool getFlowActive() const;
     bool getNetworkGraphActive() const;
     void setDirectionalBlending(const QString& targetName, const glm::vec3& blendingTarget, const QString& alphaName, float alpha);
+    const RigRole getState() const { return _state; }
 
 signals:
     void onLoadComplete();
@@ -339,15 +350,6 @@ protected:
     AnimVariantMap _animVars;
     AnimVariantMap _networkVars;
 
-    enum class RigRole {
-        Idle = 0,
-        Turn,
-        Move,
-        Hover,
-        Takeoff,
-        InAir,
-        Seated
-    };
     RigRole _state { RigRole::Idle };
     RigRole _desiredState { RigRole::Idle };
     float _desiredStateAge { 0.0f };


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-2316
This PR adjusts the camera position when in first person, to minimize the view of the avatar's cauterized head for the user when looking down or when jumping.