### PR TITLE
DEV-2475: Fix head twitching when strafing

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -906,6 +906,21 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
         updateViewBoom();
     }
 
+    // Head's look at blending needs updating
+    // before we perform rig animations and IK.
+    CameraMode mode = qApp->getCamera().getMode();
+    if (_scriptControlsHeadLookAt || mode == CAMERA_MODE_FIRST_PERSON_LOOK_AT || mode == CAMERA_MODE_FIRST_PERSON ||
+                                        mode == CAMERA_MODE_LOOK_AT || mode == CAMERA_MODE_SELFIE) {
+        if (!_pointAtActive || !_isPointTargetValid) {
+            updateHeadLookAt(deltaTime);
+        } else {
+            resetHeadLookAt();
+        }
+    } else if (_headLookAtActive) {
+        resetHeadLookAt();
+        _headLookAtActive = false;
+    }
+
     // update sensorToWorldMatrix for camera and hand controllers
     // before we perform rig animations and IK.
     updateSensorToWorldMatrix();
@@ -957,18 +972,6 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
         head->setPosition(headPosition);
         head->setScale(getModelScale());
         head->simulate(deltaTime);
-        CameraMode mode = qApp->getCamera().getMode();
-        if (_scriptControlsHeadLookAt || mode == CAMERA_MODE_FIRST_PERSON_LOOK_AT || mode == CAMERA_MODE_FIRST_PERSON ||
-                                         mode == CAMERA_MODE_LOOK_AT || mode == CAMERA_MODE_SELFIE) {
-            if (!_pointAtActive || !_isPointTargetValid) {
-                updateHeadLookAt(deltaTime);
-            } else {
-                resetHeadLookAt();
-            }
-        } else if (_headLookAtActive){
-            resetHeadLookAt();
-            _headLookAtActive = false;            
-        }
     }
 
     // Record avatars movements.

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -908,17 +908,21 @@ void MyAvatar::simulate(float deltaTime, bool inView) {
 
     // Head's look at blending needs updating
     // before we perform rig animations and IK.
-    CameraMode mode = qApp->getCamera().getMode();
-    if (_scriptControlsHeadLookAt || mode == CAMERA_MODE_FIRST_PERSON_LOOK_AT || mode == CAMERA_MODE_FIRST_PERSON ||
-                                        mode == CAMERA_MODE_LOOK_AT || mode == CAMERA_MODE_SELFIE) {
-        if (!_pointAtActive || !_isPointTargetValid) {
-            updateHeadLookAt(deltaTime);
-        } else {
+    {
+        PerformanceTimer perfTimer("lookat");
+
+        CameraMode mode = qApp->getCamera().getMode();
+        if (_scriptControlsHeadLookAt || mode == CAMERA_MODE_FIRST_PERSON_LOOK_AT || mode == CAMERA_MODE_FIRST_PERSON ||
+            mode == CAMERA_MODE_LOOK_AT || mode == CAMERA_MODE_SELFIE) {
+            if (!_pointAtActive || !_isPointTargetValid) {
+                updateHeadLookAt(deltaTime);
+            } else {
+                resetHeadLookAt();
+            }
+        } else if (_headLookAtActive) {
             resetHeadLookAt();
+            _headLookAtActive = false;
         }
-    } else if (_headLookAtActive) {
-        resetHeadLookAt();
-        _headLookAtActive = false;
     }
 
     // update sensorToWorldMatrix for camera and hand controllers


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-2475
This PR changes the order of operations when updating the avatar's head look at blending.
The bug occurred during strafing because the head was following the body rotation during one frame.
Updating the blending before the rig fixed the issue.