### PR TITLE
DEV-589: Rebase our audio plugin to Qt 5.12.3 / Qt 5.13

### DIFF
--- a/cmake/externals/wasapi/CMakeLists.txt
+++ b/cmake/externals/wasapi/CMakeLists.txt
@@ -6,8 +6,8 @@ if (WIN32)
   include(ExternalProject)
   ExternalProject_Add(
     ${EXTERNAL_NAME}
-    URL https://public.highfidelity.com/dependencies/qtaudio_wasapi11.zip
-    URL_MD5 d0eb8489455e7f79d59155535a2c8861
+    URL https://public.highfidelity.com/dependencies/qtaudio_wasapi12.zip
+    URL_MD5 9e2eef41165f85344808f754b48bf08d
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-589

WASAPI plugin from Qt 5.12.3, with only minimal patches applied:
-Fix bug in output buffer size calculation
-Add basic multichannel support using WAVEFORMATEXTENSIBLE
-Non-fatal handling of device removal while still in use
Other patches are no longer needed, or were merged upstream by Qt

The remaining patches can be reviewed here:
https://github.com/qt/qtmultimedia/compare/dev...kencooke:5.12.3-hifi

Includes Debug and Release DLLs, with symbols
