### PR TITLE
DEV-2619: WebRTC spamming logs

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1187,12 +1187,12 @@ void AudioClient::processWebrtcFarEnd(const int16_t* samples, int numFrames, int
     const webrtc::StreamConfig streamConfig = webrtc::StreamConfig(sampleRate, numChannels);
     const int numChunk = (int)streamConfig.num_frames();
 
-    if (sampleRate > WEBRTC_SAMPLE_RATE_MAX) {
-        qCWarning(audioclient) << "WebRTC does not support" << sampleRate << "output sample rate.";
-        return;
-    }
-    if (numChannels > WEBRTC_CHANNELS_MAX) {
-        qCWarning(audioclient) << "WebRTC does not support" << numChannels << "output channels.";
+    static int32_t lastWarningHash = 0;
+    if (sampleRate > WEBRTC_SAMPLE_RATE_MAX || numChannels > WEBRTC_CHANNELS_MAX) {
+        if (lastWarningHash != ((sampleRate << 8) | numChannels)) {
+            lastWarningHash = ((sampleRate << 8) | numChannels);
+            qCWarning(audioclient) << "AEC not unsupported for output format: sampleRate =" << sampleRate << "numChannels =" << numChannels;
+        }
         return;
     }
 
@@ -1228,17 +1228,14 @@ void AudioClient::processWebrtcNearEnd(int16_t* samples, int numFrames, int numC
 
     const webrtc::StreamConfig streamConfig = webrtc::StreamConfig(sampleRate, numChannels);
     const int numChunk = (int)streamConfig.num_frames();
+    assert(numFrames == chunk); // WebRTC requires exactly 10ms of input
 
-    if (sampleRate > WEBRTC_SAMPLE_RATE_MAX) {
-        qCWarning(audioclient) << "WebRTC does not support" << sampleRate << "input sample rate.";
-        return;
-    }
-    if (numChannels > WEBRTC_CHANNELS_MAX) {
-        qCWarning(audioclient) << "WebRTC does not support" << numChannels << "input channels.";
-        return;
-    }
-    if (numFrames != numChunk) {
-        qCWarning(audioclient) << "WebRTC requires exactly 10ms of input.";
+    static int32_t lastWarningHash = 0;
+    if (sampleRate > WEBRTC_SAMPLE_RATE_MAX || numChannels > WEBRTC_CHANNELS_MAX) {
+        if (lastWarningHash != ((sampleRate << 8) | numChannels)) {
+            lastWarningHash = ((sampleRate << 8) | numChannels);
+            qCWarning(audioclient) << "AEC not unsupported for input format: sampleRate =" << sampleRate << "numChannels =" << numChannels;
+        }
         return;
     }
 

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1227,8 +1227,7 @@ void AudioClient::processWebrtcFarEnd(const int16_t* samples, int numFrames, int
 void AudioClient::processWebrtcNearEnd(int16_t* samples, int numFrames, int numChannels, int sampleRate) {
 
     const webrtc::StreamConfig streamConfig = webrtc::StreamConfig(sampleRate, numChannels);
-    const int numChunk = (int)streamConfig.num_frames();
-    assert(numFrames == chunk); // WebRTC requires exactly 10ms of input
+    assert(numFrames == (int)streamConfig.num_frames());    // WebRTC requires exactly 10ms of input
 
     static int32_t lastWarningHash = 0;
     if (sampleRate > WEBRTC_SAMPLE_RATE_MAX || numChannels > WEBRTC_CHANNELS_MAX) {


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-2619
https://highfidelity.atlassian.net/browse/DEV-2605

It has diagnostic value to log a warning when AEC is disabled due to unsupported audio device configuration (in this case, 3-channel microphone and 192khz sample rate).

This PR logs only a single warning (per audio device configuration) to prevent log spam.