### PR TITLE
DEV-2585: fix for whiteboard poly lines getting their parentID incorrectly reverted

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -2707,10 +2707,12 @@ quint64 EntityItem::getLastEdited() const {
 }
 
 void EntityItem::setLastEdited(quint64 lastEdited) {
-    withWriteLock([&] {
-        _lastEdited = _lastUpdated = lastEdited;
-        _changedOnServer = glm::max(lastEdited, _changedOnServer);
-    });
+    if (lastEdited == 0 || lastEdited > _lastEdited) {
+        withWriteLock([&] {
+            _lastEdited = _lastUpdated = lastEdited;
+            _changedOnServer = glm::max(lastEdited, _changedOnServer);
+        });
+    }
 }
 
 void EntityItem::markAsChangedOnServer() {

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -5071,8 +5071,9 @@ void EntityItemProperties::convertToCloneProperties(const EntityItemID& entityID
         setEntityHostType(entity::HostType::LOCAL);
         setCollisionless(true);
     }
-    setCreated(usecTimestampNow());
-    setLastEdited(usecTimestampNow());
+    uint64_t now = usecTimestampNow();
+    setCreated(now);
+    setLastEdited(now);
     setCloneable(ENTITY_ITEM_DEFAULT_CLONEABLE);
     setCloneLifetime(ENTITY_ITEM_DEFAULT_CLONE_LIFETIME);
     setCloneLimit(ENTITY_ITEM_DEFAULT_CLONE_LIMIT);

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -1942,6 +1942,8 @@ int EntityTree::processEditPacketData(ReceivedMessage& message, const unsigned c
                 FilterType filterType = isPhysics ? FilterType::Physics : (isAdd ? FilterType::Add : FilterType::Edit);
                 bool allowed = (!isPhysics && senderNode->isAllowedEditor()) || filterProperties(existingEntity, properties, properties, wasChanged, filterType);
                 if (!allowed) {
+                    // the update failed and we need to convey that fact to the sender
+                    // our method is to re-assert the current properties and bump the lastEdited timestamp
                     auto timestamp = properties.getLastEdited();
                     properties = EntityItemProperties();
                     properties.setLastEdited(timestamp);


### PR DESCRIPTION
This PR reduces a mode by which rapid changes to a recently created entity could get overwritten by an entity update echo from the entity-server, which was what was happening to whiteboard lines whose parentID was being set shortly after entity creation.

https://highfidelity.atlassian.net/browse/DEV-2585