### PR TITLE
DEV-2442: Fix main gamepad (XBox controller) controls

### DIFF
--- a/interface/resources/controllers/xbox.json
+++ b/interface/resources/controllers/xbox.json
@@ -52,7 +52,6 @@
         { "from": "GamePad.DL", "to": "Standard.DL" },
         { "from": "GamePad.DR", "to": "Standard.DR" },
 
-        { "from": [ "GamePad.Y" ], "to": "Standard.RightPrimaryThumb", "peek": true },
         { "from": "GamePad.A", "to": "Standard.A" },
         { "from": "GamePad.B", "to": "Standard.B" },
         { "from": "GamePad.X", "to": "Standard.X" },

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5829,7 +5829,11 @@ void Application::cycleCamera() {
     } else if (menu->isOptionChecked(MenuOption::LookAtCamera)) {
 
         menu->setIsOptionChecked(MenuOption::LookAtCamera, false);
-        menu->setIsOptionChecked(MenuOption::SelfieCamera, true);
+        if (menu->getActionForOption(MenuOption::SelfieCamera)->isVisible()) {
+            menu->setIsOptionChecked(MenuOption::SelfieCamera, true);
+        } else {
+            menu->setIsOptionChecked(MenuOption::FirstPersonLookAt, true);
+        }
 
     } else if (menu->isOptionChecked(MenuOption::SelfieCamera)) {
 

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -5821,12 +5821,7 @@ void Application::centerUI() {
 
 void Application::cycleCamera() {
     auto menu = Menu::getInstance();
-    if (menu->isOptionChecked(MenuOption::FullscreenMirror)) {
-
-        menu->setIsOptionChecked(MenuOption::FullscreenMirror, false);
-        menu->setIsOptionChecked(MenuOption::FirstPersonLookAt, true);
-
-    } else if (menu->isOptionChecked(MenuOption::FirstPersonLookAt)) {
+    if (menu->isOptionChecked(MenuOption::FirstPersonLookAt)) {
 
         menu->setIsOptionChecked(MenuOption::FirstPersonLookAt, false);
         menu->setIsOptionChecked(MenuOption::LookAtCamera, true);
@@ -5839,7 +5834,7 @@ void Application::cycleCamera() {
     } else if (menu->isOptionChecked(MenuOption::SelfieCamera)) {
 
         menu->setIsOptionChecked(MenuOption::SelfieCamera, false);
-        menu->setIsOptionChecked(MenuOption::FullscreenMirror, true);
+        menu->setIsOptionChecked(MenuOption::FirstPersonLookAt, true);
 
     }
     cameraMenuChanged(); // handle the menu change

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -118,7 +118,6 @@ namespace MenuOption {
     const QString FixGaze = "Fix Gaze (no saccade)";
     const QString Forward = "Forward";
     const QString FrameTimer = "Show Timer";
-    const QString FullscreenMirror = "Mirror";
     const QString Help = "Help...";
     const QString HomeLocation = "Home ";
     const QString IncreaseAvatarSize = "Increase Avatar Size";

--- a/libraries/controllers/src/controllers/Actions.cpp
+++ b/libraries/controllers/src/controllers/Actions.cpp
@@ -176,8 +176,8 @@ namespace controller {
      *       person view.</td></tr>
      *     <tr><td><code>BoomOut</code></td><td>number</td><td>number</td><td>Zoom camera out from first person to third 
      *       person view.</td></tr>
-     *     <tr><td><code>CycleCamera</code></td><td>number</td><td>number</td><td>Cycle the camera view from first person, to 
-     *       third person, to full screen mirror, then back to first person and repeat.</td></tr>
+     *     <tr><td><code>CycleCamera</code></td><td>number</td><td>number</td><td>Cycle the camera view from first person look 
+     *       at, to (third person) look at, to selfie if in desktop mode, then back to first person and repeat.</td></tr>
      *     <tr><td><code>ContextMenu</code></td><td>number</td><td>number</td><td>Show/hide the tablet.</td></tr>
      *     <tr><td><code>ToggleMute</code></td><td>number</td><td>number</td><td>Toggle the microphone mute.</td></tr>
      *     <tr><td><code>TogglePushToTalk</code></td><td>number</td><td>number</td><td>Toggle push to talk.</td></tr>


### PR DESCRIPTION
General fixes:
- `Controller.Actions.CycleCamera` fixed so that it doesn't get stuck in third person (HMD mode) or selfie view (desktop mode). 
- JSDoc for `Controller.Actions.CycleCamera` updated to reflect new camera modes used.

Gamepad-specific fixes:
- Reinstated teleporting on "Y" button.

Case: https://highfidelity.atlassian.net/browse/DEV-2444
