### PR TITLE
RC-85: Fix for HMD mode flying

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2719,7 +2719,7 @@ void MyAvatar::updateMotors() {
         if (_characterController.getState() == CharacterController::State::Hover ||
                 _characterController.computeCollisionMask() == BULLET_COLLISION_MASK_COLLISIONLESS) {
             CameraMode mode = qApp->getCamera().getMode();
-            if (mode == CAMERA_MODE_FIRST_PERSON || mode == CAMERA_MODE_LOOK_AT || mode == CAMERA_MODE_SELFIE) {
+            if (!qApp->isHMDMode() && (mode == CAMERA_MODE_FIRST_PERSON || mode == CAMERA_MODE_LOOK_AT || mode == CAMERA_MODE_SELFIE)) {
                 motorRotation = getLookAtRotation();
             } else {
                 motorRotation = getMyHead()->getHeadOrientation();


### PR DESCRIPTION
In HMD mode you should fly/move in the direction you are looking.

(cherry picked from commit 288f9bfb16ad4ade61944944d02ff95d531de10e)

https://highfidelity.atlassian.net/browse/DEV-2427