### PR TITLE
DOC-233: MaterialCache JSDoc

### DIFF
--- a/libraries/animation/src/AnimationCacheScriptingInterface.h
+++ b/libraries/animation/src/AnimationCacheScriptingInterface.h
@@ -38,6 +38,10 @@ class AnimationCacheScriptingInterface : public ScriptableResourceCache, public 
      * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
      * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
      * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
+     * @property {number} numGlobalQueriesPending - Total number of global queries pending (across all resource cache managers).
+     *     <em>Read-only.</em>
+     * @property {number} numGlobalQueriesLoading - Total number of global queries loading (across all resource cache managers).
+     *     <em>Read-only.</em>
      *
      * @borrows ResourceCache.getResourceList as getResourceList
      * @borrows ResourceCache.updateTotalSize as updateTotalSize

--- a/libraries/audio/src/SoundCacheScriptingInterface.h
+++ b/libraries/audio/src/SoundCacheScriptingInterface.h
@@ -39,6 +39,10 @@ class SoundCacheScriptingInterface : public ScriptableResourceCache, public Depe
      * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
      * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
      * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
+     * @property {number} numGlobalQueriesPending - Total number of global queries pending (across all resource cache managers).
+     *     <em>Read-only.</em>
+     * @property {number} numGlobalQueriesLoading - Total number of global queries loading (across all resource cache managers).
+     *     <em>Read-only.</em>
      *
      * @borrows ResourceCache.getResourceList as getResourceList
      * @borrows ResourceCache.updateTotalSize as updateTotalSize

--- a/libraries/material-networking/src/material-networking/TextureCacheScriptingInterface.h
+++ b/libraries/material-networking/src/material-networking/TextureCacheScriptingInterface.h
@@ -37,6 +37,10 @@ class TextureCacheScriptingInterface : public ScriptableResourceCache, public De
      * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
      * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
      * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
+     * @property {number} numGlobalQueriesPending - Total number of global queries pending (across all resource cache managers).
+     *     <em>Read-only.</em>
+     * @property {number} numGlobalQueriesLoading - Total number of global queries loading (across all resource cache managers).
+     *     <em>Read-only.</em>
      *
      * @borrows ResourceCache.getResourceList as getResourceList
      * @borrows ResourceCache.updateTotalSize as updateTotalSize

--- a/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.h
+++ b/libraries/model-networking/src/model-networking/ModelCacheScriptingInterface.h
@@ -37,6 +37,10 @@ class ModelCacheScriptingInterface : public ScriptableResourceCache, public Depe
      * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
      * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
      * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
+     * @property {number} numGlobalQueriesPending - Total number of global queries pending (across all resource cache managers).
+     *     <em>Read-only.</em>
+     * @property {number} numGlobalQueriesLoading - Total number of global queries loading (across all resource cache managers).
+     *     <em>Read-only.</em>
      *
      * @borrows ResourceCache.getResourceList as getResourceList
      * @borrows ResourceCache.updateTotalSize as updateTotalSize

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -91,8 +91,8 @@ private:
 class ScriptableResource : public QObject {
 
     /**jsdoc
-     * Information about a cached resource. Created by {@link AnimationCache.prefetch}, {@link ModelCache.prefetch},
-     * {@link SoundCache.prefetch}, or {@link TextureCache.prefetch}.
+     * Information about a cached resource. Created by {@link AnimationCache.prefetch}, {@link MaterialCache.prefetch}, 
+     * {@link ModelCache.prefetch}, {@link SoundCache.prefetch}, or {@link TextureCache.prefetch}.
      *
      * @class ResourceObject
      *
@@ -334,7 +334,7 @@ public:
      * @function ResourceCache.getResourceList
      * @returns {string[]} The URLs of all resources in the cache.
      * @example <caption>Report cached resources.</caption>
-     * // Replace AnimationCache with ModelCache, SoundCache, or TextureCache as appropriate.
+     * // Replace AnimationCache with MaterialCache, ModelCache, SoundCache, or TextureCache as appropriate.
      *
      * var cachedResources = AnimationCache.getResourceList();
      * print("Cached resources: " + JSON.stringify(cachedResources));
@@ -354,7 +354,7 @@ public:
      * @param {string} url - The URL of the resource to prefetch.
      * @returns {ResourceObject} A resource object.
      * @example <caption>Prefetch a resource and wait until it has loaded.</caption>
-     * // Replace AnimationCache with ModelCache, SoundCache, or TextureCache as appropriate.
+     * // Replace AnimationCache with MaterialCache, ModelCache, SoundCache, or TextureCache as appropriate.
      * // TextureCache has its own version of this function.
      * 
      * var resourceURL = "https://s3-us-west-1.amazonaws.com/hifi-content/clement/production/animations/sitting_idle.fbx";

--- a/libraries/networking/src/ResourceCache.h
+++ b/libraries/networking/src/ResourceCache.h
@@ -318,9 +318,11 @@ class ScriptableResourceCache : public QObject {
     Q_PROPERTY(size_t sizeCached READ getSizeCachedResources NOTIFY dirty)
 
     /**jsdoc
-    * @property {number} numGlobalQueriesPending - Total number of global queries pending (across all resource managers). <em>Read-only.</em>
-    * @property {number} numGlobalQueriesLoading - Total number of global queries loading (across all resource managers). <em>Read-only.</em>
-    */
+     * @property {number} numGlobalQueriesPending - Total number of global queries pending (across all resource cache managers).
+     *     <em>Read-only.</em>
+     * @property {number} numGlobalQueriesLoading - Total number of global queries loading (across all resource cache managers).
+     *     <em>Read-only.</em>
+     */
     Q_PROPERTY(size_t numGlobalQueriesPending READ getNumGlobalQueriesPending NOTIFY dirty)
     Q_PROPERTY(size_t numGlobalQueriesLoading READ getNumGlobalQueriesLoading NOTIFY dirty)
 

--- a/libraries/procedural/src/procedural/MaterialCacheScriptingInterface.h
+++ b/libraries/procedural/src/procedural/MaterialCacheScriptingInterface.h
@@ -36,6 +36,10 @@ class MaterialCacheScriptingInterface : public ScriptableResourceCache, public D
      * @property {number} numCached - Total number of cached resource. <em>Read-only.</em>
      * @property {number} sizeTotal - Size in bytes of all resources. <em>Read-only.</em>
      * @property {number} sizeCached - Size in bytes of all cached resources. <em>Read-only.</em>
+     * @property {number} numGlobalQueriesPending - Total number of global queries pending (across all resource cache managers).
+     *     <em>Read-only.</em>
+     * @property {number} numGlobalQueriesLoading - Total number of global queries loading (across all resource cache managers).
+     *     <em>Read-only.</em>
      *
      * @borrows ResourceCache.getResourceList as getResourceList
      * @borrows ResourceCache.updateTotalSize as updateTotalSize

--- a/libraries/procedural/src/procedural/MaterialCacheScriptingInterface.h
+++ b/libraries/procedural/src/procedural/MaterialCacheScriptingInterface.h
@@ -24,7 +24,7 @@ class MaterialCacheScriptingInterface : public ScriptableResourceCache, public D
     // Properties are copied over from ResourceCache (see ResourceCache.h for reason).
 
     /**jsdoc
-     * The <code>TextureCache</code> API manages texture cache resources.
+     * The <code>MaterialCache</code> API manages material cache resources.
      *
      * @namespace MaterialCache
      *

--- a/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
+++ b/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
@@ -113,9 +113,9 @@ NetworkMaterialResource::ParsedMaterials NetworkMaterialResource::parseJSONMater
 /**jsdoc
  * A material used in a {@link Entities.MaterialResource|MaterialResource}.
  * @typedef {object} Entities.Material
+ * @property {string} name="" - A name for the material. Supported by all material models.
  * @property {string} model="hifi_pbr" - Different material models support different properties and rendering modes.
  *     Supported models are: <code>"hifi_pbr"</code>, <code>"hifi_shader_simple"</code>.
- * @property {string} name="" - A name for the material. Supported by all material models.
  * @property {ColorFloat|RGBS|string} emissive - The emissive color, i.e., the color that the material emits. A 
  *     {@link ColorFloat} value is treated as sRGB and must have component values in the range <code>0.0</code> &ndash; 
  *     <code>1.0</code>. A {@link RGBS} value can be either RGB or sRGB. 
@@ -144,12 +144,17 @@ NetworkMaterialResource::ParsedMaterials NetworkMaterialResource::parseJSONMater
  *     value for transparency. 
  *     <code>"hifi_pbr"</code> model only.
  * @property {number|string} opacityMapMode - The mode defining the interpretation of the opacity map. Values can be:
- *     <code>"OPACITY_MAP_OPAQUE"</code> for ignoring the opacity map information.
- *     <code>"OPACITY_MAP_MASK"</code> for using the opacity map as a mask, where only the texel greater than opacityCutoff are visible and rendered opaque.
- *     <code>"OPACITY_MAP_BLEND"</code> for using the opacity map for alpha blending the material surface with the background.
+ *     <ul>
+ *         <li><code>"OPACITY_MAP_OPAQUE"</code> for ignoring the <code>opacityMap</code> information.</li>
+ *         <li><code>"OPACITY_MAP_MASK"</code> for using the <code>opacityMap</code> as a mask, where only the texel greater 
+ *         than <code>opacityCutoff</code> are visible and rendered opaque.</li>
+ *         <li><code>"OPACITY_MAP_BLEND"</code> for using the <code>opacityMap</code> for alpha blending the material surface 
+ *         with the background.</li>
+ *     </ul>
  *     Set to <code>"fallthrough"</code> to fall through to the material below. <code>"hifi_pbr"</code> model only.
- * @property {number|string} opacityCutoff - The opacity cutoff threshold used to determine the opaque texels of the Opacity map
- *     when opacityMapMode is "OPACITY_MAP_MASK", range <code>0.0</code> &ndash; <code>1.0</code>.
+ * @property {number|string} opacityCutoff - The opacity cutoff threshold used to determine the opaque texels of the 
+ *     <code>opacityMap</code> when <code>opacityMapMode</code> is <code>"OPACITY_MAP_MASK"</code>, range <code>0.0</code> 
+ *     &ndash; <code>1.0</code>.
  *     Set to <code>"fallthrough"</code> to fall through to the material below. <code>"hifi_pbr"</code> model only.
  * @property {string} roughnessMap - The URL of the roughness texture image. You can use this or <code>glossMap</code>, but not 
  *     both. 
@@ -179,7 +184,7 @@ NetworkMaterialResource::ParsedMaterials NetworkMaterialResource::parseJSONMater
  *     Set to <code>"fallthrough"</code> to fall through to the material below. <code>"hifi_pbr"</code> model only.
  * @property {Mat4|string} texCoordTransform1 - The transform to use for <code>occlusionMap</code> and <code>lightMap</code>. 
  *     Set to <code>"fallthrough"</code> to fall through to the material below. <code>"hifi_pbr"</code> model only.
- * @property {string} lightmapParams - Parameters for controlling how lightMap is used. 
+ * @property {string} lightmapParams - Parameters for controlling how <code>lightMap</code> is used. 
  *     Set to <code>"fallthrough"</code> to fall through to the material below. <code>"hifi_pbr"</code> model only. 
  *     <p><em>Currently not used.</em></p>
  * @property {string} materialParams - Parameters for controlling the material projection and repetition. 

--- a/tools/jsdoc/plugins/hifi.js
+++ b/tools/jsdoc/plugins/hifi.js
@@ -57,6 +57,7 @@ exports.handlers = {
             '../../libraries/physics/src',
             '../../libraries/platform/src/platform/backend',
             '../../libraries/plugins/src/plugins',
+            '../../libraries/procedural/src/procedural',
             '../../libraries/pointers/src',
             '../../libraries/render-utils/src',
             '../../libraries/script-engine/src',


### PR DESCRIPTION
Namespaces:
- MaterialCache

Also:
- Added missing `numGlobalQueriesPending` and `numGlobalQueriesLoading` properties' documentation to `AnimationCache`, `ModelCache`, `SoundCache`, and `TextureCache`.
- `Entities.MaterialResource` type now appears in and is used in the JSDoc output.
- `Entities.Material` type now appears in and is used in the JSDoc output.
- `RGBS` global type now appears in and is used in the JSDoc output.
- Revised recent `Entities.Material` JSDoc changes.

Note: No executable code changes.

Case: https://highfidelity.atlassian.net/browse/DOC-233

