### PR TITLE
Fix glitches when strafing left <-> right.

### DIFF
--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -4740,11 +4740,11 @@
                                                                                                         "children": [
                                                                                                         ],
                                                                                                         "data": {
-                                                                                                            "endFrame": 30,
+                                                                                                            "endFrame": 35,
                                                                                                             "loopFlag": true,
                                                                                                             "startFrame": 1,
                                                                                                             "timeScale": 1,
-                                                                                                            "url": "qrc:///avatar/animations/side_step_short_left.fbx"
+                                                                                                            "url": "qrc:///avatar/animations/walk_left.fbx"
                                                                                                         },
                                                                                                         "id": "strafeLeftShortStep_c",
                                                                                                         "type": "clip"
@@ -4753,11 +4753,11 @@
                                                                                                         "children": [
                                                                                                         ],
                                                                                                         "data": {
-                                                                                                            "endFrame": 20,
+                                                                                                            "endFrame": 35,
                                                                                                             "loopFlag": true,
                                                                                                             "startFrame": 1,
                                                                                                             "timeScale": 1,
-                                                                                                            "url": "qrc:///avatar/animations/side_step_left.fbx"
+                                                                                                            "url": "qrc:///avatar/animations/walk_left.fbx"
                                                                                                         },
                                                                                                         "id": "strafeLeftStep_c",
                                                                                                         "type": "clip"
@@ -4838,12 +4838,12 @@
                                                                                                         "children": [
                                                                                                         ],
                                                                                                         "data": {
-                                                                                                            "endFrame": 30,
+                                                                                                            "endFrame": 35,
                                                                                                             "loopFlag": true,
-                                                                                                            "mirrorFlag": true,
+                                                                                                            "mirrorFlag": false,
                                                                                                             "startFrame": 1,
                                                                                                             "timeScale": 1,
-                                                                                                            "url": "qrc:///avatar/animations/side_step_short_left.fbx"
+                                                                                                            "url": "qrc:///avatar/animations/walk_right.fbx"
                                                                                                         },
                                                                                                         "id": "strafeRightShortStep_c",
                                                                                                         "type": "clip"
@@ -4852,12 +4852,12 @@
                                                                                                         "children": [
                                                                                                         ],
                                                                                                         "data": {
-                                                                                                            "endFrame": 20,
+                                                                                                            "endFrame": 35,
                                                                                                             "loopFlag": true,
-                                                                                                            "mirrorFlag": true,
+                                                                                                            "mirrorFlag": false,
                                                                                                             "startFrame": 1,
                                                                                                             "timeScale": 1,
-                                                                                                            "url": "qrc:///avatar/animations/side_step_left.fbx"
+                                                                                                            "url": "qrc:///avatar/animations/walk_right.fbx"
                                                                                                         },
                                                                                                         "id": "strafeRightStep_c",
                                                                                                         "type": "clip"
@@ -5617,7 +5617,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "state": "STRAFELEFT",
-                                                                                                            "var": "isInputLeft"
+                                                                                                            "var": "isMovingLeft"
                                                                                                         },
                                                                                                         {
                                                                                                             "state": "turnRight",
@@ -5681,7 +5681,7 @@
                                                                                                         },
                                                                                                         {
                                                                                                             "state": "STRAFERIGHT",
-                                                                                                            "var": "isInputRight"
+                                                                                                            "var": "isMovingRight"
                                                                                                         },
                                                                                                         {
                                                                                                             "state": "turnRight",

--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -4746,32 +4746,6 @@
                                                                                                             "timeScale": 1,
                                                                                                             "url": "qrc:///avatar/animations/walk_left.fbx"
                                                                                                         },
-                                                                                                        "id": "strafeLeftShortStep_c",
-                                                                                                        "type": "clip"
-                                                                                                    },
-                                                                                                    {
-                                                                                                        "children": [
-                                                                                                        ],
-                                                                                                        "data": {
-                                                                                                            "endFrame": 35,
-                                                                                                            "loopFlag": true,
-                                                                                                            "startFrame": 1,
-                                                                                                            "timeScale": 1,
-                                                                                                            "url": "qrc:///avatar/animations/walk_left.fbx"
-                                                                                                        },
-                                                                                                        "id": "strafeLeftStep_c",
-                                                                                                        "type": "clip"
-                                                                                                    },
-                                                                                                    {
-                                                                                                        "children": [
-                                                                                                        ],
-                                                                                                        "data": {
-                                                                                                            "endFrame": 35,
-                                                                                                            "loopFlag": true,
-                                                                                                            "startFrame": 1,
-                                                                                                            "timeScale": 1,
-                                                                                                            "url": "qrc:///avatar/animations/walk_left.fbx"
-                                                                                                        },
                                                                                                         "id": "strafeLeftWalk_c",
                                                                                                         "type": "clip"
                                                                                                     },
@@ -4819,8 +4793,6 @@
                                                                                                     "alpha": 0,
                                                                                                     "alphaVar": "moveLateralAlpha",
                                                                                                     "characteristicSpeeds": [
-                                                                                                        0.1,
-                                                                                                        0.5,
                                                                                                         1,
                                                                                                         2.55,
                                                                                                         3.35,
@@ -4834,34 +4806,6 @@
                                                                                             },
                                                                                             {
                                                                                                 "children": [
-                                                                                                    {
-                                                                                                        "children": [
-                                                                                                        ],
-                                                                                                        "data": {
-                                                                                                            "endFrame": 35,
-                                                                                                            "loopFlag": true,
-                                                                                                            "mirrorFlag": false,
-                                                                                                            "startFrame": 1,
-                                                                                                            "timeScale": 1,
-                                                                                                            "url": "qrc:///avatar/animations/walk_right.fbx"
-                                                                                                        },
-                                                                                                        "id": "strafeRightShortStep_c",
-                                                                                                        "type": "clip"
-                                                                                                    },
-                                                                                                    {
-                                                                                                        "children": [
-                                                                                                        ],
-                                                                                                        "data": {
-                                                                                                            "endFrame": 35,
-                                                                                                            "loopFlag": true,
-                                                                                                            "mirrorFlag": false,
-                                                                                                            "startFrame": 1,
-                                                                                                            "timeScale": 1,
-                                                                                                            "url": "qrc:///avatar/animations/walk_right.fbx"
-                                                                                                        },
-                                                                                                        "id": "strafeRightStep_c",
-                                                                                                        "type": "clip"
-                                                                                                    },
                                                                                                     {
                                                                                                         "children": [
                                                                                                         ],
@@ -4923,8 +4867,6 @@
                                                                                                     "alpha": 0,
                                                                                                     "alphaVar": "moveLateralAlpha",
                                                                                                     "characteristicSpeeds": [
-                                                                                                        0.1,
-                                                                                                        0.5,
                                                                                                         1,
                                                                                                         2.55,
                                                                                                         3.4,


### PR DESCRIPTION
Change strafeleft<->straferight transitions to isMoving vars and remove the sidesteps from the blendranges.  

There were bad frames when transitioning directly between left and right strafes because the new state would enter the stack while still decelerating.  This allowed the blendrange to sample from mid speed down to zero then back up to high speed.  The lowest speed range in the strafe blendranges have the hips facing forward, so we effectivly pivoted the hips forward for a few frames as velocity passed through zero.  
Removing the steps and transitioning between strafes based on velocity improves the look dramatically.  Since we have a separate sidestep state for HMD, I believe this is safe.  Those sidesteps were a holdover.

https://highfidelity.atlassian.net/browse/DEV-2475