### PR TITLE
DEV-2871: signal connection check before emit of devices changed

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -160,7 +160,7 @@ void AudioClient::checkDevices() {
     auto outputDevices = getAvailableDevices(QAudio::AudioOutput, hmdOutputName);
    
     static const QMetaMethod devicesChangedSig= QMetaMethod::fromSignal(&AudioClient::devicesChanged);
-    //only emit once the scripting interface has connecte to the signal
+    //only emit once the scripting interface has connected to the signal
     if (isSignalConnected(devicesChangedSig)) {
         Lock lock(_deviceMutex);
         if (inputDevices != _inputDevices) {

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -159,16 +159,20 @@ void AudioClient::checkDevices() {
     auto inputDevices = getAvailableDevices(QAudio::AudioInput, hmdInputName);
     auto outputDevices = getAvailableDevices(QAudio::AudioOutput, hmdOutputName);
    
-    Lock lock(_deviceMutex);
-    if (inputDevices != _inputDevices) {
-        _inputDevices.swap(inputDevices);
-        emit devicesChanged(QAudio::AudioInput, _inputDevices);
-    }
+    static const QMetaMethod devicesChangedSig= QMetaMethod::fromSignal(&AudioClient::devicesChanged);
+    //only emit once the scripting interface has connecte to the signal
+    if (isSignalConnected(devicesChangedSig)) {
+        Lock lock(_deviceMutex);
+        if (inputDevices != _inputDevices) {
+            _inputDevices.swap(inputDevices);
+            emit devicesChanged(QAudio::AudioInput, _inputDevices);
+        }
 
-    if (outputDevices != _outputDevices) {
-        _outputDevices.swap(outputDevices);
-        emit devicesChanged(QAudio::AudioOutput, _outputDevices);
-    }
+        if (outputDevices != _outputDevices) {
+            _outputDevices.swap(outputDevices);
+            emit devicesChanged(QAudio::AudioOutput, _outputDevices);
+        }
+    } 
 }
 
 HifiAudioDeviceInfo AudioClient::getActiveAudioDevice(QAudio::Mode mode) const {


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-2817

Fixing logic to emit after scripting interface has initialized the audiodevices.  