### PR TITLE
DEV-1811 redux: apply entity deletion rules

### DIFF
--- a/interface/src/InterfaceParentFinder.cpp
+++ b/interface/src/InterfaceParentFinder.cpp
@@ -45,10 +45,6 @@ SpatiallyNestableWeakPointer InterfaceParentFinder::find(QUuid parentID, bool& s
         success = true;
         return parent;
     }
-    if (parentID == AVATAR_SELF_ID) {
-        success = true;
-        return avatarManager->getMyAvatar();
-    }
 
     success = false;
     return parent;

--- a/interface/src/avatar/AvatarManager.cpp
+++ b/interface/src/avatar/AvatarManager.cpp
@@ -543,26 +543,8 @@ void AvatarManager::removeDeadAvatarEntities(const SetOfEntities& deadEntities) 
     for (auto entity : deadEntities) {
         QUuid entityOwnerID = entity->getOwningAvatarID();
         AvatarSharedPointer avatar = getAvatarBySessionID(entityOwnerID);
-        const bool REQUIRES_REMOVAL_FROM_TREE = false;
         if (avatar) {
-            avatar->clearAvatarEntity(entity->getID(), REQUIRES_REMOVAL_FROM_TREE);
-        }
-        if (entityTree && entity->isMyAvatarEntity()) {
-            entityTree->withWriteLock([&] {
-                // We only need to delete the direct children (rather than the descendants) because
-                // when the child is deleted, it will take care of its own children.  If the child
-                // is also an avatar-entity, we'll end up back here.  If it's not, the entity-server
-                // will take care of it in the usual way.
-                entity->forEachChild([&](SpatiallyNestablePointer child) {
-                    EntityItemPointer childEntity = std::dynamic_pointer_cast<EntityItem>(child);
-                    if (childEntity) {
-                        entityTree->deleteEntity(childEntity->getID(), true, true);
-                        if (avatar) {
-                            avatar->clearAvatarEntity(childEntity->getID(), REQUIRES_REMOVAL_FROM_TREE);
-                        }
-                    }
-                });
-            });
+            avatar->clearAvatarEntity(entity->getID());
         }
     }
 }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1589,14 +1589,15 @@ void MyAvatar::handleChangedAvatarEntityData() {
     // move the lists to minimize lock time
     std::vector<QUuid> cachedBlobsToDelete;
     std::vector<QUuid> cachedBlobsToUpdate;
-    QSet<EntityItemID> idsToDelete;
+    std::vector<EntityItemID> idsToDelete;
+    idsToDelete.reserve(_entitiesToDelete.size());
     std::vector<QUuid> entitiesToAdd;
     std::vector<QUuid> entitiesToUpdate;
     _avatarEntitiesLock.withWriteLock([&] {
         cachedBlobsToDelete = std::move(_cachedAvatarEntityBlobsToDelete);
         cachedBlobsToUpdate = std::move(_cachedAvatarEntityBlobsToAddOrUpdate);
         foreach (auto id, _entitiesToDelete) {
-            idsToDelete.insert(id);
+            idsToDelete.push_back(id);
         }
         _entitiesToDelete.clear();
         entitiesToAdd = std::move(_entitiesToAdd);

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2970,19 +2970,19 @@ private:
     // correctly stored in _cachedAvatarEntityBlobs.  These come from loadAvatarEntityDataFromSettings() and
     // setAvatarEntityData().  These changes need to be extracted from _cachedAvatarEntityBlobs and applied to
     // real EntityItems.
-    std::vector<QUuid> _entitiesToDelete;
-    std::vector<QUuid> _entitiesToAdd;
-    std::vector<QUuid> _entitiesToUpdate;
+    std::vector<EntityItemID> _entitiesToDelete;
+    std::vector<EntityItemID> _entitiesToAdd;
+    std::vector<EntityItemID> _entitiesToUpdate;
     //
     // The _cachedAvatarEntityBlobsToDelete/Add/Update lists are for changes whose "authoritative sources" are
     // already reflected in real EntityItems. These changes need to be propagated to _cachedAvatarEntityBlobs
     // and eventually to settings.
-    std::vector<QUuid> _cachedAvatarEntityBlobsToDelete;
-    std::vector<QUuid> _cachedAvatarEntityBlobsToAddOrUpdate;
-    std::vector<QUuid> _cachedAvatarEntityBlobUpdatesToSkip;
+    std::vector<EntityItemID> _cachedAvatarEntityBlobsToDelete;
+    std::vector<EntityItemID> _cachedAvatarEntityBlobsToAddOrUpdate;
+    std::vector<EntityItemID> _cachedAvatarEntityBlobUpdatesToSkip;
     //
     // Also these lists for tracking delayed changes to blobs and Settings
-    mutable std::set<QUuid> _staleCachedAvatarEntityBlobs;
+    mutable std::set<EntityItemID> _staleCachedAvatarEntityBlobs;
     //
     // keep a ScriptEngine around so we don't have to instantiate on the fly (these are very slow to create/delete)
     mutable std::mutex _scriptEngineLock;

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -561,16 +561,19 @@ void OtherAvatar::handleChangedAvatarEntityData() {
             _avatarEntitiesLock.withReadLock([&] {
                 packedAvatarEntityData = _packedAvatarEntityData;
             });
-            QSet<EntityItemID> idsToDelete;
-            foreach (auto entityID, recentlyRemovedAvatarEntities) {
-                if (!packedAvatarEntityData.contains(entityID)) {
-                    idsToDelete.insert(entityID);
+            if (!recentlyRemovedAvatarEntities.empty()) {
+                std::vector<EntityItemID> idsToDelete;
+                idsToDelete.reserve(recentlyRemovedAvatarEntities.size());
+                foreach (auto entityID, recentlyRemovedAvatarEntities) {
+                    if (!packedAvatarEntityData.contains(entityID)) {
+                        idsToDelete.push_back(entityID);
+                    }
                 }
-            }
-            if (!idsToDelete.empty()) {
-                bool force = true;
-                bool ignoreWarnings = true;
-                entityTree->deleteEntitiesByID(idsToDelete, force, ignoreWarnings);
+                if (!idsToDelete.empty()) {
+                    bool force = true;
+                    bool ignoreWarnings = true;
+                    entityTree->deleteEntitiesByID(idsToDelete, force, ignoreWarnings);
+                }
             }
 
             // TODO: move this outside of tree lock

--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -561,10 +561,16 @@ void OtherAvatar::handleChangedAvatarEntityData() {
             _avatarEntitiesLock.withReadLock([&] {
                 packedAvatarEntityData = _packedAvatarEntityData;
             });
+            QSet<EntityItemID> idsToDelete;
             foreach (auto entityID, recentlyRemovedAvatarEntities) {
                 if (!packedAvatarEntityData.contains(entityID)) {
-                    entityTree->deleteEntity(entityID, true, true);
+                    idsToDelete.insert(entityID);
                 }
+            }
+            if (!idsToDelete.empty()) {
+                bool force = true;
+                bool ignoreWarnings = true;
+                entityTree->deleteEntitiesByID(idsToDelete, force, ignoreWarnings);
             }
 
             // TODO: move this outside of tree lock

--- a/interface/src/ui/AvatarCertifyBanner.cpp
+++ b/interface/src/ui/AvatarCertifyBanner.cpp
@@ -62,16 +62,7 @@ void AvatarCertifyBanner::show(const QUuid& avatarID) {
 
 void AvatarCertifyBanner::clear() {
     if (_active) {
-        auto entityTreeRenderer = DependencyManager::get<EntityTreeRenderer>();
-        EntityTreePointer entityTree = entityTreeRenderer->getTree();
-        if (!entityTree) {
-            return;
-        }
-
-        entityTree->withWriteLock([&] {
-            entityTree->deleteEntity(_bannerID);
-        });
-
+        DependencyManager::get<EntityTreeRenderer>()->deleteEntity(_bannerID);
         _active = false;
     }
 }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -343,7 +343,7 @@ void Avatar::removeAvatarEntitiesFromTree() {
         _avatarEntitiesLock.withReadLock([&] {
             avatarEntityIDs = _packedAvatarEntityData.keys();
         });
-            std::vector<EntityItemID> ids;
+        std::vector<EntityItemID> ids;
         ids.reserve(avatarEntityIDs.size());
         foreach (auto id, avatarEntityIDs) {
             ids.push_back(id);

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -333,6 +333,9 @@ void Avatar::setTargetScale(float targetScale) {
 }
 
 void Avatar::removeAvatarEntitiesFromTree() {
+    if (_packedAvatarEntityData.empty()) {
+        return;
+    }
     auto treeRenderer = DependencyManager::get<EntityTreeRenderer>();
     EntityTreePointer entityTree = treeRenderer ? treeRenderer->getTree() : nullptr;
     if (entityTree) {
@@ -340,9 +343,10 @@ void Avatar::removeAvatarEntitiesFromTree() {
         _avatarEntitiesLock.withReadLock([&] {
             avatarEntityIDs = _packedAvatarEntityData.keys();
         });
-        QSet<EntityItemID> ids;
+            std::vector<EntityItemID> ids;
+        ids.reserve(avatarEntityIDs.size());
         foreach (auto id, avatarEntityIDs) {
-            ids.insert(id);
+            ids.push_back(id);
         }
         bool force = true;
         bool ignoreWarnings = true;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -339,14 +339,12 @@ void Avatar::removeAvatarEntitiesFromTree() {
     auto treeRenderer = DependencyManager::get<EntityTreeRenderer>();
     EntityTreePointer entityTree = treeRenderer ? treeRenderer->getTree() : nullptr;
     if (entityTree) {
-        QList<QUuid> avatarEntityIDs;
-        _avatarEntitiesLock.withReadLock([&] {
-            avatarEntityIDs = _packedAvatarEntityData.keys();
-        });
         std::vector<EntityItemID> ids;
-        ids.reserve(avatarEntityIDs.size());
-        foreach (auto id, avatarEntityIDs) {
-            ids.push_back(id);
+        ids.reserve(_packedAvatarEntityData.size());
+        PackedAvatarEntityMap::const_iterator itr = _packedAvatarEntityData.constBegin();
+        while (itr != _packedAvatarEntityData.constEnd()) {
+            ids.push_back(itr.key());
+            ++itr;
         }
         bool force = true;
         bool ignoreWarnings = true;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -340,11 +340,13 @@ void Avatar::removeAvatarEntitiesFromTree() {
         _avatarEntitiesLock.withReadLock([&] {
             avatarEntityIDs = _packedAvatarEntityData.keys();
         });
-        entityTree->withWriteLock([&] {
-            for (const auto& entityID : avatarEntityIDs) {
-                entityTree->deleteEntity(entityID, true, true);
-            }
-        });
+        QSet<EntityItemID> ids;
+        foreach (auto id, avatarEntityIDs) {
+            ids.insert(id);
+        }
+        bool force = true;
+        bool ignoreWarnings = true;
+        entityTree->deleteEntitiesByID(ids, force, ignoreWarnings); // locks tree
     }
 }
 

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -3033,15 +3033,12 @@ void AvatarData::updateAvatarEntity(const QUuid& entityID, const QByteArray& ent
 }
 
 void AvatarData::clearAvatarEntity(const QUuid& entityID, bool requiresRemovalFromTree) {
-
+    // NOTE: requiresRemovalFromTree is unused
     bool removedEntity = false;
-
     _avatarEntitiesLock.withWriteLock([this, &removedEntity, &entityID] {
         removedEntity = _packedAvatarEntityData.remove(entityID);
     });
-
     insertRemovedEntityID(entityID);
-
     if (removedEntity && _clientTraitsHandler) {
         // we have a client traits handler, so we need to mark this removed instance trait as deleted
         // so that changes are sent next frame

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1179,7 +1179,7 @@ public:
     /**jsdoc
      * @function Avatar.clearAvatarEntity
      * @param {Uuid} entityID - The entity ID.
-     * @param {boolean} [requiresRemovalFromTree=true] - Requires removal from tree.
+     * @param {boolean} [requiresRemovalFromTree=true] - unused
      * @deprecated This function is deprecated and will be removed.
      */
     Q_INVOKABLE virtual void clearAvatarEntity(const QUuid& entityID, bool requiresRemovalFromTree = true);

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -260,8 +260,7 @@ void EntityTreeRenderer::clearDomainAndNonOwnedEntities() {
     _renderablesToUpdate = savedRenderables;
     _entitiesInScene = savedEntities;
 
-    auto sessionUUID = getTree()->getMyAvatarSessionUUID();
-    if (_layeredZones.clearDomainAndNonOwnedZones(sessionUUID)) {
+    if (_layeredZones.clearDomainAndNonOwnedZones()) {
         applyLayeredZones();
     }
 
@@ -1215,7 +1214,7 @@ void EntityTreeRenderer::updateZone(const EntityItemID& id) {
     }
 }
 
-bool EntityTreeRenderer::LayeredZones::clearDomainAndNonOwnedZones(const QUuid& sessionUUID) {
+bool EntityTreeRenderer::LayeredZones::clearDomainAndNonOwnedZones() {
     bool zonesChanged = false;
 
     auto it = begin();

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -226,7 +226,7 @@ void EntityTreeRenderer::stopDomainAndNonOwnedEntities() {
             EntityItemPointer entityItem = getTree()->findEntityByEntityItemID(entityID);
 
             if (entityItem && !entityItem->getScript().isEmpty()) {
-                if (!(entityItem->isLocalEntity() || (entityItem->isAvatarEntity() && entityItem->getOwningAvatarID() == getTree()->getMyAvatarSessionUUID()))) {
+                if (!(entityItem->isLocalEntity() || entityItem->isMyAvatarEntity())) {
                     if (_currentEntitiesInside.contains(entityID)) {
                         _entitiesScriptEngine->callEntityScriptMethod(entityID, "leaveEntity");
                     }
@@ -240,7 +240,6 @@ void EntityTreeRenderer::stopDomainAndNonOwnedEntities() {
 void EntityTreeRenderer::clearDomainAndNonOwnedEntities() {
     stopDomainAndNonOwnedEntities();
 
-    auto sessionUUID = getTree()->getMyAvatarSessionUUID();
     std::unordered_map<EntityItemID, EntityRendererPointer> savedEntities;
     std::unordered_set<EntityRendererPointer> savedRenderables;
     // remove all entities from the scene
@@ -249,7 +248,7 @@ void EntityTreeRenderer::clearDomainAndNonOwnedEntities() {
         for (const auto& entry :  _entitiesInScene) {
             const auto& renderer = entry.second;
             const EntityItemPointer& entityItem = renderer->getEntity();
-            if (!(entityItem->isLocalEntity() || (entityItem->isAvatarEntity() && entityItem->getOwningAvatarID() == sessionUUID))) {
+            if (!(entityItem->isLocalEntity() || entityItem->isMyAvatarEntity())) {
                 fadeOutRenderable(renderer);
             } else {
                 savedEntities[entry.first] = entry.second;
@@ -261,6 +260,7 @@ void EntityTreeRenderer::clearDomainAndNonOwnedEntities() {
     _renderablesToUpdate = savedRenderables;
     _entitiesInScene = savedEntities;
 
+    auto sessionUUID = getTree()->getMyAvatarSessionUUID();
     if (_layeredZones.clearDomainAndNonOwnedZones(sessionUUID)) {
         applyLayeredZones();
     }
@@ -683,7 +683,7 @@ void EntityTreeRenderer::leaveDomainAndNonOwnedEntities() {
         QSet<EntityItemID> currentEntitiesInsideToSave;
         foreach (const EntityItemID& entityID, _currentEntitiesInside) {
             EntityItemPointer entityItem = getTree()->findEntityByEntityItemID(entityID);
-            if (!(entityItem->isLocalEntity() || (entityItem->isAvatarEntity() && entityItem->getOwningAvatarID() == getTree()->getMyAvatarSessionUUID()))) {
+            if (!(entityItem->isLocalEntity() || entityItem->isMyAvatarEntity())) {
                 emit leaveEntity(entityID);
                 if (_entitiesScriptEngine) {
                     _entitiesScriptEngine->callEntityScriptMethod(entityID, "leaveEntity");
@@ -1221,7 +1221,7 @@ bool EntityTreeRenderer::LayeredZones::clearDomainAndNonOwnedZones(const QUuid& 
     auto it = begin();
     while (it != end()) {
         auto zone = it->zone.lock();
-        if (!zone || !(zone->isLocalEntity() || (zone->isAvatarEntity() && zone->getOwningAvatarID() == sessionUUID))) {
+        if (!zone || !(zone->isLocalEntity() || zone->isMyAvatarEntity())) {
             zonesChanged = true;
             it = erase(it);
         } else {
@@ -1360,6 +1360,10 @@ EntityItemPointer EntityTreeRenderer::getEntity(const EntityItemID& id) {
         result = renderable->getEntity();
     }
     return result;
+}
+
+void EntityTreeRenderer::deleteEntity(const EntityItemID& id) const {
+    DependencyManager::get<EntityScriptingInterface>()->deleteEntity(id);
 }
 
 void EntityTreeRenderer::onEntityChanged(const EntityItemID& id) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -118,6 +118,7 @@ public:
     void setProxyWindow(const EntityItemID& id, QWindow* proxyWindow);
     void setCollisionSound(const EntityItemID& id, const SharedSoundPointer& sound);
     EntityItemPointer getEntity(const EntityItemID& id);
+    void deleteEntity(const EntityItemID& id) const;
     void onEntityChanged(const EntityItemID& id);
 
     // Access the workload Space

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -230,7 +230,7 @@ private:
 
     class LayeredZones : public std::vector<LayeredZone> {
     public:
-        bool clearDomainAndNonOwnedZones(const QUuid& sessionUUID);
+        bool clearDomainAndNonOwnedZones();
 
         void sort() { std::sort(begin(), end(), std::less<LayeredZone>()); }
         bool equals(const LayeredZones& other) const;

--- a/libraries/entities-renderer/src/RenderableEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableEntityItem.cpp
@@ -43,6 +43,7 @@ const Transform& EntityRenderer::getModelTransform() const {
 
 void EntityRenderer::makeStatusGetters(const EntityItemPointer& entity, Item::Status::Getters& statusGetters) {
     auto nodeList = DependencyManager::get<NodeList>();
+    // DANGER: nodeList->getSessionUUID() will return null id when not connected to domain.
     const QUuid& myNodeID = nodeList->getSessionUUID();
 
     statusGetters.push_back([entity]() -> render::Item::Status::Value {
@@ -103,9 +104,9 @@ void EntityRenderer::makeStatusGetters(const EntityItemPointer& entity, Item::St
             (unsigned char)render::Item::Status::Icon::HAS_ACTIONS);
     });
 
-    statusGetters.push_back([entity, myNodeID] () -> render::Item::Status::Value {
+    statusGetters.push_back([entity] () -> render::Item::Status::Value {
         if (entity->isAvatarEntity()) {
-            if (entity->getOwningAvatarID() == myNodeID) {
+            if (entity->isMyAvatarEntity()) {
                 return render::Item::Status::Value(1.0f, render::Item::Status::Value::GREEN,
                     (unsigned char)render::Item::Status::Icon::ENTITY_HOST_TYPE);
             } else {

--- a/libraries/entities/src/DeleteEntityOperator.cpp
+++ b/libraries/entities/src/DeleteEntityOperator.cpp
@@ -53,6 +53,15 @@ void DeleteEntityOperator::addEntityIDToDeleteList(const EntityItemID& searchEnt
     }
 }
 
+void DeleteEntityOperator::addEntityToDeleteList(const EntityItemPointer& entity) {
+    assert(entity && entity->getElement());
+    EntityToDeleteDetails details;
+    details.entity = entity;
+    details.containingElement = entity->getElement();
+    details.cube = details.containingElement->getAACube();
+    _entitiesToDelete << details;
+    _lookingCount++;
+}
 
 // does this entity tree element contain the old entity
 bool DeleteEntityOperator::subTreeContainsSomeEntitiesToDelete(const OctreeElementPointer& element) {

--- a/libraries/entities/src/DeleteEntityOperator.h
+++ b/libraries/entities/src/DeleteEntityOperator.h
@@ -42,6 +42,7 @@ public:
     ~DeleteEntityOperator();
 
     void addEntityIDToDeleteList(const EntityItemID& searchEntityID);
+    void addEntityToDeleteList(const EntityItemPointer& entity);
     virtual bool preRecursion(const OctreeElementPointer& element) override;
     virtual bool postRecursion(const OctreeElementPointer& element) override;
 

--- a/libraries/entities/src/EntityEditFilters.cpp
+++ b/libraries/entities/src/EntityEditFilters.cpp
@@ -43,7 +43,7 @@ QList<EntityItemID> EntityEditFilters::getZonesByPosition(glm::vec3& position) {
 }
 
 bool EntityEditFilters::filter(glm::vec3& position, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut,
-        bool& wasChanged, EntityTree::FilterType filterType, EntityItemID& itemID, EntityItemPointer& existingEntity) {
+        bool& wasChanged, EntityTree::FilterType filterType, EntityItemID& itemID, const EntityItemPointer& existingEntity) {
     
     // get the ids of all the zones (plus the global entity edit filter) that the position
     // lies within

--- a/libraries/entities/src/EntityEditFilters.h
+++ b/libraries/entities/src/EntityEditFilters.h
@@ -55,7 +55,7 @@ public:
     void removeFilter(EntityItemID entityID);
 
     bool filter(glm::vec3& position, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, 
-                EntityTree::FilterType filterType, EntityItemID& entityID, EntityItemPointer& existingEntity);
+                EntityTree::FilterType filterType, EntityItemID& entityID, const EntityItemPointer& existingEntity);
 
 signals:
     void filterAdded(EntityItemID id, bool success);

--- a/libraries/entities/src/EntityEditPacketSender.cpp
+++ b/libraries/entities/src/EntityEditPacketSender.cpp
@@ -73,8 +73,12 @@ void EntityEditPacketSender::queueEditEntityMessage(PacketType type,
     if (properties.getEntityHostType() == entity::HostType::AVATAR) {
         if (!_myAvatar) {
             qCWarning(entities) << "Suppressing entity edit message: cannot send avatar entity edit with no myAvatar";
-        } else if (properties.getOwningAvatarID() == _myAvatar->getID()) {
-            // this is an avatar-based entity --> update our avatar-data rather than sending to the entity-server
+        } else if (properties.getOwningAvatarID() == _myAvatar->getID() || properties.getOwningAvatarID() == AVATAR_SELF_ID) {
+            // this is a local avatar-entity --> update our avatar-data rather than sending to the entity-server
+            // Note: we store AVATAR_SELF_ID in EntityItem::_owningAvatarID and we usually
+            // store the actual sessionUUID in EntityItemProperties::_owningAvatarID.
+            // However at this context we check for both cases just in case.  Really we just want to know
+            // where to route the data: entity-server or avatar-mixer.
             queueEditAvatarEntityMessage(entityTree, entityItemID);
         } else {
             qCWarning(entities) << "Suppressing entity edit message: cannot send avatar entity edit for another avatar";

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -3237,13 +3237,12 @@ void EntityItem::retrieveMarketplacePublicKey() {
 
 void EntityItem::collectChildrenForDelete(std::vector<EntityItemPointer>& entitiesToDelete, const QUuid& sessionID) const {
     // Deleting an entity has consequences for its children, however there are rules dictating what can be deleted.
-    // This method helps enforce those rules for the children of entity (not for this entity).
+    // This method helps enforce those rules: not for this entity, but for its children.
     for (SpatiallyNestablePointer child : getChildren()) {
         if (child && child->getNestableType() == NestableType::Entity) {
             EntityItemPointer childEntity = std::static_pointer_cast<EntityItem>(child);
-            // NOTE: null sessionID means "collect ALL known entities", else we only collect: local-entities and authorized avatar-entities
-            if (sessionID.isNull() || childEntity->isLocalEntity() || (childEntity->isAvatarEntity() &&
-                    (childEntity->isMyAvatarEntity() || childEntity->getOwningAvatarID() == sessionID))) {
+            // NOTE: null sessionID means "collect ALL known children", else we only collect: local-entities and myAvatar-entities
+            if (sessionID.isNull() || childEntity->isLocalEntity() || childEntity->isMyAvatarEntity()) {
                 if (std::find(entitiesToDelete.begin(), entitiesToDelete.end(), childEntity) == entitiesToDelete.end()) {
                     entitiesToDelete.push_back(childEntity);
                     childEntity->collectChildrenForDelete(entitiesToDelete, sessionID);
@@ -3417,7 +3416,7 @@ void EntityItem::prepareForSimulationOwnershipBid(EntityItemProperties& properti
     properties.setSimulationOwner(Physics::getSessionUUID(), priority);
     setPendingOwnershipPriority(priority);
 
-    // ANDREW TODO: figure out if it would be OK to NOT bother set these properties here
+    // TODO: figure out if it would be OK to NOT bother set these properties here
     properties.setEntityHostType(getEntityHostType());
     properties.setOwningAvatarID(getOwningAvatarID());
     setLastBroadcast(now); // for debug/physics status icons

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -3235,7 +3235,7 @@ void EntityItem::retrieveMarketplacePublicKey() {
     });
 }
 
-void EntityItem::collectChildrenForDelete(SetOfEntities& entitiesToDelete, SetOfEntities& domainEntities, const QUuid& sessionID) const {
+void EntityItem::collectChildrenForDelete(SetOfEntities& entitiesToDelete, const QUuid& sessionID) const {
     // Deleting an entity has consequences for its children, however there are rules dictating what can be deleted.
     // This method helps enforce those rules for the children of entity (not for this entity).
     for (SpatiallyNestablePointer child : getChildren()) {
@@ -3246,10 +3246,8 @@ void EntityItem::collectChildrenForDelete(SetOfEntities& entitiesToDelete, SetOf
                     (childEntity->isMyAvatarEntity() || childEntity->getOwningAvatarID() == sessionID))) {
                 if (entitiesToDelete.find(childEntity) == entitiesToDelete.end()) {
                     entitiesToDelete.insert(childEntity);
-                    childEntity->collectChildrenForDelete(entitiesToDelete, domainEntities, sessionID);
+                    childEntity->collectChildrenForDelete(entitiesToDelete, sessionID);
                 }
-            } else if (childEntity->isDomainEntity()) {
-                domainEntities.insert(childEntity);
             }
         }
     }

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -3235,7 +3235,7 @@ void EntityItem::retrieveMarketplacePublicKey() {
     });
 }
 
-void EntityItem::collectChildrenForDelete(SetOfEntities& entitiesToDelete, const QUuid& sessionID) const {
+void EntityItem::collectChildrenForDelete(std::vector<EntityItemPointer>& entitiesToDelete, const QUuid& sessionID) const {
     // Deleting an entity has consequences for its children, however there are rules dictating what can be deleted.
     // This method helps enforce those rules for the children of entity (not for this entity).
     for (SpatiallyNestablePointer child : getChildren()) {
@@ -3244,8 +3244,8 @@ void EntityItem::collectChildrenForDelete(SetOfEntities& entitiesToDelete, const
             // NOTE: null sessionID means "collect ALL known entities", else we only collect: local-entities and authorized avatar-entities
             if (sessionID.isNull() || childEntity->isLocalEntity() || (childEntity->isAvatarEntity() &&
                     (childEntity->isMyAvatarEntity() || childEntity->getOwningAvatarID() == sessionID))) {
-                if (entitiesToDelete.find(childEntity) == entitiesToDelete.end()) {
-                    entitiesToDelete.insert(childEntity);
+                if (std::find(entitiesToDelete.begin(), entitiesToDelete.end(), childEntity) == entitiesToDelete.end()) {
+                    entitiesToDelete.push_back(childEntity);
                     childEntity->collectChildrenForDelete(entitiesToDelete, sessionID);
                 }
             }

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1347,7 +1347,7 @@ EntityItemProperties EntityItem::getProperties(const EntityPropertyFlags& desire
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(created, getCreated);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(lastEditedBy, getLastEditedBy);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(entityHostType, getEntityHostType);
-    COPY_ENTITY_PROPERTY_TO_PROPERTIES(owningAvatarID, getOwningAvatarID);
+    COPY_ENTITY_PROPERTY_TO_PROPERTIES(owningAvatarID, getOwningAvatarIDForProperties);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(queryAACube, getQueryAACube);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(canCastShadow, getCanCastShadow);
     COPY_ENTITY_PROPERTY_TO_PROPERTIES(isVisibleInSecondaryCamera, isVisibleInSecondaryCamera);
@@ -3203,6 +3203,7 @@ void EntityItem::somethingChangedNotification() {
     });
 }
 
+// static
 void EntityItem::retrieveMarketplacePublicKey() {
     QNetworkAccessManager& networkAccessManager = NetworkAccessManager::getInstance();
     QNetworkRequest networkRequest;
@@ -3232,6 +3233,26 @@ void EntityItem::retrieveMarketplacePublicKey() {
 
         networkReply->deleteLater();
     });
+}
+
+void EntityItem::collectChildrenForDelete(SetOfEntities& entitiesToDelete, SetOfEntities& domainEntities, const QUuid& sessionID) const {
+    // Deleting an entity has consequences for its children, however there are rules dictating what can be deleted.
+    // This method helps enforce those rules for the children of entity (not for this entity).
+    for (SpatiallyNestablePointer child : getChildren()) {
+        if (child && child->getNestableType() == NestableType::Entity) {
+            EntityItemPointer childEntity = std::static_pointer_cast<EntityItem>(child);
+            // NOTE: null sessionID means "collect ALL known entities", else we only collect: local-entities and authorized avatar-entities
+            if (sessionID.isNull() || childEntity->isLocalEntity() || (childEntity->isAvatarEntity() &&
+                    (childEntity->isMyAvatarEntity() || childEntity->getOwningAvatarID() == sessionID))) {
+                if (entitiesToDelete.find(childEntity) == entitiesToDelete.end()) {
+                    entitiesToDelete.insert(childEntity);
+                    childEntity->collectChildrenForDelete(entitiesToDelete, domainEntities, sessionID);
+                }
+            } else if (childEntity->isDomainEntity()) {
+                domainEntities.insert(childEntity);
+            }
+        }
+    }
 }
 
 void EntityItem::setSpaceIndex(int32_t index) {
@@ -3398,6 +3419,7 @@ void EntityItem::prepareForSimulationOwnershipBid(EntityItemProperties& properti
     properties.setSimulationOwner(Physics::getSessionUUID(), priority);
     setPendingOwnershipPriority(priority);
 
+    // ANDREW TODO: figure out if it would be OK to NOT bother set these properties here
     properties.setEntityHostType(getEntityHostType());
     properties.setOwningAvatarID(getOwningAvatarID());
     setLastBroadcast(now); // for debug/physics status icons
@@ -3409,8 +3431,26 @@ bool EntityItem::isWearable() const {
 }
 
 bool EntityItem::isMyAvatarEntity() const {
-    return _hostType == entity::HostType::AVATAR && Physics::getSessionUUID() == _owningAvatarID;
+    return _hostType == entity::HostType::AVATAR && AVATAR_SELF_ID == _owningAvatarID;
 };
+
+QUuid EntityItem::getOwningAvatarIDForProperties() const {
+    if (isMyAvatarEntity()) {
+        // NOTE: we always store AVATAR_SELF_ID for MyAvatar's avatar entities,
+        // however for EntityItemProperties to be consumed by outside contexts (e.g. JS)
+        // we use the actual "sessionUUID" which is conveniently cached in the Physics namespace
+        return Physics::getSessionUUID();
+    }
+    return _owningAvatarID;
+}
+
+void EntityItem::setOwningAvatarID(const QUuid& owningAvatarID) {
+    if (!owningAvatarID.isNull() && owningAvatarID == Physics::getSessionUUID()) {
+        _owningAvatarID = AVATAR_SELF_ID;
+    } else {
+        _owningAvatarID = owningAvatarID;
+    }
+}
 
 void EntityItem::addGrab(GrabPointer grab) {
     enableNoBootstrap();

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -18,6 +18,7 @@
 #include <glm/glm.hpp>
 
 #include <QtGui/QWindow>
+#include <QSet>
 
 #include <Octree.h> // for EncodeBitstreamParams class
 #include <OctreeElement.h> // for OctreeElement::AppendState
@@ -49,6 +50,7 @@ typedef std::shared_ptr<EntityTree> EntityTreePointer;
 typedef std::shared_ptr<EntityDynamicInterface> EntityDynamicPointer;
 typedef std::shared_ptr<EntityTreeElement> EntityTreeElementPointer;
 using EntityTreeElementExtraEncodeDataPointer = std::shared_ptr<EntityTreeElementExtraEncodeData>;
+using SetOfEntities = QSet<EntityItemPointer>;
 
 #define DONT_ALLOW_INSTANTIATION virtual void pureVirtualFunctionPlaceHolder() = 0;
 #define ALLOW_INSTANTIATION virtual void pureVirtualFunctionPlaceHolder() override { };
@@ -514,7 +516,8 @@ public:
 
     // if this entity is an avatar entity, which avatar is it associated with?
     QUuid getOwningAvatarID() const { return _owningAvatarID; }
-    virtual void setOwningAvatarID(const QUuid& owningAvatarID) { _owningAvatarID = owningAvatarID; }
+    QUuid getOwningAvatarIDForProperties() const;
+    void setOwningAvatarID(const QUuid& owningAvatarID);
 
     virtual bool wantsHandControllerPointerEvents() const { return false; }
     virtual bool wantsKeyboardFocus() const { return false; }
@@ -539,6 +542,8 @@ public:
 
     static QString _marketplacePublicKey;
     static void retrieveMarketplacePublicKey();
+
+    void collectChildrenForDelete(SetOfEntities& entitiesToDelete, SetOfEntities& domainEntities, const QUuid& sessionID) const;
 
     float getBoundingRadius() const { return _boundingRadius; }
     void setSpaceIndex(int32_t index);

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -543,7 +543,7 @@ public:
     static QString _marketplacePublicKey;
     static void retrieveMarketplacePublicKey();
 
-    void collectChildrenForDelete(SetOfEntities& entitiesToDelete, const QUuid& sessionID) const;
+    void collectChildrenForDelete(std::vector<EntityItemPointer>& entitiesToDelete, const QUuid& sessionID) const;
 
     float getBoundingRadius() const { return _boundingRadius; }
     void setSpaceIndex(int32_t index);

--- a/libraries/entities/src/EntityItem.h
+++ b/libraries/entities/src/EntityItem.h
@@ -543,7 +543,7 @@ public:
     static QString _marketplacePublicKey;
     static void retrieveMarketplacePublicKey();
 
-    void collectChildrenForDelete(SetOfEntities& entitiesToDelete, SetOfEntities& domainEntities, const QUuid& sessionID) const;
+    void collectChildrenForDelete(SetOfEntities& entitiesToDelete, const QUuid& sessionID) const;
 
     float getBoundingRadius() const { return _boundingRadius; }
     void setSpaceIndex(int32_t index);

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -3936,7 +3936,7 @@ bool EntityItemProperties::decodeCloneEntityMessage(const QByteArray& buffer, in
     processedBytes = 0;
 
     if (NUM_BYTES_RFC4122_UUID * 2 > packetLength) {
-        qCDebug(entities) << "EntityItemProperties::processEraseMessageDetails().... bailing because not enough bytes in buffer";
+        qCDebug(entities) << "EntityItemProperties::decodeCloneEntityMessage().... bailing because not enough bytes in buffer";
         return false; // bail to prevent buffer overflow
     }
 

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -1649,12 +1649,9 @@ bool EntityScriptingInterface::actionWorker(const QUuid& entityID,
         return false;
     }
 
-    auto nodeList = DependencyManager::get<NodeList>();
-    const QUuid myNodeID = nodeList->getSessionUUID();
-
     EntityItemPointer entity;
     bool doTransmit = false;
-    _entityTree->withWriteLock([this, &entity, entityID, myNodeID, &doTransmit, actor] {
+    _entityTree->withWriteLock([this, &entity, entityID, &doTransmit, actor] {
         EntitySimulationPointer simulation = _entityTree->getSimulation();
         entity = _entityTree->findEntityByEntityItemID(entityID);
         if (!entity) {

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -821,7 +821,7 @@ QUuid EntityScriptingInterface::editEntity(const QUuid& id, const EntityItemProp
                 // flag for simulation ownership, or upgrade existing ownership priority
                 // (actual bids for simulation ownership are sent by the PhysicalEntitySimulation)
                 entity->upgradeScriptSimulationPriority(properties.computeSimulationBidPriority());
-                if (entity->isMyAvatarEntity() || simulationOwner.getID() == sessionID) {
+                if (entity->isLocalEntity() || entity->isMyAvatarEntity() || simulationOwner.getID() == sessionID) {
                     // we own the simulation --> copy ALL restricted properties
                     properties.copySimulationRestrictedProperties(entity);
                 } else {

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -821,7 +821,7 @@ QUuid EntityScriptingInterface::editEntity(const QUuid& id, const EntityItemProp
                 // flag for simulation ownership, or upgrade existing ownership priority
                 // (actual bids for simulation ownership are sent by the PhysicalEntitySimulation)
                 entity->upgradeScriptSimulationPriority(properties.computeSimulationBidPriority());
-                if (simulationOwner.getID() == sessionID) {
+                if (entity->isMyAvatarEntity() || simulationOwner.getID() == sessionID) {
                     // we own the simulation --> copy ALL restricted properties
                     properties.copySimulationRestrictedProperties(entity);
                 } else {

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -43,6 +43,7 @@ void EntitySimulation::updateEntities() {
 }
 
 void EntitySimulation::removeEntityFromInternalLists(EntityItemPointer entity) {
+    // protected: _mutex lock is guaranteed
     // remove from all internal lists except _deadEntitiesToRemoveFromTree
     _entitiesToSort.remove(entity);
     _simpleKinematicEntities.remove(entity);
@@ -144,6 +145,7 @@ void EntitySimulation::sortEntitiesThatMoved() {
 }
 
 void EntitySimulation::addEntityToInternalLists(EntityItemPointer entity) {
+    // protected: _mutex lock is guaranteed
     if (entity->isMortal()) {
         _mortalEntities.insert(entity);
         uint64_t expiry = entity->getExpiry();

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -260,10 +260,11 @@ void EntitySimulation::processDeadEntities() {
     if (_deadEntitiesToRemoveFromTree.empty()) {
         return;
     }
-    SetOfEntities entitiesToDeleteImmediately;
+    std::vector<EntityItemPointer> entitiesToDeleteImmediately;
+    entitiesToDeleteImmediately.reserve(_deadEntitiesToRemoveFromTree.size());
     QUuid nullSessionID;
     foreach (auto entity, _deadEntitiesToRemoveFromTree) {
-        entitiesToDeleteImmediately.insert(entity);
+        entitiesToDeleteImmediately.push_back(entity);
         entity->collectChildrenForDelete(entitiesToDeleteImmediately, nullSessionID);
     }
     if (_entityTree) {

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -261,14 +261,10 @@ void EntitySimulation::processDeadEntities() {
         return;
     }
     SetOfEntities entitiesToDeleteImmediately;
-    // NOTE: dummyList will be empty because this base-class implementation is only used server-side
-    // for which ATM we only process domain-entities, and since we are passing nullSessionID for authorization
-    // EntityItem::collectChildrenForDelete() will not collect domain-entities into this side list.
-    SetOfEntities dummyList;
     QUuid nullSessionID;
     foreach (auto entity, _deadEntitiesToRemoveFromTree) {
         entitiesToDeleteImmediately.insert(entity);
-        entity->collectChildrenForDelete(entitiesToDeleteImmediately, dummyList, nullSessionID);
+        entity->collectChildrenForDelete(entitiesToDeleteImmediately, nullSessionID);
     }
     if (_entityTree) {
         _entityTree->deleteEntitiesByPointer(entitiesToDeleteImmediately);

--- a/libraries/entities/src/EntitySimulation.cpp
+++ b/libraries/entities/src/EntitySimulation.cpp
@@ -19,41 +19,36 @@
 
 void EntitySimulation::setEntityTree(EntityTreePointer tree) {
     if (_entityTree && _entityTree != tree) {
-        _mortalEntities.clear();
-        _nextExpiry = std::numeric_limits<uint64_t>::max();
-        _entitiesToUpdate.clear();
         _entitiesToSort.clear();
         _simpleKinematicEntities.clear();
+        _changedEntities.clear();
+        _entitiesToUpdate.clear();
+        _mortalEntities.clear();
+        _nextExpiry = std::numeric_limits<uint64_t>::max();
     }
     _entityTree = tree;
 }
 
 void EntitySimulation::updateEntities() {
+    PerformanceTimer perfTimer("EntitySimulation::updateEntities");
     QMutexLocker lock(&_mutex);
     uint64_t now = usecTimestampNow();
-    PerformanceTimer perfTimer("EntitySimulation::updateEntities");
 
     // these methods may accumulate entries in _entitiesToBeDeleted
     expireMortalEntities(now);
     callUpdateOnEntitiesThatNeedIt(now);
     moveSimpleKinematics(now);
-    updateEntitiesInternal(now);
     sortEntitiesThatMoved();
+    processDeadEntities();
 }
 
-void EntitySimulation::takeDeadEntities(SetOfEntities& entitiesToDelete) {
-    QMutexLocker lock(&_mutex);
-    entitiesToDelete.swap(_deadEntities);
-    _deadEntities.clear();
-}
-
-void EntitySimulation::removeEntityInternal(EntityItemPointer entity) {
-    // remove from all internal lists except _deadEntities
-    _mortalEntities.remove(entity);
-    _entitiesToUpdate.remove(entity);
+void EntitySimulation::removeEntityFromInternalLists(EntityItemPointer entity) {
+    // remove from all internal lists except _deadEntitiesToRemoveFromTree
     _entitiesToSort.remove(entity);
     _simpleKinematicEntities.remove(entity);
     _allEntities.remove(entity);
+    _entitiesToUpdate.remove(entity);
+    _mortalEntities.remove(entity);
     entity->setSimulated(false);
 }
 
@@ -62,10 +57,9 @@ void EntitySimulation::prepareEntityForDelete(EntityItemPointer entity) {
     assert(entity->isDead());
     if (entity->isSimulated()) {
         QMutexLocker lock(&_mutex);
-        entity->clearActions(getThisPointer());
-        removeEntityInternal(entity);
+        removeEntityFromInternalLists(entity);
         if (entity->getElement()) {
-            _deadEntities.insert(entity);
+            _deadEntitiesToRemoveFromTree.insert(entity);
             _entityTree->cleanupCloneIDs(entity->getEntityItemID());
         }
     }
@@ -149,10 +143,7 @@ void EntitySimulation::sortEntitiesThatMoved() {
     _entitiesToSort.clear();
 }
 
-void EntitySimulation::addEntity(EntityItemPointer entity) {
-    QMutexLocker lock(&_mutex);
-    assert(entity);
-    entity->deserializeActions();
+void EntitySimulation::addEntityToInternalLists(EntityItemPointer entity) {
     if (entity->isMortal()) {
         _mortalEntities.insert(entity);
         uint64_t expiry = entity->getExpiry();
@@ -163,10 +154,14 @@ void EntitySimulation::addEntity(EntityItemPointer entity) {
     if (entity->needsToCallUpdate()) {
         _entitiesToUpdate.insert(entity);
     }
-    addEntityInternal(entity);
-
     _allEntities.insert(entity);
     entity->setSimulated(true);
+}
+
+void EntitySimulation::addEntity(EntityItemPointer entity) {
+    QMutexLocker lock(&_mutex);
+    assert(entity);
+    addEntityToInternalLists(entity);
 
     // DirtyFlags are used to signal changes to entities that have already been added,
     // so we can clear them for this entity which has just been added.
@@ -218,16 +213,14 @@ void EntitySimulation::processChangedEntity(const EntityItemPointer& entity) {
 
 void EntitySimulation::clearEntities() {
     QMutexLocker lock(&_mutex);
-    _mortalEntities.clear();
-    _nextExpiry = std::numeric_limits<uint64_t>::max();
-    _entitiesToUpdate.clear();
     _entitiesToSort.clear();
     _simpleKinematicEntities.clear();
-
-    clearEntitiesInternal();
-
+    _changedEntities.clear();
     _allEntities.clear();
-    _deadEntities.clear();
+    _deadEntitiesToRemoveFromTree.clear();
+    _entitiesToUpdate.clear();
+    _mortalEntities.clear();
+    _nextExpiry = std::numeric_limits<uint64_t>::max();
 }
 
 void EntitySimulation::moveSimpleKinematics(uint64_t now) {
@@ -263,25 +256,22 @@ void EntitySimulation::moveSimpleKinematics(uint64_t now) {
     }
 }
 
-void EntitySimulation::addDynamic(EntityDynamicPointer dynamic) {
-    QMutexLocker lock(&_dynamicsMutex);
-    _dynamicsToAdd += dynamic;
-}
-
-void EntitySimulation::removeDynamic(const QUuid dynamicID) {
-    QMutexLocker lock(&_dynamicsMutex);
-    _dynamicsToRemove += dynamicID;
-}
-
-void EntitySimulation::removeDynamics(QList<QUuid> dynamicIDsToRemove) {
-    QMutexLocker lock(&_dynamicsMutex);
-    foreach(QUuid uuid, dynamicIDsToRemove) {
-        _dynamicsToRemove.insert(uuid);
+void EntitySimulation::processDeadEntities() {
+    if (_deadEntitiesToRemoveFromTree.empty()) {
+        return;
     }
-}
-
-void EntitySimulation::applyDynamicChanges() {
-    QMutexLocker lock(&_dynamicsMutex);
-    _dynamicsToAdd.clear();
-    _dynamicsToRemove.clear();
+    SetOfEntities entitiesToDeleteImmediately;
+    // NOTE: dummyList will be empty because this base-class implementation is only used server-side
+    // for which ATM we only process domain-entities, and since we are passing nullSessionID for authorization
+    // EntityItem::collectChildrenForDelete() will not collect domain-entities into this side list.
+    SetOfEntities dummyList;
+    QUuid nullSessionID;
+    foreach (auto entity, _deadEntitiesToRemoveFromTree) {
+        entitiesToDeleteImmediately.insert(entity);
+        entity->collectChildrenForDelete(entitiesToDeleteImmediately, dummyList, nullSessionID);
+    }
+    if (_entityTree) {
+        _entityTree->deleteEntitiesByPointer(entitiesToDeleteImmediately);
+    }
+    _deadEntitiesToRemoveFromTree.clear();
 }

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -16,17 +16,14 @@
 #include <unordered_set>
 
 #include <QtCore/QObject>
-#include <QSet>
 #include <QVector>
 
 #include <PerfStat.h>
 
-#include "EntityDynamicInterface.h"
 #include "EntityItem.h"
 #include "EntityTree.h"
 
 using EntitySimulationPointer = std::shared_ptr<EntitySimulation>;
-using SetOfEntities = QSet<EntityItemPointer>;
 using VectorOfEntities = QVector<EntityItemPointer>;
 
 // the EntitySimulation needs to know when these things change on an entity,
@@ -47,8 +44,8 @@ const int DIRTY_SIMULATION_FLAGS =
 
 class EntitySimulation : public QObject, public std::enable_shared_from_this<EntitySimulation> {
 public:
-    EntitySimulation() : _mutex(QMutex::Recursive), _entityTree(NULL), _nextExpiry(std::numeric_limits<uint64_t>::max()) { }
-    virtual ~EntitySimulation() { setEntityTree(NULL); }
+    EntitySimulation() : _mutex(QMutex::Recursive), _nextExpiry(std::numeric_limits<uint64_t>::max()), _entityTree(nullptr) { }
+    virtual ~EntitySimulation() { setEntityTree(nullptr); }
 
     inline EntitySimulationPointer getThisPointer() const {
         return std::const_pointer_cast<EntitySimulation>(shared_from_this());
@@ -57,12 +54,12 @@ public:
     /// \param tree pointer to EntityTree which is stored internally
     void setEntityTree(EntityTreePointer tree);
 
-    void updateEntities();
+    virtual void updateEntities();
 
-    virtual void addDynamic(EntityDynamicPointer dynamic);
-    virtual void removeDynamic(const QUuid dynamicID);
-    virtual void removeDynamics(QList<QUuid> dynamicIDsToRemove);
-    virtual void applyDynamicChanges();
+    // FIXME: remove these
+    virtual void addDynamic(EntityDynamicPointer dynamic) {}
+    virtual void removeDynamic(const QUuid dynamicID) {}
+    virtual void applyDynamicChanges() {};
 
     /// \param entity pointer to EntityItem to be added
     /// \sideeffect sets relevant backpointers in entity, but maybe later when appropriate data structures are locked
@@ -72,27 +69,22 @@ public:
     /// call this whenever an entity was changed from some EXTERNAL event (NOT by the EntitySimulation itself)
     void changeEntity(EntityItemPointer entity);
 
-    void clearEntities();
+    virtual void clearEntities();
 
     void moveSimpleKinematics(uint64_t now);
 
     EntityTreePointer getEntityTree() { return _entityTree; }
 
-    virtual void takeDeadEntities(SetOfEntities& entitiesToDelete);
-
-    /// \param entity pointer to EntityItem that needs to be put on the entitiesToDelete list and removed from others.
     virtual void prepareEntityForDelete(EntityItemPointer entity);
 
     void processChangedEntities();
+    virtual void queueEraseDomainEntities(const SetOfEntities& domainEntities) const { }
 
 protected:
-    // These pure virtual methods are protected because they are not to be called will-nilly. The base class
-    // calls them in the right places.
-    virtual void updateEntitiesInternal(uint64_t now) = 0;
-    virtual void addEntityInternal(EntityItemPointer entity) = 0;
-    virtual void removeEntityInternal(EntityItemPointer entity);
+    virtual void addEntityToInternalLists(EntityItemPointer entity);
+    virtual void removeEntityFromInternalLists(EntityItemPointer entity);
     virtual void processChangedEntity(const EntityItemPointer& entity);
-    virtual void clearEntitiesInternal() = 0;
+    virtual void processDeadEntities();
 
     void expireMortalEntities(uint64_t now);
     void callUpdateOnEntitiesThatNeedIt(uint64_t now);
@@ -102,27 +94,21 @@ protected:
 
     SetOfEntities _entitiesToSort; // entities moved by simulation (and might need resort in EntityTree)
     SetOfEntities _simpleKinematicEntities; // entities undergoing non-colliding kinematic motion
-    QList<EntityDynamicPointer> _dynamicsToAdd;
-    QSet<QUuid> _dynamicsToRemove;
-    QMutex _dynamicsMutex { QMutex::Recursive };
-
-protected:
-    SetOfEntities _deadEntities; // dead entities that might still be in the _entityTree
+    SetOfEntities _deadEntitiesToRemoveFromTree;
 
 private:
     void moveSimpleKinematics();
-
-    // back pointer to EntityTree structure
-    EntityTreePointer _entityTree;
 
     // We maintain multiple lists, each for its distinct purpose.
     // An entity may be in more than one list.
     std::unordered_set<EntityItemPointer> _changedEntities; // all changes this frame
     SetOfEntities _allEntities; // tracks all entities added the simulation
+    SetOfEntities _entitiesToUpdate; // entities that need to call EntityItem::update()
     SetOfEntities _mortalEntities; // entities that have an expiry
     uint64_t _nextExpiry;
 
-    SetOfEntities _entitiesToUpdate; // entities that need to call EntityItem::update()
+    // back pointer to EntityTree structure
+    EntityTreePointer _entityTree;
 };
 
 #endif // hifi_EntitySimulation_h

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -78,7 +78,7 @@ public:
     virtual void prepareEntityForDelete(EntityItemPointer entity);
 
     void processChangedEntities();
-    virtual void queueEraseDomainEntities(const SetOfEntities& domainEntities) const { }
+    virtual void queueEraseDomainEntity(const QUuid& id) const { }
 
 protected:
     virtual void addEntityToInternalLists(EntityItemPointer entity);

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -697,7 +697,6 @@ void EntityTree::deleteEntitiesByID(const QSet<EntityItemID>& ids, bool force, b
         });
     } else {
         SetOfEntities entitiesToDelete;
-        SetOfEntities domainEntities;
         QUuid sessionID = DependencyManager::get<NodeList>()->getSessionUUID();
         withWriteLock([&] {
             for (auto id : ids) {
@@ -708,10 +707,12 @@ void EntityTree::deleteEntitiesByID(const QSet<EntityItemID>& ids, bool force, b
                 }
                 if (entity) {
                     if (entity->isDomainEntity()) {
-                        domainEntities.insert(entity);
+                        if (_simulation) {
+                            _simulation->queueEraseDomainEntity(entity->getID());
+                        }
                     } else if (entity->isLocalEntity() || entity->isMyAvatarEntity()) {
                         entitiesToDelete.insert(entity);
-                        entity->collectChildrenForDelete(entitiesToDelete, domainEntities, sessionID);
+                        entity->collectChildrenForDelete(entitiesToDelete, sessionID);
                     }
                 }
             }
@@ -719,10 +720,6 @@ void EntityTree::deleteEntitiesByID(const QSet<EntityItemID>& ids, bool force, b
                 deleteEntitiesByPointer(entitiesToDelete);
             }
         });
-        if (!domainEntities.empty() && _simulation) {
-            // interface-client can't delete domainEntities outright, they must roundtrip through the entity-server
-            _simulation->queueEraseDomainEntities(domainEntities);
-        }
     }
 }
 
@@ -2366,7 +2363,6 @@ int EntityTree::processEraseMessage(ReceivedMessage& message, const SharedNodePo
     #ifdef EXTRA_ERASE_DEBUGGING
         qCDebug(entities) << "EntityTree::processEraseMessage()";
     #endif
-    SetOfEntities consequentialDomainEntities;
     withWriteLock([&] {
         message.seek(sizeof(OCTREE_PACKET_FLAGS) + sizeof(OCTREE_PACKET_SEQUENCE) + sizeof(OCTREE_PACKET_SENT_TIME));
 
@@ -2413,7 +2409,7 @@ int EntityTree::processEraseMessage(ReceivedMessage& message, const SharedNodePo
             SetOfEntities entitiesToDelete;
             for (auto entity : domainEntities) {
                 entitiesToDelete.insert(entity);
-                entity->collectChildrenForDelete(entitiesToDelete, consequentialDomainEntities, sessionID);
+                entity->collectChildrenForDelete(entitiesToDelete, sessionID);
             }
 
             if (!entitiesToDelete.empty()) {
@@ -2421,9 +2417,6 @@ int EntityTree::processEraseMessage(ReceivedMessage& message, const SharedNodePo
             }
         }
     });
-    if (!consequentialDomainEntities.empty() && _simulation) {
-        _simulation->queueEraseDomainEntities(consequentialDomainEntities);
-    }
     return message.getPosition();
 }
 

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -98,14 +98,15 @@ void EntityTree::eraseDomainAndNonOwnedEntities() {
             if (element) {
                 element->cleanupDomainAndNonOwnedEntities();
             }
-
-            if (entity->isLocalEntity() || (entity->isAvatarEntity() && entity->getOwningAvatarID() == getMyAvatarSessionUUID())) {
-                savedEntities[entity->getEntityItemID()] = entity;
-            } else {
-                int32_t spaceIndex = entity->getSpaceIndex();
-                if (spaceIndex != -1) {
-                    // stale spaceIndices will be freed later
-                    _staleProxies.push_back(spaceIndex);
+            if (!getIsServer()) {
+                if (entity->isLocalEntity() || entity->isMyAvatarEntity()) {
+                    savedEntities[entity->getEntityItemID()] = entity;
+                } else {
+                    int32_t spaceIndex = entity->getSpaceIndex();
+                    if (spaceIndex != -1) {
+                        // stale spaceIndices will be freed later
+                        _staleProxies.push_back(spaceIndex);
+                    }
                 }
             }
         }
@@ -121,7 +122,7 @@ void EntityTree::eraseDomainAndNonOwnedEntities() {
 
         foreach (EntityItemWeakPointer entityItem, _needsParentFixup) {
             auto entity = entityItem.lock();
-            if (entity && (entity->isLocalEntity() || (entity->isAvatarEntity() && entity->getOwningAvatarID() == getMyAvatarSessionUUID()))) {
+            if (entity && (entity->isLocalEntity() || entity->isMyAvatarEntity())) {
                 needParentFixup.push_back(entityItem);
             }
         }
@@ -144,10 +145,12 @@ void EntityTree::eraseAllOctreeElements(bool createNewRoot) {
             if (element) {
                 element->cleanupEntities();
             }
-            int32_t spaceIndex = entity->getSpaceIndex();
-            if (spaceIndex != -1) {
-                // assume stale spaceIndices will be freed later
-                _staleProxies.push_back(spaceIndex);
+            if (!getIsServer()) {
+                int32_t spaceIndex = entity->getSpaceIndex();
+                if (spaceIndex != -1) {
+                    // assume stale spaceIndices will be freed later
+                    _staleProxies.push_back(spaceIndex);
+                }
             }
         }
     });
@@ -605,61 +608,21 @@ void EntityTree::setSimulation(EntitySimulationPointer simulation) {
 }
 
 void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ignoreWarnings) {
-    EntityTreeElementPointer containingElement = getContainingElement(entityID);
-    if (!containingElement) {
-        if (!ignoreWarnings) {
-            qCWarning(entities) << "EntityTree::deleteEntity() on non-existent entityID=" << entityID;
-        }
-        return;
-    }
-
-    EntityItemPointer existingEntity = containingElement->getEntityWithEntityItemID(entityID);
-    if (!existingEntity) {
-        if (!ignoreWarnings) {
-            qCWarning(entities) << "EntityTree::deleteEntity() on non-existant entity item with entityID=" << entityID;
-        }
-        return;
-    }
-
-    if (existingEntity->getLocked() && !force) {
-        if (!ignoreWarnings) {
-            qCDebug(entities) << "ERROR! EntityTree::deleteEntity() trying to delete locked entity. entityID=" << entityID;
-        }
-        return;
-    }
-
-    cleanupCloneIDs(entityID);
-    unhookChildAvatar(entityID);
-    emit deletingEntity(entityID);
-    emit deletingEntityPointer(existingEntity.get());
-
-    // NOTE: callers must lock the tree before using this method
-    DeleteEntityOperator theOperator(getThisPointer(), entityID);
-
-    existingEntity->forEachDescendant([&](SpatiallyNestablePointer descendant) {
-        auto descendantID = descendant->getID();
-        theOperator.addEntityIDToDeleteList(descendantID);
-        emit deletingEntity(descendantID);
-        EntityItemPointer descendantEntity = std::dynamic_pointer_cast<EntityItem>(descendant);
-        if (descendantEntity) {
-            emit deletingEntityPointer(descendantEntity.get());
-        }
-    });
-
-    recurseTreeWithOperator(&theOperator);
-    processRemovedEntities(theOperator);
-    _isDirty = true;
+    // NOTE: can be called without lock because deleteEntitiesByID() will lock
+    QSet<EntityItemID> ids;
+    ids << entityID;
+    deleteEntitiesByID(ids, force, ignoreWarnings);
 }
 
 void EntityTree::unhookChildAvatar(const EntityItemID entityID) {
-
-    EntityItemPointer entity = findEntityByEntityItemID(entityID);
-
-    entity->forEachDescendant([&](SpatiallyNestablePointer child) {
-        if (child->getNestableType() == NestableType::Avatar) {
-            child->setParentID(nullptr);
-        }
-    });
+    if (!getIsServer()) {
+        EntityItemPointer entity = findEntityByEntityItemID(entityID);
+        entity->forEachDescendant([&](SpatiallyNestablePointer child) {
+            if (child->getNestableType() == NestableType::Avatar) {
+                child->setParentID(nullptr);
+            }
+        });
+    }
 }
 
 void EntityTree::cleanupCloneIDs(const EntityItemID& entityID) {
@@ -684,39 +647,100 @@ void EntityTree::cleanupCloneIDs(const EntityItemID& entityID) {
     }
 }
 
-void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool ignoreWarnings) {
-    // NOTE: callers must lock the tree before using this method
+void EntityTree::recursivelyFilterAndCollectForDelete(const EntityItemPointer& entity, SetOfEntities& entitiesToDelete, bool force) const {
+    // tree must be read-locked before calling this method
+    //TODO: assert(treeIsLocked);
+    assert(entity);
+    if (entity->getElement() && (entitiesToDelete.find(entity) == entitiesToDelete.end())) {
+        // filter
+        bool allowed = force;
+        if (!allowed) {
+            bool wasChanged = false;
+            auto startFilter = usecTimestampNow();
+            EntityItemProperties dummyProperties;
+            allowed = force || filterProperties(entity, dummyProperties, dummyProperties, wasChanged, FilterType::Delete);
+            auto endFilter = usecTimestampNow();
+            _totalFilterTime += endFilter - startFilter;
+        }
+        if (allowed) {
+            entitiesToDelete.insert(entity);
+            for (SpatiallyNestablePointer child : entity->getChildren()) {
+                if (child && child->getNestableType() == NestableType::Entity) {
+                    EntityItemPointer childEntity = std::static_pointer_cast<EntityItem>(child);
+                    recursivelyFilterAndCollectForDelete(childEntity, entitiesToDelete, force);
+                }
+            }
+        }
+    }
+}
+
+void EntityTree::deleteEntitiesByID(const QSet<EntityItemID>& ids, bool force, bool ignoreWarnings) {
+    // this method has two paths:
+    // (a) entity-server: applies delete filter
+    // (b) interface-client: deletes local- and my-avatar-entities immediately, submits domainEntity deletes to the entity-server
+    if (getIsServer()) {
+        withWriteLock([&] {
+            SetOfEntities entitiesToDelete;
+            for (auto id : ids) {
+                EntityItemPointer entity;
+                {
+                    QReadLocker locker(&_entityMapLock);
+                    entity = _entityMap.value(id);
+                }
+                if (entity) {
+                    recursivelyFilterAndCollectForDelete(entity, entitiesToDelete, force);
+                }
+            }
+            if (!entitiesToDelete.empty()) {
+                deleteEntitiesByPointer(entitiesToDelete);
+            }
+        });
+    } else {
+        SetOfEntities entitiesToDelete;
+        SetOfEntities domainEntities;
+        QUuid sessionID = DependencyManager::get<NodeList>()->getSessionUUID();
+        withWriteLock([&] {
+            for (auto id : ids) {
+                EntityItemPointer entity;
+                {
+                    QReadLocker locker(&_entityMapLock);
+                    entity = _entityMap.value(id);
+                }
+                if (entity) {
+                    if (entity->isDomainEntity()) {
+                        domainEntities.insert(entity);
+                    } else if (entity->isLocalEntity() || entity->isMyAvatarEntity()) {
+                        entitiesToDelete.insert(entity);
+                        entity->collectChildrenForDelete(entitiesToDelete, domainEntities, sessionID);
+                    }
+                }
+            }
+            if (!entitiesToDelete.empty()) {
+                deleteEntitiesByPointer(entitiesToDelete);
+            }
+        });
+        if (!domainEntities.empty() && _simulation) {
+            // interface-client can't delete domainEntities outright, they must roundtrip through the entity-server
+            _simulation->queueEraseDomainEntities(domainEntities);
+        }
+    }
+}
+
+void EntityTree::deleteEntitiesByPointer(const SetOfEntities& entities) {
+    // tree must be write-locked before calling this method
+    //TODO: assert(treeIsLocked);
+    // NOTE: there is no entity validation (i.e. is entity in tree?) nor snarfing of children beyond this point.
+    // Get those done BEFORE calling this method.
+    for (auto entity : entities) {
+        cleanupCloneIDs(entity->getID());
+    }
     DeleteEntityOperator theOperator(getThisPointer());
-    foreach(const EntityItemID& entityID, entityIDs) {
-        EntityTreeElementPointer containingElement = getContainingElement(entityID);
-        if (!containingElement) {
-            if (!ignoreWarnings) {
-                qCWarning(entities) << "EntityTree::deleteEntities() on non-existent entityID=" << entityID;
-            }
-            continue;
+    for (auto entity : entities) {
+        if (entity->getElement()) {
+            theOperator.addEntityToDeleteList(entity);
+            emit deletingEntity(entity->getID());
+            emit deletingEntityPointer(entity.get());
         }
-
-        EntityItemPointer existingEntity = containingElement->getEntityWithEntityItemID(entityID);
-        if (!existingEntity) {
-            if (!ignoreWarnings) {
-                qCWarning(entities) << "EntityTree::deleteEntities() on non-existent entity item with entityID=" << entityID;
-            }
-            continue;
-        }
-
-        if (existingEntity->getLocked() && !force) {
-            if (!ignoreWarnings) {
-                qCDebug(entities) << "ERROR! EntityTree::deleteEntities() trying to delete locked entity. entityID=" << entityID;
-            }
-            continue;
-        }
-
-        // tell our delete operator about this entityID
-        cleanupCloneIDs(entityID);
-        unhookChildAvatar(entityID);
-        theOperator.addEntityIDToDeleteList(entityID);
-        emit deletingEntity(entityID);
-        emit deletingEntityPointer(existingEntity.get());
     }
 
     if (!theOperator.getEntities().empty()) {
@@ -727,23 +751,11 @@ void EntityTree::deleteEntities(QSet<EntityItemID> entityIDs, bool force, bool i
 }
 
 void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator) {
+    // NOTE: assume tree already write-locked because this method only called in deleteEntitiesByPointer()
     quint64 deletedAt = usecTimestampNow();
     const RemovedEntities& entities = theOperator.getEntities();
     foreach(const EntityToDeleteDetails& details, entities) {
         EntityItemPointer theEntity = details.entity;
-
-        if (getIsServer()) {
-            QSet<EntityItemID> childrenIDs;
-            theEntity->forEachChild([&](SpatiallyNestablePointer child) {
-                if (child->getNestableType() == NestableType::Entity) {
-                    childrenIDs += child->getID();
-                }
-            });
-            deleteEntities(childrenIDs, true, true);
-        }
-
-        theEntity->die();
-
         if (getIsServer()) {
             removeCertifiedEntityOnServer(theEntity);
 
@@ -751,18 +763,23 @@ void EntityTree::processRemovedEntities(const DeleteEntityOperator& theOperator)
             QWriteLocker recentlyDeletedEntitiesLocker(&_recentlyDeletedEntitiesLock);
             _recentlyDeletedEntityItemIDs.insert(deletedAt, theEntity->getEntityItemID());
         } else {
+            theEntity->forEachDescendant([&](SpatiallyNestablePointer child) {
+                if (child->getNestableType() == NestableType::Avatar) {
+                    child->setParentID(nullptr);
+                }
+            });
+
             // on the client side, we also remember that we deleted this entity, we don't care about the time
             trackDeletedEntity(theEntity->getEntityItemID());
-        }
 
+            int32_t spaceIndex = theEntity->getSpaceIndex();
+            if (spaceIndex != -1) {
+                // stale spaceIndices will be freed later
+                _staleProxies.push_back(spaceIndex);
+            }
+        }
         if (theEntity->isSimulated()) {
             _simulation->prepareEntityForDelete(theEntity);
-        }
-
-        int32_t spaceIndex = theEntity->getSpaceIndex();
-        if (spaceIndex != -1) {
-            // stale spaceIndices will be freed later
-            _staleProxies.push_back(spaceIndex);
         }
     }
 }
@@ -1369,7 +1386,7 @@ void EntityTree::fixupTerseEditLogging(EntityItemProperties& properties, QList<Q
 }
 
 
-bool EntityTree::filterProperties(EntityItemPointer& existingEntity, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, FilterType filterType) {
+bool EntityTree::filterProperties(const EntityItemPointer& existingEntity, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, FilterType filterType) const {
     bool accepted = true;
     auto entityEditFilters = DependencyManager::get<EntityEditFilters>();
     if (entityEditFilters) {
@@ -1749,9 +1766,9 @@ void EntityTree::processChallengeOwnershipPacket(ReceivedMessage& message, const
     }
 }
 
+// NOTE: Caller must lock the tree before calling this.
 int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned char* editData, int maxLength,
                                      const SharedNodePointer& senderNode) {
-
     if (!getIsServer()) {
         qCWarning(entities) << "EntityTree::processEditPacketData() should only be called on a server tree.";
         return 0;
@@ -2217,7 +2234,9 @@ void EntityTree::fixupNeedsParentFixups() {
 
 void EntityTree::deleteDescendantsOfAvatar(QUuid avatarID) {
     if (_childrenOfAvatars.contains(avatarID)) {
-        deleteEntities(_childrenOfAvatars[avatarID]);
+        bool force = true;
+        bool ignoreWarnings = true;
+        deleteEntitiesByID(_childrenOfAvatars[avatarID], force, ignoreWarnings);
         _childrenOfAvatars.remove(avatarID);
     }
 }
@@ -2249,22 +2268,6 @@ void EntityTree::update(bool simulate) {
     if (simulate && _simulation) {
         withWriteLock([&] {
             _simulation->updateEntities();
-            {
-                PROFILE_RANGE(simulation_physics, "Deletes");
-                SetOfEntities deadEntities;
-                _simulation->takeDeadEntities(deadEntities);
-                if (!deadEntities.empty()) {
-                    // translate into list of ID's
-                    QSet<EntityItemID> idsToDelete;
-
-                    for (auto entity : deadEntities) {
-                        idsToDelete.insert(entity->getEntityItemID());
-                    }
-
-                    // delete these things the roundabout way
-                    deleteEntities(idsToDelete, true);
-                }
-            }
         });
     }
 }
@@ -2353,12 +2356,17 @@ bool EntityTree::shouldEraseEntity(EntityItemID entityID, const SharedNodePointe
     return allowed;
 }
 
-
-// TODO: consider consolidating processEraseMessageDetails() and processEraseMessage()
 int EntityTree::processEraseMessage(ReceivedMessage& message, const SharedNodePointer& sourceNode) {
+    // NOTE: this is only called by the interface-client on receipt of deleteEntity message from entity-server.
+    // Which means this is a state synchronization message from the the entity-server.  It is saying
+    // "The following domain-entities have already been deleted". While need to perform sanity checking
+    // (e.g. verify these are domain entities) permissions need NOT checked for the domain-entities.
+    assert(!getIsServer());
+    // TODO: remove this stuff out of EntityTree:: and into interface-client code.
     #ifdef EXTRA_ERASE_DEBUGGING
         qCDebug(entities) << "EntityTree::processEraseMessage()";
     #endif
+    SetOfEntities consequentialDomainEntities;
     withWriteLock([&] {
         message.seek(sizeof(OCTREE_PACKET_FLAGS) + sizeof(OCTREE_PACKET_SEQUENCE) + sizeof(OCTREE_PACKET_SENT_TIME));
 
@@ -2366,10 +2374,9 @@ int EntityTree::processEraseMessage(ReceivedMessage& message, const SharedNodePo
         message.readPrimitive(&numberOfIDs);
 
         if (numberOfIDs > 0) {
-            QSet<EntityItemID> entityItemIDsToDelete;
+            QSet<EntityItemID> idsToDelete;
 
             for (size_t i = 0; i < numberOfIDs; i++) {
-
                 if (NUM_BYTES_RFC4122_UUID > message.getBytesLeftToRead()) {
                     qCDebug(entities) << "EntityTree::processEraseMessage().... bailing because not enough bytes in buffer";
                     break; // bail to prevent buffer overflow
@@ -2381,64 +2388,85 @@ int EntityTree::processEraseMessage(ReceivedMessage& message, const SharedNodePo
                 #endif
 
                 EntityItemID entityItemID(entityID);
+                idsToDelete << entityItemID;
+            }
 
-                if (shouldEraseEntity(entityID, sourceNode)) {
-                    entityItemIDsToDelete << entityItemID;
-                    cleanupCloneIDs(entityItemID);
+            // domain-entity deletion can trigger deletion of other entities the entity-server doesn't know about
+            // so we must recurse down the children and collect consequential deletes however
+            // we must first identify all domain-entities in idsToDelete so as to not overstep entity-server's authority
+            SetOfEntities domainEntities;
+            for (auto id : idsToDelete) {
+                EntityItemPointer entity = _entityMap.value(id);
+                if (entity && entity->isDomainEntity()) {
+                    domainEntities.insert(entity);
                 }
             }
-            deleteEntities(entityItemIDsToDelete, true, true);
+            // now we recurse domain-entities children and snarf consequential entities
+            auto nodeList = DependencyManager::get<NodeList>();
+            QUuid sessionID = nodeList->getSessionUUID();
+            // NOTE: normally a null sessionID would be bad, as that would cause the collectDhildrenForDelete() method below
+            // to snarf domain entities for which the interface-client is not authorized to delete without explicit instructions
+            // from the entity-server, however it is ok here because that would mean:
+            // (a) interface-client is not connected to a domain which means...
+            // (b) we should never get here (since this would correspond to a message from the entity-server) but...
+            // (c) who cares? When not connected to a domain the interface-client can do whatever it wants.
+            SetOfEntities entitiesToDelete;
+            for (auto entity : domainEntities) {
+                entitiesToDelete.insert(entity);
+                entity->collectChildrenForDelete(entitiesToDelete, consequentialDomainEntities, sessionID);
+            }
+
+            if (!entitiesToDelete.empty()) {
+                deleteEntitiesByPointer(entitiesToDelete);
+            }
         }
     });
+    if (!consequentialDomainEntities.empty() && _simulation) {
+        _simulation->queueEraseDomainEntities(consequentialDomainEntities);
+    }
     return message.getPosition();
 }
 
 // This version skips over the header
-// NOTE: Caller must lock the tree before calling this.
-// TODO: consider consolidating processEraseMessageDetails() and processEraseMessage()
+// NOTE: Caller must write-lock the tree before calling this.
 int EntityTree::processEraseMessageDetails(const QByteArray& dataByteArray, const SharedNodePointer& sourceNode) {
+    //TODO: assert(treeIsLocked);
+    assert(getIsServer());
     #ifdef EXTRA_ERASE_DEBUGGING
         qCDebug(entities) << "EntityTree::processEraseMessageDetails()";
     #endif
-    const unsigned char* packetData = (const unsigned char*)dataByteArray.constData();
-    const unsigned char* dataAt = packetData;
     size_t packetLength = dataByteArray.size();
     size_t processedBytes = 0;
 
     uint16_t numberOfIds = 0; // placeholder for now
-    memcpy(&numberOfIds, dataAt, sizeof(numberOfIds));
-    dataAt += sizeof(numberOfIds);
+    memcpy(&numberOfIds, dataByteArray.constData(), sizeof(numberOfIds));
     processedBytes += sizeof(numberOfIds);
 
     if (numberOfIds > 0) {
-        QSet<EntityItemID> entityItemIDsToDelete;
+        QSet<EntityItemID> ids;
 
+        // extract ids from packet
         for (size_t i = 0; i < numberOfIds; i++) {
-
-
             if (processedBytes + NUM_BYTES_RFC4122_UUID > packetLength) {
                 qCDebug(entities) << "EntityTree::processEraseMessageDetails().... bailing because not enough bytes in buffer";
                 break; // bail to prevent buffer overflow
             }
 
             QByteArray encodedID = dataByteArray.mid((int)processedBytes, NUM_BYTES_RFC4122_UUID);
-            QUuid entityID = QUuid::fromRfc4122(encodedID);
-            dataAt += encodedID.size();
+            QUuid id = QUuid::fromRfc4122(encodedID);
             processedBytes += encodedID.size();
 
             #ifdef EXTRA_ERASE_DEBUGGING
-                qCDebug(entities) << "    ---- EntityTree::processEraseMessageDetails() contains id:" << entityID;
+                qCDebug(entities) << "    ---- EntityTree::processEraseMessageDetails() contains id:" << id;
             #endif
 
-            EntityItemID entityItemID(entityID);
-
-            if (shouldEraseEntity(entityID, sourceNode)) {
-                entityItemIDsToDelete << entityItemID;
-                cleanupCloneIDs(entityItemID);
-            }
-
+            EntityItemID entityID(id);
+            ids << entityID;
         }
-        deleteEntities(entityItemIDsToDelete, true, true);
+
+        bool force = sourceNode->isAllowedEditor();
+        bool ignoreWarnings = true;
+        deleteEntitiesByID(ids, force, ignoreWarnings);
     }
     return (int)processedBytes;
 }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -609,8 +609,8 @@ void EntityTree::setSimulation(EntitySimulationPointer simulation) {
 
 void EntityTree::deleteEntity(const EntityItemID& entityID, bool force, bool ignoreWarnings) {
     // NOTE: can be called without lock because deleteEntitiesByID() will lock
-    QSet<EntityItemID> ids;
-    ids << entityID;
+    std::vector<EntityItemID> ids;
+    ids.push_back(entityID);
     deleteEntitiesByID(ids, force, ignoreWarnings);
 }
 
@@ -674,7 +674,7 @@ void EntityTree::recursivelyFilterAndCollectForDelete(const EntityItemPointer& e
     }
 }
 
-void EntityTree::deleteEntitiesByID(const QSet<EntityItemID>& ids, bool force, bool ignoreWarnings) {
+void EntityTree::deleteEntitiesByID(const std::vector<EntityItemID>& ids, bool force, bool ignoreWarnings) {
     // this method has two paths:
     // (a) entity-server: applies delete filter
     // (b) interface-client: deletes local- and my-avatar-entities immediately, submits domainEntity deletes to the entity-server
@@ -2230,11 +2230,19 @@ void EntityTree::fixupNeedsParentFixups() {
 }
 
 void EntityTree::deleteDescendantsOfAvatar(QUuid avatarID) {
-    if (_childrenOfAvatars.contains(avatarID)) {
-        bool force = true;
-        bool ignoreWarnings = true;
-        deleteEntitiesByID(_childrenOfAvatars[avatarID], force, ignoreWarnings);
-        _childrenOfAvatars.remove(avatarID);
+    QHash<QUuid, QSet<EntityItemID>>::const_iterator itr = _childrenOfAvatars.constFind(avatarID);
+    if (itr != _childrenOfAvatars.end()) {
+        if (!itr.value().empty()) {
+            std::vector<EntityItemID> ids;
+            ids.reserve(itr.value().size());
+            for (const auto id : itr.value()) {
+                ids.push_back(id);
+            }
+            bool force = true;
+            bool ignoreWarnings = true;
+            deleteEntitiesByID(ids, force, ignoreWarnings);
+        }
+        _childrenOfAvatars.erase(itr);
     }
 }
 
@@ -2436,7 +2444,8 @@ int EntityTree::processEraseMessageDetails(const QByteArray& dataByteArray, cons
     processedBytes += sizeof(numberOfIds);
 
     if (numberOfIds > 0) {
-        QSet<EntityItemID> ids;
+        std::vector<EntityItemID> ids;
+        ids.reserve(numberOfIds);
 
         // extract ids from packet
         for (size_t i = 0; i < numberOfIds; i++) {
@@ -2454,7 +2463,7 @@ int EntityTree::processEraseMessageDetails(const QByteArray& dataByteArray, cons
             #endif
 
             EntityItemID entityID(id);
-            ids << entityID;
+            ids.push_back(entityID);
         }
 
         bool force = sourceNode->isAllowedEditor();

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -710,7 +710,7 @@ void EntityTree::deleteEntitiesByID(const QSet<EntityItemID>& ids, bool force, b
                         if (_simulation) {
                             _simulation->queueEraseDomainEntity(entity->getID());
                         }
-                    } else if (entity->isLocalEntity() || entity->isMyAvatarEntity()) {
+                    } else if (force || entity->isLocalEntity() || entity->isMyAvatarEntity()) {
                         entitiesToDelete.insert(entity);
                         entity->collectChildrenForDelete(entitiesToDelete, sessionID);
                     }

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -658,7 +658,7 @@ void EntityTree::recursivelyFilterAndCollectForDelete(const EntityItemPointer& e
             bool wasChanged = false;
             auto startFilter = usecTimestampNow();
             EntityItemProperties dummyProperties;
-            allowed = force || filterProperties(entity, dummyProperties, dummyProperties, wasChanged, FilterType::Delete);
+            allowed = filterProperties(entity, dummyProperties, dummyProperties, wasChanged, FilterType::Delete);
             auto endFilter = usecTimestampNow();
             _totalFilterTime += endFilter - startFilter;
         }

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -127,7 +127,7 @@ public:
     void cleanupCloneIDs(const EntityItemID& entityID);
     void deleteEntity(const EntityItemID& entityID, bool force = false, bool ignoreWarnings = true);
 
-    void deleteEntitiesByID(const QSet<EntityItemID>& entityIDs, bool force = false, bool ignoreWarnings = true);
+    void deleteEntitiesByID(const std::vector<EntityItemID>& entityIDs, bool force = false, bool ignoreWarnings = true);
     void deleteEntitiesByPointer(const SetOfEntities& entities);
 
     EntityItemPointer findEntityByID(const QUuid& id) const;

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -128,7 +128,7 @@ public:
     void deleteEntity(const EntityItemID& entityID, bool force = false, bool ignoreWarnings = true);
 
     void deleteEntitiesByID(const std::vector<EntityItemID>& entityIDs, bool force = false, bool ignoreWarnings = true);
-    void deleteEntitiesByPointer(const SetOfEntities& entities);
+    void deleteEntitiesByPointer(const std::vector<EntityItemPointer>& entities);
 
     EntityItemPointer findEntityByID(const QUuid& id) const;
     EntityItemPointer findEntityByEntityItemID(const EntityItemID& entityID) const;
@@ -293,7 +293,7 @@ signals:
 
 protected:
 
-    void recursivelyFilterAndCollectForDelete(const EntityItemPointer& entity, SetOfEntities& entitiesToDelete, bool force) const;
+    void recursivelyFilterAndCollectForDelete(const EntityItemPointer& entity, std::vector<EntityItemPointer>& entitiesToDelete, bool force) const;
     void processRemovedEntities(const DeleteEntityOperator& theOperator);
     bool updateEntity(EntityItemPointer entity, const EntityItemProperties& properties,
             const SharedNodePointer& senderNode = SharedNodePointer(nullptr));

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -126,7 +126,9 @@ public:
     void unhookChildAvatar(const EntityItemID entityID);
     void cleanupCloneIDs(const EntityItemID& entityID);
     void deleteEntity(const EntityItemID& entityID, bool force = false, bool ignoreWarnings = true);
-    void deleteEntities(QSet<EntityItemID> entityIDs, bool force = false, bool ignoreWarnings = true);
+
+    void deleteEntitiesByID(const QSet<EntityItemID>& entityIDs, bool force = false, bool ignoreWarnings = true);
+    void deleteEntitiesByPointer(const SetOfEntities& entities);
 
     EntityItemPointer findEntityByID(const QUuid& id) const;
     EntityItemPointer findEntityByEntityItemID(const EntityItemID& entityID) const;
@@ -291,6 +293,7 @@ signals:
 
 protected:
 
+    void recursivelyFilterAndCollectForDelete(const EntityItemPointer& entity, SetOfEntities& entitiesToDelete, bool force) const;
     void processRemovedEntities(const DeleteEntityOperator& theOperator);
     bool updateEntity(EntityItemPointer entity, const EntityItemProperties& properties,
             const SharedNodePointer& senderNode = SharedNodePointer(nullptr));
@@ -339,12 +342,12 @@ protected:
     int _totalEditMessages = 0;
     int _totalUpdates = 0;
     int _totalCreates = 0;
-    quint64 _totalDecodeTime = 0;
-    quint64 _totalLookupTime = 0;
-    quint64 _totalUpdateTime = 0;
-    quint64 _totalCreateTime = 0;
-    quint64 _totalLoggingTime = 0;
-    quint64 _totalFilterTime = 0;
+    mutable quint64 _totalDecodeTime = 0;
+    mutable quint64 _totalLookupTime = 0;
+    mutable quint64 _totalUpdateTime = 0;
+    mutable quint64 _totalCreateTime = 0;
+    mutable quint64 _totalLoggingTime = 0;
+    mutable quint64 _totalFilterTime = 0;
 
     // these performance statistics are only used in the client
     void resetClientEditStats();
@@ -364,7 +367,7 @@ protected:
 
     float _maxTmpEntityLifetime { DEFAULT_MAX_TMP_ENTITY_LIFETIME };
 
-    bool filterProperties(EntityItemPointer& existingEntity, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, FilterType filterType);
+    bool filterProperties(const EntityItemPointer& existingEntity, EntityItemProperties& propertiesIn, EntityItemProperties& propertiesOut, bool& wasChanged, FilterType filterType) const;
     bool _hasEntityEditFilter{ false };
     QStringList _entityScriptSourceWhitelist;
 

--- a/libraries/entities/src/EntityTreeElement.cpp
+++ b/libraries/entities/src/EntityTreeElement.cpp
@@ -705,7 +705,7 @@ void EntityTreeElement::cleanupDomainAndNonOwnedEntities() {
     withWriteLock([&] {
         EntityItems savedEntities;
         foreach(EntityItemPointer entity, _entityItems) {
-            if (!(entity->isLocalEntity() || (entity->isAvatarEntity() && entity->getOwningAvatarID() == getTree()->getMyAvatarSessionUUID()))) {
+            if (!(entity->isLocalEntity() || entity->isMyAvatarEntity())) {
                 entity->preDelete();
                 entity->_element = NULL;
             } else {

--- a/libraries/entities/src/SimpleEntitySimulation.h
+++ b/libraries/entities/src/SimpleEntitySimulation.h
@@ -23,16 +23,16 @@ using SimpleEntitySimulationPointer = std::shared_ptr<SimpleEntitySimulation>;
 class SimpleEntitySimulation : public EntitySimulation {
 public:
     SimpleEntitySimulation() : EntitySimulation() { }
-    ~SimpleEntitySimulation() { clearEntitiesInternal(); }
+    ~SimpleEntitySimulation() { clearEntities(); }
 
     void clearOwnership(const QUuid& ownerID);
+    void clearEntities() override;
+    void updateEntities() override;
 
 protected:
-    void updateEntitiesInternal(uint64_t now) override;
-    void addEntityInternal(EntityItemPointer entity) override;
-    void removeEntityInternal(EntityItemPointer entity) override;
+    void addEntityToInternalLists(EntityItemPointer entity) override;
+    void removeEntityFromInternalLists(EntityItemPointer entity) override;
     void processChangedEntity(const EntityItemPointer& entity) override;
-    void clearEntitiesInternal() override;
 
     void sortEntitiesThatMoved() override;
 

--- a/libraries/physics/src/EntityMotionState.h
+++ b/libraries/physics/src/EntityMotionState.h
@@ -107,7 +107,7 @@ protected:
     uint64_t getNextBidExpiry() const { return _nextBidExpiry; }
     void initForBid();
     void initForOwned();
-    void clearOwnershipState() { _ownershipState = OwnershipState::NotLocallyOwned; }
+    void clearOwnershipState();
     void updateServerPhysicsVariables();
     bool remoteSimulationOutOfSync(uint32_t simulationStep);
 

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -171,6 +171,8 @@ void PhysicalEntitySimulation::processChangedEntity(const EntityItemPointer& ent
 }
 
 void PhysicalEntitySimulation::processDeadEntities() {
+    // Note: this override is a complete rewite of the base class's method because we cannot assume all entities
+    // are domain entities, and the consequence of trying to delete a domain-entity in this case is very different.
     if (_deadEntitiesToRemoveFromTree.empty()) {
         return;
     }

--- a/libraries/physics/src/PhysicalEntitySimulation.cpp
+++ b/libraries/physics/src/PhysicalEntitySimulation.cpp
@@ -175,7 +175,8 @@ void PhysicalEntitySimulation::processDeadEntities() {
         return;
     }
     PROFILE_RANGE(simulation_physics, "Deletes");
-    SetOfEntities entitiesToDeleteImmediately;
+    std::vector<EntityItemPointer> entitiesToDeleteImmediately;
+    entitiesToDeleteImmediately.reserve(_deadEntitiesToRemoveFromTree.size());
     QUuid sessionID = Physics::getSessionUUID();
     QMutexLocker lock(&_mutex);
     for (auto entity : _deadEntitiesToRemoveFromTree) {
@@ -187,7 +188,7 @@ void PhysicalEntitySimulation::processDeadEntities() {
             // interface-client can't delete domainEntities outright, they must roundtrip through the entity-server
             _entityPacketSender->queueEraseEntityMessage(entity->getID());
         } else if (entity->isLocalEntity() || entity->isMyAvatarEntity()) {
-            entitiesToDeleteImmediately.insert(entity);
+            entitiesToDeleteImmediately.push_back(entity);
             entity->collectChildrenForDelete(entitiesToDeleteImmediately, sessionID);
         }
     }

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -19,6 +19,7 @@
 #include <btBulletDynamicsCommon.h>
 #include <BulletCollision/CollisionDispatch/btGhostObject.h>
 
+#include <EntityDynamicInterface.h>
 #include <EntityItem.h>
 #include <EntitySimulation.h>
 #include <workload/Space.h>
@@ -58,22 +59,24 @@ public:
     void init(EntityTreePointer tree, PhysicsEnginePointer engine, EntityEditPacketSender* packetSender);
     void setWorkloadSpace(const workload::SpacePointer space) { _space = space; }
 
-    virtual void addDynamic(EntityDynamicPointer dynamic) override;
-    virtual void applyDynamicChanges() override;
+    void addDynamic(EntityDynamicPointer dynamic) override;
+    void removeDynamic(const QUuid dynamicID) override;
+    void applyDynamicChanges() override;
 
-    virtual void takeDeadEntities(SetOfEntities& deadEntities) override;
     void takeDeadAvatarEntities(SetOfEntities& deadEntities);
+
+    virtual void clearEntities() override;
+    void queueEraseDomainEntities(const SetOfEntities& domainEntities) const override;
 
 signals:
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
 
 protected: // only called by EntitySimulation
     // overrides for EntitySimulation
-    virtual void updateEntitiesInternal(uint64_t now) override;
-    virtual void addEntityInternal(EntityItemPointer entity) override;
-    virtual void removeEntityInternal(EntityItemPointer entity) override;
+    void addEntityToInternalLists(EntityItemPointer entity) override;
+    void removeEntityFromInternalLists(EntityItemPointer entity) override;
     void processChangedEntity(const EntityItemPointer& entity) override;
-    virtual void clearEntitiesInternal() override;
+    void processDeadEntities() override;
 
     void removeOwnershipData(EntityMotionState* motionState);
     void clearOwnershipData();
@@ -121,8 +124,13 @@ private:
 
     VectorOfEntityMotionStates _owned;
     VectorOfEntityMotionStates _bids;
-    SetOfEntities _deadAvatarEntities;
+    SetOfEntities _deadAvatarEntities; // to remove from Avatar's lists
     std::vector<EntityItemPointer> _entitiesToDeleteLater;
+
+    QList<EntityDynamicPointer> _dynamicsToAdd;
+    QSet<QUuid> _dynamicsToRemove;
+    QMutex _dynamicsMutex { QMutex::Recursive };
+
     workload::SpacePointer _space;
     uint64_t _nextBidExpiry;
     uint32_t _lastStepSendPackets { 0 };

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -66,7 +66,7 @@ public:
     void takeDeadAvatarEntities(SetOfEntities& deadEntities);
 
     virtual void clearEntities() override;
-    void queueEraseDomainEntities(const SetOfEntities& domainEntities) const override;
+    void queueEraseDomainEntity(const QUuid& id) const override;
 
 signals:
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);

--- a/libraries/shared/src/PhysicsHelpers.cpp
+++ b/libraries/shared/src/PhysicsHelpers.cpp
@@ -10,10 +10,12 @@
 //
 
 #include "PhysicsHelpers.h"
-#include "NumericalConstants.h"
+
 #include <QUuid>
 
+#include "NumericalConstants.h"
 #include "PhysicsCollisionGroups.h"
+#include "SharedUtil.h"
 
 // This chunk of code was copied from Bullet-2.82, so we include the Bullet license here:
 /*
@@ -91,7 +93,7 @@ int32_t Physics::getDefaultCollisionMask(int32_t group) {
 QUuid _sessionID;
 
 void Physics::setSessionUUID(const QUuid& sessionID) {
-    _sessionID = sessionID;
+    _sessionID = sessionID.isNull() ? AVATAR_SELF_ID : sessionID;
 }
 
 const QUuid& Physics::getSessionUUID() {

--- a/libraries/shared/src/SpatialParentFinder.h
+++ b/libraries/shared/src/SpatialParentFinder.h
@@ -21,7 +21,7 @@ using SpatiallyNestableWeakPointer = std::weak_ptr<SpatiallyNestable>;
 using SpatiallyNestablePointer = std::shared_ptr<SpatiallyNestable>;
 class SpatialParentTree {
 public:
-    virtual SpatiallyNestablePointer findByID(const QUuid& id) const { return nullptr; }
+    virtual SpatiallyNestablePointer findByID(const QUuid& id) const = 0;
 };
 class SpatialParentFinder : public Dependency {
 

--- a/tests/octree/src/ModelTests.cpp
+++ b/tests/octree/src/ModelTests.cpp
@@ -434,12 +434,13 @@ void EntityTests::entityTreeTests(bool verbose) {
         quint64 totalElapsedFind = 0;
         for (int i = 0; i < TEST_ITERATIONS; i++) {        
 
-            QSet<EntityItemID> entitiesToDelete;
+            std::vector<EntityItemID> entitiesToDelete;
+            entitiesToDelete.reserve(ENTITIES_PER_ITERATION);
             for (int j = 0; j < ENTITIES_PER_ITERATION; j++) {        
                 //uint32_t id = 2 + (i * ENTITIES_PER_ITERATION) + j; // These are the entities we added above
                 QUuid id = QUuid::createUuid();// make sure it doesn't collide with previous entity ids
                 EntityItemID entityID(id);
-                entitiesToDelete << entityID;
+                entitiesToDelete.push_back(entityID);
             }
 
             if (extraVerbose) {

--- a/tests/octree/src/ModelTests.cpp
+++ b/tests/octree/src/ModelTests.cpp
@@ -363,7 +363,8 @@ void EntityTests::entityTreeTests(bool verbose) {
             }
 
             quint64 startDelete = usecTimestampNow();
-            tree.deleteEntity(entityID);
+            bool force = true;
+            tree.deleteEntity(entityID, force);
             quint64 endDelete = usecTimestampNow();
             totalElapsedDelete += (endDelete - startDelete);
 
@@ -446,7 +447,9 @@ void EntityTests::entityTreeTests(bool verbose) {
             }
 
             quint64 startDelete = usecTimestampNow();
-            tree.deleteEntities(entitiesToDelete);
+            bool force = true;
+            bool ignoreWarnings = true;
+            tree.deleteEntitiesByID(entitiesToDelete, force, ignoreWarnings);
             quint64 endDelete = usecTimestampNow();
             totalElapsedDelete += (endDelete - startDelete);
 


### PR DESCRIPTION
This is a second attempt to apply the entity deletion rules:

(1) deleting an avatar-entity parent doesn't delete any domain-entity children
(2) deleting a domain-entity parent does delete all of its children

https://highfidelity.atlassian.net/browse/DEV-1811

The previous attempt was PR-16307.