### PR TITLE
Edge case fix for seated rotation - it would bounce forward if you let go of Q/E at exact right time.

### DIFF
--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -3620,14 +3620,17 @@ void MyAvatar::updateOrientation(float deltaTime) {
             ajustedYawVector = (leftRightDot < 0.0f ? -avatarVectorRight : avatarVectorRight);
         }
         if (frontBackDot < limitAngle) {
+            _seatedBodyYawDelta = 0.0f;
+
             if (!isRotatingWhileSeated) {
-                if (frontBackDot < triggerAngle) {
+                if (frontBackDot < triggerAngle && isCameraYawing) {
                     _shouldTurnToFaceCamera = true;
                     _firstPersonSteadyHeadTimer = 0.0f;
+                } else {
+                    setWorldOrientation(previousOrientation);
                 }
             } else {
                 setWorldOrientation(previousOrientation);
-                _seatedBodyYawDelta = 0.0f;
             }
         } else if (frontBackDot > glm::sin(glm::radians(reorientAngle))) {
             _shouldTurnToFaceCamera = false;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -3620,14 +3620,14 @@ void MyAvatar::updateOrientation(float deltaTime) {
             ajustedYawVector = (leftRightDot < 0.0f ? -avatarVectorRight : avatarVectorRight);
         }
         if (frontBackDot < limitAngle) {
-            _seatedBodyYawDelta = 0.0f;
 
             if (!isRotatingWhileSeated) {
-                if (frontBackDot < triggerAngle && isCameraYawing) {
+                if (frontBackDot < triggerAngle && _seatedBodyYawDelta == 0.0f) {
                     _shouldTurnToFaceCamera = true;
                     _firstPersonSteadyHeadTimer = 0.0f;
                 } else {
                     setWorldOrientation(previousOrientation);
+                    _seatedBodyYawDelta = 0.0f;
                 }
             } else {
                 setWorldOrientation(previousOrientation);


### PR DESCRIPTION
Clamp rotation velocity if hit trigger angle, but only bounce forward if cameraYaw is true.

https://highfidelity.atlassian.net/browse/DEV-2753