### PR TITLE
DEV-2760 - Fix Realtime Unfocused to be 60hz

### DIFF
--- a/interface/src/RefreshRateManager.cpp
+++ b/interface/src/RefreshRateManager.cpp
@@ -42,7 +42,7 @@ static const std::array<int, RefreshRateManager::RefreshRateRegime::REGIME_NUM> 
     { { 30, 20, 10, 2, 30, 30 } };
 
 static const std::array<int, RefreshRateManager::RefreshRateRegime::REGIME_NUM> REALTIME_PROFILE =
-    { { 60, 60, 10, 2, 30, 30} };
+    { { 60, 60, 60, 2, 30, 30} };
 
 static const std::array<std::array<int, RefreshRateManager::RefreshRateRegime::REGIME_NUM>, RefreshRateManager::RefreshRateProfile::PROFILE_NUM> REFRESH_RATE_PROFILES =
     { { ECO_PROFILE, INTERACTIVE_PROFILE, REALTIME_PROFILE } };


### PR DESCRIPTION
When choosing "Realtime" rendering in custom graphics or if you're using the High Quality graphics setting, the render/game rate should still target 60hz even when the window is focused. This is so that people doing streaming can still have high frame rate rendering when using apps like OBS