### PR TITLE
In Bookmarks, attach avatar entities after the skeleton is loaded

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -349,7 +349,8 @@ MyAvatar::MyAvatar(QThread* thread) :
         }
     });
 
-    connect(&(_skeletonModel->getRig()), SIGNAL(onLoadComplete()), this, SIGNAL(onLoadComplete()));
+    connect(&(_skeletonModel->getRig()), &Rig::onLoadComplete, this, &MyAvatar::onLoadComplete);
+    connect(&(_skeletonModel->getRig()), &Rig::onLoadFailed, this, &MyAvatar::onLoadFailed);
 
     _characterController.setDensity(_density);
 }
@@ -2626,6 +2627,8 @@ void MyAvatar::useFullAvatarURL(const QUrl& fullAvatarURL, const QString& modelN
     if (urlString.isEmpty() || (fullAvatarURL != getSkeletonModelURL())) {
         setSkeletonModelURL(fullAvatarURL);
         UserActivityLogger::getInstance().changedModel("skeleton", urlString);
+    } else {
+        emit onLoadComplete();
     }
 }
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2435,9 +2435,16 @@ signals:
     /**jsdoc
      * Triggered when the avatar's model finishes loading.
      * @function MyAvatar.onLoadComplete
-     * @returns {Signal} 
+     * @returns {Signal}
      */
     void onLoadComplete();
+
+    /**jsdoc
+     * Triggered when the avatar's model has failed to load.
+     * @function MyAvatar.onLoadFailed
+     * @returns {Signal}
+     */
+    void onLoadFailed();
 
     /**jsdoc
      * Triggered when your avatar changes from being active to being away.

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -2353,6 +2353,7 @@ void Rig::initAnimGraph(const QUrl& url) {
             // abort load if the previous skeleton was deleted.
             auto sharedSkeletonPtr = weakSkeletonPtr.lock();
             if (!sharedSkeletonPtr) {
+                emit onLoadFailed();
                 return;
             }
 
@@ -2386,8 +2387,9 @@ void Rig::initAnimGraph(const QUrl& url) {
             }
             emit onLoadComplete();
         });
-        connect(_animLoader.get(), &AnimNodeLoader::error, [url](int error, QString str) {
+        connect(_animLoader.get(), &AnimNodeLoader::error, [this, url](int error, QString str) {
             qCritical(animation) << "Error loading: code = " << error << "str =" << str;
+            emit onLoadFailed();
         });
 
         connect(_networkLoader.get(), &AnimNodeLoader::success, [this, weakSkeletonPtr, networkUrl](AnimNode::Pointer nodeIn) {
@@ -2415,6 +2417,8 @@ void Rig::initAnimGraph(const QUrl& url) {
         connect(_networkLoader.get(), &AnimNodeLoader::error, [networkUrl](int error, QString str) {
             qCritical(animation) << "Error loading: code = " << error << "str =" << str;
         });
+    } else {
+        emit onLoadComplete();
     }
 }
 

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -260,6 +260,7 @@ public:
 
 signals:
     void onLoadComplete();
+    void onLoadFailed();
 
 protected:
     bool isIndexValid(int index) const { return _animSkeleton && index >= 0 && index < _animSkeleton->getNumJoints(); }


### PR DESCRIPTION
When loading an Avatar Bookmark, only attach the avatar entities after the skeleton has finished loading. Otherwise, the code that attaches the entities might use the current (old) skeleton when determining which joints to use. This is fine if both skeletons have similar joints, but if they have different joints then this can cause the avatar entities to get attached to the wrong joints.