### PR TITLE
temp reverting the call to display plugin

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -83,25 +83,11 @@ Mutex _recordMutex;
 
 QString defaultAudioDeviceName(QAudio::Mode mode);
 
-static QString getHmdAudioDeviceName(QAudio::Mode mode) {
-    foreach(DisplayPluginPointer displayPlugin, PluginManager::getInstance()->getAllDisplayPlugins()) {
-        if (displayPlugin && displayPlugin->isHmd()) {
-            if (mode == QAudio::AudioInput) {
-                return displayPlugin->getPreferredAudioInDevice();
-            } else {
-                return displayPlugin->getPreferredAudioOutDevice();
-            }
-            break;
-        }
-    }
-    return QString();
-}
-
 // thread-safe
 QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode) {
     //get hmd device name prior to locking device mutex. in case of shutdown, this thread will be locked and audio client
     //cannot properly shut down. 
-    QString hmdDeviceName = QString(); //getHmdAudioDeviceName(mode);
+    QString hmdDeviceName = QString();
     QString defDeviceName = defaultAudioDeviceName(mode);
 
     // NOTE: availableDevices() clobbers the Qt internal device list

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -101,7 +101,7 @@ static QString getHmdAudioDeviceName(QAudio::Mode mode) {
 QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode) {
     //get hmd device name prior to locking device mutex. in case of shutdown, this thread will be locked and audio client
     //cannot properly shut down. 
-    QString hmdDeviceName = getHmdAudioDeviceName(mode);
+    QString hmdDeviceName = QString(); //getHmdAudioDeviceName(mode);
     QString defDeviceName = defaultAudioDeviceName(mode);
 
     // NOTE: availableDevices() clobbers the Qt internal device list


### PR DESCRIPTION
Reverting call to display plugin from audio client until a better alternative is implemented that does not cause a shutdown lock