### PR TITLE
DEV-2742: Fix Graphics.exportModelToOBJ() JavaScript crash

### DIFF
--- a/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
@@ -258,8 +258,8 @@ scriptable::ScriptableMeshPointer GraphicsScriptingInterface::newMesh(const QVar
     return scriptable::make_scriptowned<scriptable::ScriptableMesh>(mesh, nullptr);
 }
 
-QString GraphicsScriptingInterface::exportModelToOBJ(const scriptable::ScriptableModel& _in) {
-    const auto& in = _in.getConstMeshes();
+QString GraphicsScriptingInterface::exportModelToOBJ(const scriptable::ScriptableModelPointer& model) {
+    const auto& in = model->getConstMeshes();
     if (in.size()) {
         QList<scriptable::MeshPointer> meshes;
         foreach (auto meshProxy, in) {

--- a/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.h
+++ b/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.h
@@ -93,7 +93,7 @@ public slots:
      * @param {Graphics.Model} model
      * @returns {string}
      */
-    QString exportModelToOBJ(const scriptable::ScriptableModel& in);
+    QString exportModelToOBJ(const scriptable::ScriptableModelPointer& model);
 
 private:
     scriptable::ModelProviderPointer getModelProvider(const QUuid& uuid);


### PR DESCRIPTION
Case: https://highfidelity.atlassian.net/browse/DEV-2742