### PR TITLE
Sign Windows installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ else()
 endif()
 
 # Use default time server if none defined in environment
-set_from_env(TIMESERVER_URL TIMESERVER_URL "http://sha256timestamp.ws.symantec.com/sha256/timestamp")
+set_from_env(TIMESERVER_URL TIMESERVER_URL "http://timestamp.digicert.com")
 
 set(HIFI_USE_OPTIMIZED_IK_OPTION OFF)
 set(BUILD_CLIENT_OPTION ON)

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -206,6 +206,9 @@
         !warning "BYPASS_SIGNING set - installer will not be signed"
       !else
         !system '"@SIGNTOOL_EXECUTABLE@" sign /fd sha256 /f %HF_PFX_FILE% /p %HF_PFX_PASSPHRASE% /tr http://timestamp.digicert.com /td SHA256 $%TEMP%\@UNINSTALLER_NAME@' = 0
+
+        ; Once the real installer is ready, sign it too
+        !finalize '"@SIGNTOOL_EXECUTABLE@" sign /fd sha256 /f %HF_PFX_FILE% /p %HF_PFX_PASSPHRASE% /tr http://timestamp.digicert.com /td SHA256 "%1"'
       !endif
     !endif
 

--- a/cmake/templates/NSIS.template.in
+++ b/cmake/templates/NSIS.template.in
@@ -205,7 +205,7 @@
       !if @BYPASS_SIGNING@ == 1
         !warning "BYPASS_SIGNING set - installer will not be signed"
       !else
-        !system '"@SIGNTOOL_EXECUTABLE@" sign /fd sha256 /f %HF_PFX_FILE% /p %HF_PFX_PASSPHRASE% /tr http://sha256timestamp.ws.symantec.com/sha256/timestamp /td SHA256 $%TEMP%\@UNINSTALLER_NAME@' = 0
+        !system '"@SIGNTOOL_EXECUTABLE@" sign /fd sha256 /f %HF_PFX_FILE% /p %HF_PFX_PASSPHRASE% /tr http://timestamp.digicert.com /td SHA256 $%TEMP%\@UNINSTALLER_NAME@' = 0
       !endif
     !endif
 

--- a/tools/ci-scripts/postbuild.py
+++ b/tools/ci-scripts/postbuild.py
@@ -137,7 +137,7 @@ def signBuild(executablePath):
             '/fd', 'sha256',
             '/f', HF_PFX_FILE,
             '/p', HF_PFX_PASSPHRASE,
-            '/tr', 'http://sha256timestamp.ws.symantec.com/sha256/timestamp',
+            '/tr', 'http://timestamp.digicert.com',
             '/td', 'SHA256',
             executablePath
         ])


### PR DESCRIPTION
When the Windows installer is built, automatically sign it. (Previously only the EXE files inside the installer were signed, e.g. interface.exe, but not the installer itself.)

Also, changed the timestamp server, because the old one will stop working on October 31st, 2019. I got an email about this: it said that the Symantec timestamp servers at  sha1timestamp.ws.symantec.com and sha256timestamp.ws.symantec.com are getting shut down, and to switch to timestamp.digicert.com.

Test plan:

1. Before this pull request: build the Windows installer. Check: a) The installer itself doesn't have a digital signature; b) The EXE files inside it (which you can see after you run the installer) do have a digital signature, and its timestamp server is called: "Symantec SHA256 TimeStamping Signer - G3"

2. After this pull request: build the installer again. Check: a) The installer **does** have a digital signature; b) The digital signatures use this timestamp server: "DigiCert SHA2 Timestamp Responder".

