### PR TITLE
Remove AvatarTransit log spam

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -165,9 +165,6 @@ AvatarTransit::Status AvatarTransit::update(float deltaTime, const glm::vec3& av
         _status = Status::ENDED;
     }
 
-    if (previousStatus != _status) {
-        qDebug(avatars_renderer) << "AvatarTransit " << avatarTransitStatusToStringMap[(int)previousStatus] << "->" << avatarTransitStatusToStringMap[_status];
-    }
     return _status;
 }
 


### PR DESCRIPTION
These lines should no longer appear in the logs:

    [10/02 16:43:36] [DEBUG] [hifi.avatars.rendering] AvatarTransit  PRE_TRANSIT -> END_TRANSIT

https://highfidelity.atlassian.net/browse/DEV-2298