### PR TITLE
Fix HMD strafe locomotion animation.

### DIFF
--- a/interface/resources/avatar/avatar-animation.json
+++ b/interface/resources/avatar/avatar-animation.json
@@ -5995,14 +5995,6 @@
                                                                                                             "var": "isInAirRun"
                                                                                                         },
                                                                                                         {
-                                                                                                            "state": "strafeRightHmd",
-                                                                                                            "var": "isMovingRightHmd"
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "state": "strafeLeftHmd",
-                                                                                                            "var": "isMovingLeftHmd"
-                                                                                                        },
-                                                                                                        {
                                                                                                             "state": "seated",
                                                                                                             "var": "isSeated"
                                                                                                         }
@@ -6061,14 +6053,6 @@
                                                                                                         {
                                                                                                             "state": "INAIRRUN",
                                                                                                             "var": "isInAirRun"
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "state": "strafeRightHmd",
-                                                                                                            "var": "isMovingRightHmd"
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "state": "strafeLeftHmd",
-                                                                                                            "var": "isMovingLeftHmd"
                                                                                                         },
                                                                                                         {
                                                                                                             "state": "seated",
@@ -6214,7 +6198,7 @@
                                                                                                     "transitions": [
                                                                                                         {
                                                                                                             "state": "idleSettle",
-                                                                                                            "var": "isNotInput"
+                                                                                                            "var": "isNotMoving"
                                                                                                         },
                                                                                                         {
                                                                                                             "state": "WALKFWD",
@@ -6227,14 +6211,6 @@
                                                                                                         {
                                                                                                             "state": "strafeLeftHmd",
                                                                                                             "var": "isMovingLeftHmd"
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "state": "STRAFERIGHT",
-                                                                                                            "var": "isInputRight"
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "state": "STRAFELEFT",
-                                                                                                            "var": "isInputLeft"
                                                                                                         },
                                                                                                         {
                                                                                                             "state": "turnRight",
@@ -6278,7 +6254,7 @@
                                                                                                     "transitions": [
                                                                                                         {
                                                                                                             "state": "idleSettle",
-                                                                                                            "var": "isNotInput"
+                                                                                                            "var": "isNotMoving"
                                                                                                         },
                                                                                                         {
                                                                                                             "state": "WALKFWD",
@@ -6291,14 +6267,6 @@
                                                                                                         {
                                                                                                             "state": "strafeRightHmd",
                                                                                                             "var": "isMovingRightHmd"
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "state": "STRAFERIGHT",
-                                                                                                            "var": "isInputRight"
-                                                                                                        },
-                                                                                                        {
-                                                                                                            "state": "STRAFELEFT",
-                                                                                                            "var": "isInputLeft"
                                                                                                         },
                                                                                                         {
                                                                                                             "state": "turnRight",

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1510,19 +1510,29 @@ void Rig::computeMotionAnimationState(float deltaTime, const glm::vec3& worldPos
 
             if (_previousControllerParameters.inputX > 0.0f) {
                 // right
+                if (!_headEnabled) {
+                    _animVars.set("isInputRight", true);
+                } else {
+                    _animVars.set("isInputRight", false);
+                }
+
+                _animVars.set("isInputLeft", false);
                 _animVars.set("isInputForward", false);
                 _animVars.set("isInputBackward", false);
-                _animVars.set("isInputRight", true);
-                _animVars.set("isInputLeft", false);
                 _animVars.set("isNotInput", false);
                 _animVars.set("isNotInputSlow", false);
                 _animVars.set("isNotInputNoMomentum", false);
             } else {
                 // left
+                if (!_headEnabled) {
+                    _animVars.set("isInputLeft", true);
+                } else {
+                    _animVars.set("isInputLeft", false);
+                }
+
                 _animVars.set("isInputForward", false);
                 _animVars.set("isInputBackward", false);
                 _animVars.set("isInputRight", false);
-                _animVars.set("isInputLeft", true);
                 _animVars.set("isNotInput", false);
                 _animVars.set("isNotInputSlow", false);
                 _animVars.set("isNotInputNoMomentum", false);


### PR DESCRIPTION
Handle HMD in input vars in Rig.cpp, remove buggy json transitions between normal/HMD strafe states, and use isNotMoving to leave HMD strafe states.

https://highfidelity.atlassian.net/browse/DEV-2741