### PR TITLE
Fixed the sprint speeds of Desktop vs HMD

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -5205,10 +5205,9 @@ bool MyAvatar::isReadyForPhysics() const {
 
 void MyAvatar::setSprintMode(bool sprint) {
     if (qApp->isHMDMode()) {
-        _walkSpeedScalar = sprint ? AVATAR_DESKTOP_SPRINT_SPEED_SCALAR : AVATAR_WALK_SPEED_SCALAR;
-    }
-    else {
         _walkSpeedScalar = sprint ? AVATAR_HMD_SPRINT_SPEED_SCALAR : AVATAR_WALK_SPEED_SCALAR;
+    } else {
+        _walkSpeedScalar = sprint ? AVATAR_DESKTOP_SPRINT_SPEED_SCALAR : AVATAR_WALK_SPEED_SCALAR;
     }
 }
 

--- a/libraries/shared/src/AvatarConstants.h
+++ b/libraries/shared/src/AvatarConstants.h
@@ -103,7 +103,7 @@ static const float MAX_AVATAR_HEIGHT = 1000.0f * DEFAULT_AVATAR_HEIGHT; // meter
 static const float MIN_AVATAR_HEIGHT = 0.005f * DEFAULT_AVATAR_HEIGHT; // meters
 static const float MIN_AVATAR_RADIUS = 0.5f * MIN_AVATAR_HEIGHT;
 static const float AVATAR_WALK_SPEED_SCALAR = 1.0f;
-static const float AVATAR_DESKTOP_SPRINT_SPEED_SCALAR = 3.0f;
+static const float AVATAR_DESKTOP_SPRINT_SPEED_SCALAR = 2.0f;
 static const float AVATAR_HMD_SPRINT_SPEED_SCALAR = 2.0f;
 
 enum AvatarTriggerReaction {


### PR DESCRIPTION
Avatars have different sprint speeds in HMD and Desktop modes. The code that sets the speed had the values reversed.