### PR TITLE
DEV-606: Remove excessive avatar-mixer logging

### DIFF
--- a/assignment-client/src/avatars/AvatarMixerSlave.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlave.cpp
@@ -448,13 +448,6 @@ void AvatarMixerSlave::broadcastAvatarDataToAgent(const SharedNodePointer& node)
             // or that somehow we haven't sent
             if (lastSeqToReceiver == lastSeqFromSender && lastSeqToReceiver != 0) {
                 ++numAvatarsHeldBack;
-
-                // BUGZ-781 verbose debugging:
-                auto usecLastTimeSent = destinationNodeData->getLastOtherAvatarEncodeTime(sourceAvatarNodeData->getNodeLocalID());
-                if (usecLastTimeSent != 0 && startIgnoreCalculation - usecLastTimeSent > 10 * USECS_PER_SECOND) {
-                    qCDebug(avatars) << "Not sent avatar" << *sourceAvatarNode << "to Node" << *destinationNode << "in > 10 s";
-                }
-
                 sendAvatar = false;
             } else if (lastSeqFromSender == 0) {
                 // We have have not yet received any data about this avatar. Ignore it for now


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-606 (part of)

The "Not sent avatar ..." messages can cause log spam due to being sent for many avatars every frame under certain conditions. This was added to debug certain loading-orb issues but wasn't particularly useful, so this PR removes them.