### PR TITLE
DEV-2293: secondary canera shadow config should recognize performance tier restrictions

### DIFF
--- a/interface/src/scripting/RenderScriptingInterface.cpp
+++ b/interface/src/scripting/RenderScriptingInterface.cpp
@@ -82,10 +82,17 @@ void RenderScriptingInterface::forceShadowsEnabled(bool enabled) {
         _shadowsEnabled = (enabled);
         _shadowsEnabledSetting.set(enabled);
 
-        auto lightingModelConfig = qApp->getRenderEngine()->getConfiguration()->getConfig<MakeLightingModel>("RenderMainView.LightingModel");
+        auto renderConfig = qApp->getRenderEngine()->getConfiguration();
+        assert(renderConfig);
+        auto lightingModelConfig = renderConfig->getConfig<MakeLightingModel>("RenderMainView.LightingModel");
         if (lightingModelConfig) {
             Menu::getInstance()->setIsOptionChecked(MenuOption::Shadows, enabled);
             lightingModelConfig->setShadow(enabled);
+        }
+        auto secondaryLightingModelConfig = renderConfig->getConfig<MakeLightingModel>("RenderSecondView.LightingModel");
+        if (secondaryLightingModelConfig) {
+            Menu::getInstance()->setIsOptionChecked(MenuOption::Shadows, enabled);
+            secondaryLightingModelConfig->setShadow(enabled);
         }
     });
 }


### PR DESCRIPTION
This PR makes the RenderSecondView pipeline follow the shadow config of RenderMainView.

https://highfidelity.atlassian.net/browse/DEV-2293