### PR TITLE
dev-829: waiting on local injector prep

### DIFF
--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -2065,7 +2065,7 @@ bool AudioClient::switchOutputToAudioDevice(const HifiAudioDeviceInfo outputDevi
     _localSamplesAvailable.exchange(0, std::memory_order_release);
 
     //wait on local injectors prep to finish running
-    if (_localPrepInjectorFuture.isStarted() || _localPrepInjectorFuture.isRunning()) {
+    if ( !_localPrepInjectorFuture.isFinished()) {
         _localPrepInjectorFuture.waitForFinished();
     }
 
@@ -2347,9 +2347,9 @@ qint64 AudioClient::AudioOutputIODevice::readData(char * data, qint64 maxSize) {
             qCDebug(audiostream, "Read %d samples from injectors (%d available, %d requested)", injectorSamplesPopped, _localInjectorsStream.samplesAvailable(), samplesRequested);
         }
     }
-
+    
     // prepare injectors for the next callback
-    _audio->_localPrepInjectorFuture = QtConcurrent::run(QThreadPool::globalInstance(), [this] {
+     _audio->_localPrepInjectorFuture = QtConcurrent::run(QThreadPool::globalInstance(), [this] {
         _audio->prepareLocalAudioInjectors();
     });
 

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <queue>
 
+#include <QFuture>
 #include <QtCore/QtGlobal>
 #include <QtCore/QByteArray>
 #include <QtCore/QElapsedTimer>
@@ -506,7 +507,8 @@ private:
 #endif
 
     AudioSolo _solo;
-
+    
+    QFuture<void> _localPrepInjectorFuture;
     QReadWriteLock _hmdNameLock;
     Mutex _checkDevicesMutex;
     QTimer* _checkDevicesTimer { nullptr };


### PR DESCRIPTION
https://highfidelity.atlassian.net/browse/DEV-829

adding a future to the thread pool(ed) call to preparelocalinjectors. since the function call runs on a separate thread it does not get notified that he device has swapped. Before switching we check if the prep local injectors is running and wait until its completed. Switching devices has lower priority than preparing local injectors. (otherwise we can cause starve problems)