### PR TITLE
case dev-2663: Adding safeguard in case device list is empty

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -114,7 +114,7 @@ QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode, const QString&
         if (devices.size() > 0) {
             qCDebug(audioclient) << __FUNCTION__ << "Default device not found in list:" << defDeviceName
                 << "Setting Default to: " << devices.first().deviceName();
-            defaultDesktopDevice = HifiAudioDeviceInfo(devices.first(), true, mode, HifiAudioDeviceInfo::desktop);
+            newDevices.push_front(HifiAudioDeviceInfo(devices.first(), true, mode, HifiAudioDeviceInfo::desktop));
         } else {
             //current audio list is empty for some reason.
             qCDebug(audioclient) << __FUNCTION__ << "Default device not found in list no alternative selection available";

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -111,11 +111,17 @@ QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode, const QString&
     }
 
     if (defaultDesktopDevice.getDevice().isNull()) {
-        qCDebug(audioclient) << __FUNCTION__ << "Default device not found in list:" << defDeviceName
-            << "Setting Default to: " << devices.first().deviceName();
-        defaultDesktopDevice = HifiAudioDeviceInfo(devices.first(), true, mode, HifiAudioDeviceInfo::desktop);
+        if (devices.size() > 0) {
+            qCDebug(audioclient) << __FUNCTION__ << "Default device not found in list:" << defDeviceName
+                << "Setting Default to: " << devices.first().deviceName();
+            defaultDesktopDevice = HifiAudioDeviceInfo(devices.first(), true, mode, HifiAudioDeviceInfo::desktop);
+        } else {
+            //current audio list is empty for some reason.
+            qCDebug(audioclient) << __FUNCTION__ << "Default device not found in list no alternative selection available";
+        }
+    } else {
+        newDevices.push_front(defaultDesktopDevice);
     }
-    newDevices.push_front(defaultDesktopDevice);
 
     if (!hmdName.isNull()) {
         HifiAudioDeviceInfo hmdDevice;


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-2663

This one may be hard to reproduce but Andrew ran into this scenario. Unless his headphones are  plugged in seems like the device list is empty. this pr adds a safeguard to make sure we are enumerating an object in a populated list.