### PR TITLE
Renaming the env variable to enable Material Procedural Shaders

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -471,9 +471,9 @@ Menu::Menu() {
     addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::ComputeBlendshapes, 0, true,
         DependencyManager::get<ModelBlender>().data(), SLOT(setComputeBlendshapes(bool)));
 
-    action = addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::MeshShaders, 0, false);
+    action = addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::MaterialProceduralShaders, 0, false);
     connect(action, &QAction::triggered, [action] {
-        MeshPartPayload::enableMeshShaders = action->isChecked();
+        MeshPartPayload::enableMaterialProceduralShaders = action->isChecked();
     });
 
     {

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -228,7 +228,7 @@ namespace MenuOption {
     const QString ForceCoarsePicking = "Force Coarse Picking";
     const QString ComputeBlendshapes = "Compute Blendshapes";
     const QString HighlightTransitions = "Highlight Transitions";
-    const QString MeshShaders = "Enable Procedural Materials on Meshes";
+    const QString MaterialProceduralShaders = "Enable Procedural Materials";
 }
 
 #endif // hifi_Menu_h

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -103,15 +103,15 @@ void setupPreferences() {
         preference->setItems(refreshRateProfiles);
         preferences->addPreference(preference);
 
-        auto getterMeshShaders = []() -> bool {
+        auto getterMaterialProceduralShaders = []() -> bool {
             auto menu = Menu::getInstance();
-            return menu->isOptionChecked(MenuOption::MeshShaders);
+            return menu->isOptionChecked(MenuOption::MaterialProceduralShaders);
         };
-        auto setterMeshShaders = [](bool value) {
+        auto setterMaterialProceduralShaders = [](bool value) {
             auto menu = Menu::getInstance();
-            menu->setIsOptionChecked(MenuOption::MeshShaders, value);
+            menu->setIsOptionChecked(MenuOption::MaterialProceduralShaders, value);
         };
-        preferences->addPreference(new CheckPreference(GRAPHICS_QUALITY, "Enable Procedural Materials on Meshes", getterMeshShaders, setterMeshShaders));
+        preferences->addPreference(new CheckPreference(GRAPHICS_QUALITY, "Enable Procedural Materials", getterMaterialProceduralShaders, setterMaterialProceduralShaders));
     }
     {
         // Expose the Viewport Resolution Scale

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -23,10 +23,10 @@
 
 #include "RenderPipelines.h"
 
-static const QString ENABLE_MESH_SHADERS_STRING { "HIFI_ENABLE_MESH_SHADERS" };
-static bool ENABLE_MESH_SHADERS = QProcessEnvironment::systemEnvironment().contains(ENABLE_MESH_SHADERS_STRING);
+static const QString ENABLE_MATERIAL_PROCEDURAL_SHADERS_STRING { "HIFI_ENABLE_MATERIAL_PROCEDURAL_SHADERS" };
+static bool ENABLE_MATERIAL_PROCEDURAL_SHADERS = QProcessEnvironment::systemEnvironment().contains(ENABLE_MATERIAL_PROCEDURAL_SHADERS_STRING);
 
-bool MeshPartPayload::enableMeshShaders = false;
+bool MeshPartPayload::enableMaterialProceduralShaders = false;
 
 using namespace render;
 
@@ -471,7 +471,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
 
     if (!_drawMaterials.empty() && _drawMaterials.top().material && _drawMaterials.top().material->isProcedural() &&
             _drawMaterials.top().material->isReady()) {
-        if (!(enableMeshShaders && ENABLE_MESH_SHADERS)) {
+        if (!(enableMaterialProceduralShaders && ENABLE_MATERIAL_PROCEDURAL_SHADERS)) {
             return;
         }
         auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(_drawMaterials.top().material);

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -73,7 +73,7 @@ public:
     void addMaterial(graphics::MaterialLayer material);
     void removeMaterial(graphics::MaterialPointer material);
 
-    static bool enableMeshShaders;
+    static bool enableMaterialProceduralShaders;
 
 protected:
     render::ItemKey _itemKey{ render::ItemKey::Builder::opaqueShape().build() };


### PR DESCRIPTION
Refining the name we used to describe the feature "MaterialProceduralShaders"