### PR TITLE
Fix for unused avatar transit warnings on mac and linux

### DIFF
--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -133,21 +133,7 @@ void Avatar::setShowNamesAboveHeads(bool show) {
     showNamesAboveHeads = show;
 }
 
-static const char* avatarTransitStatusToStringMap[] = {
-    "IDLE",
-    "STARTED",
-    "PRE_TRANSIT",
-    "START_TRANSIT",
-    "TRANSITING",
-    "END_TRANSIT",
-    "POST_TRANSIT",
-    "ENDED",
-    "ABORT_TRANSIT"
-};
-
 AvatarTransit::Status AvatarTransit::update(float deltaTime, const glm::vec3& avatarPosition, const AvatarTransit::TransitConfig& config) {
-    AvatarTransit::Status previousStatus = _status;
-
     float oneFrameDistance = _isActive ? glm::length(avatarPosition - _endPosition) : glm::length(avatarPosition - _lastPosition);
     if (oneFrameDistance > (config._minTriggerDistance * _scale)) {
         if (oneFrameDistance < (config._maxTriggerDistance * _scale)) {


### PR DESCRIPTION
This was introduced by PR #16403

https://github.com/highfidelity/hifi/pull/16403