### PR TITLE
DEV-1828: hifi_vcpkg.py crashes try downloading not defined qt url on an unknown linux system or unknown operating system

### DIFF
--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -273,8 +273,10 @@ endif()
                     url = 'https://hifi-public.s3.amazonaws.com/dependencies/vcpkg/qt5-install-5.12.3-ubuntu-18.04.tar.gz'
                 else:
                     print('UNKNOWN LINUX VERSION!!!')
+                    return;
             else:
                 print('UNKNOWN OPERATING SYSTEM!!!')
+                return;
 
             print('Extracting ' + url + ' to ' + dest)
             hifi_utils.downloadAndExtract(url, dest)


### PR DESCRIPTION
Ticket - https://highfidelity.atlassian.net/browse/DEV-1828