### PR TITLE
Procedural vertex shaders

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2107,7 +2107,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         }
         return false;
     });
-    EntityTree::setGetUnscaledDimensionsForEntityIDOperator([this](const QUuid& id) {
+    EntityTree::setGetUnscaledDimensionsForIDOperator([this](const QUuid& id) {
         if (_aboutToQuit) {
             return glm::vec3(1.0f);
         }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2107,6 +2107,23 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
         }
         return false;
     });
+    EntityTree::setGetUnscaledDimensionsForEntityIDOperator([this](const QUuid& id) {
+        if (_aboutToQuit) {
+            return glm::vec3(1.0f);
+        }
+
+        auto entity = getEntities()->getEntity(id);
+        if (entity) {
+            return entity->getUnscaledDimensions();
+        }
+
+        auto avatarManager = DependencyManager::get<AvatarManager>();
+        auto avatar = static_pointer_cast<Avatar>(avatarManager->getAvatarBySessionID(id));
+        if (avatar) {
+            return avatar->getSNScale();
+        }
+        return glm::vec3(1.0f);
+    });
     Procedural::opaqueStencil = [](gpu::StatePointer state) { PrepareStencil::testMaskDrawShape(*state); };
     Procedural::transparentStencil = [](gpu::StatePointer state) { PrepareStencil::testMask(*state); };
 

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -396,7 +396,8 @@ void MaterialEntityRenderer::applyMaterial(const TypedEntityPointer& entity) {
 
     graphics::MaterialLayer materialLayer = graphics::MaterialLayer(material, _priority);
 
-    if (auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(material)) {
+    if (material->isProcedural()) {
+        auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(material);
         procedural->setBoundOperator([this] { return getBound(); });
         entity->setHasVertexShader(procedural->hasVertexShader());
     }

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.cpp
@@ -153,13 +153,13 @@ void MaterialEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPo
 
         if (urlChanged && !usingMaterialData) {
             _networkMaterial = DependencyManager::get<MaterialCache>()->getMaterial(_materialURL);
-            auto onMaterialRequestFinished = [this, oldParentID, oldParentMaterialName, newCurrentMaterialName](bool success) {
+            auto onMaterialRequestFinished = [this, entity, oldParentID, oldParentMaterialName, newCurrentMaterialName](bool success) {
                 if (success) {
                     deleteMaterial(oldParentID, oldParentMaterialName);
                     _texturesLoaded = false;
                     _parsedMaterials = _networkMaterial->parsedMaterials;
                     setCurrentMaterialName(newCurrentMaterialName);
-                    applyMaterial();
+                    applyMaterial(entity);
                 } else {
                     deleteMaterial(oldParentID, oldParentMaterialName);
                     _retryApply = false;
@@ -183,13 +183,13 @@ void MaterialEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPo
             _parsedMaterials = NetworkMaterialResource::parseJSONMaterials(QJsonDocument::fromJson(_materialData.toUtf8()), _materialURL);
             // Since our material changed, the current name might not be valid anymore, so we need to update
             setCurrentMaterialName(newCurrentMaterialName);
-            applyMaterial();
+            applyMaterial(entity);
         } else {
             if (deleteNeeded) {
                 deleteMaterial(oldParentID, oldParentMaterialName);
             }
             if (addNeeded) {
-                applyMaterial();
+                applyMaterial(entity);
             }
         }
 
@@ -382,7 +382,7 @@ void MaterialEntityRenderer::applyTextureTransform(std::shared_ptr<NetworkMateri
     material->setTextureTransforms(textureTransform, _materialMappingMode, _materialRepeat);
 }
 
-void MaterialEntityRenderer::applyMaterial() {
+void MaterialEntityRenderer::applyMaterial(const TypedEntityPointer& entity) {
     _retryApply = false;
 
     std::shared_ptr<NetworkMaterial> material = getMaterial();
@@ -395,6 +395,11 @@ void MaterialEntityRenderer::applyMaterial() {
     applyTextureTransform(material);
 
     graphics::MaterialLayer materialLayer = graphics::MaterialLayer(material, _priority);
+
+    if (auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(material)) {
+        procedural->setBoundOperator([this] { return getBound(); });
+        entity->setHasVertexShader(procedural->hasVertexShader());
+    }
 
     // Our parent could be an entity or an avatar
     std::string parentMaterialName = _parentMaterialName.toStdString();

--- a/libraries/entities-renderer/src/RenderableMaterialEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableMaterialEntityItem.h
@@ -56,7 +56,7 @@ private:
     void setCurrentMaterialName(const std::string& currentMaterialName);
 
     void applyTextureTransform(std::shared_ptr<NetworkMaterial>& material);
-    void applyMaterial();
+    void applyMaterial(const TypedEntityPointer& entity);
     void deleteMaterial(const QUuid& oldParentID, const QString& oldParentMaterialName);
 
     NetworkMaterialResourcePointer _networkMaterial;

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.cpp
@@ -207,6 +207,18 @@ ShapeKey ShapeEntityRenderer::getShapeKey() {
     return builder.build();
 }
 
+Item::Bound ShapeEntityRenderer::getBound() {
+    auto mat = _materials.find("0");
+    if (mat != _materials.end() && mat->second.top().material && mat->second.top().material->isProcedural() &&
+        mat->second.top().material->isReady()) {
+        auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(mat->second.top().material);
+        if (procedural->hasVertexShader() && procedural->hasBoundOperator()) {
+           return procedural->getBound();
+        }
+    }
+    return Parent::getBound();
+}
+
 void ShapeEntityRenderer::doRender(RenderArgs* args) {
     PerformanceTimer perfTimer("RenderableShapeEntityItem::render");
     Q_ASSERT(args->_batch);

--- a/libraries/entities-renderer/src/RenderableShapeEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableShapeEntityItem.h
@@ -26,6 +26,7 @@ public:
 
 protected:
     ShapeKey getShapeKey() override;
+    Item::Bound getBound() override;
 
 private:
     virtual bool needsRenderUpdate() const override;

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -3154,6 +3154,7 @@ std::function<QObject*(const QUuid&)> EntityTree::_getEntityObjectOperator = nul
 std::function<QSizeF(const QUuid&, const QString&)> EntityTree::_textSizeOperator = nullptr;
 std::function<bool()> EntityTree::_areEntityClicksCapturedOperator = nullptr;
 std::function<void(const QUuid&, const QVariant&)> EntityTree::_emitScriptEventOperator = nullptr;
+std::function<glm::vec3(const QUuid&)> EntityTree::_getUnscaledDimensionsForEntityIDOperator = nullptr;
 
 QObject* EntityTree::getEntityObject(const QUuid& id) {
     if (_getEntityObjectOperator) {
@@ -3180,6 +3181,13 @@ void EntityTree::emitScriptEvent(const QUuid& id, const QVariant& message) {
     if (_emitScriptEventOperator) {
         _emitScriptEventOperator(id, message);
     }
+}
+
+glm::vec3 EntityTree::getUnscaledDimensionsForEntityID(const QUuid& id) {
+    if (_getUnscaledDimensionsForEntityIDOperator) {
+        return _getUnscaledDimensionsForEntityIDOperator(id);
+    }
+    return glm::vec3(1.0f);
 }
 
 void EntityTree::updateEntityQueryAACubeWorker(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -3154,7 +3154,7 @@ std::function<QObject*(const QUuid&)> EntityTree::_getEntityObjectOperator = nul
 std::function<QSizeF(const QUuid&, const QString&)> EntityTree::_textSizeOperator = nullptr;
 std::function<bool()> EntityTree::_areEntityClicksCapturedOperator = nullptr;
 std::function<void(const QUuid&, const QVariant&)> EntityTree::_emitScriptEventOperator = nullptr;
-std::function<glm::vec3(const QUuid&)> EntityTree::_getUnscaledDimensionsForEntityIDOperator = nullptr;
+std::function<glm::vec3(const QUuid&)> EntityTree::_getUnscaledDimensionsForIDOperator = nullptr;
 
 QObject* EntityTree::getEntityObject(const QUuid& id) {
     if (_getEntityObjectOperator) {
@@ -3183,9 +3183,9 @@ void EntityTree::emitScriptEvent(const QUuid& id, const QVariant& message) {
     }
 }
 
-glm::vec3 EntityTree::getUnscaledDimensionsForEntityID(const QUuid& id) {
-    if (_getUnscaledDimensionsForEntityIDOperator) {
-        return _getUnscaledDimensionsForEntityIDOperator(id);
+glm::vec3 EntityTree::getUnscaledDimensionsForID(const QUuid& id) {
+    if (_getUnscaledDimensionsForIDOperator) {
+        return _getUnscaledDimensionsForIDOperator(id);
     }
     return glm::vec3(1.0f);
 }

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -273,8 +273,8 @@ public:
     static void setEmitScriptEventOperator(std::function<void(const QUuid&, const QVariant&)> emitScriptEventOperator) { _emitScriptEventOperator = emitScriptEventOperator; }
     static void emitScriptEvent(const QUuid& id, const QVariant& message);
 
-    static void setGetUnscaledDimensionsForEntityIDOperator(std::function<glm::vec3(const QUuid&)> getUnscaledDimensionsForEntityIDOperator) { _getUnscaledDimensionsForEntityIDOperator = getUnscaledDimensionsForEntityIDOperator; }
-    static glm::vec3 getUnscaledDimensionsForEntityID(const QUuid& id);
+    static void setGetUnscaledDimensionsForIDOperator(std::function<glm::vec3(const QUuid&)> getUnscaledDimensionsForIDOperator) { _getUnscaledDimensionsForIDOperator = getUnscaledDimensionsForIDOperator; }
+    static glm::vec3 getUnscaledDimensionsForID(const QUuid& id);
 
     std::map<QString, QString> getNamedPaths() const { return _namedPaths; }
 
@@ -392,7 +392,7 @@ private:
     static std::function<QSizeF(const QUuid&, const QString&)> _textSizeOperator;
     static std::function<bool()> _areEntityClicksCapturedOperator;
     static std::function<void(const QUuid&, const QVariant&)> _emitScriptEventOperator;
-    static std::function<glm::vec3(const QUuid&)> _getUnscaledDimensionsForEntityIDOperator;
+    static std::function<glm::vec3(const QUuid&)> _getUnscaledDimensionsForIDOperator;
 
     std::vector<int32_t> _staleProxies;
 

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -273,6 +273,9 @@ public:
     static void setEmitScriptEventOperator(std::function<void(const QUuid&, const QVariant&)> emitScriptEventOperator) { _emitScriptEventOperator = emitScriptEventOperator; }
     static void emitScriptEvent(const QUuid& id, const QVariant& message);
 
+    static void setGetUnscaledDimensionsForEntityIDOperator(std::function<glm::vec3(const QUuid&)> getUnscaledDimensionsForEntityIDOperator) { _getUnscaledDimensionsForEntityIDOperator = getUnscaledDimensionsForEntityIDOperator; }
+    static glm::vec3 getUnscaledDimensionsForEntityID(const QUuid& id);
+
     std::map<QString, QString> getNamedPaths() const { return _namedPaths; }
 
     void updateEntityQueryAACube(SpatiallyNestablePointer object, EntityEditPacketSender* packetSender,
@@ -389,6 +392,7 @@ private:
     static std::function<QSizeF(const QUuid&, const QString&)> _textSizeOperator;
     static std::function<bool()> _areEntityClicksCapturedOperator;
     static std::function<void(const QUuid&, const QVariant&)> _emitScriptEventOperator;
+    static std::function<glm::vec3(const QUuid&)> _getUnscaledDimensionsForEntityIDOperator;
 
     std::vector<int32_t> _staleProxies;
 

--- a/libraries/entities/src/MaterialEntityItem.cpp
+++ b/libraries/entities/src/MaterialEntityItem.cpp
@@ -293,7 +293,7 @@ void MaterialEntityItem::setHasVertexShader(bool hasVertexShader) {
     if (hasVertexShader && !prevHasVertexShader) {
         setLocalPosition(glm::vec3(0.0f));
         setLocalOrientation(glm::quat());
-        setUnscaledDimensions(EntityTree::getUnscaledDimensionsForEntityID(getParentID()));
+        setUnscaledDimensions(EntityTree::getUnscaledDimensionsForID(getParentID()));
     } else if (!hasVertexShader && prevHasVertexShader) {
         setUnscaledDimensions(_desiredDimensions);
     }

--- a/libraries/entities/src/MaterialEntityItem.cpp
+++ b/libraries/entities/src/MaterialEntityItem.cpp
@@ -139,10 +139,10 @@ void MaterialEntityItem::debugDump() const {
 
 void MaterialEntityItem::setUnscaledDimensions(const glm::vec3& value) {
     _desiredDimensions = value;
-    if (_materialMappingMode == MaterialMappingMode::UV) {
-        EntityItem::setUnscaledDimensions(ENTITY_ITEM_DEFAULT_DIMENSIONS);
-    } else if (_materialMappingMode == MaterialMappingMode::PROJECTED) {
+    if (_hasVertexShader || _materialMappingMode == MaterialMappingMode::PROJECTED) {
         EntityItem::setUnscaledDimensions(value);
+    } else if (_materialMappingMode == MaterialMappingMode::UV) {
+        EntityItem::setUnscaledDimensions(ENTITY_ITEM_DEFAULT_DIMENSIONS);
     }
 }
 
@@ -264,6 +264,13 @@ void MaterialEntityItem::setMaterialRepeat(bool value) {
     });
 }
 
+void MaterialEntityItem::setParentID(const QUuid& parentID) {
+    if (parentID != getParentID()) {
+        EntityItem::setParentID(parentID);
+        _hasVertexShader = false;
+    }
+}
+
 AACube MaterialEntityItem::calculateInitialQueryAACube(bool& success) {
     AACube aaCube = EntityItem::calculateInitialQueryAACube(success);
     // A Material entity's queryAACube contains its parent's queryAACube
@@ -277,4 +284,17 @@ AACube MaterialEntityItem::calculateInitialQueryAACube(bool& success) {
         }
     }
     return aaCube;
+}
+
+void MaterialEntityItem::setHasVertexShader(bool hasVertexShader) {
+    bool prevHasVertexShader = _hasVertexShader;
+    _hasVertexShader = hasVertexShader;
+
+    if (hasVertexShader && !prevHasVertexShader) {
+        setLocalPosition(glm::vec3(0.0f));
+        setLocalOrientation(glm::quat());
+        setUnscaledDimensions(EntityTree::getUnscaledDimensionsForEntityID(getParentID()));
+    } else if (!hasVertexShader && prevHasVertexShader) {
+        setUnscaledDimensions(_desiredDimensions);
+    }
 }

--- a/libraries/entities/src/MaterialEntityItem.h
+++ b/libraries/entities/src/MaterialEntityItem.h
@@ -64,6 +64,8 @@ public:
     QString getParentMaterialName() const;
     void setParentMaterialName(const QString& parentMaterialName);
 
+    void setParentID(const QUuid& parentID) override;
+
     glm::vec2 getMaterialMappingPos() const;
     void setMaterialMappingPos(const glm::vec2& materialMappingPos);
     glm::vec2 getMaterialMappingScale() const;
@@ -72,6 +74,8 @@ public:
     void setMaterialMappingRot(float materialMappingRot);
 
     AACube calculateInitialQueryAACube(bool& success) override;
+
+    void setHasVertexShader(bool hasVertexShader);
 
 private:
     // URL for this material.  Currently, only JSON format is supported.  Set to "materialData" to use the material data to live edit a material.
@@ -107,6 +111,8 @@ private:
     // How much to rotate this material within its parent's UV-space (degrees)
     float _materialMappingRot { 0 };
     QString _materialData;
+
+    bool _hasVertexShader { false };
 
 };
 

--- a/libraries/procedural/src/procedural/ProceduralCommon.slh
+++ b/libraries/procedural/src/procedural/ProceduralCommon.slh
@@ -60,6 +60,17 @@ LAYOUT_STD140(binding=PROCEDURAL_BUFFER_INPUTS) uniform standardInputsBuffer {
 #define iChannelResolution standardInputs.channelResolution
 #define iWorldOrientation standardInputs.worldOrientation
 
+struct ProceduralVertexData {
+    vec4 position;
+    vec4 nonSkinnedPosition;    // input only
+    vec3 normal;
+    vec3 nonSkinnedNormal;      // input only
+    vec3 tangent;               // input only
+    vec3 nonSkinnedTangent;     // input only
+    vec4 color;
+    vec2 texCoord0;
+};
+
 struct ProceduralFragment {
     vec3 normal;
     vec3 diffuse;

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -110,6 +110,13 @@ ItemKey MeshPartPayload::getKey() const {
 }
 
 Item::Bound MeshPartPayload::getBound() const {
+    graphics::MaterialPointer material = _drawMaterials.empty() ? nullptr : _drawMaterials.top().material;
+    if (material && material->isProcedural() && material->isReady()) {
+        auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(_drawMaterials.top().material);
+        if (procedural->hasVertexShader() && procedural->hasBoundOperator()) {
+           return procedural->getBound();
+        }
+    }
     return _worldBound;
 }
 
@@ -175,6 +182,9 @@ void MeshPartPayload::render(RenderArgs* args) {
 
     if (!_drawMaterials.empty() && _drawMaterials.top().material && _drawMaterials.top().material->isProcedural() &&
             _drawMaterials.top().material->isReady()) {
+        if (!(enableMaterialProceduralShaders && ENABLE_MATERIAL_PROCEDURAL_SHADERS)) {
+            return;
+        }
         auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(_drawMaterials.top().material);
         auto& schema = _drawMaterials.getSchemaBuffer().get<graphics::MultiMaterial::Schema>();
         glm::vec4 outColor = glm::vec4(ColorUtils::tosRGBVec3(schema._albedo), schema._opacity);

--- a/libraries/render-utils/src/simple_procedural.slv
+++ b/libraries/render-utils/src/simple_procedural.slv
@@ -20,9 +20,9 @@
 <@if HIFI_USE_DEFORMED or HIFI_USE_DEFORMEDDQ@>
     <@include MeshDeformer.slh@>
     <@if HIFI_USE_DEFORMED@>
-        <$declareMeshDeformer(1, _SCRIBE_NULL, 1, _SCRIBE_NULL, 1)$>
+        <$declareMeshDeformer(1, 1, 1, _SCRIBE_NULL, 1)$>
     <@else@>
-        <$declareMeshDeformer(1, _SCRIBE_NULL, 1, 1, 1)$>
+        <$declareMeshDeformer(1, 1, 1, 1, 1)$>
     <@endif@>
     <$declareMeshDeformerActivation(1, 1)$>
 <@endif@>
@@ -34,24 +34,56 @@ layout(location=RENDER_UTILS_ATTR_NORMAL_WS) out vec3 _normalWS;
 layout(location=RENDER_UTILS_ATTR_COLOR) out vec4 _color;
 layout(location=RENDER_UTILS_ATTR_TEXCOORD01) out vec4 _texCoord01;
 
+<@include procedural/ProceduralCommon.slh@>
+
+#line 1001
+//PROCEDURAL_BLOCK_BEGIN
+
+void getProceduralVertex(inout ProceduralVertexData proceduralData) {}
+
+//PROCEDURAL_BLOCK_END
+
+#line 2030
 void main(void) {
     vec4 positionMS = inPosition;
     vec3 normalMS = inNormal.xyz;
+    vec3 tangentMS = inTangent.xyz;
+    vec4 color = color_sRGBAToLinear(inColor);
+    vec2 texCoord0 = inTexCoord0.st;
 
 <@if HIFI_USE_DEFORMED or HIFI_USE_DEFORMEDDQ@>
-        evalMeshDeformer(inPosition, positionMS, inNormal.xyz, normalMS,
+        evalMeshDeformer(inPosition, positionMS, inNormal.xyz, normalMS, inTangent.xyz, tangentMS,
                          meshDeformer_doSkinning(_drawCallInfo.y), inSkinClusterIndex, inSkinClusterWeight,
                          meshDeformer_doBlendshape(_drawCallInfo.y), gl_VertexID);
 <@endif@>
 
+#if defined(PROCEDURAL_V1) || defined(PROCEDURAL_V2) || defined(PROCEDURAL_V3)
+    ProceduralVertexData proceduralData = ProceduralVertexData(
+        positionMS,
+        inPosition,
+        normalMS,
+        inNormal.xyz,
+        tangentMS,
+        inTangent.xyz,
+        color,
+        texCoord0
+    );
+
+    getProceduralVertex(proceduralData);
+
+    positionMS = proceduralData.position;
+    normalMS = proceduralData.normal;
+    color = proceduralData.color;
+    texCoord0 = proceduralData.texCoord0;
+#endif
+
     _positionMS = positionMS;
     _normalMS = normalMS;
+    _color = color;
+    _texCoord01 = vec4(texCoord0, 0.0, 0.0);
 
     TransformCamera cam = getTransformCamera();
     TransformObject obj = getTransformObject();
     <$transformModelToEyeAndClipPos(cam, obj, positionMS, _positionES, gl_Position)$>
     <$transformModelToWorldDir(cam, obj, normalMS, _normalWS)$>
-
-    _color = color_sRGBAToLinear(inColor);
-    _texCoord01 = vec4(inTexCoord0.st, 0.0, 0.0);
 }


### PR DESCRIPTION
https://roadmap.highfidelity.com/open-source-project-proposals/p/procedural-vertex-shaders

labels: engine, jsdoc, open source, feedback welcome

Procedural Material Entities can specify a "vertexShaderURL", a glsl snippet that implements a function `void getProceduralVertex(inout ProceduralVertexData proceduralData)`.  If this URL is present, the material entity's bounds are used to cull the object that it is applied to.  In other words, if your vertex shader moves vertices, you are responsible for updating the material entity's bounding box to contain those vertices so that the object will be culled correctly.  This is consistent with how other engines handle this case, usually they'll turn off culling or force you to manage the bounds yourself.  To help with this, when you apply a procedural vertex material entity, it will snap to the bounds of the object it is applied to.

![hifi-snap-by-SamGondelman-on-2019-11-15_01-24-30](https://user-images.githubusercontent.com/53453710/68932093-c0161800-0746-11ea-956d-dea87c94a6b3.gif)

Test plan:
- Enable Developer -> Render -> Enable Procedural Materials and add an environment variable `HIFI_ENABLE_MATERIAL_PROCEDURAL_SHADERS` with value 1.
- Run [this](https://gist.githubusercontent.com/HifiExperiments/403ed313cc51c986610ee82848220a4f/raw/45fdb2f502f96fee821af8471fbea6b3fa79121b/ProceduralMaterial.js), you'll see:
![image](https://user-images.githubusercontent.com/53453710/68931274-0e2a1c00-0745-11ea-8617-bcdf95a8e7df.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931389-4a5d7c80-0745-11ea-8d71-c44aaa110eff.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931419-58130200-0745-11ea-9f55-62a91b1eafb5.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931437-62350080-0745-11ea-82d9-6bddc0b0dfda.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931457-6c56ff00-0745-11ea-9871-d84743e19014.png)
- Press "u" (and get close to the mannequin):
![image](https://user-images.githubusercontent.com/53453710/68931532-95778f80-0745-11ea-8207-c24f685665c3.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931557-a1fbe800-0745-11ea-967f-3ffc32fb4134.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931577-ac1de680-0745-11ea-8305-c5772c59a057.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931604-b93ad580-0745-11ea-9b84-e543e7aa889a.png)
- Press "u" (and get close to the gnome):
![image](https://user-images.githubusercontent.com/53453710/68931635-cbb50f00-0745-11ea-89ef-163de9a08ad2.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931646-d1aaf000-0745-11ea-8c25-f367fc705467.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931757-1171d780-0746-11ea-9e91-b100ff97a39b.png)
- Press "u": 
![image](https://user-images.githubusercontent.com/53453710/68931724-fe5f0780-0745-11ea-8ca3-41056aab31bc.png)
- Press "u" (and look at yourself):
![image](https://user-images.githubusercontent.com/53453710/68931844-38c8a480-0746-11ea-8985-643776e51d5c.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931851-3e25ef00-0746-11ea-8147-f231b7bb8e91.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931861-467e2a00-0746-11ea-98d5-0c33bc9b690b.png)
- Press "u":
![image](https://user-images.githubusercontent.com/53453710/68931877-4f6efb80-0746-11ea-9e8d-36c624eac354.png)
