### PR TITLE
Speculative fix for infinite loop in SafeLanding

### DIFF
--- a/interface/src/octree/SafeLanding.cpp
+++ b/interface/src/octree/SafeLanding.cpp
@@ -151,7 +151,7 @@ void SafeLanding::updateTracking() {
             shouldStop = (sequenceSize == 0 ||
                     (startIter != _sequenceNumbers.end() &&
                      endIter != _sequenceNumbers.end() &&
-                     !tooManySequenceNumbers &&
+                     tooManySequenceNumbers &&
                      ((distance(startIter, endIter) == sequenceSize - 1) || !missingSequenceNumbers)));
 
             if (shouldStop) {

--- a/interface/src/octree/SafeLanding.h
+++ b/interface/src/octree/SafeLanding.h
@@ -51,8 +51,8 @@ private:
     bool isEntityPhysicsReady(const EntityItemPointer& entity);
     void debugDumpSequenceIDs() const;
 
-    std::mutex _lock;
-    using Locker = std::lock_guard<std::mutex>;
+    mutable std::recursive_mutex _lock;
+    using Locker = std::lock_guard<std::recursive_mutex>;
     bool _trackingEntities { false };
     QSharedPointer<EntityTreeRenderer> _entityTreeRenderer;
     using EntityMap = std::map<EntityItemID, EntityItemPointer>;


### PR DESCRIPTION
This PR contains two fixes.

1) Tightening up the locks in the SafeLanding class to prevent race conditions.
By inspection there are cases where variables are read and modified outside of locks.

2) A check to help prevent an infinite loop in the _sequenceNumber std::distance calculation. This is the main issue, in some cases backtrace is reporting the main thread as deadlocked. The stacktrace points to an issue with the std::distance() calculation. If the EntityQueryInitialResultsComplete is delayed significantly, there could be a rare case where the _sequenceNumber map grows large enough for the wraparound less then operator will no longer function correctly. This will cause the std::distance calculation to never complete. I've added a guard to prevent this from happening and some logs to help diagnose this issue in the future.

https://highfidelity.atlassian.net/browse/DEV-825