### PR TITLE
DEV-1943: Make MyAvatar.getAvatarEntityData() return all properties

### DIFF
--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -279,7 +279,18 @@ void ScriptableAvatar::setJointMappingsFromNetworkReply() {
     networkReply->deleteLater();
 }
 
+AvatarEntityMap ScriptableAvatar::getAvatarEntityData() const {
+    auto data = getAvatarEntityDataInternal(true);
+    return data;
+}
+
 AvatarEntityMap ScriptableAvatar::getAvatarEntityDataNonDefault() const {
+    auto data = getAvatarEntityDataInternal(false);
+    return data;
+
+}
+
+AvatarEntityMap ScriptableAvatar::getAvatarEntityDataInternal(bool allProperties) const {
     // DANGER: Now that we store the AvatarEntityData in packed format this call is potentially Very Expensive!
     // Avoid calling this method if possible.
     AvatarEntityMap data;
@@ -290,7 +301,7 @@ AvatarEntityMap ScriptableAvatar::getAvatarEntityDataNonDefault() const {
             EntityItemPointer entity = itr.second;
             EntityItemProperties properties = entity->getProperties();
             QByteArray blob;
-            EntityItemProperties::propertiesToBlob(_scriptEngine, sessionID, properties, blob);
+            EntityItemProperties::propertiesToBlob(_scriptEngine, sessionID, properties, blob, allProperties);
             data[id] = blob;
         }
     });

--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -299,7 +299,16 @@ AvatarEntityMap ScriptableAvatar::getAvatarEntityDataInternal(bool allProperties
         for (const auto& itr : _entities) {
             QUuid id = itr.first;
             EntityItemPointer entity = itr.second;
-            EntityItemProperties properties = entity->getProperties();
+
+            EncodeBitstreamParams params;
+            auto desiredProperties = entity->getEntityProperties(params);
+            desiredProperties += PROP_LOCAL_POSITION;
+            desiredProperties += PROP_LOCAL_ROTATION;
+            desiredProperties += PROP_LOCAL_VELOCITY;
+            desiredProperties += PROP_LOCAL_ANGULAR_VELOCITY;
+            desiredProperties += PROP_LOCAL_DIMENSIONS;
+            EntityItemProperties properties = entity->getProperties(desiredProperties);
+
             QByteArray blob;
             EntityItemProperties::propertiesToBlob(_scriptEngine, sessionID, properties, blob, allProperties);
             data[id] = blob;

--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -279,7 +279,7 @@ void ScriptableAvatar::setJointMappingsFromNetworkReply() {
     networkReply->deleteLater();
 }
 
-AvatarEntityMap ScriptableAvatar::getAvatarEntityData() const {
+AvatarEntityMap ScriptableAvatar::getAvatarEntityDataNonDefault() const {
     // DANGER: Now that we store the AvatarEntityData in packed format this call is potentially Very Expensive!
     // Avoid calling this method if possible.
     AvatarEntityMap data;

--- a/assignment-client/src/avatars/ScriptableAvatar.h
+++ b/assignment-client/src/avatars/ScriptableAvatar.h
@@ -178,8 +178,11 @@ public:
      * var avatarEntityData = Avatar.getAvatarEntityData();
      * print("Avatar entities: " + JSON.stringify(avatarEntityData));
      */
+    Q_INVOKABLE AvatarEntityMap getAvatarEntityData() const override;
 
     AvatarEntityMap getAvatarEntityDataNonDefault() const override;
+
+    AvatarEntityMap getAvatarEntityDataInternal(bool allProperties) const;
 
     /**jsdoc
      * Sets all avatar entities from an object.

--- a/assignment-client/src/avatars/ScriptableAvatar.h
+++ b/assignment-client/src/avatars/ScriptableAvatar.h
@@ -178,7 +178,8 @@ public:
      * var avatarEntityData = Avatar.getAvatarEntityData();
      * print("Avatar entities: " + JSON.stringify(avatarEntityData));
      */
-    Q_INVOKABLE AvatarEntityMap getAvatarEntityData() const override;
+
+    AvatarEntityMap getAvatarEntityDataNonDefault() const override;
 
     /**jsdoc
      * Sets all avatar entities from an object.

--- a/assignment-client/src/avatars/ScriptableAvatar.h
+++ b/assignment-client/src/avatars/ScriptableAvatar.h
@@ -173,7 +173,7 @@ public:
      * Gets details of all avatar entities.
      * <p><strong>Warning:</strong> Potentially an expensive call. Do not use if possible.</p>
      * @function Avatar.getAvatarEntityData
-     * @returns {AvatarEntityMap} Details of the avatar entities.
+     * @returns {AvatarEntityMap} Details of all avatar entities.
      * @example <caption>Report the current avatar entities.</caption>
      * var avatarEntityData = Avatar.getAvatarEntityData();
      * print("Avatar entities: " + JSON.stringify(avatarEntityData));

--- a/interface/src/AvatarBookmarks.cpp
+++ b/interface/src/AvatarBookmarks.cpp
@@ -154,7 +154,7 @@ void AvatarBookmarks::deleteBookmark() {
 
 void AvatarBookmarks::updateAvatarEntities(const QVariantList &avatarEntities) {
     auto myAvatar = DependencyManager::get<AvatarManager>()->getMyAvatar();
-    auto currentAvatarEntities = myAvatar->getAvatarEntityData();
+    auto currentAvatarEntities = myAvatar->getAvatarEntityDataNonDefault();
     std::set<QUuid> newAvatarEntities;
 
     // Update or add all the new avatar entities
@@ -296,7 +296,7 @@ QVariantMap AvatarBookmarks::getAvatarDataToBookmark() {
 
     if (entityTree) {
         QScriptEngine scriptEngine;
-        auto avatarEntities = myAvatar->getAvatarEntityData();
+        auto avatarEntities = myAvatar->getAvatarEntityDataNonDefault();
         for (auto entityID : avatarEntities.keys()) {
             auto entity = entityTree->findEntityByID(entityID);
             if (!entity || !isWearableEntity(entity)) {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -2562,6 +2562,9 @@ QVariantList MyAvatar::getAvatarEntitiesVariant() {
             auto desiredProperties = entity->getEntityProperties(params);
             desiredProperties += PROP_LOCAL_POSITION;
             desiredProperties += PROP_LOCAL_ROTATION;
+            desiredProperties += PROP_LOCAL_VELOCITY;
+            desiredProperties += PROP_LOCAL_ANGULAR_VELOCITY;
+            desiredProperties += PROP_LOCAL_DIMENSIONS;
             QVariantMap avatarEntityData;
             avatarEntityData["id"] = entityID;
             EntityItemProperties entityProperties = entity->getProperties(desiredProperties);

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1810,7 +1810,7 @@ void MyAvatar::prepareAvatarEntityDataForReload() {
     _reloadAvatarEntityDataFromSettings = true;
 }
 
-AvatarEntityMap MyAvatar::getAvatarEntityData() const {
+AvatarEntityMap MyAvatar::getAvatarEntityDataNonDefault() const {
     // NOTE: the return value is expected to be a map of unfortunately-formatted-binary-blobs
     updateStaleAvatarEntityBlobs();
     AvatarEntityMap result;

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1856,11 +1856,12 @@ public:
     /**jsdoc
      * Gets details of all avatar entities.
      * @function MyAvatar.getAvatarEntityData
-     * @returns {AvatarEntityMap} Details of the avatar entities.
+     * @returns {AvatarEntityMap} Details of all avatar entities.
      * @example <caption>Report the current avatar entities.</caption>
      * var avatarEntityData = MyAvatar.getAvatarEntityData();
      * print("Avatar entities: " + JSON.stringify(avatarEntityData));
      */
+    AvatarEntityMap getAvatarEntityData() const override;
 
     AvatarEntityMap getAvatarEntityDataNonDefault() const override;
 

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1855,6 +1855,7 @@ public:
 
     /**jsdoc
      * Gets details of all avatar entities.
+     * <p><strong>Warning:</strong> Potentially an expensive call. Do not use if possible.</p>
      * @function MyAvatar.getAvatarEntityData
      * @returns {AvatarEntityMap} Details of all avatar entities.
      * @example <caption>Report the current avatar entities.</caption>

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1861,7 +1861,8 @@ public:
      * var avatarEntityData = MyAvatar.getAvatarEntityData();
      * print("Avatar entities: " + JSON.stringify(avatarEntityData));
      */
-    AvatarEntityMap getAvatarEntityData() const override;
+
+    AvatarEntityMap getAvatarEntityDataNonDefault() const override;
 
     /**jsdoc
      * Sets all avatar entities from an object.

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -3046,7 +3046,7 @@ void AvatarData::clearAvatarEntity(const QUuid& entityID, bool requiresRemovalFr
     }
 }
 
-AvatarEntityMap AvatarData::getAvatarEntityData() const {
+AvatarEntityMap AvatarData::getAvatarEntityDataNonDefault() const {
     // overridden where needed
     // NOTE: the return value is expected to be a map of unfortunately-formatted-binary-blobs
     return AvatarEntityMap();

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -3046,6 +3046,12 @@ void AvatarData::clearAvatarEntity(const QUuid& entityID, bool requiresRemovalFr
     }
 }
 
+AvatarEntityMap AvatarData::getAvatarEntityData() const {
+    // overridden where needed
+    // NOTE: the return value is expected to be a map of unfortunately-formatted-binary-blobs
+    return AvatarEntityMap();
+}
+
 AvatarEntityMap AvatarData::getAvatarEntityDataNonDefault() const {
     // overridden where needed
     // NOTE: the return value is expected to be a map of unfortunately-formatted-binary-blobs

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1390,7 +1390,9 @@ public:
     /**jsdoc
      * @comment Documented in derived classes' JSDoc because implementations are different.
      */
-    Q_INVOKABLE virtual AvatarEntityMap getAvatarEntityData() const;
+
+    // Get avatar entity data with non-default property values. Used internally.
+    virtual AvatarEntityMap getAvatarEntityDataNonDefault() const;
 
     /**jsdoc
      * @comment Documented in derived classes' JSDoc because implementations are different.

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1390,6 +1390,8 @@ public:
     /**jsdoc
      * @comment Documented in derived classes' JSDoc because implementations are different.
      */
+     // Get avatar entity data with all property values. Used in API.
+     Q_INVOKABLE virtual AvatarEntityMap getAvatarEntityData() const;
 
     // Get avatar entity data with non-default property values. Used internally.
     virtual AvatarEntityMap getAvatarEntityDataNonDefault() const;

--- a/libraries/avatars/src/ScriptAvatarData.cpp
+++ b/libraries/avatars/src/ScriptAvatarData.cpp
@@ -278,7 +278,7 @@ AvatarEntityMap ScriptAvatarData::getAvatarEntities() const {
     AvatarEntityMap scriptEntityData;
 
     if (AvatarSharedPointer sharedAvatarData = _avatarData.lock()) {
-        return sharedAvatarData->getAvatarEntityData();
+        return sharedAvatarData->getAvatarEntityDataNonDefault();
     }
 
     return scriptEntityData;

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -5097,10 +5097,13 @@ bool EntityItemProperties::blobToProperties(QScriptEngine& scriptEngine, const Q
     return true;
 }
 
-void EntityItemProperties::propertiesToBlob(QScriptEngine& scriptEngine, const QUuid& myAvatarID, const EntityItemProperties& properties, QByteArray& blob) {
+void EntityItemProperties::propertiesToBlob(QScriptEngine& scriptEngine, const QUuid& myAvatarID, 
+            const EntityItemProperties& properties, QByteArray& blob, bool allProperties) {
     // DANGER: this method is NOT efficient.
     // begin recipe for extracting unfortunately-formatted-binary-blob from EntityItem
-    QScriptValue scriptValue = EntityItemNonDefaultPropertiesToScriptValue(&scriptEngine, properties);
+    QScriptValue scriptValue = allProperties
+        ? EntityItemPropertiesToScriptValue(&scriptEngine, properties)
+        : EntityItemNonDefaultPropertiesToScriptValue(&scriptEngine, properties);
     QVariant variantProperties = scriptValue.toVariant();
     QJsonDocument jsonProperties = QJsonDocument::fromVariant(variantProperties);
     // the ID of the parent/avatar changes from session to session.  use a special UUID to indicate the avatar

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -118,7 +118,8 @@ class EntityItemProperties {
     friend class MaterialEntityItem;
 public:
     static bool blobToProperties(QScriptEngine& scriptEngine, const QByteArray& blob, EntityItemProperties& properties);
-    static void propertiesToBlob(QScriptEngine& scriptEngine, const QUuid& myAvatarID, const EntityItemProperties& properties, QByteArray& blob);
+    static void propertiesToBlob(QScriptEngine& scriptEngine, const QUuid& myAvatarID, const EntityItemProperties& properties, 
+        QByteArray& blob, bool allProperties = false);
 
     EntityItemProperties(EntityPropertyFlags desiredProperties = EntityPropertyFlags());
     virtual ~EntityItemProperties() = default;

--- a/libraries/shared/src/VariantMapToScriptValue.cpp
+++ b/libraries/shared/src/VariantMapToScriptValue.cpp
@@ -28,7 +28,7 @@ QScriptValue variantToScriptValue(QVariant& qValue, QScriptEngine& scriptEngine)
             break;
         case QVariant::String:
         case QVariant::Url:
-            return scriptEngine.newVariant(qValue);
+            return qValue.toString();
             break;
         case QVariant::Map: {
             QVariantMap childMap = qValue.toMap();

--- a/scripts/system/libraries/WebTablet.js
+++ b/scripts/system/libraries/WebTablet.js
@@ -82,9 +82,7 @@ function calcSpawnInfo(hand, landscape) {
 cleanUpOldMaterialEntities = function() {
     var avatarEntityData = MyAvatar.getAvatarEntityData();
     for (var entityID in avatarEntityData) {
-        var entityName = Entities.getEntityProperties(entityID, ["name"]).name;
-
-        if (entityName === TABLET_MATERIAL_ENTITY_NAME) {
+        if (avatarEntityData[entityID].name === TABLET_MATERIAL_ENTITY_NAME) {
             Entities.deleteEntity(entityID);
         }
     }


### PR DESCRIPTION
Make MyAvatar.getAvatarEntityData() return all properties rather than just changed properties.

Also:
- Fixed string property values to be returned as string primitives instead of String objects. (So the JSON.stringify() produces the expected results.)
- Included localPosition etc. properties in values returned by `MyAvatar.getAvatarEntitiesVariant()` and `Avatar.getAvatarEntitiesData()`, to match those returned by `Entities.getEntityProperties()`.
- Removed now-unnecessary call to `Entities.getEntityProperties()` in WebTablet.js.
- Make Agent.getAvatarEntityData() return all properties.

Case: https://highfidelity.atlassian.net/browse/DEV-1943
