### PR TITLE
Oculus Quest: Fix for the hand controllers in the latest version

### DIFF
--- a/android/apps/questInterface/src/main/AndroidManifest.xml
+++ b/android/apps/questInterface/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-feature android:name="android.hardware.sensor.gyroscope" android:required="true"/>
     <uses-feature android:name="android.software.vr.mode" android:required="true"/>
     <uses-feature android:name="android.hardware.vr.high_performance" android:required="true"/>
+    <uses-feature android:name="android.hardware.vr.headtracking" android:version="1" android:required="true" />
 
     <application
         android:name="org.qtproject.qt5.android.bindings.QtApplication"


### PR DESCRIPTION
PR contains fix for the following issue: https://highfidelity.canny.io/bugs/p/oculus-quest-controllers-update-needed

I've tested the change in the AndroidManifest.xml and it let me use both my hands on the Quest. Without this 6DOF fix it will assume that the user is holding a Oculus GearVR remote controller.

See more info about this issue at:
- https://developer.oculus.com/documentation/quest/latest/concepts/mobile-native-manifest/?fbclid=IwAR3AgasGPJFVGsz7lyzfJNfuTB8R1FOg88Quq8YZz67eQlwEFvgEMDGjSdo
- https://developers.google.com/vr/develop/android/3dof-to-6dof


### Testing
- use an oculus quest
- without this PR your hands are bound together and only one of the controllers responds.
- with this PR your hands should be separate and both of the quest controllers should respond.