### PR TITLE
Added environment variables to change domain server ports

### DIFF
--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -37,7 +37,7 @@ const unsigned short DEFAULT_DOMAIN_SERVER_PORT =
     .contains("HIFI_DOMAIN_SERVER_PORT")
         ? QProcessEnvironment::systemEnvironment()
             .value("HIFI_DOMAIN_SERVER_PORT")
-            .toShort()
+            .toUShort()
         : 40102;
 
 const unsigned short DEFAULT_DOMAIN_SERVER_DTLS_PORT = 
@@ -45,7 +45,7 @@ const unsigned short DEFAULT_DOMAIN_SERVER_DTLS_PORT =
     .contains("HIFI_DOMAIN_SERVER_DTLS_PORT")
         ? QProcessEnvironment::systemEnvironment()
             .value("HIFI_DOMAIN_SERVER_DTLS_PORT")
-            .toShort()
+            .toUShort()
         : 40103;
 
 const quint16 DOMAIN_SERVER_HTTP_PORT = 
@@ -53,7 +53,7 @@ const quint16 DOMAIN_SERVER_HTTP_PORT =
     .contains("HIFI_DOMAIN_SERVER_HTTP_PORT")
         ? QProcessEnvironment::systemEnvironment()
             .value("HIFI_DOMAIN_SERVER_HTTP_PORT")
-            .toShort()
+            .toUInt()
         : 40100;
 
 const quint16 DOMAIN_SERVER_HTTPS_PORT = 
@@ -61,7 +61,7 @@ const quint16 DOMAIN_SERVER_HTTPS_PORT =
     .contains("HIFI_DOMAIN_SERVER_HTTPS_PORT")
         ? QProcessEnvironment::systemEnvironment()
             .value("HIFI_DOMAIN_SERVER_HTTPS_PORT")
-            .toShort()
+            .toUInt()
         : 40101;
 
 const int MAX_SILENT_DOMAIN_SERVER_CHECK_INS = 5;

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -12,6 +12,8 @@
 #ifndef hifi_DomainHandler_h
 #define hifi_DomainHandler_h
 
+#include <QProcessEnvironment>
+
 #include <QtCore/QJsonObject>
 #include <QtCore/QObject>
 #include <QtCore/QTimer>
@@ -30,10 +32,37 @@
 #include "ReceivedMessage.h"
 #include "NetworkingConstants.h"
 
-const unsigned short DEFAULT_DOMAIN_SERVER_PORT = 40102;
-const unsigned short DEFAULT_DOMAIN_SERVER_DTLS_PORT = 40103;
-const quint16 DOMAIN_SERVER_HTTP_PORT = 40100;
-const quint16 DOMAIN_SERVER_HTTPS_PORT = 40101;
+const unsigned short DEFAULT_DOMAIN_SERVER_PORT = 
+    QProcessEnvironment::systemEnvironment()
+    .contains("HIFI_DOMAIN_SERVER_PORT")
+        ? QProcessEnvironment::systemEnvironment()
+            .value("HIFI_DOMAIN_SERVER_PORT")
+            .toShort()
+        : 40102;
+
+const unsigned short DEFAULT_DOMAIN_SERVER_DTLS_PORT = 
+    QProcessEnvironment::systemEnvironment()
+    .contains("HIFI_DOMAIN_SERVER_DTLS_PORT")
+        ? QProcessEnvironment::systemEnvironment()
+            .value("HIFI_DOMAIN_SERVER_DTLS_PORT")
+            .toShort()
+        : 40103;
+
+const quint16 DOMAIN_SERVER_HTTP_PORT = 
+    QProcessEnvironment::systemEnvironment()
+    .contains("HIFI_DOMAIN_SERVER_HTTP_PORT")
+        ? QProcessEnvironment::systemEnvironment()
+            .value("HIFI_DOMAIN_SERVER_HTTP_PORT")
+            .toShort()
+        : 40100;
+
+const quint16 DOMAIN_SERVER_HTTPS_PORT = 
+    QProcessEnvironment::systemEnvironment()
+    .contains("HIFI_DOMAIN_SERVER_HTTPS_PORT")
+        ? QProcessEnvironment::systemEnvironment()
+            .value("HIFI_DOMAIN_SERVER_HTTPS_PORT")
+            .toShort()
+        : 40101;
 
 const int MAX_SILENT_DOMAIN_SERVER_CHECK_INS = 5;
 


### PR DESCRIPTION
https://roadmap.highfidelity.com/open-source-project-proposals/p/ability-to-change-domain-server-ports

My commit probably isn't the best solution but the idea is that this would work with Docker compose like this.

```yml
version: "3.6"
services:
    domain:
        image: makitsune/hifi:0.85.0
        network_mode: host
        restart: always
        volumes:
            - ./domain:/root/.local/share/High Fidelity
        environment:
            - HIFI_DOMAIN_SERVER_HTTP_PORT=40100
            - HIFI_DOMAIN_SERVER_HTTPS_PORT=40101
            - HIFI_DOMAIN_SERVER_PORT=40102
            - HIFI_DOMAIN_SERVER_DTLS_PORT=40103

            - HIFI_ASSIGNMENT_CLIENT_AUDIO_MIXER_PORT=48000
            - HIFI_ASSIGNMENT_CLIENT_AVATAR_MIXER_PORT=48001
            - HIFI_ASSIGNMENT_CLIENT_SCRIPTED_AGENT_PORT=
            - HIFI_ASSIGNMENT_CLIENT_ASSET_SERVER_PORT=48003
            - HIFI_ASSIGNMENT_CLIENT_MESSAGES_MIXER_PORT=48004
            - HIFI_ASSIGNMENT_CLIENT_ENTITY_SCRIPT_SERVER_PORT=48005
            - HIFI_ASSIGNMENT_CLIENT_ENTITIES_SERVER_PORT=48006
```

I'm distributing my own Docker image at the moment. Here's the link to the Dockerfile.
https://github.com/makitsune/docker-hifi-domain-server/blob/master/docker/Dockerfile

On container launch, it will also run a Python script that will modify `domain-server/config.json` as well.
https://github.com/makitsune/docker-hifi-domain-server/blob/master/docker/modify-domain-port.py

If I had more time, I would send better code but at least this can be an initiative to the problem.

