### PR TITLE
case dev-2662: removing double calls to switch devices, handling default changes fro…

### DIFF
--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -395,7 +395,6 @@ void AudioDeviceList::onDevicesChanged(QAudio::Mode mode, const QList<HifiAudioD
     if (_selectedDesktopDevice.isDefault() && _selectedDesktopDevice != oldDesktopDevice) {
         emit selectedDevicePlugged(_selectedDesktopDevice, false);
     }
-    
 }
 
 bool AudioInputDeviceList::peakValuesAvailable() {

--- a/interface/src/scripting/AudioDevices.cpp
+++ b/interface/src/scripting/AudioDevices.cpp
@@ -350,7 +350,8 @@ void AudioDeviceList::onDevicesChanged(QAudio::Mode mode, const QList<HifiAudioD
 
             if (!isSelected) {
                 if (selectedDevice.isDefault() && device.info.isDefault()) {
-                    if ((isHMD && device.info.getDeviceType() != HifiAudioDeviceInfo::desktop) || (!isHMD && device.info.getDeviceType() != HifiAudioDeviceInfo::hmd)) {
+                    if ((isHMD && device.info.getDeviceType() != HifiAudioDeviceInfo::desktop) || 
+                        (!isHMD && device.info.getDeviceType() != HifiAudioDeviceInfo::hmd)) {
                         selectedDevice = device.info;
                         isSelected = true;
                     }
@@ -388,7 +389,7 @@ void AudioDeviceList::onDevicesChanged(QAudio::Mode mode, const QList<HifiAudioD
     endResetModel();
     
     if (_selectedHMDDevice.isDefault() && _selectedHMDDevice != oldHmdDevice) {
-        emit selectedDevicePlugged(_selectedHMDDevice,true);
+        emit selectedDevicePlugged(_selectedHMDDevice, true);
     }
 
     if (_selectedDesktopDevice.isDefault() && _selectedDesktopDevice != oldDesktopDevice) {

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -324,12 +324,10 @@ AudioClient::AudioClient() {
 
     connect(&_receivedAudioStream, &InboundAudioStream::mismatchedAudioCodec, this, &AudioClient::handleMismatchAudioFormat);
 
-    {
-        QReadLocker readLock(&_hmdNameLock);
-        // initialize wasapi; if getAvailableDevices is called from the CheckDevicesThread before this, it will crash
-        getAvailableDevices(QAudio::AudioInput, _hmdInputName);
-        getAvailableDevices(QAudio::AudioOutput, _hmdOutputName);
-    }
+    // initialize wasapi; if getAvailableDevices is called from the CheckDevicesThread before this, it will crash
+    getAvailableDevices(QAudio::AudioInput, QString());
+    getAvailableDevices(QAudio::AudioOutput, QString());
+    
     // start a thread to detect any device changes
     _checkDevicesTimer = new QTimer(this);
     const unsigned long DEVICE_CHECK_INTERVAL_MSECS = 2 * 1000;

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -237,8 +237,6 @@ public slots:
     int setOutputBufferSize(int numFrames, bool persist = true);
 
     bool shouldLoopbackInjectors() override { return _shouldEchoToServer; }
-    Q_INVOKABLE void changeDefault(HifiAudioDeviceInfo newDefault, QAudio::Mode mode);
-    void checkDefaultChanges(QList<HifiAudioDeviceInfo>& devices);
 
     // calling with a null QAudioDevice will use the system default
     bool switchAudioDevice(QAudio::Mode mode, const HifiAudioDeviceInfo& deviceInfo = HifiAudioDeviceInfo());

--- a/libraries/audio-client/src/HifiAudioDeviceInfo.cpp
+++ b/libraries/audio-client/src/HifiAudioDeviceInfo.cpp
@@ -23,6 +23,7 @@ HifiAudioDeviceInfo& HifiAudioDeviceInfo::operator=(const HifiAudioDeviceInfo& o
     _mode = other.getMode();
     _isDefault = other.isDefault();
     _deviceType = other.getDeviceType();
+    _debugName = other.getDevice().deviceName();
     return *this;
 }
 

--- a/libraries/audio-client/src/HifiAudioDeviceInfo.h
+++ b/libraries/audio-client/src/HifiAudioDeviceInfo.h
@@ -35,13 +35,15 @@ public:
         _mode = deviceInfo.getMode();
         _isDefault = deviceInfo.isDefault();
         _deviceType = deviceInfo.getDeviceType();
+        _debugName = deviceInfo.getDevice().deviceName();
     }
 
     HifiAudioDeviceInfo(QAudioDeviceInfo deviceInfo, bool isDefault, QAudio::Mode mode, DeviceType devType=both) :
         _audioDeviceInfo(deviceInfo),
         _isDefault(isDefault),
         _mode(mode),
-        _deviceType(devType){
+        _deviceType(devType),
+        _debugName(deviceInfo.deviceName()) {
     }
     
     void setMode(QAudio::Mode mode) { _mode = mode; }
@@ -70,6 +72,7 @@ private:
     bool _isDefault { false };
     QAudio::Mode _mode { QAudio::AudioInput };
     DeviceType _deviceType{ both };
+    QString _debugName;
 
 public:
     static const QString DEFAULT_DEVICE_NAME;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-2662

Moved default device switching to scripting interface. When devices list is switched the scripting interface will automatically fire a call to change device which was causing double calls if defaults changed. Moved logic to determine if defaults have changed to the scripting interface. 