### PR TITLE
case dev 2450: Wireless headphones crash due to missing device

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -542,18 +542,18 @@ QString defaultAudioDeviceName(QAudio::Mode mode) {
 
 
         OSStatus getPropertyError = AudioObjectGetPropertyData(kAudioObjectSystemObject,
-            &propertyAddress,
-            0,
-            NULL,
-            &propertySize,
-            &defaultDeviceID);
+                                                               &propertyAddress,
+                                                               0,
+                                                               NULL,
+                                                               &propertySize,
+                                                               &defaultDeviceID);
 
         if (!getPropertyError && propertySize) {
             CFStringRef devName = NULL;
             propertySize = sizeof(devName);
             propertyAddress.mSelector = kAudioDevicePropertyDeviceNameCFString;
             getPropertyError = AudioObjectGetPropertyData(defaultDeviceID, &propertyAddress, 0,
-                NULL, &propertySize, &devName);
+                                                          NULL, &propertySize, &devName);
 
             if (!getPropertyError && propertySize) {
                 deviceName = CFStringGetCStringPtr(devName, kCFStringEncodingMacRoman);

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -545,7 +545,7 @@ QString defaultAudioDeviceName(QAudio::Mode mode) {
                                                       NULL, &propertySize, &devName);
 
         if (!getPropertyError && propertySize) {
-            deviceName = CFStringGetCStringPtr(devName, kCFStringEncodingMacRoman));
+            deviceName = CFStringGetCStringPtr(devName, kCFStringEncodingMacRoman);
             }
         }
 #endif

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -117,14 +117,13 @@ QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode) {
         } 
     }
 
-    if (!defaultDesktopDevice.getDevice().isNull()) {
-        newDevices.push_front(defaultDesktopDevice);
-    } else {
-        qCDebug(audioclient) << __FUNCTION__ << "Default device not found in list:" << defDeviceName 
+    if (defaultDesktopDevice.getDevice().isNull()) {
+        qCDebug(audioclient) << __FUNCTION__ << "Default device not found in list:" << defDeviceName
             << "Setting Default to: " << devices.first().deviceName();
         defaultDesktopDevice = HifiAudioDeviceInfo(devices.first(), true, mode, HifiAudioDeviceInfo::desktop);
     }
-  
+    newDevices.push_front(defaultDesktopDevice);
+    
     if (!hmdDeviceName.isNull() && !hmdDeviceName.isEmpty()) {
         HifiAudioDeviceInfo hmdDevice;
         foreach(auto device, newDevices) {

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -517,40 +517,37 @@ QString defaultAudioDeviceName(QAudio::Mode mode) {
     QString deviceName;
 
 #ifdef __APPLE__
-    if (devices.size() > 1) {
-        AudioDeviceID defaultDeviceID = 0;
-        uint32_t propertySize = sizeof(AudioDeviceID);
-        AudioObjectPropertyAddress propertyAddress = {
-            kAudioHardwarePropertyDefaultInputDevice,
-            kAudioObjectPropertyScopeGlobal,
-            kAudioObjectPropertyElementMaster
-        };
+    AudioDeviceID defaultDeviceID = 0;
+    uint32_t propertySize = sizeof(AudioDeviceID);
+    AudioObjectPropertyAddress propertyAddress = {
+        kAudioHardwarePropertyDefaultInputDevice,
+        kAudioObjectPropertyScopeGlobal,
+        kAudioObjectPropertyElementMaster
+    };
 
-        if (mode == QAudio::AudioOutput) {
-            propertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
-        }
+    if (mode == QAudio::AudioOutput) {
+        propertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
+    }
 
 
-        OSStatus getPropertyError = AudioObjectGetPropertyData(kAudioObjectSystemObject,
-                                                               &propertyAddress,
-                                                               0,
-                                                               NULL,
-                                                               &propertySize,
-                                                               &defaultDeviceID);
+    OSStatus getPropertyError = AudioObjectGetPropertyData(kAudioObjectSystemObject,
+                                                           &propertyAddress,
+                                                           0,
+                                                           NULL,
+                                                           &propertySize,
+                                                           &defaultDeviceID);
+
+    if (!getPropertyError && propertySize) {
+        CFStringRef devName = NULL;
+        propertySize = sizeof(devName);
+        propertyAddress.mSelector = kAudioDevicePropertyDeviceNameCFString;
+        getPropertyError = AudioObjectGetPropertyData(defaultDeviceID, &propertyAddress, 0,
+                                                      NULL, &propertySize, &devName);
 
         if (!getPropertyError && propertySize) {
-            CFStringRef deviceName = NULL;
-            propertySize = sizeof(deviceName);
-            propertyAddress.mSelector = kAudioDevicePropertyDeviceNameCFString;
-            getPropertyError = AudioObjectGetPropertyData(defaultDeviceID, &propertyAddress, 0,
-                                                          NULL, &propertySize, &deviceName);
-
-            if (!getPropertyError && propertySize) {
-                deviceName = CFStringGetCStringPtr(deviceName, kCFStringEncodingMacRoman));
-                }
+            deviceName = CFStringGetCStringPtr(devName, kCFStringEncodingMacRoman));
             }
         }
-    }
 #endif
 #ifdef WIN32
     //Check for Windows Vista or higher, IMMDeviceEnumerator doesn't work below that.

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -81,7 +81,7 @@ using Lock = std::unique_lock<Mutex>;
 Mutex _deviceMutex;
 Mutex _recordMutex;
 
-HifiAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode);
+QString defaultAudioDeviceName(QAudio::Mode mode);
 
 static QString getHmdAudioDeviceName(QAudio::Mode mode) {
     foreach(DisplayPluginPointer displayPlugin, PluginManager::getInstance()->getAllDisplayPlugins()) {
@@ -102,18 +102,29 @@ QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode) {
     //get hmd device name prior to locking device mutex. in case of shutdown, this thread will be locked and audio client
     //cannot properly shut down. 
     QString hmdDeviceName = getHmdAudioDeviceName(mode);
+    QString defDeviceName = defaultAudioDeviceName(mode);
 
     // NOTE: availableDevices() clobbers the Qt internal device list
     Lock lock(_deviceMutex);
     auto devices = QAudioDeviceInfo::availableDevices(mode);
-
+   
+    HifiAudioDeviceInfo defaultDesktopDevice;
     QList<HifiAudioDeviceInfo> newDevices;
     for (auto& device : devices) {
         newDevices.push_back(HifiAudioDeviceInfo(device, false, mode));
+        if (device.deviceName() == defDeviceName.trimmed()) {
+            defaultDesktopDevice = HifiAudioDeviceInfo(device, true, mode, HifiAudioDeviceInfo::desktop);
+        } 
     }
-    
-    newDevices.push_front(defaultAudioDeviceForMode(mode));
-   
+
+    if (!defaultDesktopDevice.getDevice().isNull()) {
+        newDevices.push_front(defaultDesktopDevice);
+    } else {
+        qCDebug(audioclient) << __FUNCTION__ << "Default device not found in list:" << defDeviceName 
+            << "Setting Default to: " << devices.first().deviceName();
+        defaultDesktopDevice = HifiAudioDeviceInfo(devices.first(), true, mode, HifiAudioDeviceInfo::desktop);
+    }
+  
     if (!hmdDeviceName.isNull() && !hmdDeviceName.isEmpty()) {
         HifiAudioDeviceInfo hmdDevice;
         foreach(auto device, newDevices) {
@@ -484,8 +495,27 @@ QString AudioClient::getWinDeviceName(wchar_t* guid) {
 #endif
 
 HifiAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode) {
-    QList<QAudioDeviceInfo> devices = QAudioDeviceInfo::availableDevices(mode);
-    
+    QString deviceName = defaultAudioDeviceName(mode);
+#if defined (Q_OS_ANDROID)
+    if (mode == QAudio::AudioInput) {
+        Setting::Handle<bool> enableAEC(SETTING_AEC_KEY, DEFAULT_AEC_ENABLED);
+        bool aecEnabled = enableAEC.get();
+        auto audioClient = DependencyManager::get<AudioClient>();
+        bool headsetOn = audioClient ? audioClient->isHeadsetPluggedIn() : false;
+        for (QAudioDeviceInfo inputDevice : devices) {
+            if (((headsetOn || !aecEnabled) && inputDevice.deviceName() == VOICE_RECOGNITION) ||
+                ((!headsetOn && aecEnabled) && inputDevice.deviceName() == VOICE_COMMUNICATION)) {
+                return HifiAudioDeviceInfo(inputDevice, false, QAudio::AudioInput);
+            }
+        }
+    }
+#endif
+    return getNamedAudioDeviceForMode(mode, deviceName);
+}
+
+QString defaultAudioDeviceName(QAudio::Mode mode) {
+    QString deviceName;
+
 #ifdef __APPLE__
     if (devices.size() > 1) {
         AudioDeviceID defaultDeviceID = 0;
@@ -516,18 +546,13 @@ HifiAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode) {
                                                           NULL, &propertySize, &deviceName);
 
             if (!getPropertyError && propertySize) {
-                // find a device in the list that matches the name we have and return it
-                foreach(QAudioDeviceInfo audioDevice, devices){
-                    if (audioDevice.deviceName() == CFStringGetCStringPtr(deviceName, kCFStringEncodingMacRoman)) {
-                        return HifiAudioDeviceInfo(audioDevice, true, mode, HifiAudioDeviceInfo::desktop);
-                    }
+                deviceName = CFStringGetCStringPtr(deviceName, kCFStringEncodingMacRoman));
                 }
             }
         }
     }
 #endif
 #ifdef WIN32
-    QString deviceName;
     //Check for Windows Vista or higher, IMMDeviceEnumerator doesn't work below that.
     if (!IsWindowsVistaOrGreater()) { // lower then vista
         if (mode == QAudio::AudioInput) {
@@ -571,37 +596,13 @@ HifiAudioDeviceInfo defaultAudioDeviceForMode(QAudio::Mode mode) {
         CoUninitialize();
     }
 
-    HifiAudioDeviceInfo foundDevice;
-    foreach(QAudioDeviceInfo audioDevice, devices) {
-        if (audioDevice.deviceName().trimmed() == deviceName.trimmed()) {
-            foundDevice = HifiAudioDeviceInfo(audioDevice, true, mode, HifiAudioDeviceInfo::desktop);
-            break;
-        }
-    }
 #if !defined(NDEBUG) 
     qCDebug(audioclient) << "defaultAudioDeviceForMode mode: " << (mode == QAudio::AudioOutput ? "Output" : "Input") 
-	<< " [" << deviceName << "] [" << foundDevice.deviceName() << "]";
-#endif
-    return foundDevice;
+	<< " [" << deviceName << "] [" << "]";
 #endif
 
-#if defined (Q_OS_ANDROID)
-    if (mode == QAudio::AudioInput) {
-        Setting::Handle<bool> enableAEC(SETTING_AEC_KEY, DEFAULT_AEC_ENABLED);
-        bool aecEnabled = enableAEC.get();
-        auto audioClient = DependencyManager::get<AudioClient>();
-        bool headsetOn = audioClient ? audioClient->isHeadsetPluggedIn() : false;
-        for (QAudioDeviceInfo inputDevice : devices) {
-            if (((headsetOn || !aecEnabled) && inputDevice.deviceName() == VOICE_RECOGNITION) ||
-                   ((!headsetOn && aecEnabled) && inputDevice.deviceName() == VOICE_COMMUNICATION)) {
-                return HifiAudioDeviceInfo(inputDevice, false, QAudio::AudioInput); 
-            }
-        }
-    }
 #endif
-    // fallback for failed lookup is the default device
-    return (mode == QAudio::AudioInput) ? HifiAudioDeviceInfo(QAudioDeviceInfo::defaultInputDevice(), true, mode, HifiAudioDeviceInfo::desktop) : 
-        HifiAudioDeviceInfo(QAudioDeviceInfo::defaultOutputDevice(), true, mode, HifiAudioDeviceInfo::desktop);
+   return deviceName;
 }
 
 bool AudioClient::getNamedAudioDeviceForModeExists(QAudio::Mode mode, const QString& deviceName) {


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-2450

Found that the audio device list sometimes (when hot plugging/unplugging) a wireless device will create a null HifiAudioDeviceInfo object because the Qt list is stale.  

During testing for airpods under same situation, found that getting device name returns null at times. Qt's implementation of defaultInput/output device seemed to be more reliable than our existing platform code. 
Decoupled getting a device from getting a device name from platform code. This reduced one call to availableDevices from qt in the process.