### PR TITLE
Fix for head not turning in third person look at camera mode

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -733,7 +733,7 @@ void MyAvatar::update(float deltaTime) {
         _physicsSafetyPending = getCollisionsEnabled();
         _characterController.recomputeFlying(); // In case we've gone to into the sky.
     }
-    if (_goToFeetAjustment && _skeletonModelLoaded) {
+    if (_goToFeetAjustment && _skeletonModel->isLoaded()) {
         auto feetAjustment = getWorldPosition() - getWorldFeetPosition();
         _goToPosition = getWorldPosition() + feetAjustment;
         setWorldPosition(_goToPosition);
@@ -2501,7 +2501,6 @@ void MyAvatar::setSkeletonModelURL(const QUrl& skeletonModelURL) {
 
     _headBoneSet.clear();
     _cauterizationNeedsUpdate = true;
-    _skeletonModelLoaded = false;
 
     std::shared_ptr<QMetaObject::Connection> skeletonConnection = std::make_shared<QMetaObject::Connection>();
     *skeletonConnection = QObject::connect(_skeletonModel.get(), &SkeletonModel::skeletonLoaded, [this, skeletonModelChangeCount, skeletonConnection]() {
@@ -2520,8 +2519,6 @@ void MyAvatar::setSkeletonModelURL(const QUrl& skeletonModelURL) {
             _fstAnimGraphOverrideUrl = _skeletonModel->getGeometry()->getAnimGraphOverrideUrl();
             initAnimGraph();
             initFlowFromFST();
-
-            _skeletonModelLoaded = true;
         }
         QObject::disconnect(*skeletonConnection);
     });
@@ -6782,7 +6779,7 @@ glm::vec3 MyAvatar::aimToBlendValues(const glm::vec3& aimVector, const glm::quat
 }
 
 void MyAvatar::resetHeadLookAt() {
-    if (_skeletonModelLoaded) {
+    if (_skeletonModel->isLoaded()) {
         _skeletonModel->getRig().setDirectionalBlending(HEAD_BLEND_DIRECTIONAL_ALPHA_NAME, glm::vec3(),
                                                         HEAD_BLEND_LINEAR_ALPHA_NAME, HEAD_ALPHA_BLENDING);
     }
@@ -6798,7 +6795,7 @@ void MyAvatar::resetLookAtRotation(const glm::vec3& avatarPosition, const glm::q
 }
 
 void MyAvatar::updateHeadLookAt(float deltaTime) {    
-    if (_skeletonModelLoaded) {
+    if (_skeletonModel->isLoaded()) {
         glm::vec3 lookAtTarget = _scriptControlsHeadLookAt ? _lookAtScriptTarget : _lookAtCameraTarget;
         glm::vec3 aimVector = lookAtTarget - getDefaultEyePosition();
         glm::vec3 lookAtBlend = MyAvatar::aimToBlendValues(aimVector, getWorldOrientation());
@@ -6912,7 +6909,7 @@ bool MyAvatar::setPointAt(const glm::vec3& pointAtTarget) {
             Q_ARG(const glm::vec3&, pointAtTarget));
         return result;
     }
-    if (_skeletonModelLoaded && _pointAtActive) {
+    if (_skeletonModel->isLoaded() && _pointAtActive) {
         glm::vec3 aimVector = pointAtTarget - getJointPosition(POINT_REF_JOINT_NAME);
         _isPointTargetValid = glm::dot(aimVector, getWorldOrientation() * Vectors::FRONT) > 0.0f;
         if (_isPointTargetValid) {
@@ -6926,7 +6923,7 @@ bool MyAvatar::setPointAt(const glm::vec3& pointAtTarget) {
 }
 
 void MyAvatar::resetPointAt() {
-    if (_skeletonModelLoaded) {
+    if (_skeletonModel->isLoaded()) {
         _skeletonModel->getRig().setDirectionalBlending(POINT_BLEND_DIRECTIONAL_ALPHA_NAME, glm::vec3(),
                                                         POINT_BLEND_LINEAR_ALPHA_NAME, POINT_ALPHA_BLENDING);
     }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2918,7 +2918,6 @@ private:
 
     bool _haveReceivedHeightLimitsFromDomain { false };
     int _disableHandTouchCount { 0 };
-    bool _skeletonModelLoaded { false };
     bool _reloadAvatarEntityDataFromSettings { true };
 
     TimePoint _nextTraitsSendWindow;


### PR DESCRIPTION
If MyAvatar::setSkeletonModelURL() is called with the same url that has already been loaded the
SkeletonModel::skeletonLoaded signal will not be triggered.  In this case the MyAvatar local variable
MyAvatar::_skeletonModelLoaded will be set to false and never re-set to true.  This, in turn,
caused MyAvatar::updateHeadLookAt() to skip setting the proper blend values that would turn the head.

Rather then try to make MyAvatar::_skeletonModelLoaded handle all the possible edge cases. It has
been removed.  All conditionals that used to use it have been replaced with _skeletonModel->isLoaded().

https://highfidelity.atlassian.net/browse/DEV-2302