### PR TITLE
Implement DEV-2654: Allow ESS to make use of signals like `avatarRemovedEvent`

### DIFF
--- a/assignment-client/src/avatars/AvatarMixer.cpp
+++ b/assignment-client/src/avatars/AvatarMixer.cpp
@@ -512,10 +512,10 @@ void AvatarMixer::handleAvatarKilled(SharedNodePointer avatarNode) {
             // we relay avatar kill packets to agents that are not upstream
             // and downstream avatar mixers, if the node that was just killed was being replicatedConnectedAgent
             return node->getActiveSocket() &&
-                ((node->getType() == NodeType::Agent && !node->isUpstream()) ||
+                (((node->getType() == NodeType::Agent || node->getType() == NodeType::EntityScriptServer) && !node->isUpstream()) ||
                  (avatarNode->isReplicated() && shouldReplicateTo(*avatarNode, *node)));
         }, [&](const SharedNodePointer& node) {
-            if (node->getType() == NodeType::Agent) {
+            if (node->getType() == NodeType::Agent || node->getType() == NodeType::EntityScriptServer) {
                 if (!killPacket) {
                     killPacket = NLPacket::create(PacketType::KillAvatar, NUM_BYTES_RFC4122_UUID + sizeof(KillAvatarReason), true);
                     killPacket->write(avatarNode->getUUID().toRfc4122());

--- a/libraries/avatars/src/AvatarHashMap.h
+++ b/libraries/avatars/src/AvatarHashMap.h
@@ -44,6 +44,7 @@ const quint64 MIN_TIME_BETWEEN_MY_AVATAR_DATA_SENDS = USECS_PER_SECOND / CLIENT_
  * @namespace AvatarList
  *
  * @hifi-assignment-client
+ * @hifi-server-entity
  */
 
 class AvatarReplicas {


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-2654

This is happening because I missed some code when writing [this PR](https://github.com/highfidelity/hifi/pull/16387), which was meant to resolve DEV-257.

It's possible I've missed some other edge cases here that prevent the ESS from having full access to all functionality of the `AvatarHashMap`, but hey, one step at a time.